### PR TITLE
PaperUI: Fixed error in listing firmwares for a thing

### DIFF
--- a/bundles/org.openhab.ui.paper/web-src/js/firmware/controller.firmware.js
+++ b/bundles/org.openhab.ui.paper/web-src/js/firmware/controller.firmware.js
@@ -19,7 +19,7 @@ firmwareControllers.controller('FirmwareController', function($scope, $mdDialog,
             });
         }
 
-        var thingUID = $scope.$parent.thing.thingUID;
+        var thingUID = $scope.$parent.thing.UID;
         if (thingUID) {
             thingService.getFirmwares({
                 thingUID : thingUID


### PR DESCRIPTION
Paper UI is throwing an error in the console when listing firmwares for a thing that has firmware updates available

`angular.min.js:117 TypeError: Cannot read property 'changelog' of undefined
    at m.$scope.hasChangelog (controller.firmware.js:74)
    at fn (eval at compile (angular.min.js:231), <anonymous>:4:690)
    at m.$digest (angular.min.js:142)
    at m.$apply (angular.min.js:145)
    at l (angular.min.js:97)
    at K (angular.min.js:101)
    at XMLHttpRequest.y.onload (angular.min.js:102)`

Signed-off-by: Sebastian Irimia <aisebastian@yahoo.com>