### PR TITLE
Try to fix routing bug after thing creation

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -181,7 +181,7 @@ export default {
               destroyOnClose: true,
               closeTimeout: 2000
             }).open()
-            this.$f7router.back('/settings/things/', { force: true })
+            setTimeout(() => { this.$f7router.navigate('/settings/things/', { reloadCurrent: true }) }, 300)
           }).catch((err) => {
             this.$f7.toast.create({
               text: 'Error during thing creation: ' + err,
@@ -204,7 +204,7 @@ export default {
             closeTimeout: 2000
           }).open()
           dialog.close()
-          this.$f7router.back('/settings/things/', { force: true })
+          setTimeout(() => { this.$f7router.navigate('/settings/things/', { reloadCurrent: true }) }, 300)
         }).catch((err) => {
           dialog.close()
           console.error(err)

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -143,7 +143,7 @@ export default {
           closeTimeout: 2000
         }).open()
       })
-      this.$f7router.back('/settings/things/', { force: true })
+      setTimeout(() => { this.$f7router.navigate('/settings/things/', { reloadCurrent: true }) }, 300)
     }
   }
 }


### PR DESCRIPTION
After adding things after a series of pages, f7's router will sometimes
act up and display a backdrop on the main view and then freeze the UI,
only a page refresh would get it working back again.

These changes seem to help at least in these cases.

Signed-off-by: Yannick Schaus <github@schaus.net>