### PR TITLE
cometvisu (+php): fix dependencies

### DIFF
--- a/org.openhab.ui.cometvisu.php/pom.xml
+++ b/org.openhab.ui.cometvisu.php/pom.xml
@@ -25,8 +25,8 @@
       <version>${ohc.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.ui.dashboard</artifactId>
+      <groupId>org.openhab.ui</groupId>
+      <artifactId>org.openhab.ui.dashboard</artifactId>
       <version>${ohc.version}</version>
     </dependency>
     <dependency>

--- a/org.openhab.ui.cometvisu/pom.xml
+++ b/org.openhab.ui.cometvisu/pom.xml
@@ -20,8 +20,8 @@
       <version>${ohc.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.ui.dashboard</artifactId>
+      <groupId>org.openhab.ui</groupId>
+      <artifactId>org.openhab.ui.dashboard</artifactId>
       <version>${ohc.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
The cometvisu UI depends on dashboard bundle from openHAB Core that does
not exist anymore. The dashboard has been moved to the UI namespace.

Fixes: https://github.com/openhab/openhab-webui/issues/25