### PR TITLE
[paper] Add kind to dynamically created channels

### DIFF
--- a/bundles/org.openhab.ui.paper/web-src/js/things/controller.things.view.js
+++ b/bundles/org.openhab.ui.paper/web-src/js/things/controller.things.view.js
@@ -526,6 +526,7 @@ angular.module('PaperUI.things') //
             uid : thing.UID + ':' + $scope.channelId,
             id : $scope.channelId,
             channelTypeUID : $scope.channelType.UID,
+            kind : $scope.channelType.kind,
             itemType : $scope.channelType.itemType,
             label : $scope.channelLabel,
             configuration : $scope.configuration,


### PR DESCRIPTION
- Add `kind` to dynamically created channels

I am not an UI expert thus I did not test it. Wdyt?

Fixes https://github.com/openhab/openhab2-addons/issues/5410

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>