### PR TITLE
Support for re-styling rest docs via bundle fragments.

### DIFF
--- a/bundles/org.openhab.ui.restdocs/bnd.bnd
+++ b/bundles/org.openhab.ui.restdocs/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-SymbolicName: ${project.artifactId}
+Bundle-ClassPath: patch/,.
+


### PR DESCRIPTION
This is a small change solving #169. It allows usage of bundle fragments to load additional resources from fragments before using original ones.