### PR TITLE
Update all license headers to openHAB EPL-2.0

### DIFF
--- a/licenses/epl-2.0/header.txt
+++ b/licenses/epl-2.0/header.txt
@@ -1,0 +1,10 @@
+Copyright (c) 2010-${year} Contributors to the openHAB project
+ 
+See the NOTICE file(s) distributed with this work for additional
+information.
+ 
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License 2.0 which is available at
+http://www.eclipse.org/legal/epl-2.0
+ 
+SPDX-License-Identifier: EPL-2.0

--- a/licenses/epl-2.0/xml-header-style.xml
+++ b/licenses/epl-2.0/xml-header-style.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<additionalHeaders>
+	<xml-header-style>
+		<firstLine><![CDATA[<!--EOL]]></firstLine>
+		<beforeEachLine>&#x9;</beforeEachLine>
+		<endLine><![CDATA[EOL-->]]></endLine>
+		<skipLine><![CDATA[^<\?xml.*>$]]></skipLine>
+		<firstLineDetectionPattern><![CDATA[(\s|\t)*<!--.*$]]></firstLineDetectionPattern>
+		<lastLineDetectionPattern><![CDATA[.*-->(\s|\t)*$]]></lastLineDetectionPattern>
+		<allowBlankLines>true</allowBlankLines>
+		<isMultiline>true</isMultiline>
+	</xml-header-style>
+</additionalHeaders>

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/HABminConstants.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/HABminConstants.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.ui.habmin;
 
 public class HABminConstants {

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/HABminUIDashboardTile.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/HABminUIDashboardTile.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartAxisConfigBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartAxisConfigBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.chart;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartConfigBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartConfigBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.chart;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartItemConfigBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartItemConfigBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.chart;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartListBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartListBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.chart;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartResource.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/chart/ChartResource.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.chart;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardConfigBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardConfigBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.dashboard;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardListBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardListBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.dashboard;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardResource.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardResource.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.dashboard;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardWidgetBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardWidgetBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.dashboard;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardWidgetOptionsBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/dashboard/DashboardWidgetOptionsBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.dashboard;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerBlockBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerBlockBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerChildBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerChildBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerCommentBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerCommentBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerFieldBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerFieldBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerListBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerListBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerMutationBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerMutationBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerResource.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/DesignerResource.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/ControlIfBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/ControlIfBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/DesignerRuleCreator.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/DesignerRuleCreator.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicBooleanBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicBooleanBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicCompareBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicCompareBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicNegateBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicNegateBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicOperationBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/LogicOperationBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathArithmeticBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathArithmeticBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathConstrainBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathConstrainBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathNumberBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathNumberBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathRoundBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/MathRoundBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabConstantGetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabConstantGetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabConstantSetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabConstantSetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabIfTimerBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabIfTimerBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabItemCmdBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabItemCmdBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabItemGetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabItemGetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabItemSetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabItemSetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabPersistenceGetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabPersistenceGetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabRuleBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabRuleBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabStateOnOffBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabStateOnOffBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabStateOpenClosedBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabStateOpenClosedBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabTimeBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/OpenhabTimeBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/RuleContext.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/RuleContext.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/TextBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/TextBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/VariableGetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/VariableGetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/VariableSetBlock.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/designer/blocks/VariableSetBlock.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.designer.blocks;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanConfigBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanConfigBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.floorplan;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanHotspotConfigBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanHotspotConfigBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.floorplan;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanListBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanListBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.floorplan;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanResource.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/floorplan/FloorplanResource.java
@@ -1,3 +1,15 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
 package org.openhab.ui.habmin.internal.services.floorplan;
 
 import java.io.BufferedOutputStream;

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.rule;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleResource.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleResource.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.rule;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleSourceBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleSourceBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.rule;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleSourceListBean.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/services/rule/RuleSourceListBean.java
@@ -1,10 +1,14 @@
 /**
- * Copyright (c) 2010-2013, openHAB.org and others.
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
  *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.services.rule;
 

--- a/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/servlet/HABminApp.java
+++ b/org.openhab.ui.habmin/src/main/java/org/openhab/ui/habmin/internal/servlet/HABminApp.java
@@ -1,9 +1,14 @@
 /**
- * Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of the Eclipse Public License v1.0
- * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.ui.habmin.internal.servlet;
 

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/chartresource.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/chartresource.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	Copyright (c) 2010-2019 Contributors to the openHAB project
+
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.habmin.charts">

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/dashboardresource.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/dashboardresource.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	Copyright (c) 2010-2019 Contributors to the openHAB project
+
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.habmin.dashboard">

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/dashboardtile.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/dashboardtile.xml
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
+	Copyright (c) 2010-2019 Contributors to the openHAB project
 
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.habmin.dashboardtile">

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/designerresource.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/designerresource.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	Copyright (c) 2010-2019 Contributors to the openHAB project
+
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.habmin.designer">

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/floorplanresource.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/floorplanresource.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	Copyright (c) 2010-2019 Contributors to the openHAB project
+
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.habmin.floorplan">

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/habminapp.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/habminapp.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014 openHAB UG (haftungsbeschraenkt) and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	Copyright (c) 2010-2019 Contributors to the openHAB project
+
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" name="org.openhab.ui.habmin.HABminApp">

--- a/org.openhab.ui.habmin/src/main/resources/OSGI-INF/ruleresource.xml
+++ b/org.openhab.ui.habmin/src/main/resources/OSGI-INF/ruleresource.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2014-2015 openHAB UG (haftungsbeschraenkt) and others.
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of the Eclipse Public License v1.0
-    which accompanies this distribution, and is available at
-    http://www.eclipse.org/legal/epl-v10.html
+	Copyright (c) 2010-2019 Contributors to the openHAB project
+
+	See the NOTICE file(s) distributed with this work for additional
+	information.
+
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
+
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.ui.habmin.rules">

--- a/org.openhab.ui.habpanel/src/main/resources/OSGI-INF/dashboardtile.xml
+++ b/org.openhab.ui.habpanel/src/main/resources/OSGI-INF/dashboardtile.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2019 Contributors to the openHAB project
+	Copyright (c) 2010-2019 Contributors to the openHAB project
 
-    See the NOTICE file(s) distributed with this work for additional
-    information.
+	See the NOTICE file(s) distributed with this work for additional
+	information.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" activate="activate" deactivate="deactivate" immediate="true" name="org.openhab.habpanel">

--- a/org.openhab.ui.habpanel/src/main/resources/OSGI-INF/habpanelresource.xml
+++ b/org.openhab.ui.habpanel/src/main/resources/OSGI-INF/habpanelresource.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2010-2019 Contributors to the openHAB project
+	Copyright (c) 2010-2019 Contributors to the openHAB project
 
-    See the NOTICE file(s) distributed with this work for additional
-    information.
+	See the NOTICE file(s) distributed with this work for additional
+	information.
 
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License 2.0 which is available at
-    http://www.eclipse.org/legal/epl-2.0
+	This program and the accompanying materials are made available under the
+	terms of the Eclipse Public License 2.0 which is available at
+	http://www.eclipse.org/legal/epl-2.0
 
-    SPDX-License-Identifier: EPL-2.0
+	SPDX-License-Identifier: EPL-2.0
 
 -->
 <scr:component xmlns:scr="http://www.osgi.org/xmlns/scr/v1.1.0" immediate="true" name="org.openhab.habpanel.rest">


### PR DESCRIPTION
I've add some files so we can use `mvn license:format` in this repo.
Then I used the command so now the same headers are used in all files. :-)