### PR TITLE
[habpanel] Widget gallery: handle short attachment urls

### DIFF
--- a/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/gallery/community/CommunityWidgetGalleryProvider.java
+++ b/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/gallery/community/CommunityWidgetGalleryProvider.java
@@ -114,6 +114,8 @@ public class CommunityWidgetGalleryProvider implements GalleryWidgetProvider {
                         GalleryWidgetAttachment widget = new GalleryWidgetAttachment();
                         if (link.url.startsWith("//")) {
                             link.url = "https:" + link.url;
+                        } else if (link.url.startsWith("/uploads")) {
+                            link.url = COMMUNITY_BASE_URL + link.url;
                         }
                         widget.sourceUrl = link.url;
                         URL widgetUrl = new URL(link.url);


### PR DESCRIPTION
Discourse now seems to use relative "short URLs" redirects (`/uploads/short-url/...`) instead of linking to the absolute URL of the attachment on S3 (for new posts only, those created before are not affected).

Signed-off-by: Yannick Schaus <github@schaus.net>