### PR TITLE
Renamed service pid for regional settings from "org.eclipse.smarthome.core.localeprovider" -> "org.eclipse.smarthome.core.i18nprovider" to "org.eclipse.smarthome.i18n"

### DIFF
--- a/bundles/org.openhab.ui.dashboard/web/js/geolocation.js
+++ b/bundles/org.openhab.ui.dashboard/web/js/geolocation.js
@@ -24,7 +24,7 @@
 
         var output = $('#geolocation')
 
-        $.getJSON(window.location.origin + '/rest/services/org.eclipse.smarthome.core.i18nprovider/config', function(response) {
+        $.getJSON(window.location.origin + '/rest/services/org.eclipse.smarthome.i18n/config', function(response) {
             window.language = response;
 
             if (!response.location) {
@@ -37,7 +37,7 @@
 
     function send(configuration) {
         $.ajax({
-            url : window.location.origin + '/rest/services/org.eclipse.smarthome.core.i18nprovider/config',
+            url : window.location.origin + '/rest/services/org.eclipse.smarthome.i18n/config',
             data : JSON.stringify(configuration),
             type : 'PUT',
             dataType : 'json',

--- a/bundles/org.openhab.ui.habpanel/web/app/services/openhab.service.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/services/openhab.service.js
@@ -89,7 +89,7 @@
             if (locale) {
                 deferred.resolve(locale);
             } else {
-                $http.get('/rest/services/org.eclipse.smarthome.core.i18nprovider/config')
+                $http.get('/rest/services/org.eclipse.smarthome.i18n/config')
                 .then(function (response) {
                     var language;
                     if (!response.data.language) {

--- a/bundles/org.openhab.ui.homebuilder/web/src/AppForm.vue
+++ b/bundles/org.openhab.ui.homebuilder/web/src/AppForm.vue
@@ -121,7 +121,7 @@
             getLocale: function () {
                 const DEFAULT_LOCALE = 'en-UK';
                 this.$http
-                    .get('services/org.eclipse.smarthome.core.i18nprovider/config')
+                    .get('services/org.eclipse.smarthome.i18n/config')
                     .then(response => {
                         const body = response.body;
                         let selectedLang = DEFAULT_LOCALE;


### PR DESCRIPTION
- Renamed service pid for regional settings from "org.eclipse.smarthome.core.localeprovider" -> "org.eclipse.smarthome.core.i18nprovider" to "org.eclipse.smarthome.i18n"

See openhab/openhab-core#1112 and https://github.com/openhab/openhab-distro/pull/979

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>