### PR TITLE
Do not display empty channel group headers

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-list :accordion-list="!pickerMode">
-    <f7-list-item group-title v-if="group && group.label"
+    <f7-list-item group-title v-if="group && group.label && group.channels.length > 0"
       :title="group.label"
       :description="group.description"
       :footer="group.description" />


### PR DESCRIPTION
Following discussion on https://github.com/openhab/openhab-core/issues/1402

Signed-off-by: Yannick Schaus <github@schaus.net>