### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
         local command=(mvn $@)
         exec "${command[@]}" 2>&1 | # execute, redirect stderr to stdout
             tee .build.log | # write output to log
-            stdbuf -oL grep -E '^\[INFO\] Building .+ \[.+\]$' | # filter progress
+            stdbuf -oL grep -aE '^\[INFO\] Building .+ \[.+\]$' | # filter progress
             sed -uE 's/^\[INFO\] Building (.*[^ ])[ ]+\[([0-9]+\/[0-9]+)\]$/\2| \1/' | # prefix project name with progress
             sed -e :a -e 's/^.\{1,4\}|/ &/;ta' & # right align progress with padding
         local pid=$!


### PR DESCRIPTION
Using the -a switch grep will treat binary data as text so the pipe no longer chokes on it.