### PR TITLE
Merge Inbox into the Things section

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
@@ -2,11 +2,11 @@
   "inbox.title": "The Inbox is empty",
   "inbox.text": "Discovery results from your bindings that can be added as things will appear here.<br><br>You can also start a scan for a certain binding or add things manually with the button below.",
 
+  "things.title": "No things yet",
+  "things.text": "Things are the devices and services connected to openHAB, they are provided by binding add-ons.<br><br>Installed bindings which support auto-discovery will add thing candidates to your Inbox. You can also start a scan for a certain binding or add your first thing manually with the button below.",
+
   "things.nobindings.title": "No bindings installed",
   "things.nobindings.text": "You need to install binding add-ons to add things they support to your system. Click the button below to install some.",
-
-  "things.title": "No things yet",
-  "things.text": "Things are the devices and services connected to openHAB, they are provided by binding add-ons.<br><br>Check the Inbox to add auto-discovered things. You can also start a scan for a certain binding or add your first thing manually with the button below.",
 
   "items.title": "No items yet",
   "items.text": "Items represent the functional side of your home - you can link them to the channels defined by your things. Start with the Model view to create a clean initial structure.<br><br>You can also define items with configuration files, or with the button below.",

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -25,23 +25,20 @@
         </f7-list-item>
         <li v-if="showAdministrationMenu">
           <ul class="admin-sublinks">
-          <f7-list-item inset link="/settings/inbox/" title="Inbox" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
-          </f7-list-item>
           <f7-list-item inset link="/settings/things/" title="Things" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="lightbulb" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/items/" title="Items" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="square_on_circle" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/model/" title="Model" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="list_bullet_indent" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/rules/" title="Rules" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="wand_rays" color="gray"></f7-icon>
           </f7-list-item>
           <f7-list-item inset link="/settings/schedule/" title="Schedule" view=".view-main" panel-close :animate="false">
-            <!-- <f7-icon slot="media" ios="f7:gears" aurora="f7:gears" md="material:settings"></f7-icon> -->
+            <f7-icon slot="media" f7="calendar" color="gray"></f7-icon>
           </f7-list-item>
           </ul>
         </li>

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -23,7 +23,7 @@ import AddThingChooseBindingPage from '../pages/settings/things/add/choose-bindi
 import AddThingChooseThingTypePage from '../pages/settings/things/add/choose-thing-type.vue'
 import AddThingPage from '../pages/settings/things/add/thing-add.vue'
 
-import InboxListPage from '../pages/settings/inbox/inbox-list.vue'
+import InboxListPage from '../pages/settings/things/inbox/inbox-list.vue'
 
 import SemanticModelPage from '../pages/settings/model/model.vue'
 
@@ -172,6 +172,10 @@ export default [
             ]
           },
           {
+            path: 'inbox',
+            component: InboxListPage
+          },
+          {
             path: ':thingId',
             component: ThingDetailsPage
           }
@@ -249,10 +253,10 @@ export default [
           }
         ]
       },
-      {
-        path: 'inbox/',
-        component: InboxListPage
-      },
+      // {
+      //   path: 'inbox/',
+      //   component: InboxListPage
+      // },
       {
         path: 'addons/:addonType',
         component: AddonsListPage,

--- a/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
@@ -18,16 +18,6 @@
         :disable-button="!$theme.aurora"
       ></f7-searchbar>
     </f7-navbar>
-    <!-- <f7-block>
-      <f7-row tag="p">
-        <f7-col tag="span">
-          <f7-segmented>
-            <f7-button big round outline><big>16</big> Things</f7-button>
-            <f7-button big round outline><big>138</big> Items</f7-button>
-          </f7-segmented>
-        </f7-col>
-      </f7-row>
-    </f7-block>-->
     <f7-block class="block-narrow after-big-title settings-menu" v-show="addonsLoaded && servicesLoaded">
       <f7-row>
         <f7-col width="100" medium="50">
@@ -35,20 +25,11 @@
           <f7-list media-list class="search-list">
             <f7-list-item
               media-item
-              color="red"
-              link="inbox/"
-              title="Inbox"
-              :badge="(inboxCount > 0) ? inboxCount : undefined"
-              badge-color="red"
-              :footer="objectsSubtitles.inbox">
-              <f7-icon slot="media" f7="tray" color="gray"></f7-icon>
-            </f7-list-item>
-            <f7-list-item
-              media-item
               link="things/"
               title="Things"
-              :after="thingsCount"
-              badge-color="blue"
+              :badge="(inboxCount > 0) ? inboxCount : undefined"
+              :after="(inboxCount > 0) ? undefined : thingsCount"
+              :badge-color="inboxCount ? 'red' : 'blue'"
               :footer="objectsSubtitles.things">
               <f7-icon slot="media" f7="lightbulb" color="gray"></f7-icon>
             </f7-list-item>
@@ -141,7 +122,6 @@ export default {
       systemServices: [],
       otherServices: [],
       objectsSubtitles: {
-        inbox: 'Add new things to your system',
         things: 'Manage the physical layer',
         items: 'Manage the functional layer',
         model: 'The semantic model of your home',

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -46,6 +46,8 @@
             :link="binding.id"
             :title="binding.name"
             :header="binding.id"
+            :badge="inbox.filter((e) => e.thingTypeUID.split(':')[0] === binding.id && e.flag !== 'IGNORED').length || undefined"
+            badge-color="red"
             :footer="(binding.description && binding.description.indexOf('<br>') >= 0) ?
                       binding.description.split('<br>')[0] : binding.description">
           </f7-list-item>
@@ -68,7 +70,8 @@ export default {
       ready: false,
       loading: false,
       initSearchbar: false,
-      bindings: []
+      bindings: [],
+      inbox: []
     }
   },
   methods: {
@@ -79,6 +82,9 @@ export default {
         this.loading = false
         this.initSearchbar = true
         this.ready = true
+      })
+      this.$oh.api.get('/rest/inbox').then((data) => {
+        this.inbox = data
       })
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:afterout="stopEventSource">
-    <f7-navbar title="Inbox" back-link="Settings" back-link-url="/settings/" back-link-force>
+    <f7-navbar title="Inbox" back-link="Things" back-link-url="/settings/things/" back-link-force>
       <f7-nav-right>
         <f7-link icon-md="material:done_all" @click="toggleCheck()"
         :text="(!$theme.md) ? ((showCheckboxes) ? 'Done' : 'Select') : ''"></f7-link>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -48,7 +48,7 @@
             </f7-list-item>
           </f7-list-group>
         </f7-list>
-        <f7-list v-else class="searchbar-found col" :contacts-list="groupBy === 'alphabetical'">
+        <f7-list v-else class="searchbar-found col things-list" :contacts-list="groupBy === 'alphabetical'">
           <f7-list-group v-for="(thingsWithInitial, initial) in indexedThings" :key="initial">
             <f7-list-item v-if="thingsWithInitial.length" :title="initial" group-title></f7-list-item>
             <f7-list-item v-for="thing in thingsWithInitial"
@@ -71,15 +71,23 @@
       <empty-state-placeholder icon="lightbulb" title="things.title" text="things.text" />
     </f7-block>
     <f7-fab position="right-bottom" slot="fixed" color="blue" href="add">
-      <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus"></f7-icon>
-      <f7-icon ios="f7:close" md="material:close" aurora="f7:close"></f7-icon>
+      <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus">
+      </f7-icon>
       <!-- <f7-fab-buttons position="top">
         <f7-fab-button label="Scan and add to Inbox">S</f7-fab-button>
         <f7-fab-button label="Add thing manually">M</f7-fab-button>
       </f7-fab-buttons> -->
     </f7-fab>
+    <f7-fab v-show="inbox.length > 0" position="center-bottom" :text="`Inbox (${inboxCount})`" slot="fixed" :color="inboxCount > 0 ? 'red' : 'gray'" href="inbox">
+      <f7-icon f7="tray" />
+    </f7-fab>
   </f7-page>
 </template>
+
+<style lang="stylus">
+.things-list
+  margin-bottom calc(var(--f7-fab-size) + 2 * calc(var(--f7-fab-margin) + var(--f7-safe-area-bottom)))
+</style>
 
 <script>
 export default {
@@ -89,6 +97,7 @@ export default {
       loading: false,
       initSearchbar: false,
       things: [],
+      inbox: [],
       // indexedThings: {},
       groupBy: 'alphabetical',
       eventSource: null
@@ -120,6 +129,9 @@ export default {
           return prev
         }, {})
       }
+    },
+    inboxCount () {
+      return this.inbox.filter((e) => e.flag !== 'IGNORED').length
     }
   },
   methods: {
@@ -136,22 +148,32 @@ export default {
         setTimeout(() => { this.$refs.listIndex.update() })
         if (!this.eventSource) this.startEventSource()
       })
+      this.loadInbox()
+    },
+    loadInbox () {
+      this.$oh.api.get('/rest/inbox').then((data) => {
+        this.inbox = data
+      })
     },
     startEventSource () {
-      this.eventSource = this.$oh.sse.connect('/rest/events?topics=smarthome/things/*/added,smarthome/things/*/removed,smarthome/things/*/updated,smarthome/things/*/status', null, (event) => {
+      this.eventSource = this.$oh.sse.connect('/rest/events?topics=smarthome/things/*/added,smarthome/things/*/removed,smarthome/things/*/updated,smarthome/things/*/status,smarthome/inbox/*', null, (event) => {
         console.log(event)
         const topicParts = event.topic.split('/')
-        switch (topicParts[3]) {
-          case 'status':
-            const updatedThing = this.things.find((t) => t.UID === topicParts[2])
-            if (updatedThing) {
-              this.$set(updatedThing, 'statusInfo', JSON.parse(event.payload))
-            }
-            break
-          case 'added':
-          case 'removed':
-            this.load()
-            break
+        if (topicParts[2] === 'inbox') {
+          this.loadInbox()
+        } else {
+          switch (topicParts[3]) {
+            case 'status':
+              const updatedThing = this.things.find((t) => t.UID === topicParts[2])
+              if (updatedThing) {
+                this.$set(updatedThing, 'statusInfo', JSON.parse(event.payload))
+              }
+              break
+            case 'added':
+            case 'removed':
+              this.load()
+              break
+          }
         }
       })
     },
@@ -162,6 +184,3 @@ export default {
   }
 }
 </script>
-
-<style>
-</style>


### PR DESCRIPTION
Move the Inbox concept, which is closely related to Things,
from the top-level to a level of indirection below the Things list.
Red badges and buttons are displayed to clearly highlight the
Inbox when there is something in it.

Additionally, the number of inbox entries (auto-discovered things)
for a given binding is displayed in the
"choose binding" page when adding a thing.

Signed-off-by: Yannick Schaus <github@schaus.net>