### PR TITLE
Optimize webpack bundling

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -6,7 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const OptimizeCSSPlugin = require('optimize-css-assets-webpack-plugin')
 const TerserPlugin = require('terser-webpack-plugin')
 const WorkboxPlugin = require('workbox-webpack-plugin')
-// const WebpackAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const WebpackAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
 
 const path = require('path')
 
@@ -57,7 +57,7 @@ module.exports = {
       '/chart': apiBaseUrl,
       '/proxy': apiBaseUrl,
       '/icon': apiBaseUrl,
-      '/static': apiBaseUrl,
+      '/static': apiBaseUrl
     }
   },
   optimization: {
@@ -230,6 +230,9 @@ module.exports = {
       new WorkboxPlugin.InjectManifest({
         swSrc: resolvePath('src/service-worker.js')
       })
+    ] : []),
+    ...(process.env.WEBPACK_ANALYZER ? [
+      new WebpackAnalyzerPlugin()
     ] : [])
   ]
 }

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -39,6 +39,7 @@
   "scripts": {
     "build-prod": "cross-env NODE_ENV=production node ./build/build.js",
     "build-cordova-prod": "cross-env TARGET=cordova cross-env NODE_ENV=production node ./build/build.js && cd cordova && cordova build",
+    "webpack-analyzer": "cross-env NODE_ENV=production cross-env WEBPACK_ANALYZER=1 node ./build/build.js",
     "dev": "cross-env NODE_ENV=development webpack-dev-server --config ./build/webpack.config.js",
     "start": "npm run dev",
     "test:unit": "npx jest",

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -61,12 +61,10 @@
 </style>
 
 <script>
-import ConfigParameter from './config-parameter.vue'
-
 export default {
   props: ['parameterGroups', 'parameters', 'configuration'],
   components: {
-    ConfigParameter
+    'config-parameter': () => import('./config-parameter.vue')
   },
   data () {
     return {

--- a/bundles/org.openhab.ui/web/src/js/openhab/auth.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/auth.js
@@ -1,4 +1,3 @@
-import PkceChallenge from 'pkce-challenge'
 import { Utils } from 'framework7'
 
 export default {
@@ -7,16 +6,18 @@ export default {
       return localStorage.getItem('openhab.ui:refreshToken') || null
     },
     authorize () {
-      const pkceChallenge = PkceChallenge()
-      sessionStorage.setItem('openhab.ui:codeVerifier', pkceChallenge.code_verifier)
+      import('pkce-challenge').then((PkceChallenge) => {
+        const pkceChallenge = PkceChallenge.default()
+        sessionStorage.setItem('openhab.ui:codeVerifier', pkceChallenge.code_verifier)
 
-      window.location = '/auth' +
-        '?response_type=code' +
-        '&client_id=' + encodeURIComponent(window.location.origin) +
-        '&redirect_uri=' + encodeURIComponent(window.location.origin) +
-        '&scope=admin' +
-        '&code_challenge_method=S256' +
-        '&code_challenge=' + encodeURIComponent(pkceChallenge.code_challenge)
+        window.location = '/auth' +
+          '?response_type=code' +
+          '&client_id=' + encodeURIComponent(window.location.origin) +
+          '&redirect_uri=' + encodeURIComponent(window.location.origin) +
+          '&scope=admin' +
+          '&code_challenge_method=S256' +
+          '&code_challenge=' + encodeURIComponent(pkceChallenge.code_challenge)
+      })
     },
     tryExchangeAuthorizationCode () {
       return new Promise((resolve, reject) => {

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -31,8 +31,6 @@ import InboxListPage from '../pages/settings/things/inbox/inbox-list.vue'
 import SemanticModelPage from '../pages/settings/model/model.vue'
 
 import RulesListPage from '../pages/settings/rules/rules-list.vue'
-import RuleEditPage from '../pages/settings/rules/rule-edit.vue'
-import RuleConfigureModulePage from '../pages/settings/rules/rule-configure-module.vue'
 
 import PagesListPage from '../pages/settings/pages/pages-list.vue'
 
@@ -42,7 +40,6 @@ import Analyzer from '../pages/analyzer/analyzer.vue'
 
 import DeveloperToolsPage from '../pages/developer/developer-tools.vue'
 import WidgetsListPage from '../pages/developer/widgets/widget-list.vue'
-import WidgetEditPage from '../pages/developer/widgets/widget-edit.vue'
 
 export default [
   {
@@ -210,26 +207,23 @@ export default [
         keepAlive: true,
         routes: [
           {
-            path: 'add',
-            component: RuleEditPage,
-            options: {
-              props: {
-                createMode: true
-              }
-            }
-          },
-          {
             path: ':ruleId',
-            component: RuleEditPage,
-            // master: true,
-            // detailRoutes: [
-            routes: [
-              {
-                path: ':moduleType/:moduleId',
-                // path: '/settings/rules/:ruleId/:moduleType/:moduleId',
-                component: RuleConfigureModulePage
-              }
-            ]
+            async (routeTo, routeFrom, resolve, reject) {
+              // dynamic import component; returns promise
+              const ruleEditComponent = () => import('../pages/settings/rules/rule-edit.vue')
+              // resolve promise
+              ruleEditComponent().then((vc) => {
+                // resolve with component
+                resolve({
+                  component: vc.default
+                },
+                (routeTo.params.uid === 'add') ? {
+                  props: {
+                    createMode: true
+                  }
+                } : {})
+              })
+            }
           }
         ]
       },
@@ -249,12 +243,21 @@ export default [
         routes: [
           {
             path: 'add',
-            component: RuleEditPage,
-            options: {
-              props: {
-                createMode: true,
-                schedule: true
-              }
+            async (routeTo, routeFrom, resolve, reject) {
+              // dynamic import component; returns promise
+              const ruleEditComponent = () => import('../pages/settings/rules/rule-edit.vue')
+              // resolve promise
+              ruleEditComponent().then((vc) => {
+                // resolve with component
+                resolve({
+                  component: vc.default
+                }, {
+                  props: {
+                    createMode: true,
+                    schedule: true
+                  }
+                })
+              })
             }
           }
         ]
@@ -296,20 +299,22 @@ export default [
         component: WidgetsListPage,
         routes: [
           {
-            path: 'add',
-            component: WidgetEditPage,
-            options: {
-              animate: false,
-              props: {
-                createMode: true
-              }
-            }
-          },
-          {
             path: ':uid',
-            component: WidgetEditPage,
-            options: {
-              animate: false
+            async (routeTo, routeFrom, resolve, reject) {
+              // dynamic import component; returns promise
+              const widgetEditComponent = () => import('../pages/developer/widgets/widget-edit.vue')
+              // resolve promise
+              widgetEditComponent().then((vc) => {
+                // resolve with component
+                resolve({
+                  component: vc.default
+                },
+                (routeTo.params.uid === 'add') ? {
+                  props: {
+                    createMode: true
+                  }
+                } : {})
+              })
             }
           }
         ]

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -138,12 +138,6 @@ import * as LayoutWidgets from '@/components/widgets/layout/index'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
@@ -156,12 +150,12 @@ export default {
       pageReady: false,
       loading: false,
       page: {
-        uid: 'page_' + uuidv4().split('-')[0],
+        uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-layout-page',
         config: {},
         slots: { default: [] }
       },
-      pageKey: uuidv4(),
+      pageKey: this.$f7.utils.id(),
       pageYaml: null,
       previewMode: false,
       currentTab: 'design',
@@ -460,7 +454,7 @@ export default {
       this.forceUpdate()
     },
     forceUpdate () {
-      this.pageKey = uuidv4()
+      this.pageKey = this.$f7.utils.id()
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -170,12 +170,6 @@ const ConfigurableWidgets = {
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
@@ -188,12 +182,12 @@ export default {
       pageReady: false,
       loading: false,
       page: {
-        uid: 'page_' + uuidv4().split('-')[0],
+        uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-map-page',
         config: {},
         slots: { default: [] }
       },
-      pageKey: uuidv4(),
+      pageKey: this.$f7.utils.id(),
       pageYaml: null,
       previewMode: false,
       currentTab: 'design',
@@ -454,7 +448,7 @@ export default {
       this.forceUpdate()
     },
     forceUpdate () {
-      this.pageKey = uuidv4()
+      this.pageKey = this.$f7.utils.id()
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -176,12 +176,6 @@ const ConfigurableWidgets = {
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
@@ -195,12 +189,12 @@ export default {
       loading: false,
       pageWidgetDefinition: OhPlanPage.widget,
       page: {
-        uid: 'page_' + uuidv4().split('-')[0],
+        uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-plan-page',
         config: {},
         slots: { default: [] }
       },
-      pageKey: uuidv4(),
+      pageKey: this.$f7.utils.id(),
       pageYaml: null,
       previewMode: false,
       currentTab: 'design',
@@ -461,7 +455,7 @@ export default {
       this.forceUpdate()
     },
     forceUpdate () {
-      this.pageKey = uuidv4()
+      this.pageKey = this.$f7.utils.id()
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -159,12 +159,6 @@ import SitemapCode from '@/components/pagedesigner/sitemap/sitemap-code.vue'
 import WidgetDetails from '@/components/pagedesigner/sitemap/widget-details.vue'
 import MappingDetails from '@/components/pagedesigner/sitemap/mapping-details.vue'
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     SitemapCode,
@@ -177,7 +171,7 @@ export default {
       ready: false,
       loading: false,
       sitemap: {
-        uid: 'page_' + uuidv4().split('-')[0],
+        uid: 'page_' + this.$f7.utils.id(),
         component: 'Sitemap',
         config: {
           label: 'New Sitemap'

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -157,12 +157,6 @@ import ConfigSheet from '@/components/config/config-sheet.vue'
 
 const ConfigurableWidgets = { OhTab }
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
@@ -174,12 +168,12 @@ export default {
       pageReady: false,
       loading: false,
       page: {
-        uid: 'page_' + uuidv4().split('-')[0],
+        uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-tabs-page',
         config: {},
         slots: { default: [] }
       },
-      pageKey: uuidv4(),
+      pageKey: this.$f7.utils.id(),
       pageYaml: null,
       previewMode: false,
       currentTab: 'design',
@@ -433,7 +427,7 @@ export default {
       this.forceUpdate()
     },
     forceUpdate () {
-      this.pageKey = uuidv4()
+      this.pageKey = this.$f7.utils.id()
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-configure-module.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-configure-module.vue
@@ -46,12 +46,10 @@
 </template>
 
 <script>
-import ConfigParameter from '@/components/config/config-parameter.vue'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
   components: {
-    ConfigParameter,
     ConfigSheet
   },
   props: ['rule', 'moduleTypes', 'currentSection'],

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -208,12 +208,6 @@ import TagInput from '@/components/tags/tag-input.vue'
 const ScriptEditorPopup = () => import('@/components/config/controls/script-editor-popup.vue')
 import CronEditor from '@/components/config/controls/cronexpression-editor.vue'
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     ConfigSheet,
@@ -284,7 +278,7 @@ export default {
         this.moduleTypes.triggers = data[2]
         if (this.createMode) {
           this.$set(this, 'rule', {
-            uid: uuidv4().split('-')[0],
+            uid: this.$f7.utils.id(),
             name: '',
             triggers: [],
             actions: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/services/service-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/services/service-settings.vue
@@ -37,12 +37,10 @@
 
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
-import ConfigParameter from '@/components/config/config-parameter.vue'
 
 export default {
   components: {
-    ConfigSheet,
-    ConfigParameter
+    ConfigSheet
   },
   props: ['serviceId'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -83,12 +83,6 @@ import ConfigSheet from '@/components/config/config-sheet.vue'
 
 import ThingGeneralSettings from '@/components/thing/thing-general-settings.vue'
 
-function uuidv4 () {
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, c =>
-    (c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
-  )
-}
-
 export default {
   components: {
     ConfigSheet,
@@ -116,7 +110,7 @@ export default {
       this.$oh.api.get('/rest/thing-types/' + this.thingTypeId).then(data => {
         this.thingType = data
         try {
-          this.thing.ID = uuidv4().split('-')[0]
+          this.thing.ID = this.$f7.utils.id()
           this.thing.UID = this.thingTypeId + ':' + this.thing.ID
         } catch (e) {
           console.log('Cannot generate ID: ' + e)


### PR DESCRIPTION
Split heavy dependencies away from the entrypoint
by using dynamic imports at critical places along with
some cleanup.

Also replace crypto-based `uuidv4()` by `f7.utils.id()`.

This reduces the main app.js by more than 25%
(from >2 MB to around 1.4 MB).

Add npm script to launch the Webpack bundle
analyzer (`npm run webpack-analyzer`) after a
production build.

Signed-off-by: Yannick Schaus <github@schaus.net>