### PR TITLE
Fix SAT errors in resources and tests

### DIFF
--- a/bundles/org.openhab.ui.habot/src/main/resources/ESH-INF/automation/moduletypes/HABotTypes.json
+++ b/bundles/org.openhab.ui.habot/src/main/resources/ESH-INF/automation/moduletypes/HABotTypes.json
@@ -1,33 +1,33 @@
-{  
-   "actions":[  
-      {  
-         "uid":"habot.WebPushNotificationAction",
-         "label":"send a web push notification to HABot",
-         "description":"Push the message to all subscribed HABot clients.",
-         "configDescriptions":[  
-            {  
-               "name":"title",
-               "type":"TEXT",
-               "description":"the title of the notification - only for the native notification, in the chat page the title will NOT appear!"
-            },
-            {  
-               "name":"body",
-               "type":"TEXT",
-               "description":"the body of the native notification message which is also the chat message from HABot (required)",
-               "required":true
-            },
-            {  
-               "name":"cardUID",
-               "type":"TEXT",
-               "description":"the explicit UID of a card to make HABot display when the notification is clicked"
-            },
-            {
-                "name":"tags",
-                "type":"TEXT",
-                "multiple":true,
-                "description":"the tags associated with the message, HABot will try to find a matching card with those tags if you don't specify an explicit UID" 
-            }
-         ]
-      }
-   ]
+{
+	"actions": [
+		{
+			"uid": "habot.WebPushNotificationAction",
+			"label": "send a web push notification to HABot",
+			"description": "Push the message to all subscribed HABot clients.",
+			"configDescriptions": [
+				{
+					"name": "title",
+					"type": "TEXT",
+					"description": "the title of the notification - only for the native notification, in the chat page the title will NOT appear!"
+				},
+				{
+					"name": "body",
+					"type": "TEXT",
+					"description": "the body of the native notification message which is also the chat message from HABot (required)",
+					"required": true
+				},
+				{
+					"name": "cardUID",
+					"type": "TEXT",
+					"description": "the explicit UID of a card to make HABot display when the notification is clicked"
+				},
+				{
+					"name": "tags",
+					"type": "TEXT",
+					"multiple": true,
+					"description": "the tags associated with the message, HABot will try to find a matching card with those tags if you don't specify an explicit UID"
+				}
+			]
+		}
+	]
 }

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/AbstractTrainerTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/AbstractTrainerTest.java
@@ -12,8 +12,7 @@
  */
 package org.openhab.ui.habot.test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -27,6 +26,9 @@ import org.openhab.ui.habot.nlp.Skill;
 import org.openhab.ui.habot.nlp.UnsupportedLanguageException;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
+/**
+ * @author Stephan Strittmatter - Initial contribution
+ */
 public class AbstractTrainerTest {
 
     IntentTrainer trainer = null;

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TokenizerTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TokenizerTest.java
@@ -17,6 +17,9 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.openhab.ui.habot.nlp.internal.AlphaNumericTokenizer;
 
+/**
+ * @author Yannick Schaus - Initial contribution
+ */
 public class TokenizerTest {
 
     private void printTokens(String[] tokens) {

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerDeTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerDeTest.java
@@ -18,6 +18,9 @@ import org.junit.Test;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
+/**
+ * @author Stephan Strittmatter - Initial contribution
+ */
 public class TrainerDeTest extends AbstractTrainerTest {
 
     @Test

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerEnTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerEnTest.java
@@ -15,6 +15,9 @@ package org.openhab.ui.habot.test;
 import org.junit.Test;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
+/**
+ * @author Stephan Strittmatter - Initial contribution
+ */
 public class TrainerEnTest extends AbstractTrainerTest {
 
     @Test

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerFrTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerFrTest.java
@@ -18,6 +18,9 @@ import org.junit.Test;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
+/**
+ * @author Stephan Strittmatter - Initial contribution
+ */
 public class TrainerFrTest extends AbstractTrainerTest {
 
     @Test

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerItTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerItTest.java
@@ -15,6 +15,9 @@ package org.openhab.ui.habot.test;
 import org.junit.Test;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
+/**
+ * @author Luciano Legovich - Initial contribution
+ */
 public class TrainerItTest extends AbstractTrainerTest {
 
     @Test
@@ -44,7 +47,7 @@ public class TrainerItTest extends AbstractTrainerTest {
         assertIsActivate("vorrei un po' di luce in bagno", "luce", "bagno");
         assertIsActivate("voglio un po' d'aria condizionata in cucina", "aria condizionata", "cucina");
 
-        //assertIsDeactivate("spegni i radiatori", "radiatori", null);
+        // assertIsDeactivate("spegni i radiatori", "radiatori", null);
         assertIsDeactivate("disattiva l'allarme", "allarme", null);
         assertIsDeactivate("spegni la musica in soggiorno", "musica", "soggiorno");
         assertIsDeactivate("non voglio più musica in cucina", "musica", "cucina");
@@ -54,12 +57,11 @@ public class TrainerItTest extends AbstractTrainerTest {
         assertIsDeactivate("spegni le luci", "luci", null);
 
         checkInterpretation(Skills.GET_HISTORY_HOURLY,
-                "mostrami un grafico della temperatura del soggiorno delle ultime 3 ore", "temperatura",
-                "soggiorno");
+                "mostrami un grafico della temperatura del soggiorno delle ultime 3 ore", "temperatura", "soggiorno");
         checkInterpretation(Skills.GET_HISTORY_DAILY, "grafico del consumo di acqua degli ultimi 2 giorni",
                 "consumo di acqua", null);
-        checkInterpretation(Skills.GET_HISTORY_WEEKLY, "vorrei un grafico dell'umidità deglle ultime 2 settimane", "umidità",
-                null);
+        checkInterpretation(Skills.GET_HISTORY_WEEKLY, "vorrei un grafico dell'umidità deglle ultime 2 settimane",
+                "umidità", null);
         checkInterpretation(Skills.GET_HISTORY_MONTHLY, "temperatura del piano di sotto nell'ultimo mese",
                 "temperatura", "piano di sotto");
         checkInterpretation(Skills.GET_HISTORY_MONTHLY, "luminosità del soggiorno negli ultimi 6 mesi", "luminosità",
@@ -86,5 +88,5 @@ public class TrainerItTest extends AbstractTrainerTest {
         assertIs("create-rule", "imposta una regola che si attivi fra 90 minuti");
         assertIs("create-rule", "imposta una nuova regola per domani alle 8");
         assertIs("create-rule", "imposta una nuova regola per tutti i mercoledì alle 11h30");
-   }
+    }
 }

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerNlTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerNlTest.java
@@ -18,6 +18,9 @@ import org.junit.Test;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
+/**
+ * @author Jorg de Jong - Initial contribution
+ */
 public class TrainerNlTest extends AbstractTrainerTest {
 
     @Test


### PR DESCRIPTION
Fixes all SAT errors in resources and tests reported by SAT 0.8.0-SNAPSHOT.

Related to: openhab/static-code-analysis#363