### PR TITLE
Better support for non-editable rules

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -1,7 +1,15 @@
 <template>
-  <div v-if="item && item.tags" class="tag-editor" style="margin-top: 0">
-    <f7-list no-hairlines>
+  <div v-if="item && item.tags" class="tag-editor">
+    <f7-list>
+      <f7-list-item>
+        <div slot="inner">
+          <f7-chip v-for="tag in item.tags.filter((t) => !isSemanticTag(t))" :key="tag" :text="tag" :deleteable="!disabled" @delete="deleteTag" media-bg-color="blue">
+            <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" ></f7-icon>
+          </f7-chip>
+        </div>
+      </f7-list-item>
       <f7-list-input
+        v-if="!disabled"
         type="text"
         placeholder="Add tag"
         :value="pendingTag"
@@ -14,11 +22,6 @@
         <input slot="input" type="text" placeholder="Add tag" @keypress="keyPressed" />
       </f7-list-input>
     </f7-list>
-    <f7-block strong no-hairlines-md v-if="item.tags" style="margin-top: 0" class="tags">
-      <f7-chip v-for="tag in item.tags.filter((t) => !isSemanticTag(t))" :key="tag" :text="tag" deleteable @delete="deleteTag" media-bg-color="blue">
-        <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" ></f7-icon>
-      </f7-chip>
-    </f7-block>
   </div>
 </template>
 
@@ -26,7 +29,7 @@
 import * as SemanticClasses from '@/assets/semantics.js'
 
 export default {
-  props: ['item'],
+  props: ['item', 'disabled'],
   data () {
     return {
       pendingTag: ''
@@ -54,7 +57,8 @@ export default {
       }
     },
     deleteTag (ev) {
-      const tag = ev.target.previousSibling.innerText
+      let tag = ev.target.previousSibling.innerText
+      if (tag === 'tag_fill') tag = ''
       if (this.item.tags.indexOf(tag) >= 0) {
         this.item.tags.splice(this.item.tags.indexOf(tag), 1)
       }
@@ -64,7 +68,7 @@ export default {
 </script>
 
 <style lang="stylus">
-.tags-editor
+.tag-editor
   margin-bottom 0
   .tags
     text-align center
@@ -73,7 +77,6 @@ export default {
     margin-bottom 0
     border 0
   .chip
-    margin-left 3px
-    margin-right 3px
+    margin-right 6px !important
 
 </style>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/module-description-suggestions.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/module-description-suggestions.js
@@ -1,0 +1,96 @@
+import cronstrue from 'cronstrue'
+
+export default {
+  methods: {
+    suggestedModuleTitle (mod, moduleType, section) {
+      if (!moduleType) {
+        moduleType = this.moduleTypes[section].find((m) => m.uid === mod.type)
+        if (!moduleType) return 'Name'
+      }
+      const config = mod.configuration
+      switch (moduleType.uid) {
+        // triggers
+        case 'timer.TimeOfDayTrigger':
+          if (!config.time) return moduleType.label
+          return 'When the time is ' + config.time
+        case 'timer.GenericCronTrigger':
+          if (!config.cronExpression) return moduleType.label
+          try {
+            return cronstrue.toString(config.cronExpression, {
+              use24HourTimeFormat: true
+            })
+          } catch (err) {
+            return err.toString()
+          }
+        case 'core.ItemCommandTrigger':
+          if (!config.itemName && !config.command) return moduleType.label
+          if (!config.command) return 'When ' + config.itemName + ' received a command'
+          return 'When ' + config.itemName + ' received command ' + config.command
+        case 'core.ItemStateUpdateTrigger':
+          if (!config.itemName) return moduleType.label
+          return 'When ' + config.itemName + ' was updated' +
+                        ((config.state) ? ' to ' + config.state : '')
+        case 'core.ItemStateChangeTrigger':
+          if (!config.itemName) return moduleType.label
+          return 'When ' + config.itemName + ' changed' +
+              ((config.previousState) ? ' from ' + config.previousState : '') +
+              ((config.state) ? ' to ' + config.state : '')
+        case 'core.ChannelEventTrigger':
+          if (!config.channelUID) return moduleType.label
+          return 'When channel ' + config.channelUID + ' was triggered'
+        case 'core.GroupCommandTrigger':
+          if (!config.groupName && !config.command) return moduleType.label
+          if (!config.command) return 'When a member of ' + config.groupName + ' received a command'
+          return 'When a member of ' + config.itemName + ' received command ' + config.command
+        case 'core.GroupStateUpdateTrigger':
+          if (!config.groupName) return moduleType.label
+          return 'When ' + config.itemName + ' was updated' +
+                        ((config.state) ? ' to ' + config.state : '')
+        case 'core.GroupStateChangeTrigger':
+          if (!config.groupName) return moduleType.label
+          return 'When a member of ' + config.groupName + ' changed' +
+              ((config.previousState) ? ' from ' + config.previousState : '') +
+              ((config.state) ? ' to ' + config.state : '')
+        // actions
+        case 'core.ItemCommandAction':
+          if (!config.itemName || !config.command) return moduleType.label
+          return 'Send command ' + config.command + ' to ' + config.itemName
+        case 'media.SayAction':
+          if (!config.text) return moduleType.label
+          return 'Say "' + config.text + '"'
+        case 'media.PlaySound':
+          if (!config.sound) return moduleType.label
+          return 'Say ' + config.sound
+        // conditions
+        case 'timer.DayOfWeekCondition':
+          if (!config.days || !config.days.join || !config.days.length) return moduleType.label
+          return 'If the day is ' + config.days.join(',')
+        case 'core.TimeOfDayCondition':
+          if (!config.startTime || !config.endTime) return moduleType.label
+          return 'If the time is between ' + config.startTime + ' and ' + config.endTime
+        case 'core.ItemStateCondition':
+          if (!config.itemName || !config.operator || !config.state) return moduleType.label
+          return 'If ' + config.itemName + ' ' + config.operator + ' ' + config.state
+
+        default:
+          return moduleType.label
+      }
+    },
+    suggestedModuleDescription (mod, moduleType, section) {
+      if (!moduleType) {
+        moduleType = this.moduleTypes[section].find((m) => m.uid === mod.type)
+        if (!moduleType) return 'Description'
+      }
+      const config = mod.configuration
+      switch (moduleType.uid) {
+        // triggers
+        case 'timer.GenericCronTrigger':
+          if (!config.cronExpression) return moduleType.description
+          return 'Cron: ' + config.cronExpression
+
+        default:
+          return moduleType.description
+      }
+    }
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/1451.

Change the rules list to a "contacts" list with initials in
headers and a list index.
Add a lock icon to denote rules which cannot be edited with the
rule editor.

Strip all editing features in the rule editor when the rule is
not editable.

Move the module title/description suggestions to a mixin and add
the new group member triggers.

Fix bug, look & feel in tag editor.

Signed-off-by: Yannick Schaus <github@schaus.net>