### PR TITLE
Improve channel list logic

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -4,11 +4,11 @@
       <f7-list media-list>
         <ul>
           <f7-list-item v-for="l in enrichedLinks" :key="l.itemName" media-item
-            :title="l.thing.label" :subtitle="l.channel.label" :footer="l.link.channelUID"
+            :title="l.thing.label" :subtitle="l.channel.label || '?'" :footer="l.link.channelUID"
             :badge="l.thing.statusInfo.status"
             :badge-color="l.thing.statusInfo.status === 'ONLINE' ? 'green' : 'red'"
             link="#" @click="editLink(l)">
-            <span slot="media" class="item-initial">{{l.channel.label[0]}}</span>
+            <span slot="media" class="item-initial">{{l.channel.label ? l.channel.label[0] : '?'}}</span>
           </f7-list-item>
           <f7-list-button v-if="!$theme.md" color="blue" title="Add Link" @click="addLink"></f7-list-button>
         </ul>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -18,21 +18,7 @@
     </div>
   </div>
   <f7-list media-list v-else inset class="margin-left searchbar-ignore">
-    <!-- <f7-list-group v-if="!ready">
-      <f7-list-item
-        media-item
-        v-for="n in links.length"
-        :key="n"
-        :class="`skeleton-text skeleton-effect-blink`"
-        title="Label of the item"
-        subtitle="type + semantic metadata"
-        after="The item state"
-        footer="This contains the type of the item"
-      >
-        <f7-skeleton-block style="width: 32px; height: 32px; border-radius: 50%" slot="media"></f7-skeleton-block>
-      </f7-list-item>
-    </f7-list-group> -->
-    <f7-list-group>
+    <f7-list-group v-if="links">
       <f7-list-item
         v-for="link in links" :key="link.itemName"
         media-item link
@@ -49,11 +35,15 @@
         <!-- <f7-button slot="after-start" color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
       </f7-list-item>
     </f7-list-group>
+    <!-- <f7-list-item class="searchbar-ignore" media-item link
+      color="blue" title="Add Link..." subtitle="Adds another link" @click="addLink()">
+        <f7-icon slot="media" color="green" aurora="f7:plus_circle" ios="f7:plus_circle" md="material:control_point" size="32" width="32"></f7-icon>
+    </f7-list-item> -->
     <f7-list-item class="searchbar-ignore" link
       color="blue" subtitle="Add Link to Item..." @click="addLink()">
         <f7-icon slot="media" color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point"></f7-icon>
     </f7-list-item>
-    <f7-list-button class="searchbar-ignore" color="blue" title="Configure Channel" @click="configureChannel()"></f7-list-button>
+    <f7-list-button class="searchbar-ignore" color="blue" :title="(channelType.parameterGroups.length || channelType.parameters.length) ? 'Configure Channel' : 'Channel Details'" @click="configureChannel()"></f7-list-button>
     <f7-list-button class="searchbar-ignore" v-if="extensible" color="red" title="Remove Channel" @click="removeChannel()"></f7-list-button>
   </f7-list>
 </template>
@@ -73,19 +63,17 @@ import ConfigureLinkPage from '@/pages/settings/things/link/link-edit.vue'
 import ConfigureChannelPage from '@/pages/settings/things/channel/channel-edit.vue'
 
 export default {
-  props: ['channelType', 'channelId', 'thing', 'opened', 'extensible'],
+  props: ['channelType', 'channelId', 'channel', 'thing', 'opened', 'extensible'],
   data () {
     return {
       ready: false,
       loading: false,
-      channel: null,
       links: [],
       channelKind: ''
     }
   },
   methods: {
     buildLinks () {
-      this.channel = this.thing.channels.find((c) => c.id === this.channelId)
       if (this.channel) {
         this.channelKind = this.channel.kind
         let links = []

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -178,7 +178,7 @@ export default {
       })
     },
     onPageAfterIn () {
-      this.$oh.api.get('/rest/links').then((data) => {
+      this.$oh.api.get('/rest/links?itemName=' + this.item.name).then((data) => {
         console.dir(data.filter((l) => l.itemName === this.item.name))
         this.links = data
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -50,8 +50,8 @@
               The newly created Points will be linked to their respective channels with the default profile
               (you will be able to configure the links individually later if needed).
             </f7-block-footer>
-            <channel-list :thing="selectedThing" :thingType="selectedThingType"
-              :multiple-links-mode="true"
+            <channel-list :thing="selectedThing" :thingType="selectedThingType" :channelTypes="selectedThingChannelTypes"
+              :multiple-links-mode="true" :new-items-prefix="(createEquipment) ? newEquipmentItem.name : (parentGroup) ? parentGroup : ''"
               @selected="(channel) => toggleSelect(channel)" :new-items="newPointItems" />
         </div>
       </f7-col>
@@ -83,6 +83,7 @@ export default {
       selectedThingId: '',
       selectedThing: {},
       selectedThingType: {},
+      selectedThingChannelTypes: {},
       newEquipmentItem: {},
       newPointItems: []
     }
@@ -177,8 +178,13 @@ export default {
       this.$oh.api.get('/rest/things/' + this.selectedThingId).then((data) => {
         this.selectedThing = data
 
-        this.$oh.api.get('/rest/thing-types/' + this.selectedThing.thingTypeUID).then(data2 => {
-          this.selectedThingType = data2
+        let typePromises = [this.$oh.api.get('/rest/thing-types/' + this.selectedThing.thingTypeUID),
+          this.$oh.api.get('/rest/channel-types?prefixes=system,' + this.selectedThing.thingTypeUID.split(':')[0])]
+
+        Promise.all(typePromises).then(data2 => {
+          this.selectedThingType = data2[0]
+          this.selectedThingChannelTypes = data2[1]
+
           if (this.createEquipment) {
             this.newEquipmentItem = {
               name: this.selectedThing.label.replace(/[^0-9a-z]/gi, ''),

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -120,7 +120,7 @@ export default {
     },
     onPageAfterIn () {
       this.loading = true
-      this.$oh.api.get('/rest/thing-types').then((data) => {
+      this.$oh.api.get('/rest/thing-types?bindingId=' + this.bindingId).then((data) => {
         this.thingTypes = data.filter((tt) => tt.UID.split(':')[0] === this.bindingId && tt.listed)
           .sort((a, b) => {
             if (a.bridge && !b.bridge) return -1

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -21,12 +21,12 @@
           <ul>
             <f7-list-item divider title="Channel"></f7-list-item>
             <f7-list-item media-item class="channel-item"
-              :title="channel.label"
+              :title="channel.label || channelType.label"
               :footer="channel.uid"
               :subtitle="thing.label"
               :badge="thing.statusInfo.status"
               :badge-color="thing.statusInfo.status === 'ONLINE' ? 'green' : 'red'">
-              <span slot="media" class="item-initial">{{channel.label[0]}}</span>
+              <span slot="media" class="item-initial">{{(channel.label) ? channel.label[0] : (channelType.label) ? channelType.label[0] : '?'}}</span>
             </f7-list-item>
             <f7-list-item divider title="Item"></f7-list-item>
             <item :item="item" />
@@ -92,7 +92,8 @@ export default {
       },
       profileTypes: [],
       currentProfileType: { uid: '' },
-      profileTypeConfiguration: null
+      profileTypeConfiguration: null,
+      channelType: {}
     }
   },
   methods: {
@@ -111,6 +112,9 @@ export default {
           }
           this.ready = true
         })
+      })
+      this.$oh.api.get('/rest/channel-types/' + this.channel.channelTypeUID).then((data3) => {
+        this.channelType = data3
       })
     },
     onProfileTypeChange (profileTypeUid) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -107,7 +107,7 @@
 
       <f7-tab id="channels" disabled="!thingType.channels" @tab:show="() => this.currentTab = 'channels'" :tab-active="currentTab === 'channels'">
         <f7-block v-if="currentTab === 'channels'" class="block-narrow">
-          <channel-list :thingType="thingType" :thing="thing"
+          <channel-list :thingType="thingType" :thing="thing" :channelTypes="channelTypes"
             @channels-updated="onChannelsUpdated"
           />
           <f7-col v-if="isExtensible || thing.channels.length > 0">
@@ -221,6 +221,7 @@ export default {
       currentTab: 'info',
       thing: {},
       thingType: {},
+      channelTypes: {},
       configDescriptions: {},
       zwaveActions: {},
       thingEnabled: true,
@@ -262,8 +263,12 @@ export default {
       this.$oh.api.get('/rest/things/' + this.thingId).then(data => {
         this.$set(this, 'thing', data)
 
-        this.$oh.api.get('/rest/thing-types/' + this.thing.thingTypeUID).then(data2 => {
-          this.thingType = data2
+        let typePromises = [this.$oh.api.get('/rest/thing-types/' + this.thing.thingTypeUID),
+          this.$oh.api.get('/rest/channel-types?prefixes=system,' + this.thing.thingTypeUID.split(':')[0])]
+
+        Promise.all(typePromises).then(data2 => {
+          this.thingType = data2[0]
+          this.channelTypes = data2[1]
 
           this.$oh.api.get('/rest/config-descriptions/thing:' + this.thingId).then(data3 => {
             this.configDescriptions = data3


### PR DESCRIPTION
Fix a flaw in the channel list rendering
where a dynamically provided channel was
not appearing unless its type was extensible.
It was previously assumed that all
non-extensible channel types would appear
in the thing type's "channelGroups" or
"channels" property.

Some bindings have ChannelTypeProviders
which will define thing-specific channels
along with channel types which don't
appear on the thing type object. Example:
the "input" channel of the yamahareceiver
binding's zone thing.

The channel-list component now has a
mandatory "channelTypes" prop which must
be provided by the parent component. This
prop should contain an array of channel types
that can appear for the thing. It should be
retrieved using the /rest/channel-types API
call, eventually using the "prefixes" filter;
providing channel types prefixed by "system"
or the binding id should be enough.

This PR thus depends on:
https://github.com/openhab/openhab-core/pull/1340).
More filters were also added to relevant places.

In the "add equipment/points from thing"
screens, the prefix of the name suggestions
for the Point items will now be the name of the
parent Equipment if available (instead of the
normalized thing's label).

Signed-off-by: Yannick Schaus <github@schaus.net>