### PR TITLE
[paper] Sort serial port parameter options

### DIFF
--- a/bundles/org.openhab.ui.paper/web-src/js/configuration/directive.configDescription.html
+++ b/bundles/org.openhab.ui.paper/web-src/js/configuration/directive.configDescription.html
@@ -39,18 +39,19 @@
 								<div ng-switch-when="select" ng-show="(part==='normal' && !parameter.advanced) || (part==='advance' && parameter.advanced && isAdvanced)">
 									<label class="config-textInput">{{parameter.label}}</label>
 									<md-input-container class="col-xs-12 configContainer no-animation"> 
-									   <md-select class="config-select" isrequired="{{parameter.required}}" ng-init="focus=false" name="{{parameter.name}}" ng-model="$ctrl.configuration[parameter.name]" placeholder="Select a value" ng-focus="focus=true" ng-blur="focus=false" ng-required="parameter.required" aria-label="parameter.label"> 
-									       <md-option ng-value="option.value" ng-repeat="option in parameter.options" ng-finish-render> 
-									           <span style="display: inline-block;" ng-if="parameter.context">{{option.label}}
-										           <span class="md-caption" style="color: grey;">({{option.value}})</span>
-									           </span>
-									           <span ng-if="!parameter.context">{{option.label}}</span> 
-									      </md-option>
-									   </md-select>
-									<div ng-messages="$ctrl.form.configForm[parameter.name].$error" ng-show="focus">
-										<div ng-message="required">Field is required</div>
-									</div>
-									<parameter-description description="parameter.description" /> </md-input-container>
+										<md-select class="config-select" isrequired="{{parameter.required}}" ng-init="focus=false" name="{{parameter.name}}" ng-model="$ctrl.configuration[parameter.name]" placeholder="Select a value" ng-focus="focus=true" ng-blur="focus=false" ng-required="parameter.required" aria-label="parameter.label"> 
+											<md-option ng-value="option.value" ng-repeat="option in $ctrl.getParameterOptions(parameter)" ng-finish-render> 
+												<span style="display: inline-block;" ng-if="parameter.context">{{option.label}}
+													<span class="md-caption" style="color: grey;">({{option.value}})</span>
+												</span>
+												<span ng-if="!parameter.context">{{option.label}}</span> 
+											</md-option>
+										</md-select>
+										<div ng-messages="$ctrl.form.configForm[parameter.name].$error" ng-show="focus">
+											<div ng-message="required">Field is required</div>
+										</div>
+										<parameter-description description="parameter.description" />
+									</md-input-container>
 								</div>
 								<div ng-switch-when="multiSelect">
 									<label class="config-textInput">{{parameter.label}}</label>

--- a/bundles/org.openhab.ui.paper/web-src/js/configuration/directive.configDescription.js
+++ b/bundles/org.openhab.ui.paper/web-src/js/configuration/directive.configDescription.js
@@ -18,12 +18,22 @@
         var ctrl = this;
 
         this.getName = getName;
+        this.getParameterOptions = getParameterOptions;
 
         function getName(parameter, option) {
             if (!option) {
                 return undefined;
             }
             return option.name ? option.name : parameter.context == 'thing' ? option.UID : parameter.context == 'channel' ? option.id : undefined;
+        }
+
+        function getParameterOptions(parameter) {
+            if (parameter.context == 'serial-port') {
+                return parameter.options.sort(function(o1, o2) {
+                    return o1.label.localeCompare(o2.label);
+                });
+            }
+            return parameter.options;
         }
     }
 


### PR DESCRIPTION
When you have many serial ports it's easier to find them in a sorted list.

I've only sorted the generated list of serial ports because I think contributors sometimes purposefully order configuration parameter options.

There was some mixed tabs/spaces indentation I've also corrected in `directive.configDescription.html`, the only real change in that file is:

```javascript
ng-repeat="option in $ctrl.getParameterOptions(parameter)"
```