### PR TITLE
Paper UI: NG rule sort criteria change from uid to name

### DIFF
--- a/bundles/org.openhab.ui.paper/web-src/js/rules/rules.html
+++ b/bundles/org.openhab.ui.paper/web-src/js/rules/rules.html
@@ -13,7 +13,7 @@
 		<div class="container">
 			<p class="text-center" ng-show="data.rules.length == 0">No rules defined yet.</p>
 			<div class="groups">
-				<div class="clickable" ng-repeat="rule in rules | orderBy:'uid'" ng-click="configure(rule, $event)">
+				<div class="clickable" ng-repeat="rule in rules | orderBy:'name'" ng-click="configure(rule, $event)">
 					<div class="rule fab-item text-left">
 						<div class="circle">{{rule.name.substring(0,1)}}</div>
 						<div class="item-content" ng-class="{'enabled' : isEnabled(rule), 'disabled' : !isEnabled(rule)}">


### PR DESCRIPTION
Sort criteria of the rule list for NG rules changed to name.

**Reason for change:**

When developing NG rules, it is annoying that they move around in the rule list every time a rule file is updated and therefore reloaded by openHAB.
The same happens for all rules, when openHAB is restarted.

Actually the above statements might not be true in all circumstances, but practically, it is. Namely, when the UID is a randomly generated ID. This is the case when a rule is created from scratch in the Paper UI or when using the class SimpleRule (as done by the openHAB Helper Libraries and probably the Paper UI), which are likely the most common ways to create NG rules. Therefore sorting by UID is sorting by random , which basically is like not sorting at all (or more precise giving it a good shuffle once and then remembering the order).
