### PR TITLE
Fix empty reactor summary on newer Maven versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
         done
     }
     function print_reactor_summary() {
-        sed -ne '/\[INFO\] Reactor Summary:/,$ p' "$1" | sed 's/\[INFO\] //'
+        sed -ne '/\[INFO\] Reactor Summary.*:/,$ p' "$1" | sed 's/\[INFO\] //'
     }
     function mvnp() {
         set -o pipefail # exit build with error when pipes fail


### PR DESCRIPTION
On newer Maven versions the reactor summary also contains the project name and version so the regexp needs to be adjusted for this.