### PR TITLE
Fix various chart range boundaries problems

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-calendar-axis.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-calendar-axis.js
@@ -1,7 +1,7 @@
 export default {
   get (component, startTime, endTime, chart, orient) {
     let calendar = Object.assign({}, component.config)
-    calendar.range = [startTime.toDate(), endTime.toDate()]
+    calendar.range = [startTime.toDate(), endTime.subtract(1, 'day').toDate()]
     if (orient) calendar.orient = orient
     calendar.dayLabel = {
       firstDay: 1,

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -132,7 +132,7 @@ export default {
         let query = {
           serviceId: component.config.service || undefined,
           starttime: seriesStartTime.toISOString(),
-          endtime: seriesEndTime.toISOString()
+          endtime: seriesEndTime.subtract(1, 'millisecond').toISOString()
         }
 
         return this.$oh.api.get(url, query)

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.js
@@ -30,7 +30,7 @@ export default {
       // e.g. if dimension1=day, dimension2 can be hour but not month
       let groupStart = dimension2 || dimension1
       if (groupStart === 'weekday' || groupStart === 'isoWeekday') groupStart = 'day'
-      let start = dayjs(p.time).startOf(dimension2 || dimension1)
+      let start = dayjs(p.time).startOf(groupStart)
       if (acc.length && acc[acc.length - 1][0].isSame(start)) {
         acc[acc.length - 1][1].push(p.state)
       } else {

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-calendar-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-calendar-series.js
@@ -20,7 +20,7 @@ export default {
 
     console.debug(groups)
 
-    const formatter = new Intl.NumberFormat('en', { maximumFractionDigits: 3 })
+    const formatter = new Intl.NumberFormat('en', { useGrouping: false, maximumFractionDigits: 3 })
     const data = groups.map((arr, idx, days) => {
       const aggregationFunction = component.config.aggregationFunction || 'average'
       let value = aggregate(aggregationFunction, arr, idx, days)

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
@@ -19,7 +19,7 @@ export default {
     if (component.config.item) {
       const itemPoints = points.find(p => p.name === component.config.item).data
 
-      const formatter = new Intl.NumberFormat('en', { maximumFractionDigits: 3 })
+      const formatter = new Intl.NumberFormat('en', { useGrouping: false, maximumFractionDigits: 3 })
       const data = itemPoints.map((p) => {
         return [new Date(p.time), formatter.format(p.state)]
       })


### PR DESCRIPTION
- Don't include the start time of the next period

Fixes aggregate series problems when going back in time:

![image](https://user-images.githubusercontent.com/2004147/79360087-b8e87580-7f43-11ea-84dd-89cdbf6dc330.png)

- Don't include first day of the next month in calendars

- Fix weekly aggregate series

Signed-off-by: Yannick Schaus <github@schaus.net>