### PR TITLE
[dashboard] show ui version instead of core version on dashboard

### DIFF
--- a/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardServlet.java
+++ b/bundles/org.openhab.ui.dashboard/src/main/java/org/openhab/ui/dashboard/internal/DashboardServlet.java
@@ -112,7 +112,7 @@ public class DashboardServlet extends HttpServlet {
             }
         }
         Map<String, String> replaceMap = new HashMap<>();
-        replaceMap.put("version", OpenHAB.getVersion() + " " + OpenHAB.buildString());
+        replaceMap.put("version", getVersion() + " " + OpenHAB.buildString());
         replaceMap.put("entries", entries.toString());
         replaceMap.put("warn", isExposed(req) ? warnTemplate : "");
         // Set the messages in the session


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-webui/pull/165, which unfortunately only changed it on the setup page, but not the dashboard.

Signed-off-by: Kai Kreuzer <kai@openhab.org>