### PR TITLE
Items: metadata & group management, improve default rendering

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
@@ -36,6 +36,43 @@ const categories = [
   'WEARABLE'
 ]
 
+const labels = {
+  'Switchable': [],
+  'Lighting': [],
+  'Blind': [],
+  'Door': [],
+  'Lock': [],
+  'Outlet': [],
+  'CurrentHumidity': [],
+  'CurrentTemperature': [],
+  'TargetTemperature': [],
+  'LowerTemperature': [],
+  'UpperTemperature': [],
+  'HeatingCoolingMode': [],
+  'ColorTemperature': [],
+  'Activity': [],
+  'Scene': [],
+  'EntertainmentChannel': [],
+  'EntertainmentInput': [],
+  'EqualizerBass': [],
+  'EqualizerMidrange': [],
+  'EqualizerTreble': [],
+  'EqualizerMode': [],
+  'MediaPlayer': [],
+  'SpeakerMute': [],
+  'SpeakerVolume': [],
+  'ContactSensor': [],
+  'MotionSensor': [],
+  'SecurityAlarmMode': [],
+  'BurglaryAlarm': [],
+  'FireAlarm': [],
+  'CarbonMonoxideAlarm': [],
+  'WaterAlarm': [],
+  'ModeComponent': [],
+  'RangeComponent': [],
+  'ToggleComponent': []
+}
+
 const p = (type, name, label, description, options, advanced) => {
   return {
     name,
@@ -51,6 +88,7 @@ const p = (type, name, label, description, options, advanced) => {
   }
 }
 
+const categoryParameter = p('TEXT', 'category', 'Category', 'Override the default category for the class', categories.join(','), true)
 const scaleParameter = p('TEXT', 'scale', 'Scale', 'Temperature Unit', 'Celsius,Fahrenheit')
 const comfortRangeParameter = p('TEXT', 'comfortRange', 'Comfort Range', 'Number to define the comfort range, defaults: 2°F or 1°C')
 const setpointRangeParameter = p('TEXT', 'setpointRange', 'Setpoint Range', 'Format: <code>minRange:maxRange</code>')
@@ -62,7 +100,7 @@ const languageParameter = p('TEXT', 'language', 'Language', 'defaults to your se
 const actionMappingsParameter = p('TEXT', 'actionMappings', 'Action Mappings')
 const stateMappingsParameter = p('TEXT', 'stateMappings', 'State Mappings')
 
-const classes = {
+const capabilities = {
   'PowerController.powerState': [],
   'BrightnessController.brightness': [],
   'PowerLevelController.powerLevel': [],
@@ -189,8 +227,16 @@ const classes = {
   ]
 }
 
-for (let c in classes) {
-  classes[c].unshift(p('TEXT', 'category', 'Category', 'Override the default category for the class', categories.join(','), true))
+let classes = {}
+
+for (let l in labels) {
+  labels[l].unshift(categoryParameter)
+  classes['label:' + l] = labels[l]
+}
+
+for (let c in capabilities) {
+  capabilities[c].unshift(categoryParameter)
+  classes[c] = capabilities[c]
 }
 
 export default classes

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
@@ -1,0 +1,196 @@
+
+const categories = [
+  'ACTIVITY_TRIGGER',
+  'CAMERA',
+  'COMPUTER',
+  'CONTACT_SENSOR',
+  'DOOR',
+  'DOORBELL',
+  'EXTERIOR_BLIND',
+  'FAN',
+  'GAME_CONSOLE',
+  'GARAGE_DOOR',
+  'INTERIOR_BLIND',
+  'LAPTOP',
+  'LIGHT',
+  'MICROWAVE',
+  'MOBILE_PHONE',
+  'MOTION_SENSOR',
+  'MUSIC_SYSTEM',
+  'NETWORK_HARDWARE',
+  'OTHER',
+  'OVEN',
+  'PHONE',
+  'SCENE_TRIGGER',
+  'SCREEN',
+  'SECURITY_PANEL',
+  'SMARTLOCK',
+  'SMARTPLUG',
+  'SPEAKER',
+  'STREAMING_DEVICE',
+  'SWITCH',
+  'TABLET',
+  'TEMPERATURE_SENSOR',
+  'THERMOSTAT',
+  'TV',
+  'WEARABLE'
+]
+
+const p = (type, name, label, description, options, advanced) => {
+  return {
+    name,
+    type,
+    label,
+    description,
+    advanced,
+    limitToOptions: !!options,
+    options: (!options) ? undefined : options.split(',').map((o) => {
+      const parts = o.split('=')
+      return { value: parts[0], label: parts[1] || parts[0] }
+    })
+  }
+}
+
+const scaleParameter = p('TEXT', 'scale', 'Scale', 'Temperature Unit', 'Celsius,Fahrenheit')
+const comfortRangeParameter = p('TEXT', 'comfortRange', 'Comfort Range', 'Number to define the comfort range, defaults: 2°F or 1°C')
+const setpointRangeParameter = p('TEXT', 'setpointRange', 'Setpoint Range', 'Format: <code>minRange:maxRange</code>')
+const rangeParameter = p('TEXT', 'range', 'Range', 'Format: <code>minRange:maxRange</code>')
+const volumeIncrementParameter = p('INTEGER', 'increment', 'Increment')
+const friendlyNamesParameter = p('TEXT', 'friendlyNames', 'Friendly Names', 'each name formatted as <code>@assetIdOrName</code>, defaults to item label name')
+const nonControllableParameter = p('BOOLEAN', 'nonControllable', 'Non Controllable')
+const languageParameter = p('TEXT', 'language', 'Language', 'defaults to your server regional settings, if defined, otherwise en', 'de,en,es,fr,hi,it,ja,pt')
+const actionMappingsParameter = p('TEXT', 'actionMappings', 'Action Mappings')
+const stateMappingsParameter = p('TEXT', 'stateMappings', 'State Mappings')
+
+const classes = {
+  'PowerController.powerState': [],
+  'BrightnessController.brightness': [],
+  'PowerLevelController.powerLevel': [],
+  'PercentageController.percentage': [],
+  'ThermostatController.targetSetpoint': [
+    scaleParameter,
+    setpointRangeParameter
+  ],
+  'ThermostatController.upperSetpoint': [
+    scaleParameter,
+    comfortRangeParameter,
+    setpointRangeParameter
+  ],
+  'ThermostatController.lowerSetpoint': [
+    scaleParameter,
+    comfortRangeParameter,
+    setpointRangeParameter
+  ],
+  'ThermostatController.thermostatMode': [
+    p('TEXT', 'OFF', 'OFF State'),
+    p('TEXT', 'HEAT', 'HEAT State'),
+    p('TEXT', 'COOL', 'COOL State'),
+    p('TEXT', 'ECO', 'ECO State'),
+    p('TEXT', 'AUTO', 'AUTO State'),
+    p('TEXT', 'binding', 'Binding', 'Auto-configure modes for binding', 'daikin,max,nest,zwave'),
+    p('TEXT', 'supportedModes', 'Supported modes'),
+    p('BOOLEAN', 'supportsSetpointMode', 'Supports Setpoint Mode', '', null, true)
+  ],
+  'TemperatureSensor.temperature': [scaleParameter],
+  'LockController.lockState': [
+    p('TEXT', 'LOCKED', 'Locked State'),
+    p('TEXT', 'UNLOCKED', 'Unlocked State'),
+    p('TEXT', 'JAMMED', 'Jammed State')
+  ],
+  'ColorController.color': [],
+  'ColorTemperatureController.colorTemperatureInKelvin': [
+    p('INTEGER', 'increment', 'Increment'),
+    rangeParameter,
+    p('TEXT', 'binding', 'Binding', 'Auto-configure range for binding', 'hue,lifx,milight,tradfri,yeelight')
+  ],
+  'SceneController.scene': [
+    p('TEXT', 'supportsDeactivation', 'Supports deactivation')
+  ],
+  'ChannelController.channel': [
+    // User should switch to YAML for this one
+  ],
+  'InputController.input': [
+    p('TEXT', 'supportedInputs', 'required list of supported input values (e.g. "HMDI1,TV,XBOX")')
+  ],
+  'Speaker.volume': [
+    volumeIncrementParameter
+  ],
+  'Speaker.muted': [],
+  'StepSpeaker.volume': [
+    volumeIncrementParameter
+  ],
+  'StepSpeaker.muted': [],
+  'PlaybackController.playback': [],
+  'EqualizerController.bands:bass': [
+    rangeParameter
+  ],
+  'EqualizerController.bands:midrange': [
+    rangeParameter
+  ],
+  'EqualizerController.bands:treble': [
+    rangeParameter
+  ],
+  'EqualizerController.modes': [
+    p('TEXT', 'MOVIE', 'MOVIE State'),
+    p('TEXT', 'MUSIC', 'MUSIC State'),
+    p('TEXT', 'NIGHT', 'NIGHT State'),
+    p('TEXT', 'SPORT', 'SPORT State'),
+    p('TEXT', 'TV', 'TV State'),
+    p('TEXT', 'supportedModes', 'Supported modes')
+  ],
+
+  // TODO the rest
+  'ContactSensor.detectionState': [],
+  'MotionSensor.detectionState': [],
+  'SecurityPanelController.armState': [
+    p('TEXT', 'DISARMED', 'DISARMED State'),
+    p('TEXT', 'ARMED_STAY', 'ARMED_STAY State'),
+    p('TEXT', 'ARMED_AWAY', 'ARMED_AWAY State'),
+    p('TEXT', 'ARMED_NIGHT', 'ARMED_NIGHT State'),
+    p('TEXT', 'AUTHORIZATION_REQUIRED', 'AUTHORIZATION_REQUIRED State'),
+    p('TEXT', 'UNAUTHORIZED', 'UNAUTHORIZED State'),
+    p('TEXT', 'NOT_READY', 'NOT_READY State'),
+    p('TEXT', 'UNCLEARED_ALARM', 'UNCLEARED_ALARM State'),
+    p('TEXT', 'UNCLEARED_TROUBLE', 'UNCLEARED_TROUBLE State'),
+    p('TEXT', 'BYPASS_NEEDED', 'BYPASS_NEEDED State'),
+    p('TEXT', 'supportedArmStates', 'Supported arm states'),
+    p('BOOLEAN', 'supportsPinCodes', 'Supports pin codes'),
+    p('INTEGER', 'exitDelay', 'Exit Delay')
+  ],
+  'SecurityPanelController.burglaryAlarm': [],
+  'SecurityPanelController.fireAlarm': [],
+  'SecurityPanelController.carbonMonoxideAlarm': [],
+  'SecurityPanelController.waterAlarm': [],
+  'ModeController.mode': [
+    friendlyNamesParameter,
+    nonControllableParameter,
+    p('TEXT', 'supportedModes', 'Supported Modes'),
+    p('BOOLEAN', 'ordered', 'Ordered'),
+    languageParameter,
+    actionMappingsParameter,
+    stateMappingsParameter
+  ],
+  'RangeController.rangeValue': [
+    friendlyNamesParameter,
+    nonControllableParameter,
+    p('TEXT', 'supportedRange', 'Supported Range'),
+    p('TEXT', 'presets', 'Presets'),
+    p('TEXT', 'unitOfMeasure', 'Unit of Measure'),
+    languageParameter,
+    actionMappingsParameter,
+    stateMappingsParameter
+  ],
+  'ToggleController.toggleState': [
+    friendlyNamesParameter,
+    nonControllableParameter,
+    languageParameter,
+    actionMappingsParameter,
+    stateMappingsParameter
+  ]
+}
+
+for (let c in classes) {
+  classes[c].unshift(p('TEXT', 'category', 'Category', 'Override the default category for the class', categories.join(','), true))
+}
+
+export default classes

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
@@ -1,0 +1,64 @@
+const p = (type, name, label, description, options, advanced) => {
+  return {
+    name,
+    type,
+    label,
+    description,
+    advanced,
+    limitToOptions: !!options,
+    options: (!options) ? undefined : options.split(',').map((o) => {
+      const parts = o.split('=')
+      return { value: parts[0], label: parts[1] || parts[0] }
+    })
+  }
+}
+
+const tfaAckParameter = p('BOOLEAN', 'tfaAck', 'TFA Ack Needed')
+const tfaPinParameter = p('TEXT', 'tfaPin', 'TFA Pin')
+const nameParameter = p('TEXT', 'name', 'Name', 'Custom name (use of the synonyms is preferred)', null, true)
+const roomHintParameter = p('TEXT', 'roomHint', 'Room Hint', null, null, true)
+const invertedParameter = p('BOOLEAN', 'inverted', 'Inverted')
+const speedParameter = p('TEXT', 'speed', 'Speed', 'Mappings between items states and Google modes')
+const orderedParameter = p('BOOLEAN', 'ordered', 'Ordered')
+const useFahrenheitParameter = p('BOOLEAN', 'useFahrenheit', 'Use Fahrenheit')
+const thermostatModesParameter = p('TEXT', 'modes', 'Thermostat Modes', 'Mappings between items states and Google modes')
+
+const classes = {
+  'Light': [],
+  'Switch': [],
+  'Outlet': [],
+  'CoffeeMaker': [],
+  'WaterHeater': [],
+  'Fireplace': [],
+  'Valve': [],
+  'Sprinkler': [],
+  'Vacuum': [],
+  'Scene': [],
+  'Lock': [],
+  'SecuritySystem': [],
+  'Speaker': [],
+  'Fan': [ speedParameter, orderedParameter ],
+  'Hood': [ speedParameter, orderedParameter ],
+  'AirPurifier': [ speedParameter, orderedParameter ],
+  'Awning': [ invertedParameter ],
+  'Blinds': [ invertedParameter ],
+  'Curtain': [ invertedParameter ],
+  'Door': [ invertedParameter ],
+  'Garage': [ invertedParameter ],
+  'Gate': [ invertedParameter ],
+  'Pergola': [ invertedParameter ],
+  'Shutter': [ invertedParameter ],
+  'Window': [ invertedParameter ],
+  'Thermostat': [ useFahrenheitParameter, thermostatModesParameter ],
+  'thermostatTemperatureAmbient': [],
+  'thermostatHumidityAmbient': [],
+  'thermostatTemperatureSetpoint': [],
+  'thermostatMode': [],
+  'Camera': []
+}
+
+for (let c in classes) {
+  classes[c] = [...classes[c], tfaAckParameter, tfaPinParameter, nameParameter, roomHintParameter]
+}
+
+export default classes

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -1,0 +1,10 @@
+export default [
+  { name: 'stateDescription', label: 'State Description' },
+  { name: 'commandDescription', label: 'Command Options' },
+  { name: 'synonyms', label: 'Synonyms' },
+  { name: 'widget', label: 'Default Standalone Widget' },
+  { name: 'listwidget', label: 'Default List Item Widget' },
+  { name: 'autoupdate', label: 'Auto-update' },
+  { name: 'alexa', label: 'Amazon Alexa' },
+  { name: 'ga', label: 'Google Assistant' }
+]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -3,7 +3,7 @@ export default [
   { name: 'commandDescription', label: 'Command Options' },
   { name: 'synonyms', label: 'Synonyms' },
   { name: 'widget', label: 'Default Standalone Widget' },
-  { name: 'listwidget', label: 'Default List Item Widget' },
+  { name: 'listWidget', label: 'Default List Item Widget' },
   { name: 'autoupdate', label: 'Auto-update' },
   { name: 'alexa', label: 'Amazon Alexa' },
   { name: 'ga', label: 'Google Assistant' }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -150,7 +150,15 @@
 </template>
 
 <style lang="stylus" scoped>
+.panel-left::-webkit-scrollbar /* WebKit */
+  width 0
+  height 0
+
 .panel-left
+  overflow-y scroll
+  scrollbar-width none /* Firefox */
+  -ms-overflow-style none  /* IE 10+ */
+
   .page
     background #f5f5f5 !important
     padding-bottom 4rem

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -1,0 +1,95 @@
+<template>
+  <f7-card>
+    <f7-list>
+      <ul v-if="!editMembers">
+        <item
+          v-for="member in groupItem.members" :key="member.name"
+          :item="member" :link="'/settings/items/' + member.name"
+          :context="context"
+          :ignore-editable="true"
+          />
+        <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" />
+      </ul>
+      <item-picker v-if="editMembers" :multiple="true" name="groupMembers" :value="memberNames" title="Members" @input="(members) => memberNames = members" />
+      <ul v-if="editMembers">
+        <f7-list-button color="blue" title="Apply" @click="updateMembers" />
+        <f7-list-button color="red" title="Cancel" @click="cancelEditMode" />
+      </ul>
+    </f7-list>
+    <f7-list v-if="editMembers">
+    </f7-list>
+  </f7-card>
+</template>
+
+<style>
+
+</style>
+
+<script>
+import Item from './item'
+import ItemPicker from '@/components/config/controls/item-picker.vue'
+
+export default {
+  props: ['groupItem', 'context'],
+  components: {
+    Item,
+    ItemPicker
+  },
+  data () {
+    return {
+      editMembers: false,
+      memberNames: [],
+      newMemberNames: []
+    }
+  },
+  methods: {
+    enableEditMode () {
+      this.memberNames = this.groupItem.members.map((m) => m.name)
+      this.editMembers = true
+    },
+    cancelEditMode () {
+      this.editMembers = false
+    },
+    updateMembers () {
+      const itemsToAdd = this.memberNames.filter((n) => this.groupItem.members.findIndex((m) => m.name === n) < 0)
+      const itemsToRemove = this.groupItem.members.filter((m) => (this.memberNames.indexOf(m.name) < 0)).map((m) => m.name)
+
+      if (!itemsToAdd.length && !itemsToRemove.length) {
+        this.$f7.dialog.alert('Nothing to do')
+        return
+      }
+      if (itemsToAdd.indexOf(this.groupItem.name) >= 0) {
+        this.$f7.dialog.alert('Cannot add this group as a member of itself')
+        return
+      }
+      // Note: this routine doesn't check cyclic memberships
+
+      const vm = this
+      this.$f7.dialog.confirm(
+        `This will add ${itemsToAdd.length} item(s) and remove ${itemsToRemove.length} item(s) from this group. Continue?`,
+        'Add or Remove Members',
+        () => {
+          const promises = [
+            ...itemsToAdd.map((item) => this.$oh.api.put(`/rest/items/${vm.groupItem.name}/members/${item}`)),
+            ...itemsToRemove.map((item) => this.$oh.api.delete(`/rest/items/${vm.groupItem.name}/members/${item}`))
+          ]
+
+          Promise.all(promises)
+            .then((d) => {
+              vm.$emit('updated')
+              vm.$f7.toast.create({
+                text: 'Member list updated',
+                destroyOnClose: true,
+                closeTimeout: 2000
+              }).open()
+              this.editMembers = false
+            })
+            .catch((err) => {
+              vm.$f7.dialog.alert('Error while updating the member list: ' + err)
+            })
+        }
+      )
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -1,23 +1,24 @@
 <template>
   <f7-card>
-    <f7-list>
-      <ul v-if="!editMembers">
-        <item
-          v-for="member in groupItem.members" :key="member.name"
-          :item="member" :link="'/settings/items/' + member.name"
-          :context="context"
-          :ignore-editable="true"
-          />
-        <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" />
-      </ul>
-      <item-picker v-if="editMembers" :multiple="true" name="groupMembers" :value="memberNames" title="Members" @input="(members) => memberNames = members" />
-      <ul v-if="editMembers">
-        <f7-list-button color="blue" title="Apply" @click="updateMembers" />
-        <f7-list-button color="red" title="Cancel" @click="cancelEditMode" />
-      </ul>
-    </f7-list>
-    <f7-list v-if="editMembers">
-    </f7-list>
+    <f7-card-content>
+      <f7-list>
+        <ul v-if="!editMembers">
+          <item
+            v-for="member in groupItem.members" :key="member.name"
+            :item="member" :link="'/settings/items/' + member.name"
+            :context="context"
+            :ignore-editable="true"
+            />
+          <!-- <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" /> -->
+        </ul>
+        <item-picker v-if="editMembers" :multiple="true" name="groupMembers" :value="memberNames" title="Members" @input="(members) => memberNames = members" />
+      </f7-list>
+    </f7-card-content>
+    <f7-card-footer>
+      <f7-button color="blue" v-if="!editMembers" @click="enableEditMode">Change</f7-button>
+      <f7-button color="blue" v-if="editMembers" fill raised @click="updateMembers">Apply</f7-button>
+      <f7-button color="blue" v-if="editMembers" @click="cancelEditMode">Cancel</f7-button>
+    </f7-card-footer>
   </f7-card>
 </template>
 
@@ -55,7 +56,7 @@ export default {
       const itemsToRemove = this.groupItem.members.filter((m) => (this.memberNames.indexOf(m.name) < 0)).map((m) => m.name)
 
       if (!itemsToAdd.length && !itemsToRemove.length) {
-        this.$f7.dialog.alert('Nothing to do')
+        this.$f7.dialog.alert('Nothing to change')
         return
       }
       if (itemsToAdd.indexOf(this.groupItem.name) >= 0) {

--- a/bundles/org.openhab.ui/web/src/components/item/item-standalone-control.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-standalone-control.vue
@@ -1,0 +1,68 @@
+<template>
+  <generic-widget-component v-if="widgetContext" :context="widgetContext" />
+  <!-- <div v-else>{{context.store[item.name].displayState || context.store[item.name].state}}</div> -->
+</template>
+
+<script>
+export default {
+  props: ['item', 'context', 'rawLabel'],
+  computed: {
+    widgetContext () {
+      if (!this.item) return
+
+      let ctx = {}
+
+      if (this.item.metadata && this.item.metadata.widget) {
+        ctx.component = {
+          component: this.item.metadata.widget.value,
+          config: this.item.metadata.widget.config
+        }
+      } else {
+        const stateDescription = this.item.stateDescription || {}
+
+        if (this.item.type === 'Switch' && !stateDescription.readOnly) {
+          ctx.component = {
+            component: 'oh-toggle-card'
+          }
+        }
+
+        // temporary until we have a colorpicker control
+        if ((this.item.type === 'Dimmer' || this.item.type === 'Color') && !stateDescription.readOnly) {
+          ctx.component = {
+            component: 'oh-slider-card',
+            config: {
+              scale: true,
+              label: true,
+              scaleSubSteps: 5,
+              min: stateDescription.min,
+              max: stateDescription.max,
+              step: stateDescription.step
+            }
+          }
+        }
+      }
+
+      if (!ctx.component) {
+        ctx.component = {
+          component: 'oh-label-card'
+        }
+
+        if (this.item.commandDescription && this.item.commandDescription.commandOptions) {
+          ctx.component.config = {
+            action: 'options',
+            actionItem: this.item.name,
+            actionOptions: this.item.commandDescription.commandOptions.map((o) => (o.label) ? o.command + '=' + o.label : o.command).join(',')
+          }
+        }
+      }
+
+      if (!ctx.component.config) ctx.component.config = {}
+      ctx.component.config.item = this.item.name
+
+      ctx.store = this.context.store
+
+      return ctx
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/item-standalone-control.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-standalone-control.vue
@@ -12,14 +12,14 @@ export default {
 
       let ctx = {}
 
+      const stateDescription = this.item.stateDescription || {}
+
       if (this.item.metadata && this.item.metadata.widget) {
         ctx.component = {
           component: this.item.metadata.widget.value,
           config: this.item.metadata.widget.config
         }
       } else {
-        const stateDescription = this.item.stateDescription || {}
-
         if (this.item.type === 'Switch' && !stateDescription.readOnly) {
           ctx.component = {
             component: 'oh-toggle-card'
@@ -40,6 +40,15 @@ export default {
             }
           }
         }
+
+        if (this.item.type === 'Rollershutter' && !stateDescription.readOnly) {
+          ctx.component = {
+            component: 'oh-rollershutter-card',
+            config: {
+              vertical: true
+            }
+          }
+        }
       }
 
       if (!ctx.component) {
@@ -47,7 +56,7 @@ export default {
           component: 'oh-label-card'
         }
 
-        if (this.item.commandDescription && this.item.commandDescription.commandOptions) {
+        if (this.item.commandDescription && this.item.commandDescription.commandOptions && !stateDescription.readOnly) {
           ctx.component.config = {
             action: 'options',
             actionItem: this.item.name,

--- a/bundles/org.openhab.ui/web/src/components/item/item-state-preview.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-state-preview.vue
@@ -1,0 +1,21 @@
+<template>
+  <div>
+    <item-standalone-control :item="item" :context="context" />
+    <div class="display-flex justify-content-center flex-direction-column">
+      <div v-if="item.type.indexOf('Number') === 0 || item.type === 'Switch'" class="display-flex justify-content-center flex-direction-row">
+        <f7-button :href="'/analyzer/?items=' + item.name">Analyze</f7-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import ItemStandaloneControl from '@/components/item/item-standalone-control.vue'
+
+export default {
+  props: ['item', 'context'],
+  components: {
+    ItemStandaloneControl
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -6,17 +6,23 @@
   :title="(item.label) ? item.label :item.name"
   :footer="(item.label) ? item.name : '\xa0'"
   :subtitle="getItemTypeAndMetaLabel(item)"
-  :after="item.state"
+  :after="state"
 >
   <oh-icon v-if="item.category" slot="media" :icon="item.category" height="32" width="32" />
   <span v-else slot="media" class="item-initial">{{item.name[0]}}</span>
-  <f7-icon v-if="!item.editable" slot="after-title" f7="lock_fill" size="1rem" color="gray"></f7-icon>
+  <f7-icon v-if="!item.editable && !ignoreEditable" slot="after-title" f7="lock_fill" size="1rem" color="gray"></f7-icon>
 </f7-list-item>
 </template>
 
 <script>
 export default {
-  props: ['item', 'link'],
+  props: ['item', 'context', 'ignoreEditable', 'link'],
+  computed: {
+    state () {
+      if (!this.context || !this.context.store) return this.item.state
+      return this.context.store[this.item.name].displayState || this.context.store[this.item.name].state
+    }
+  },
   methods: {
     getItemTypeAndMetaLabel () {
       let ret = this.item.type

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -16,9 +16,10 @@
 
 <script>
 export default {
-  props: ['item', 'context', 'ignoreEditable', 'link'],
+  props: ['item', 'context', 'ignoreEditable', 'noState', 'link'],
   computed: {
     state () {
+      if (this.noState) return
       if (!this.context || !this.context.store) return this.item.state
       return this.context.store[this.item.name].displayState || this.context.store[this.item.name].state
     }

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -8,7 +8,20 @@
          :title="(multiple) ? 'Alexa Classes' : 'Alexa Class'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }" ref="classes">
         <select name="parameters" @change="updateClasses" :multiple="multiple">
           <option v-if="!multiple" value=""></option>
-          <option v-for="cl in classesDefs" :value="cl" :key="cl" :selected="isSelected(cl)">{{cl}}</option>
+          <optgroup label="Labels" v-if="!multiple">
+            <option v-for="cl in classesDefs.filter((c) => c.indexOf('label:') === 0)"
+              :value="cl.replace('label:', '')" :key="cl"
+              :selected="isSelected(cl.replace('label:', ''))">
+              {{cl.replace('label:', '')}}
+            </option>
+          </optgroup>
+          <optgroup label="Capabilities">
+            <option v-for="cl in classesDefs.filter((c) => c.indexOf('label:') !== 0)"
+              :value="cl" :key="cl"
+              :selected="isSelected(cl)">
+              {{cl}}
+            </option>
+          </optgroup>
         </select>
       </f7-list-item>
     </f7-list>
@@ -41,7 +54,9 @@ export default {
     },
     parameters () {
       if (!this.classes) return []
-      if (!this.multiple) return [...AlexaDefinitions[this.classes]]
+      if (!this.multiple) {
+        return AlexaDefinitions['label:' + this.classes] || [...AlexaDefinitions[this.classes]]
+      }
       const params = []
       this.classes.forEach((c) => {
         for (const p of AlexaDefinitions[c]) {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <div style="text-align:right" class="padding-right">
+      <label @click="toggleMultiple" style="cursor:pointer">Multiple</label> <f7-checkbox :checked="multiple" @change="toggleMultiple"></f7-checkbox>
+    </div>
+    <f7-list>
+      <f7-list-item :key="classSelectKey"
+         :title="(multiple) ? 'Alexa Classes' : 'Alexa Class'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }" ref="classes">
+        <select name="parameters" @change="updateClasses" :multiple="multiple">
+          <option v-if="!multiple" value=""></option>
+          <option v-for="cl in classesDefs" :value="cl" :key="cl" :selected="isSelected(cl)">{{cl}}</option>
+        </select>
+      </f7-list-item>
+    </f7-list>
+    <div>
+      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
+    </div>
+  </div>
+</template>
+
+<script>
+import AlexaDefinitions from '@/assets/definitions/metadata/alexa'
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  components: {
+    ConfigSheet
+  },
+  data () {
+    return {
+      classesDefs: Object.keys(AlexaDefinitions),
+      multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
+      classSelectKey: this.$f7.utils.id()
+    }
+  },
+  computed: {
+    classes () {
+      if (!this.multiple) return this.metadata.value
+      return (this.metadata.value) ? this.metadata.value.split(',') : []
+    },
+    parameters () {
+      if (!this.classes) return []
+      if (!this.multiple) return [...AlexaDefinitions[this.classes]]
+      const params = []
+      this.classes.forEach((c) => {
+        for (const p of AlexaDefinitions[c]) {
+          if (!params.find(p2 => p2.name === p.name)) params.push(p)
+        }
+      })
+      return params
+    }
+  },
+  methods: {
+    isSelected (cl) {
+      return (this.multiple) ? this.classes.indexOf(cl) >= 0 : this.classes === cl
+    },
+    toggleMultiple () {
+      this.multiple = !this.multiple
+      this.metadata.value = ''
+      this.classSelectKey = this.$f7.utils.id()
+    },
+    updateClasses () {
+      const value = this.$refs.classes.f7SmartSelect.getValue()
+      this.metadata.value = (Array.isArray(value)) ? value.join(',') : value
+      this.$set(this.metadata, 'config', {})
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-item title="Force auto-update">
+        <f7-toggle slot="after" name="autoupdate" :checked="typeof (metadata.value) === 'string' ? metadata.value === 'true' : metadata.value"
+          @toggle:change="(ev) => metadata.value = ev"></f7-toggle>
+      </f7-list-item>
+    </f7-list>
+    <f7-block-footer class="param-description">
+      <small>Force the state to auto-update on command.</small>
+    </f7-block-footer>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['itemName', 'metadata', 'namespace']
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -1,0 +1,50 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-item :key="classSelectKey"
+         :title="'Google Assistant Class'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }" ref="classes">
+        <select name="classes" @change="updateClass">
+          <option value=""></option>
+          <option v-for="cl in classesDefs" :value="cl" :key="cl" :selected="isSelected(cl)">{{cl}}</option>
+        </select>
+      </f7-list-item>
+    </f7-list>
+    <div>
+      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
+    </div>
+  </div>
+</template>
+
+<script>
+import GoogleDefinitions from '@/assets/definitions/metadata/ga'
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  components: {
+    ConfigSheet
+  },
+  data () {
+    return {
+      classesDefs: Object.keys(GoogleDefinitions),
+      classSelectKey: this.$f7.utils.id()
+    }
+  },
+  computed: {
+    parameters () {
+      if (!this.metadata.value) return []
+      return [...GoogleDefinitions[this.metadata.value]]
+    }
+  },
+  methods: {
+    isSelected (cl) {
+      return this.classes === cl
+    },
+    updateClass () {
+      const value = this.$refs.classes.f7SmartSelect.getValue()
+      this.metadata.value = value
+      this.$set(this.metadata, 'config', {})
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -11,10 +11,10 @@
         :value="options"
         @input="updateOptions"
       />
+      <f7-block-footer class="param-description" alot="after-list">
+        <small>Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the option.</small>
+      </f7-block-footer>
     </f7-list>
-    <f7-block-footer class="param-description">
-      <small>Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the option.</small>
-    </f7-block-footer>
   </div>
 </template>
 
@@ -29,7 +29,7 @@ export default {
   data () {
     return {
       stateDescriptionParameters: [
-        { type: 'BOOLEAN', name: 'readOnly', label: 'Read only', description: 'Item is read-only and may not accept commands or updates' },
+        { type: 'BOOLEAN', name: 'readOnly', label: 'Read only', description: 'Item is read-only and should not accept commands' },
         { type: 'TEXT', name: 'pattern', label: 'Pattern', description: 'Pattern or transformation applied to the state for display purposes' },
         { type: 'TEXT', name: 'min', label: 'Min', description: 'Minimum allowed value' },
         { type: 'TEXT', name: 'max', label: 'Max', description: 'Maximum allowed value' },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <config-sheet v-if="namespace === 'stateDescription'" :parameterGroups="[]" :parameters="stateDescriptionParameters" :configuration="metadata.config" />
+    <f7-list>
+      <f7-list-input
+        ref="input"
+        type="textarea"
+        :floating-label="$theme.md"
+        :label="'Options'"
+        name="options"
+        :value="options"
+        @input="updateOptions"
+      />
+    </f7-list>
+    <f7-block-footer class="param-description">
+      <small>Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the option.</small>
+    </f7-block-footer>
+  </div>
+</template>
+
+<script>
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  components: {
+    ConfigSheet
+  },
+  data () {
+    return {
+      stateDescriptionParameters: [
+        { type: 'BOOLEAN', name: 'readOnly', label: 'Read only', description: 'Item is read-only and may not accept commands or updates' },
+        { type: 'TEXT', name: 'pattern', label: 'Pattern', description: 'Pattern or transformation applied to the state for display purposes' },
+        { type: 'TEXT', name: 'min', label: 'Min', description: 'Minimum allowed value' },
+        { type: 'TEXT', name: 'max', label: 'Max', description: 'Maximum allowed value' },
+        { type: 'TEXT', name: 'step', label: 'Step', description: 'Minimum interval between values' }
+      ]
+    }
+  },
+  computed: {
+    options () {
+      if (!this.metadata.config.options) return []
+      return this.metadata.config.options.trim().split(',').map((s) => s.trim()).join('\n')
+    }
+  },
+  methods: {
+    updateOptions (ev) {
+      this.metadata.config.options = ev.target.value.split('\n').map((s) => s.trim()).join(',').trim()
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -1,0 +1,33 @@
+<template>
+  <f7-list>
+    <f7-list-item
+      v-for="namespace in metadataNamespaces" :key="namespace.name"
+      :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+      :title="namespace.label"
+      :after="(item.metadata && item.metadata[namespace.name]) ? item.metadata[namespace.name].value : 'Not Set'"
+    />
+    <f7-list-button color="blue" @click="editCustomMetadata">Edit Custom Metadata</f7-list-button>
+  </f7-list>
+</template>
+
+<script>
+import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
+
+export default {
+  props: ['item'],
+  data () {
+    return {
+      metadataNamespaces: MetadataNamespaces
+    }
+  },
+  methods: {
+    editCustomMetadata () {
+      this.$f7.dialog.prompt(`Please type in the namespace you would like to edit:`,
+        'Edit Custom Metadata',
+        (namespace) => {
+          if (namespace) this.$f7.views.main.router.navigate('metadata/' + namespace)
+        })
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-input
+        ref="input"
+        type="textarea"
+        :floating-label="$theme.md"
+        :label="'Synonyms'"
+        name="synonyms"
+        :value="synonyms"
+        @input="updateValue"
+      />
+    </f7-list>
+    <f7-block-footer class="param-description">
+      <small>Enter each synonym on a separate line.</small>
+    </f7-block-footer>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  computed: {
+    synonyms () {
+      if (!this.metadata.value) return []
+      return this.metadata.value.split(',').map((s) => s.trim()).join('\n')
+    }
+  },
+  methods: {
+    updateValue (ev) {
+      this.metadata.value = ev.target.value.split('\n').map((s) => s.trim()).join(',')
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
@@ -10,10 +10,10 @@
         :value="synonyms"
         @input="updateValue"
       />
+      <f7-block-footer class="param-description" slot="after-list">
+        <small>Enter each synonym on a separate line.</small>
+      </f7-block-footer>
     </f7-list>
-    <f7-block-footer class="param-description">
-      <small>Enter each synonym on a separate line.</small>
-    </f7-block-footer>
   </div>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -1,0 +1,70 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-item :key="componentSelectKey"
+         :title="'Widget'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }" ref="widgets">
+        <select name="widgets" @change="updateComponent">
+          <option value=""></option>
+          <optgroup v-if="$store.getters.widgets.length" label="Widgets">
+            <option v-for="widget in $store.getters.widgets" :value="'widget:' + widget.uid" :key="widget.uid" :selected="metadata.value.replace('widget:', '') === widget.uid">{{widget.uid}}</option>
+          </optgroup>
+          <optgroup label="Standard Library">
+            <option v-for="widget in standardWidgets" :key="widget.name" :value="widget.name" :selected="metadata.value === widget.name">{{widget.label}}</option>
+          </optgroup>
+          <!-- <optgroup label="System Widgets">
+            <option v-for="widget in systemWidgets" :key="widget.name" :value="widget.name">{{widget.label}}</option>
+          </optgroup> -->
+        </select>
+      </f7-list-item>
+    </f7-list>
+    <div v-if="configDescriptions.parameters">
+      <f7-block-title>Configuration</f7-block-title>
+      <f7-block-footer class="padding-horizontal">Note: a parameter named 'item' will be set automatically with the name of this item - no need to specify it here.</f7-block-footer>
+      <config-sheet :parameterGroups="configDescriptions.parameterGroups || []" :parameters="configDescriptions.parameters || []" :configuration="metadata.config" />
+    </div>
+  </div>
+</template>
+
+<script>
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+import * as SystemWidgets from '@/components/widgets/system/index'
+import * as StandardWidgets from '@/components/widgets/standard/index'
+
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  components: {
+    ConfigSheet
+  },
+  data () {
+    return {
+      componentSelectKey: this.$f7.utils.id(),
+      standardWidgets: Object.values(StandardWidgets).filter((c) => c.widget).map((c) => c.widget),
+      systemWidgets: Object.values(SystemWidgets).filter((c) => c.widget).map((c) => c.widget)
+    }
+  },
+  computed: {
+    configDescriptions () {
+      if (!this.metadata.value) return {}
+
+      const widget = this.$store.getters.widgets.find((w) => w.uid === this.metadata.value.replace('widget:', ''))
+      if (widget && widget.props) return widget.props
+
+      const standardWidget = this.standardWidgets.find((w) => w.name === this.metadata.value)
+      if (standardWidget && standardWidget.props) return standardWidget.props
+
+      return {}
+    }
+  },
+  methods: {
+    isSelected (cl) {
+      return this.component === cl
+    },
+    updateComponent () {
+      const value = this.$refs.widgets.f7SmartSelect.getValue()
+      this.metadata.value = value
+      this.$set(this.metadata, 'config', {})
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
@@ -1,5 +1,7 @@
 <template>
   <div>
+    <item-state-preview :item="model.item" :context="context" />
+
     <f7-block-title>Item</f7-block-title>
     <item-details :model="model" :links="links" @item-updated="$emit('item-updated')" @item-created="$emit('item-created')" @item-removed="$emit('item-removed')" @cancel-create="$emit('cancel-create')" />
     <f7-block-title v-if="model.item.type !== 'Group' && model.item.created !== false">Channel Links</f7-block-title>
@@ -8,12 +10,14 @@
 </template>
 
 <script>
+import ItemStatePreview from '@/components/item/item-state-preview.vue'
 import ItemDetails from '@/components/model/item-details.vue'
 import LinkDetails from '@/components/model/link-details.vue'
 
 export default {
-  props: ['model', 'links'],
+  props: ['model', 'links', 'context'],
   components: {
+    ItemStatePreview,
     ItemDetails,
     LinkDetails
   },

--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -1,15 +1,22 @@
 <template>
   <f7-card v-if="model">
     <f7-card-content>
-      <f7-list media-list>
+      <f7-list media-list accordion-list>
         <ul>
-          <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" />
+          <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" :no-state="true" />
           <!-- <f7-list-button v-if="!editMode && !createMode" color="blue" title="Edit Item" @click="editMode = true">Edit Item</f7-list-button> -->
         </ul>
       </f7-list>
 
       <div class="padding-top" v-if="editMode">
         <item-form :item="model.item" :hide-type="true" :force-semantics="forceSemantics"></item-form>
+        <f7-list accordion-list v-if="editMode" inset class="padding-top">
+          <f7-list-item accordion-item title="Metadata">
+            <f7-accordion-content>
+              <metadata-menu :item="model.item" />
+            </f7-accordion-content>
+          </f7-list-item>
+        </f7-list>
       </div>
       <div class="padding-top" v-else-if="createMode">
         <item-form :item="model.item" :enable-name="true" :force-semantics="forceSemantics"></item-form>
@@ -30,12 +37,14 @@
 <script>
 import Item from '@/components/item/item.vue'
 import ItemForm from '@/components/item/item-form.vue'
+import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 
 export default {
   props: ['model', 'links'],
   components: {
     Item,
-    ItemForm
+    ItemForm,
+    MetadataMenu
   },
   data () {
     return {

--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-card v-if="item.type !== 'Group' && item.created !== false">
-    <f7-card-content v-if="!$theme.md || enrichedLinks.length > 0">
+    <f7-card-content v-if="enrichedLinks.length > 0">
       <f7-list media-list>
         <ul>
           <f7-list-item v-for="l in enrichedLinks" :key="l.itemName" media-item
@@ -10,11 +10,11 @@
             link="#" @click="editLink(l)">
             <span slot="media" class="item-initial">{{l.channel.label ? l.channel.label[0] : '?'}}</span>
           </f7-list-item>
-          <f7-list-button v-if="!$theme.md" color="blue" title="Add Link" @click="addLink"></f7-list-button>
+          <!-- <f7-list-button v-if="!$theme.md" color="blue" title="Add Link" @click="addLink"></f7-list-button> -->
         </ul>
       </f7-list>
     </f7-card-content>
-    <f7-card-footer v-if="$theme.md">
+    <f7-card-footer>
       <f7-button color="blue" @click="addLink">Add Link</f7-button>
     </f7-card-footer>
   </f7-card>

--- a/bundles/org.openhab.ui/web/src/components/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/oh-icon.vue
@@ -1,9 +1,7 @@
 <template>
-  <transition name="fade">
-    <img :src="iconUrl" :width="width" :height="height"
-      :style="{ width: (width) ? width + 'px' : 'auto', height: (height) ? height + 'px' : 'auto' }"
-      onload="this.className=''" onerror="this.className='no-icon'" />
-  </transition>
+  <img :src="iconUrl" :width="width" :height="height"
+    :style="{ width: (width) ? width + 'px' : 'auto', height: (height) ? height + 'px' : 'auto' }"
+    onload="this.className=''" onerror="this.className='no-icon'" />
 </template>
 
 <style lang="stylus">
@@ -17,6 +15,7 @@ export default {
   data () {
     return {
       currentState: this.state,
+      currentIcon: this.icon,
       iconUrl: null
     }
   },
@@ -24,6 +23,12 @@ export default {
     state (val) {
       if (val !== this.currentState) {
         this.currentState = val
+        this.updateIcon()
+      }
+    },
+    icon (val) {
+      if (val !== this.currentIcon) {
+        this.currentIcon = val
         this.updateIcon()
       }
     }

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -27,7 +27,7 @@
         :title="(link.item.label) ? link.item.label : link.item.name"
         :footer="(link.item.label) ? link.item.name : '\xa0'"
         :subtitle="getItemTypeAndMetaLabel(link.item)"
-        :after="link.item.state"
+        :after="context.store[link.item.name].displayState || context.store[link.item.name].state"
       >
         <oh-icon v-if="link.item.category" slot="media" :icon="link.item.category" height="32" width="32" />
         <span v-else slot="media" class="item-initial">{{link.item.name[0]}}</span>
@@ -63,7 +63,7 @@ import ConfigureLinkPage from '@/pages/settings/things/link/link-edit.vue'
 import ConfigureChannelPage from '@/pages/settings/things/channel/channel-edit.vue'
 
 export default {
-  props: ['channelType', 'channelId', 'channel', 'thing', 'opened', 'extensible'],
+  props: ['channelType', 'channelId', 'channel', 'thing', 'opened', 'extensible', 'context'],
   data () {
     return {
       ready: false,

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -36,7 +36,7 @@
               @channel-opened="channelOpened">
               <template v-slot:default="{ channelId, channelType, channel, extensible }" v-if="!pickerMode && !multipleLinksMode">
                 <channel-link :opened="openedChannelId === channelId"
-                  :thing="thing" :channelId="channelId" :channelType="channelType" :channel="channel" :extensible="extensible"
+                  :thing="thing" :channelId="channelId" :channelType="channelType" :channel="channel" :extensible="extensible" :context="context"
                   @channel-updated="(e) => $emit('channels-updated', e)">
                 </channel-link>
               </template>
@@ -79,7 +79,7 @@ import ChannelLink from './channel-link.vue'
 import ItemForm from '@/components/item/item-form.vue'
 
 export default {
-  props: ['thingType', 'thing', 'channelTypes', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems'],
+  props: ['thingType', 'thing', 'channelTypes', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems', 'context'],
   components: {
     ChannelGroup,
     ChannelLink,

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/index.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/index.js
@@ -3,6 +3,7 @@
 export { default as OhTestCard } from './oh-test-card.vue'
 export { default as OhLabelCard } from './oh-label-card.vue'
 export { default as OhToggleCard } from './oh-toggle-card.vue'
+export { default as OhRollershutterCard } from './oh-rollershutter-card.vue'
 export { default as OhSliderCard } from './oh-slider-card.vue'
 export { default as OhStepperCard } from './oh-stepper-card.vue'
 export { default as OhPlayerCard } from './oh-player-card.vue'

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-rollershutter-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-rollershutter-card.vue
@@ -1,0 +1,136 @@
+<template>
+  <f7-card :no-border="config.noBorder" :no-shadow="config.noShadow" :outline="config.outline">
+    <f7-card-header v-if="config.title">
+      <div>{{config.title}}</div>
+    </f7-card-header>
+    <f7-card-content class="display-flex justify-content-center" :style="{ height: config.vertical ? '10em' : undefined }">
+      <oh-rollershutter :class="{ vertical: config.vertical }" :context="context" @command="onCommand" />
+    </f7-card-content>
+    <f7-card-footer v-if="config.footer">
+      {{config.footer}}
+    </f7-card-footer>
+  </f7-card>
+</template>
+
+<style lang="stylus">
+.rollershutter-controls
+  .button
+    text-overflow clip
+  &.vertical
+    transform rotate(90deg)
+    transform-origin center
+  .icon
+    margin-bottom 2px
+    margin-left 2px
+
+</style>
+
+<script>
+import mixin from '../widget-mixin'
+import OhRollershutter from '../system/oh-rollershutter.vue'
+
+export default {
+  mixins: [mixin],
+  components: {
+    OhRollershutter
+  },
+  widget: {
+    name: 'oh-rollershutter-card',
+    label: 'Simple rollershutter',
+    description: 'Display a rollershutter control in a card',
+    props: {
+      parameters: [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'TEXT',
+          description: 'Title of the card'
+        },
+        {
+          name: 'item',
+          label: 'Item',
+          type: 'TEXT',
+          context: 'item',
+          description: 'Item to control'
+        },
+        {
+          name: 'color',
+          label: 'Color',
+          type: 'TEXT',
+          description: 'Color of the control'
+        },
+        {
+          name: 'footer',
+          label: 'Footer text',
+          type: 'TEXT',
+          description: 'Footer of the card'
+        },
+        {
+          name: 'vertical',
+          label: 'Vertical',
+          type: 'BOOLEAN',
+          description: 'Vertical arrangement'
+        },
+        {
+          name: 'dirIconsStyle',
+          label: 'Direction Icons Style',
+          type: 'TEXT',
+          limitToOptions: true,
+          options: [
+            'arrowtriangle_{dir}',
+            'arrowtriangle_{dir}_fill',
+            'arrowtriangle_{dir}_circle',
+            'arrowtriangle_{dir}_circle_fill',
+            'arrowtriangle_{dir}_square',
+            'arrowtriangle_{dir}_square_fill',
+            'chevron_{dir}',
+            'chevron_{dir}_2',
+            'chevron_compact_{dir}_2',
+            'chevron_{dir}_fill',
+            'chevron_{dir}_circle',
+            'chevron_{dir}_circle_fill',
+            'chevron_{dir}_square',
+            'chevron_{dir}_square_fill',
+            'arrow_{dir}',
+            'arrow_{dir}_2',
+            'arrow_{dir}_fill',
+            'arrow_{dir}_circle',
+            'arrow_{dir}_circle_fill',
+            'arrow_{dir}_square',
+            'arrow_{dir}_square_fill',
+            'arrow_{dir}_to_line',
+            'arrow_{dir}_to_line_alt'
+          ].map((o) => { return { value: o, label: o } })
+        },
+        {
+          name: 'stopIconStyle',
+          label: 'Stop Icon Style',
+          type: 'TEXT',
+          limitToOptions: true,
+          options: [
+            'stop',
+            'stop_fill',
+            'stop_circle',
+            'stop_circle_fill',
+            'multiply',
+            'multiply_fill',
+            'multiply_circle',
+            'multiply_circle_fill'
+          ].map((o) => { return { value: o, label: o } })
+        },
+        {
+          name: 'stateInCenter',
+          label: 'State in Center',
+          type: 'BOOLEAN',
+          description: 'Display state value'
+        }
+      ]
+    }
+  },
+  data () {
+    return {
+      value: Math.random()
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/index.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/index.js
@@ -3,6 +3,7 @@
 export { default as OhButton } from './oh-button.vue'
 export { default as OhLink } from './oh-link.vue'
 export { default as OhToggle } from './oh-toggle.vue'
+export { default as OhRollershutter } from './oh-rollershutter.vue'
 export { default as OhSlider } from './oh-slider.vue'
 export { default as OhStepper } from './oh-stepper.vue'
 export { default as OhPlayerControls } from './oh-player-controls.vue'

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
@@ -1,0 +1,57 @@
+<template>
+  <f7-segmented round outline strong class="rollershutter-controls">
+    <f7-button @click="up()" large :icon-ios="upIcon" :icon-md="upIcon" :icon-aurora="upIcon" icon-size="24" icon-color="gray" />
+    <f7-button v-if="config.stateInCenter" @click="stop()" large class="state"><small>{{context.store[config.item].state}}</small></f7-button>
+    <f7-button v-else @click="stop()" large :icon-ios="stopIcon" :icon-md="stopIcon" :icon-aurora="stopIcon" icon-size="24" icon-color="red" />
+    <f7-button @click="down()" large  :icon-ios="downIcon" :icon-md="downIcon" :icon-aurora="downIcon" icon-size="24" icon-color="gray" />
+  </f7-segmented>
+</template>
+
+<style lang="stylus">
+.rollershutter-controls
+  .button
+    height 48px
+    width 48px
+.aurora .rollershutter-controls
+  .button
+    height 37px
+</style>
+
+<script>
+import mixin from '../widget-mixin'
+
+export default {
+  name: 'oh-rollershutter',
+  mixins: [mixin],
+  mounted () {
+    delete this.config.value
+  },
+  computed: {
+    upIcon (theme) {
+      const dir = (this.config.vertical) ? 'left' : 'up'
+      const style = this.config.dirIconsStyle || 'arrowtriangle_{dir}'
+      return 'f7:' + style.replace('{dir}', dir)
+    },
+    downIcon (theme) {
+      const dir = (this.config.vertical) ? 'right' : 'down'
+      const style = this.config.dirIconsStyle || 'arrowtriangle_{dir}'
+      return 'f7:' + style.replace('{dir}', dir)
+    },
+    stopIcon (theme) {
+      const style = this.config.stopIconStyle || 'stop'
+      return 'f7:' + style
+    }
+  },
+  methods: {
+    up (value) {
+      this.$store.dispatch('sendCommand', { itemName: this.config.item, cmd: 'UP' })
+    },
+    down (value) {
+      this.$store.dispatch('sendCommand', { itemName: this.config.item, cmd: 'DOWN' })
+    },
+    stop (value) {
+      this.$store.dispatch('sendCommand', { itemName: this.config.item, cmd: 'STOP' })
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -13,8 +13,10 @@ export default {
   },
   computed: {
     value () {
-      const value = parseFloat(this.context.store[this.config.item].state)
-      return value
+      const value = this.context.store[this.config.item].state
+      // use as a brightness control for HSB values
+      if (value.split && value.split(',').length === 3) return parseFloat(value.split(',')[2])
+      return parseFloat(value)
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -180,10 +180,10 @@ export const actionsMixin = {
             }
           })
           this.$f7.actions.create({
-            buttons: [...actions, {
-              text: 'Cancel',
-              color: 'red'
-            }]
+            buttons: [
+              actions,
+              [{ text: 'Cancel', color: 'red' }]
+            ]
           }).open()
           break
         case 'popup':

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -166,6 +166,26 @@ export const actionsMixin = {
           const cmd = this.context.store[actionToggleItem].state === actionToggleCommand ? actionToggleCommandAlt : actionToggleCommand
           this.$store.dispatch('sendCommand', { itemName: actionToggleItem, cmd })
           break
+        case 'options':
+          const actionCommandOptionsItem = this.config[prefix + 'actionItem']
+          const actionCommandOptions = this.config[prefix + 'actionOptions']
+          const actions = actionCommandOptions.split(',').map((o) => {
+            const parts = o.split('=')
+            return {
+              text: parts[1] || parts[0],
+              color: 'blue',
+              onClick: () => {
+                this.$store.dispatch('sendCommand', { itemName: actionCommandOptionsItem, cmd: parts[0] })
+              }
+            }
+          })
+          this.$f7.actions.create({
+            buttons: [...actions, {
+              text: 'Cancel',
+              color: 'red'
+            }]
+          }).open()
+          break
         case 'popup':
         case 'popover':
         case 'sheet':

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -159,6 +159,9 @@ html
   height: var(--f7-navbar-height);
 }
 
+.panel-left .page-content::-webkit-scrollbar
+  width 0
+
 .page-home
   .page-content::-webkit-scrollbar
     width 0

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -115,6 +115,20 @@ export default [
               {
                 path: 'edit',
                 component: ItemEditPage
+              },
+              {
+                path: 'metadata/:namespace',
+                async (routeTo, routeFrom, resolve, reject) {
+                  // dynamic import component; returns promise
+                  const editorComponent = () => import(`../pages/settings/items/metadata/item-metadata-edit.vue`)
+                  // resolve promise
+                  editorComponent().then((vc) => {
+                    // resolve with component
+                    resolve({
+                      component: vc.default
+                    })
+                  })
+                }
               }
             ]
           }

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -2,8 +2,7 @@
   <f7-page stacked name="HomePage" class="page-home" @page:init="onPageInit">
     <f7-navbar :large="$f7.data.themeOptions.homeNavbar !== 'simple'" :large-transparent="true">
       <f7-nav-left>
-        <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left"
-          icon-color="($f7.data.themeOptions.homeNavbar !== 'simple' && $f7.data.themeOptions.bars === 'filled') ? 'orange' : undefined"></f7-link>
+        <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left"></f7-link>
       </f7-nav-left>
       <f7-nav-title-large v-if="$f7.data.themeOptions.homeNavbar !== 'simple'" class="home-title-large">
         <span class="today">{{new Date().toLocaleString('default', { weekday: 'long', day: 'numeric', month: 'long' }) }}</span>
@@ -44,6 +43,12 @@
 <style lang="stylus">
 .theme-filled .home-title-large .title-large-text
   color var(--f7-text-color)
+.theme-filled .navbar-large:not(.navbar-large-collapsed) .link.icon-only
+  color var(--f7-theme-color)
+  transition color 0.3s
+.theme-filled .navbar-large.navbar-large-collapsed .link.icon-only
+  color var(--f7-navbar-link-color)
+  transition color 0.3s
 .home-title-large .title-large-text
   line-height 0.95
   .today

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -2,7 +2,8 @@
   <f7-page stacked name="HomePage" class="page-home" @page:init="onPageInit">
     <f7-navbar :large="$f7.data.themeOptions.homeNavbar !== 'simple'" :large-transparent="true">
       <f7-nav-left>
-        <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left"></f7-link>
+        <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left"
+          icon-color="($f7.data.themeOptions.homeNavbar !== 'simple' && $f7.data.themeOptions.bars === 'filled') ? 'orange' : undefined"></f7-link>
       </f7-nav-left>
       <f7-nav-title-large v-if="$f7.data.themeOptions.homeNavbar !== 'simple'" class="home-title-large">
         <span class="today">{{new Date().toLocaleString('default', { weekday: 'long', day: 'numeric', month: 'long' }) }}</span>
@@ -41,6 +42,8 @@
 </template>
 
 <style lang="stylus">
+.theme-filled .home-title-large .title-large-text
+  color var(--f7-text-color)
 .home-title-large .title-large-text
   line-height 0.95
   .today

--- a/bundles/org.openhab.ui/web/src/pages/panel-right.vue
+++ b/bundles/org.openhab.ui/web/src/pages/panel-right.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page class="other-apps">
-    <f7-navbar bg-color="blue" title="Other Apps"></f7-navbar>
+    <f7-navbar color="blue" title="Other Apps"></f7-navbar>
     <f7-link class="app-link" v-for="app in apps" :key="app.url" :href="app.url.replace(/^\.\./, '')" external target="_blank">
       <f7-card class="app-card">
         <f7-card-content :padding="false">

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-page class="item-details-page" @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn">
+  <f7-page class="item-details-page" @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar :title="item.name" back-link="Back" no-shadow no-hairline class="item-details-navbar">
       <f7-nav-right>
         <f7-link icon-md="material:edit" href="edit">{{ $theme.md ? '' : 'Edit' }}</f7-link>
@@ -20,13 +20,12 @@
       <f7-row v-if="item.state">
         <f7-col>
           <f7-block-title>Current State</f7-block-title>
-          <f7-block strong class="state-block">
-            {{item.transformedState || item.state}}
-            <f7-button v-show="$theme.md" :href="'/analyzer/?items=' + item.name">Analyze</f7-button>
-          </f7-block>
-          <f7-list class="analyze-button" v-show="!$theme.md">
-            <f7-list-button :href="'/analyzer/?items=' + item.name">Analyze</f7-list-button>
-          </f7-list>
+          <item-standalone-control :item="item" :context="context" />
+          <div class="display-flex justify-content-center flex-direction-column">
+            <div v-if="item.type.indexOf('Number') === 0 || item.type === 'Switch'" class="margin-top display-flex justify-content-center flex-direction-row">
+              <f7-button :href="'/analyzer/?items=' + item.name">Analyze</f7-button>
+            </div>
+          </div>
         </f7-col>
       </f7-row>
       <f7-row  v-if="item && item.tags && item.tags.length > 0">
@@ -41,7 +40,7 @@
       </f7-row>
       <f7-row  v-if="item && item.groupNames && item.groupNames.length > 0">
         <f7-col>
-          <f7-block-title>Member of (Direct)</f7-block-title>
+          <f7-block-title>Direct Parent Groups</f7-block-title>
           <f7-card>
             <f7-list>
               <f7-list-item
@@ -54,29 +53,10 @@
           </f7-card>
         </f7-col>
       </f7-row>
-      <f7-row  v-if="item && item.members && item.members.length > 0">
+      <f7-row  v-if="item && item.type === 'Group'">
         <f7-col>
-          <f7-block-title>Group Members (Children Items)</f7-block-title>
-          <f7-card>
-            <f7-list>
-              <f7-list-item
-                v-for="member in item.members" :key="member.name"
-                media-item
-                class="itemlist-item"
-                @change="(e) => toggleItemCheck(e, member.name)"
-                :link="'/settings/items/' + member.name"
-                :title="(member.label) ? member.label : member.name"
-                :footer="(member.label) ? member.name : '\xa0'"
-                :subtitle="getItemTypeAndMetaLabel(member)"
-                :after="member.state"
-              >
-                <oh-icon v-if="member.category" slot="media" :icon="member.category" height="32" width="32" />
-                <span v-else slot="media" class="item-initial">{{member.name[0]}}</span>
-                <!-- <f7-icon v-if="!member.editable" slot="after-title" f7="lock_fill" size="1rem" color="gray"></f7-icon> -->
-                <!-- <f7-button slot="after-start" color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
-              </f7-list-item>
-            </f7-list>
-          </f7-card>
+          <f7-block-title>Direct Group Members</f7-block-title>
+          <group-members :group-item="item" :context="context" @updated="load" />
         </f7-col>
       </f7-row>
       <f7-row  v-if="item && item.metadata && item.metadata.semantics">
@@ -90,6 +70,20 @@
               :title="key"
               :after="value"
             ></f7-list-item>
+          </f7-list>
+        </f7-col>
+      </f7-row>
+      <f7-row v-if="item.name">
+        <f7-col>
+          <f7-block-title>Metadata</f7-block-title>
+          <f7-list>
+            <f7-list-item
+              v-for="namespace in metadataNamespaces" :key="namespace.name"
+              :link="'metadata/' + namespace.name"
+              :title="namespace.label"
+              :after="(item.metadata && item.metadata[namespace.name]) ? item.metadata[namespace.name].value : 'Not Set'"
+            />
+            <f7-list-button color="blue" @click="editCustomMetadata">Edit Custom Metadata</f7-list-button>
           </f7-list>
         </f7-col>
       </f7-row>
@@ -142,40 +136,45 @@
       margin-top 0
 .after-item-header
   margin-top 10rem !important
-.state-block
-  margin-bottom 0
-  text-align center
-  font-size 36px
 .tags-block
   margin-bottom 0
   text-align center
   .chip
     margin-left 3px
     margin-right 3px
-.analyze-button
-  margin-top -1px
 </style>
 
 <script>
+import ItemStandaloneControl from '@/components/item/item-standalone-control.vue'
 import LinkDetails from '@/components/model/link-details.vue'
+import GroupMembers from '@/components/item/group-members.vue'
+import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
 
 export default {
   props: ['itemName'],
   components: {
-    LinkDetails
+    LinkDetails,
+    GroupMembers,
+    ItemStandaloneControl
   },
   data () {
     return {
       item: {},
-      links: []
+      links: [],
+      metadataNamespaces: MetadataNamespaces
+    }
+  },
+  computed: {
+    context () {
+      return {
+        store: this.$store.getters.trackedItems
+      }
     }
   },
   methods: {
     onPageBeforeIn () {
-      this.$oh.api.get('/rest/items/' + this.itemName + '?metadata=semantics').then((data) => {
-        this.item = data
-        this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
-      })
+      this.$store.dispatch('startTrackingStates')
+      this.load()
     },
     onPageAfterIn () {
       this.$oh.api.get('/rest/links?itemName=' + this.item.name).then((data) => {
@@ -183,17 +182,21 @@ export default {
         this.links = data
       })
     },
-    getItemTypeAndMetaLabel (item) {
-      let ret = item.type
-      if (item.metadata && item.metadata.semantics) {
-        ret += ' · '
-        const classParts = item.metadata.semantics.value.split('_')
-        ret += classParts[0]
-        if (classParts.length > 1) {
-          ret += '>' + classParts.pop()
-        }
-      }
-      return ret
+    onPageBeforeOut () {
+      this.$store.dispatch('stopTrackingStates')
+    },
+    load () {
+      this.$oh.api.get(`/rest/items/${this.itemName}?metadata=semantics,${this.metadataNamespaces.map((n) => n.name).join(',')}`).then((data) => {
+        this.item = data
+        this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
+      })
+    },
+    editCustomMetadata () {
+      this.$f7.dialog.prompt(`Please type in the namespace you would like to edit:`,
+        'Edit Custom Metadata',
+        (namespace) => {
+          if (namespace) this.$f7.views.main.router.navigate('metadata/' + namespace)
+        })
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -1,0 +1,187 @@
+<template>
+  <f7-page @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn">
+    <f7-navbar :title="'Edit Item Metadata: ' + namespace" back-link="Cancel" no-hairline>
+      <f7-nav-right>
+        <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
+        <f7-link @click="save()" v-if="!$theme.md">Save</f7-link>
+      </f7-nav-right>
+    </f7-navbar>
+    <f7-toolbar v-if="ready" tabbar position="top">
+      <f7-link v-if="!generic" @click="currentTab = 'config'; fromYaml()" :tab-link-active="currentTab === 'config'" class="tab-link">Config</f7-link>
+      <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
+    </f7-toolbar>
+    <f7-tabs class="metadata-editor-tabs">
+      <f7-tab id="config" class="metadata-editor-config-tab" @tab:show="() => this.currentTab = 'config'" :tab-active="currentTab === 'config'">
+      <f7-block class="block-narrow" v-if="ready && currentTab === 'config'">
+        <f7-col>
+          <component :is="editorControl" :item="item" :metadata="metadata" :namespace="namespace" />
+        </f7-col>
+      </f7-block>
+      <f7-block class="block-narrow" v-if="ready">
+        <f7-col>
+          <f7-list>
+            <f7-list-button color="red" v-if="!creationMode" @click="remove()">Remove metadata</f7-list-button>
+          </f7-list>
+        </f7-col>
+      </f7-block>
+      </f7-tab>
+
+      <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
+        <editor v-if="currentTab === 'code'" class="metadata-code-editor" mode="text/x-yaml" :value="yaml" @input="(value) => yaml = value" />
+        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+      </f7-tab>
+    </f7-tabs>
+
+  </f7-page>
+</template>
+
+<style lang="stylus">
+.metadata-code-editor.vue-codemirror
+  display block
+  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+  height calc(80% - 2*var(--f7-navbar-height))
+  width 100%
+.yaml-message
+  display block
+  position absolute
+  top 80%
+  white-space pre-wrap
+</style>
+
+<script>
+import YAML from 'yaml'
+
+import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
+
+import ItemMetadataItemDescription from '@/components/item/metadata/item-metadata-itemdescription.vue'
+import ItemMetadataSynonyms from '@/components/item/metadata/item-metadata-synonyms.vue'
+import ItemMetadataWidget from '@/components/item/metadata/item-metadata-widget.vue'
+import ItemMetadataAutoUpdate from '@/components/item/metadata/item-metadata-autoupdate.vue'
+import ItemMetadataAlexa from '@/components/item/metadata/item-metadata-alexa.vue'
+import ItemMetadataGa from '@/components/item/metadata/item-metadata-ga.vue'
+
+export default {
+  props: ['itemName', 'namespace'],
+  components: {
+    'editor': () => import('@/components/config/controls/script-editor.vue')
+  },
+  data () {
+    return {
+      ready: false,
+      currentTab: 'config',
+      creationMode: true,
+      generic: false,
+      item: {},
+      metadata: { value: '', config: {} },
+      yaml: null
+    }
+  },
+  computed: {
+    editorControl () {
+      switch (this.namespace) {
+        case 'stateDescription':
+        case 'commandDescription':
+          return ItemMetadataItemDescription
+        case 'synonyms':
+          return ItemMetadataSynonyms
+        case 'widget':
+        case 'listwidget':
+          return ItemMetadataWidget
+        case 'autoupdate':
+          return ItemMetadataAutoUpdate
+        case 'alexa':
+          return ItemMetadataAlexa
+        case 'ga':
+          return ItemMetadataGa
+        default:
+          return null
+      }
+    },
+    yamlError () {
+      if (this.currentTab !== 'code') return null
+      try {
+        YAML.parse(this.yaml, { prettyErrors: true })
+        return 'OK'
+      } catch (e) {
+        return e
+      }
+    }
+  },
+  methods: {
+    onPageBeforeIn () {
+      this.generic = MetadataNamespaces.map((n) => n.name).indexOf(this.namespace) < 0
+    },
+    onPageAfterIn () {
+      this.$oh.api.get(`/rest/items/${this.itemName}?metadata=${this.namespace}`).then((data) => {
+        this.item = data
+        if (this.item.metadata) {
+          this.metadata = this.item.metadata[this.namespace]
+          if (!this.metadata.config) this.$set(this.metadata, 'config', {})
+          this.creationMode = false
+        }
+        this.ready = true
+        if (this.generic) {
+          this.currentTab = 'code'
+          this.toYaml()
+        }
+      })
+    },
+    save () {
+      if (this.currentTab === 'code' && !this.fromYaml()) return
+      if (!this.metadata.value) this.metadata.value = ' '
+      this.$oh.api.put(`/rest/items/${this.itemName}/metadata/${this.namespace}`, this.metadata).then((data) => {
+        if (this.creationMode) {
+          this.$f7.toast.create({
+            text: 'Metadata created',
+            destroyOnClose: true,
+            closeTimeout: 2000
+          }).open()
+        } else {
+          this.$f7.toast.create({
+            text: 'Metadata updated',
+            destroyOnClose: true,
+            closeTimeout: 2000
+          }).open()
+        }
+        this.$f7router.back({ force: true })
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while saving metadata: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
+    },
+    remove () {
+      this.$oh.api.delete(`/rest/items/${this.itemName}/metadata/${this.namespace}`).then(() => {
+        this.$f7.toast.create({
+          text: 'Metadata deleted',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        this.$f7router.back({ force: true })
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while deleting metadata: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
+    },
+    toYaml () {
+      this.yaml = YAML.stringify(this.metadata)
+    },
+    fromYaml () {
+      try {
+        const updatedMetadata = YAML.parse(this.yaml)
+        this.metadata.value = updatedMetadata.value
+        if (updatedMetadata.config) this.$set(this.metadata, 'config', updatedMetadata.config)
+        return true
+      } catch (e) {
+        this.$f7.dialog.alert(e).open()
+        return false
+      }
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -85,7 +85,7 @@ export default {
         case 'synonyms':
           return ItemMetadataSynonyms
         case 'widget':
-        case 'listwidget':
+        case 'listWidget':
           return ItemMetadataWidget
         case 'autoupdate':
           return ItemMetadataAutoUpdate

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -143,7 +143,7 @@ export default {
             closeTimeout: 2000
           }).open()
         }
-        this.$f7router.back({ force: true })
+        this.$f7router.back()
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while saving metadata: ' + err,
@@ -159,7 +159,7 @@ export default {
           destroyOnClose: true,
           closeTimeout: 2000
         }).open()
-        this.$f7router.back({ force: true })
+        this.$f7router.back()
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while deleting metadata: ' + err,

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -11,8 +11,8 @@
       <f7-link @click="currentTab = 'code'" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
     <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'tree'">
-      <f7-link class="left details-link" @click="detailsOpened = true">Details</f7-link>
-      <f7-link :disabled="selectedWidget != null" class="right" @click="selectedWidget = null">Clear</f7-link>
+      <f7-link :disabled="selectedWidget != null" class="left" @click="selectedWidget = null">Clear</f7-link>
+      <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up"></f7-link>
     </f7-toolbar>
     <f7-tabs class="sitemap-editor-tabs">
       <f7-tab id="tree" @tab:show="() => this.currentTab = 'tree'" :tab-active="currentTab === 'tree'">
@@ -78,7 +78,7 @@
     <f7-sheet class="sitemap-details-sheet" :backdrop="false" :close-on-escape="true" :opened="detailsOpened" @sheet:closed="detailsOpened = false">
       <f7-page>
         <f7-toolbar tabbar>
-          <f7-link class="padding-left padding-right" :tab-link-active="detailsTab === 'item'" @click="detailsTab = 'widget'">Widget</f7-link>
+          <f7-link class="padding-left padding-right" :tab-link-active="detailsTab === 'widget'" @click="detailsTab = 'widget'">Widget</f7-link>
           <f7-link class="padding-left padding-right" :tab-link-active="detailsTab === 'mappings'" @click="detailsTab = 'mappings'">Mappings</f7-link>
           <div class="right">
             <f7-link sheet-close class="padding-right"><f7-icon f7="chevron_down"></f7-icon></f7-link>
@@ -347,6 +347,11 @@ export default {
       this.$nextTick(() => {
         this.selectedWidget = widget
         this.selectedWidgetParent = parentWidget
+        const detailsLink = this.$refs.detailsLink
+        const visibility = window.getComputedStyle(detailsLink.$el).visibility
+        if (!visibility || visibility !== 'hidden') {
+          this.detailsOpened = true
+        }
       })
     },
     clearSelection (ev) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -13,30 +13,29 @@
         </div>
 
         <f7-block-title>Link</f7-block-title>
-        <f7-list media-list>
-          <ul>
-            <f7-list-item divider title="Channel"></f7-list-item>
-            <f7-list-item media-item class="channel-item"
-              :title="channel.label || channelType.label"
-              :footer="channel.uid"
-              :subtitle="thing.label"
-              :badge="thing.statusInfo.status"
-              :badge-color="thing.statusInfo.status === 'ONLINE' ? 'green' : 'red'">
-              <span slot="media" class="item-initial">{{(channel.label) ? channel.label[0] : (channelType.label) ? channelType.label[0] : '?'}}</span>
-            </f7-list-item>
-            <f7-list-item divider title="Item"></f7-list-item>
-            <item :item="item" :context="context" :no-state="true" />
-          </ul>
-          <ul>
-            <f7-list-button color="red" title="Unlink" @click="unlink()"></f7-list-button>
-            <f7-list-button color="red" title="Unlink and Delete Item" @click="unlinkAndDelete()" v-if="source === 'thing'"></f7-list-button>
-          </ul>
-        </f7-list>
-        <!-- <f7-block strong>
-          <f7-block-title>{{channel.label}}</f7-block-title>
-          <div>{{channel.uid}}</div>
-          <f7-block-footer>{{channel.description}}</f7-block-footer>
-        </f7-block> -->
+        <f7-card>
+          <f7-card-content>
+          <f7-list media-list>
+            <ul>
+              <f7-list-item divider title="Channel"></f7-list-item>
+              <f7-list-item media-item class="channel-item"
+                :title="channel.label || channelType.label"
+                :footer="channel.uid"
+                :subtitle="thing.label"
+                :badge="thing.statusInfo.status"
+                :badge-color="thing.statusInfo.status === 'ONLINE' ? 'green' : 'red'">
+                <span slot="media" class="item-initial">{{(channel.label) ? channel.label[0] : (channelType.label) ? channelType.label[0] : '?'}}</span>
+              </f7-list-item>
+              <f7-list-item divider title="Item"></f7-list-item>
+              <item :item="item" :context="context" :no-state="true" />
+            </ul>
+          </f7-list>
+          </f7-card-content>
+          <f7-card-footer>
+            <f7-button color="red" fill @click="unlinkAndDelete()" v-if="source === 'thing'">Unlink &amp; Remove Item</f7-button>
+            <f7-button color="red" @click="unlink()">{{source === 'thing' ? 'Unlink Only' : 'Unlink'}}</f7-button>
+          </f7-card-footer>
+        </f7-card>
       </f7-col>
       <f7-col>
         <f7-block-title>Profile</f7-block-title>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -9,13 +9,7 @@
     <f7-block class="block-narrow">
       <f7-col>
         <div v-if="item.state">
-          <f7-block-title>Current State</f7-block-title>
-          <item-standalone-control :item="item" :context="context" raw-label />
-          <div class="display-flex justify-content-center flex-direction-column">
-            <div v-if="item.type.indexOf('Number') === 0 || item.type === 'Switch'" class="margin-top display-flex justify-content-center flex-direction-row">
-              <f7-button :href="'/analyzer/?items=' + item.name">Analyze</f7-button>
-            </div>
-          </div>
+          <item-state-preview :item="item" :context="context" />
         </div>
 
         <f7-block-title>Link</f7-block-title>
@@ -31,7 +25,7 @@
               <span slot="media" class="item-initial">{{(channel.label) ? channel.label[0] : (channelType.label) ? channelType.label[0] : '?'}}</span>
             </f7-list-item>
             <f7-list-item divider title="Item"></f7-list-item>
-            <item :item="item" :context="context" />
+            <item :item="item" :context="context" :no-state="true" />
           </ul>
           <ul>
             <f7-list-button color="red" title="Unlink" @click="unlink()"></f7-list-button>
@@ -77,13 +71,13 @@
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import Item from '@/components/item/item.vue'
-import ItemStandaloneControl from '@/components/item/item-standalone-control.vue'
+import ItemStatePreview from '@/components/item/item-state-preview.vue'
 
 export default {
   components: {
     ConfigSheet,
     Item,
-    ItemStandaloneControl
+    ItemStatePreview
   },
   props: ['thing', 'channel', 'item', 'source'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -108,7 +108,7 @@
       <f7-tab id="channels" disabled="!thingType.channels" @tab:show="() => this.currentTab = 'channels'" :tab-active="currentTab === 'channels'">
         <f7-block v-if="currentTab === 'channels'" class="block-narrow">
           <channel-list :thingType="thingType" :thing="thing" :channelTypes="channelTypes"
-            @channels-updated="onChannelsUpdated"
+            @channels-updated="onChannelsUpdated" :context="context"
           />
           <f7-col v-if="isExtensible || thing.channels.length > 0">
             <f7-list>
@@ -242,10 +242,16 @@ export default {
     },
     textualDefinition () {
       return buildTextualDefinition(this.thing, this.thingType)
+    },
+    context () {
+      return {
+        store: this.$store.getters.trackedItems
+      }
     }
   },
   methods: {
     onPageAfterIn (event) {
+      this.$store.dispatch('startTrackingStates')
       // When coming back from the channel add/edit page with a change, let the handler below take care of the reloading logic (the thing has to be saved first)
       if (!event.pageFrom || !event.pageFrom.name || event.pageFrom.name.indexOf('channel') < 0) {
         console.log('Loading')
@@ -254,6 +260,7 @@ export default {
       }
     },
     onPageAfterOut (event) {
+      this.$store.dispatch('stopTrackingStates')
       this.stopEventSource()
     },
     load () {


### PR DESCRIPTION
Add the ability to edit metadata from the items details page:

- Provide interactive forms for the alexa, ga, synonyms, widget,
  listwidget, stateDescription, commandDescription namespaces
- Fallback to YAML view for other namespaces (or in a tab for
  supported namespaces as an alternative).

Add "options" widget action to open an action sheet with a list
of command options.

Add default representation for items: look in the widget for
a preconfigured widget (custom or from the standard library),
or try to build a default live representation of the item's state
(WIP), considering its type, state/command descriptions and
other properties.

Change the "current state" part of the items details & link edit
pages with the default representation.

Add a convenient way to add or remove members to/from a group item.

Signed-off-by: Yannick Schaus <github@schaus.net>