### PR TITLE
Fixed font weight for Group element value in Sitemap

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/group.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/group.html
@@ -5,7 +5,7 @@
 	<span %labelstyle% class="mdl-form__label">
 		%label%
 	</span>
-	<div %valuestyle% class="mdl-form__value mdl-form__value--text-link">%value%</div>
+	<div %valuestyle% class="mdl-form__value">%value%</div>
 	<div
 		class="mdl-form__control mdl-form__group"
 		data-control-type="group"


### PR DESCRIPTION
- Fixed font weight for Group element value in Sitemap

When using a Group element in a Sitemap the value will be displayed in font weight 400. All other Sitemap elements use font weight 700 for their values:

```
    Frame label="Wetter" {
        Group item=gTEMPERATURE label="Current Temperature [%.1f °C]"
        Text item=gTEMPERATURE label="Current Temperature [%.1f °C]" {
            ...
        }
        ...
    }
```

Before:
![grafik](https://user-images.githubusercontent.com/5131747/69876456-efd52c00-12bf-11ea-9351-bd473a8864b3.png)

After:
![grafik](https://user-images.githubusercontent.com/5131747/69876480-fd8ab180-12bf-11ea-825e-159e218ed1e8.png)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>