### PR TITLE
Use bnd for including resources to workaround infinite Eclipse builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,18 +67,6 @@
   </properties>
 
   <build>
-    <resources>
-      <resource>
-        <directory>src/main/resources</directory>
-      </resource>
-      <resource>
-        <directory>.</directory>
-        <includes>
-          <include>NOTICE</include> <!-- general -->
-          <include>*.xsd</include> <!-- only a very rare -->
-        </includes>
-      </resource>
-    </resources>
     <pluginManagement>
       <plugins>
 
@@ -108,6 +96,7 @@ Import-Package: \\
   org.openhab.*
 -sources: false
 -contract: *
+-includeresource: -${.}/NOTICE, -${.}/*.xsd
 ]]></bnd>
 <!--
 -dsannotations-options: norequirements


### PR DESCRIPTION
When "Build Automatically" is enabled in Eclipse, the build never ends.
It seems there is a bnd issue with the way resources are defined in the reactor POM.
The workaround seems to be to include all resources using bnd.

See also:

* https://github.com/bndtools/bnd/issues/3220
* https://github.com/openhab/openhab2-addons/issues/5554