### PR TITLE
Merge Inbox into the Things section

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
@@ -1,0 +1,28 @@
+{
+  "inbox.title": "The Inbox is empty",
+  "inbox.text": "Discovery results from your bindings that can be added as things will appear here.<br><br>You can also start a scan for a certain binding or add things manually with the button below.",
+
+  "things.title": "No things yet",
+  "things.text": "Things are the devices and services connected to openHAB, they are provided by binding add-ons.<br><br>Installed bindings which support auto-discovery will add thing candidates to your Inbox. You can also start a scan for a certain binding or add your first thing manually with the button below.",
+
+  "things.nobindings.title": "No bindings installed",
+  "things.nobindings.text": "You need to install binding add-ons to add things they support to your system. Click the button below to install some.",
+
+  "items.title": "No items yet",
+  "items.text": "Items represent the functional side of your home - you can link them to the channels defined by your things. Start with the Model view to create a clean initial structure.<br><br>You can also define items with configuration files, or with the button below.",
+
+  "model.title": "Start modelling your home",
+  "model.text": "Build a model from your items to organize them and relate them to each other semantically.<br><br>Begin with a hierarchy of locations: buildings, outside areas, floors and rooms, as needed. Then, insert equipments and points from your things (or manually).",
+
+  "rules.title": "No rules yet",
+  "rules.text": "Rules are the basic building blocks to automate your home - they define which actions to perform when certain events occur.<br><br>Create your first rule with the button below; for more advanced scenarios, you can also write script files in your configuration folder.",
+
+  "schedule.title": "Nothing in the schedule",
+  "schedule.text": "The schedule displays up to 30 days of times when rules specifically tagged \"Schedule\" are expected to run.<br><br>Click the button below to create your first scheduled rule.",
+
+  "rules.missingengine.title": "Rule engine not installed",
+  "rules.missingengine.text": "The rule engine must be installed before rules can be created.",
+
+  "addons.title": "No add-ons installed",
+  "addons.text": "Add-ons add functionality to your openHAB system.<br><br>Install them with the button below."
+}

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -25,23 +25,20 @@
         </f7-list-item>
         <li v-if="showAdministrationMenu">
           <ul class="admin-sublinks">
-          <f7-list-item inset link="/settings/inbox/" title="Inbox" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
-          </f7-list-item>
           <f7-list-item inset link="/settings/things/" title="Things" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="lightbulb" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/items/" title="Items" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="square_on_circle" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/model/" title="Model" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="list_bullet_indent" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/rules/" title="Rules" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="wand_rays" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/schedule/" title="Schedule" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="calendar" color="gray"></f7-icon>
           </f7-list-item>
           </ul>
         </li>

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -23,7 +23,7 @@ import AddThingChooseBindingPage from '../pages/settings/things/add/choose-bindi
 import AddThingChooseThingTypePage from '../pages/settings/things/add/choose-thing-type.vue'
 import AddThingPage from '../pages/settings/things/add/thing-add.vue'
 
-import InboxListPage from '../pages/settings/inbox/inbox-list.vue'
+import InboxListPage from '../pages/settings/things/inbox/inbox-list.vue'
 
 import SemanticModelPage from '../pages/settings/model/model.vue'
 
@@ -172,6 +172,10 @@ export default [
             ]
           },
           {
+            path: 'inbox',
+            component: InboxListPage
+          },
+          {
             path: ':thingId',
             component: ThingDetailsPage
           }
@@ -249,10 +253,10 @@ export default [
           }
         ]
       },
-      {
-        path: 'inbox/',
-        component: InboxListPage
-      },
+      // {
+      //   path: 'inbox/',
+      //   component: InboxListPage
+      // },
       {
         path: 'addons/:addonType',
         component: AddonsListPage,

--- a/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
@@ -18,16 +18,6 @@
         :disable-button="!$theme.aurora"
       ></f7-searchbar>
     </f7-navbar>
-    <!-- <f7-block>
-      <f7-row tag="p">
-        <f7-col tag="span">
-          <f7-segmented>
-            <f7-button big round outline><big>16</big> Things</f7-button>
-            <f7-button big round outline><big>138</big> Items</f7-button>
-          </f7-segmented>
-        </f7-col>
-      </f7-row>
-    </f7-block>-->
     <f7-block class="block-narrow after-big-title settings-menu" v-show="addonsLoaded && servicesLoaded">
       <f7-row>
         <f7-col width="100" medium="50">
@@ -35,20 +25,11 @@
           <f7-list media-list class="search-list">
             <f7-list-item
               media-item
-              color="red"
-              link="inbox/"
-              title="Inbox"
-              :badge="(inboxCount > 0) ? inboxCount : undefined"
-              badge-color="red"
-              :footer="objectsSubtitles.inbox">
-              <f7-icon slot="media" f7="tray" color="gray"></f7-icon>
-            </f7-list-item>
-            <f7-list-item
-              media-item
               link="things/"
               title="Things"
-              :after="thingsCount"
-              badge-color="blue"
+              :badge="(inboxCount > 0) ? inboxCount : undefined"
+              :after="(inboxCount > 0) ? undefined : thingsCount"
+              :badge-color="inboxCount ? 'red' : 'blue'"
               :footer="objectsSubtitles.things">
               <f7-icon slot="media" f7="lightbulb" color="gray"></f7-icon>
             </f7-list-item>
@@ -141,7 +122,6 @@ export default {
       systemServices: [],
       otherServices: [],
       objectsSubtitles: {
-        inbox: 'Add new things to your system',
         things: 'Manage the physical layer',
         items: 'Manage the functional layer',
         model: 'The semantic model of your home',

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -42,9 +42,10 @@
             :link="binding.id"
             :title="binding.name"
             :header="binding.id"
-            :footer="binding.description"
-            media-item
-          >
+            :badge="inbox.filter((e) => e.thingTypeUID.split(':')[0] === binding.id && e.flag !== 'IGNORED').length || undefined"
+            badge-color="red"
+            :footer="(binding.description && binding.description.indexOf('<br>') >= 0) ?
+                      binding.description.split('<br>')[0] : binding.description">
           </f7-list-item>
         </f7-list>
 
@@ -70,7 +71,8 @@ export default {
       ready: false,
       loading: false,
       initSearchbar: false,
-      bindings: []
+      bindings: [],
+      inbox: []
     }
   },
   created () {
@@ -85,6 +87,9 @@ export default {
         this.loading = false
         this.initSearchbar = true
         this.ready = true
+      })
+      this.$oh.api.get('/rest/inbox').then((data) => {
+        this.inbox = data
       })
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:afterout="stopEventSource">
-    <f7-navbar title="Inbox" back-link="Settings" back-link-url="/settings/" back-link-force>
+    <f7-navbar title="Inbox" back-link="Things" back-link-url="/settings/things/" back-link-force>
       <f7-nav-right>
         <f7-link icon-md="material:done_all" @click="toggleCheck()"
         :text="(!$theme.md) ? ((showCheckboxes) ? 'Done' : 'Select') : ''"></f7-link>
@@ -47,7 +47,7 @@
           <label @click="toggleIgnored" style="cursor:pointer">Show ignored</label> <f7-checkbox :checked="showIgnored" @change="toggleIgnored"></f7-checkbox>
         </div>
         </f7-block-title>
-        <div class="padding-left padding-right">
+        <div class="padding-left padding-right" v-show="!ready || inboxCount > 0">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="groupBy = 'alphabetical'; $nextTick(() => $refs.listIndex.update())">Alphabetical</f7-button>
             <f7-button :active="groupBy === 'binding'" @click="groupBy = 'binding'">By binding</f7-button>
@@ -95,12 +95,8 @@
 
       </f7-col>
     </f7-block>
-    <f7-block v-if="ready && !inbox.length" class="block-narrow">
-      <f7-col>
-        <f7-block strong>
-          <p>Inbox is empty.</p>
-        </f7-block>
-      </f7-col>
+    <f7-block v-if="ready && inboxCount === 0" class="block-narrow">
+      <empty-state-placeholder icon="tray" title="inbox.title" text="inbox.text" />
     </f7-block>
     <f7-fab v-show="!showCheckboxes" position="right-bottom" slot="fixed" color="blue" href="/settings/things/add">
       <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus"></f7-icon>
@@ -209,7 +205,7 @@ export default {
               bold: true,
               onClick: () => {
                 console.log(`Add ${entry.thingUID} as thing`)
-                this.$f7.dialog.prompt(`This will create a new Thing ${entry.thingUID} with the following name:`,
+                this.$f7.dialog.prompt(`This will create a new Thing of type ${entry.thingTypeUID} with the following name:`,
                   'Add as Thing',
                   (name) => {
                     this.$oh.api.postPlain(`/rest/inbox/${entry.thingUID}/approve`, name).then((res) => {
@@ -259,7 +255,7 @@ export default {
               text: 'Remove',
               color: 'red',
               onClick: () => {
-                this.$f7.dialog.confirm(`Remove ${entry.label} from Inbox?`, 'Remove Entry', () => {
+                this.$f7.dialog.confirm(`Remove ${entry.label} from the Inbox?`, 'Remove Entry', () => {
                   this.$oh.api.delete('/rest/inbox/' + entry.thingUID).then((res) => {
                     this.$f7.toast.create({
                       text: 'Entry removed',


### PR DESCRIPTION
Move the Inbox concept, which is closely related to Things,
from the top-level to a level of indirection below the Things list.
Red badges and buttons are displayed to clearly highlight and
navigate to the Inbox when there is something in it.

Additionally, the number of inbox entries (auto-discovered things)
for a given binding is displayed in the"choose binding" page when
adding a thing.

Signed-off-by: Yannick Schaus <github@schaus.net>