### PR TITLE
[classic] Remove "patch" from Bundle-ClassPath

### DIFF
--- a/org.openhab.ui.classic/META-INF/MANIFEST.MF
+++ b/org.openhab.ui.classic/META-INF/MANIFEST.MF
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 Bundle-Activator: org.openhab.ui.classic.internal.WebAppActivator
-Bundle-ClassPath: patch/,.
+Bundle-ClassPath: .
 Bundle-License: https://www.eclipse.org/legal/epl-2.0/
 Bundle-ManifestVersion: 2
 Bundle-Name: Classic UI


### PR DESCRIPTION
Fixes the following exception when the Classic UI bundle is installed:

```
20:37:49.949 [INFO ] [org.openhab.ui.classic               ] - FrameworkEvent INFO - org.openhab.ui.classic
org.osgi.framework.BundleException: The bundle class path entry "patch/" could not be found for the bundle "osgi.identity; osgi.identity="org.openhab.ui.classic"; type="osgi.bundle"; version:Version="2.5.0.201902231905""
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.findClassPathEntry(ClasspathManager.java:174) ~[?:?]
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.buildClasspath(ClasspathManager.java:152) ~[?:?]
	at org.eclipse.osgi.internal.loader.classpath.ClasspathManager.<init>(ClasspathManager.java:81) ~[?:?]
	at org.eclipse.osgi.internal.loader.EquinoxClassLoader.<init>(EquinoxClassLoader.java:43) ~[?:?]
	at org.eclipse.osgi.internal.loader.BundleLoader.createClassLoaderPrivledged(BundleLoader.java:316) ~[?:?]
	at org.eclipse.osgi.internal.loader.BundleLoader$2.run(BundleLoader.java:239) ~[?:?]
	at org.eclipse.osgi.internal.loader.BundleLoader$2.run(BundleLoader.java:1) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at org.eclipse.osgi.internal.loader.BundleLoader.getModuleClassLoader(BundleLoader.java:236) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxBundle$1.run(EquinoxBundle.java:595) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxBundle$1.run(EquinoxBundle.java:1) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxBundle.getModuleClassLoader(EquinoxBundle.java:588) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxBundle.getResource(EquinoxBundle.java:530) ~[?:?]
	at org.apache.servicemix.specs.activation.Activator.register(Activator.java:58) ~[?:?]
	at org.apache.servicemix.specs.locator.Activator.bundleChanged(Activator.java:93) ~[?:?]
	at org.eclipse.osgi.internal.framework.BundleContextImpl.dispatchEvent(BundleContextImpl.java:908) [?:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230) ~[?:?]
	at org.eclipse.osgi.framework.eventmgr.ListenerQueue.dispatchEventSynchronous(ListenerQueue.java:148) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEventPrivileged(EquinoxEventPublisher.java:213) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher$1.run(EquinoxEventPublisher.java:124) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher$1.run(EquinoxEventPublisher.java:1) ~[?:?]
	at java.security.AccessController.doPrivileged(Native Method) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:122) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxEventPublisher.publishBundleEvent(EquinoxEventPublisher.java:112) ~[?:?]
	at org.eclipse.osgi.internal.framework.EquinoxContainerAdaptor.publishModuleEvent(EquinoxContainerAdaptor.java:168) ~[?:?]
	at org.eclipse.osgi.container.ModuleContainer.applyDelta(ModuleContainer.java:719) ~[?:?]
	at org.eclipse.osgi.container.ModuleContainer.resolveAndApply(ModuleContainer.java:511) ~[?:?]
	at org.eclipse.osgi.container.ModuleContainer.resolve(ModuleContainer.java:457) ~[?:?]
	at org.eclipse.osgi.container.ModuleContainer.refresh(ModuleContainer.java:1001) ~[?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerWiring.dispatchEvent(ModuleContainer.java:1382) ~[?:?]
	at org.eclipse.osgi.container.ModuleContainer$ContainerWiring.dispatchEvent(ModuleContainer.java:1) ~[?:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager.dispatchEvent(EventManager.java:230) [?:?]
	at org.eclipse.osgi.framework.eventmgr.EventManager$EventThread.run(EventManager.java:340) [?:?]
```