### PR TITLE
[BasicUI] Ignore too big item state when updating widget icon

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -351,14 +351,23 @@
 			// Some widgets don't have icons
 			if (_t.icon !== null) {
 				_t.icon.addEventListener("error", replaceImageWithNone);
-				_t.icon.setAttribute("src",
-					"/icon/" +
-					_t.iconName +
-					"?state=" +
-					encodeURIComponent(state) +
-					"&format=" +
-					smarthome.UI.iconType
-				);
+				if (state.length < 200) {
+					_t.icon.setAttribute("src",
+						"/icon/" +
+						_t.iconName +
+						"?state=" +
+						encodeURIComponent(state) +
+						"&format=" +
+						smarthome.UI.iconType
+					);
+				} else {
+					_t.icon.setAttribute("src",
+						"/icon/" +
+						_t.iconName +
+						"?format=" +
+						smarthome.UI.iconType
+					);
+				}
 			}
 		};
 


### PR DESCRIPTION
When reloading a widget icon, Basic UI frontend was building an URL that included the item state without any limit on the size of this state.
This could be a problem when the state was big (like the image data of an Image item).
Item state is now ignored when building the icon URL if its size is greater or equal to 200.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>