### PR TITLE
[paper] Hide command options for read only items

### DIFF
--- a/bundles/org.openhab.ui.paper/web-src/js/control/string/component.control.string.html
+++ b/bundles/org.openhab.ui.paper/web-src/js/control/string/component.control.string.html
@@ -31,4 +31,4 @@
 <div layout="row" layout-align="start center" ng-if="::($ctrl.isOptionList($ctrl.item) && !$ctrl.item.readOnly)">
     <item-state-dropdown item="$ctrl.item" on-change="$ctrl.updateState()"></item-state-dropdown>
 </div>
-<item-command-options item="$ctrl.item" ng-if="::$ctrl.isCommandOptions()"></item-command-options>
+<item-command-options item="$ctrl.item" ng-if="::$ctrl.isCommandOptions() && !$ctrl.item.readOnly"></item-command-options>

--- a/bundles/org.openhab.ui.paper/web-src/js/control/switch/component.control.switch.html
+++ b/bundles/org.openhab.ui.paper/web-src/js/control/switch/component.control.switch.html
@@ -17,4 +17,4 @@
 <div layout="row" layout-align="start center" ng-if="::($ctrl.isOptionList($ctrl.item) && !$ctrl.item.readOnly)">
     <item-state-dropdown item="$ctrl.item" on-change="$ctrl.updateState()"></item-state-dropdown>
 </div>
-<item-command-options item="$ctrl.item" ng-if="::$ctrl.isCommandOptions()"></item-command-options>
+<item-command-options item="$ctrl.item" ng-if="::$ctrl.isCommandOptions() && !$ctrl.item.readOnly"></item-command-options>


### PR DESCRIPTION
Hides the command options (added in https://github.com/eclipse/smarthome/pull/5131) for controls of read only items.

This should stop people from messing with the sun and the moon. ;-)

### Before fix

![1](https://user-images.githubusercontent.com/12213581/58373573-86e7b280-7f30-11e9-8017-50e32f7da625.png)

### After fix

![2](https://user-images.githubusercontent.com/12213581/58373577-8b13d000-7f30-11e9-9909-de6adf661fcb.png)
