### PR TITLE
[habpanel] Send early update events

### DIFF
--- a/bundles/org.openhab.ui.habpanel/web/app/services/openhab.service.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/services/openhab.service.js
@@ -29,6 +29,11 @@
         }
 
         function loadItems() {
+            /* send the update event early if the items are already there (to speed up the dashboard switches) */
+            if ($rootScope.items && $rootScope.items.length > 0) {
+                $timeout($rootScope.$emit('openhab-update'));
+            }
+
             $http.get('/rest/items')
             .then(function (data) {
                 if (angular.isArray(data.data)) {

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/chart/chart.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/chart/chart.widget.js
@@ -209,9 +209,8 @@
                         vm.interactiveChartOptions.liveUpdates.fillValues = vm.widget.liveUpdates.fillValues;
                     }
 
+                    vm.interactiveChartReady = true;
                 });
-
-                vm.interactiveChartReady = true;
             };
 
             var updateValue = function(item) {


### PR DESCRIPTION
This change broadcasts the 'openhab-update' event immediately, not waiting for
the result of the /rest/items request, if the items are already populated, when
OHService.reloadItems() is called.  This improves the dashboard switching latency
significantly at the expanse of reliability - some widgets (e.g. slider) might
'flicker' slighly.

Signed-off-by: Yannick Schaus <github@schaus.net>