### PR TITLE
Refactor page editors, conditional visibility

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
@@ -33,5 +33,8 @@
   "rules.missingengine.text": "The rule engine must be installed before rules can be created.",
 
   "addons.title": "No add-ons installed",
-  "addons.text": "Add-ons add functionality to your openHAB system.<br><br>Install them with the button below."
+  "addons.text": "Add-ons add functionality to your openHAB system.<br><br>Install them with the button below.",
+
+  "page.unavailable.title": "Page Unavailable",
+  "page.unavailable.text": "You are not allowed to view this page because of visibility restrictions."
 }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -324,7 +324,7 @@ export default {
         this.sitemaps = data[0]
         this.$store.commit('setPages', { pages: data[1] })
         this.$store.commit('setWidgets', { widgets: data[2] })
-        this.pages = data[1].filter((p) => p.config.sidebar)
+        this.pages = data[1].filter((p) => p.config.sidebar && this.pageIsVisible(p))
           .sort((p1, p2) => {
             const order1 = p1.config.order || 1000
             const order2 = p2.config.order || 1000
@@ -333,6 +333,14 @@ export default {
 
         this.ready = true
       })
+    },
+    pageIsVisible (page) {
+      if (!page.config.visibleTo) return true
+      const user = this.$store.getters.user
+      if (!user) return false
+      if (user.roles && user.roles.some(r => page.config.visibleTo.indexOf('role:' + r) >= 0)) return true
+      if (page.config.visibleTo.indexOf('user:' + user.name) >= 0) return true
+      return false
     },
     pageIcon (page) {
       switch (page.component) {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -1,0 +1,57 @@
+<template>
+  <f7-col>
+    <f7-list inline-labels accordion-list no-hairline-md>
+      <f7-list-input label="ID" type="text" placeholder="ID" :value="page.uid" @input="page.uid = $event.target.value"
+        required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only" :disabled="!createMode">
+      </f7-list-input>
+      <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" clear-button>
+      </f7-list-input>
+      <f7-list-item accordion-item title="Sidebar &amp; Visibility">
+        <f7-accordion-content>
+          <f7-list-item ref="pageVisibility" title="Visible only to" smart-select :smart-select-params="{openIn: 'popover'}">
+            <select name="pagevisibility" multiple @change="updatePageVisibility">
+              <optgroup label="Roles">
+                <option value="role:administrator" :selected="isVisibleTo('role:administrator')">Administrators</option>
+                <option value="role:user" :selected="isVisibleTo('role:user')">Users</option>
+              </optgroup>
+            </select>
+          </f7-list-item>
+          <f7-list inline-labels no-hairline-md>
+            <f7-list-item title="Show on sidebar">
+              <f7-toggle slot="after" :checked="page.config.sidebar" @toggle:change="page.config.sidebar = $event"></f7-toggle>
+            </f7-list-item>
+            <f7-list-input label="Sidebar order" type="number" placeholder="Assign order index to rearrange pages on sidebar" :value="page.config.order" @input="page.config.order = $event.target.value" clear-button>
+            </f7-list-input>
+          </f7-list>
+        </f7-accordion-content>
+      </f7-list-item>
+    </f7-list>
+  </f7-col>
+</template>
+
+<script>
+export default {
+  props: ['page', 'createMode'],
+  data () {
+    return {}
+  },
+  methods: {
+    isVisibleTo (userrole) {
+      return Array.isArray(this.page.config.visibleTo) && this.page.config.visibleTo.indexOf(userrole) >= 0
+    },
+    updatePageVisibility (userrole) {
+      let value = this.$refs.pageVisibility.f7SmartSelect.getValue()
+      if (value && value.length === 0) {
+        this.$delete(this.page.config, 'visibleTo')
+      } else {
+        this.$set(this.page.config, 'visibleTo', value)
+        this.$f7.toast.create({
+          text: 'Please be advised: the visibility restriction is not a security feature - items can be controlled by other means!',
+          closeButton: true,
+          destroyOnClose: true
+        }).open()
+      }
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
@@ -1,0 +1,69 @@
+<template>
+  <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape
+    :opened="opened" @popup:open="widgetCodeOpened" @popup:closed="widgetCodeClosed">
+    <f7-page v-if="component && opened">
+      <f7-navbar>
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
+        </f7-nav-left>
+        <f7-nav-title>Edit Widget Code</f7-nav-title>
+        <f7-nav-right>
+          <f7-link @click="updateWidgetCode">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <editor class="page-code-editor" mode="text/x-yaml" :value="code" @input="(value) => code = value" />
+      <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<style lang="stylus">
+.widgetcode-popup
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(80% - 2*var(--f7-navbar-height))
+    width 100%
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
+</style>
+
+<script>
+import YAML from 'yaml'
+
+export default {
+  props: ['opened', 'component'],
+  components: {
+    'editor': () => import('@/components/config/controls/script-editor.vue')
+  },
+  data () {
+    return {
+      code: ''
+    }
+  },
+  computed: {
+    widgetYamlError () {
+      try {
+        YAML.parse(this.code, { prettyErrors: true })
+        return 'OK'
+      } catch (e) {
+        return e
+      }
+    }
+  },
+  methods: {
+    widgetCodeOpened () {
+      this.code = YAML.stringify(this.component)
+    },
+    widgetCodeClosed () {
+      this.$emit('closed')
+    },
+    updateWidgetCode () {
+      this.$emit('update', this.code)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-config-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-config-popup.vue
@@ -1,0 +1,53 @@
+<template>
+  <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape
+    :opened="opened" @popup:open="widgetConfigOpened" @popup:closed="widgetConfigClosed">
+    <f7-page v-if="component && widget">
+      <f7-navbar>
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
+        </f7-nav-left>
+        <f7-nav-title>Edit {{widget.label || widget.uid}}</f7-nav-title>
+        <f7-nav-right>
+          <f7-link @click="updateWidgetConfig">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-block v-if="widget.props">
+        <f7-col>
+          <config-sheet
+            :parameterGroups="widget.props.parameterGroups || []"
+            :parameters="widget.props.parameters || []"
+            :configuration="config"
+            @updated="dirty = true"
+          />
+        </f7-col>
+      </f7-block>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<script>
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+export default {
+  props: ['opened', 'component', 'widget'],
+  components: {
+    ConfigSheet
+  },
+  data () {
+    return {
+      config: {}
+    }
+  },
+  methods: {
+    widgetConfigOpened () {
+      this.config = JSON.parse(JSON.stringify(this.component.config))
+    },
+    widgetConfigClosed () {
+      this.$emit('closed')
+    },
+    updateWidgetConfig () {
+      this.$emit('update', this.config)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -1,5 +1,5 @@
 <template>
-  <component v-if="componentType && componentType.startsWith('f7-')" :is="componentType" v-bind="config" @command="onCommand">
+  <component v-if="componentType && componentType.startsWith('f7-') && visible" :is="componentType" v-bind="config" @command="onCommand">
     <template v-for="(slotComponents, slotName) in context.component.slots" v-slot:[slotName]>
       <ul v-if="componentType === 'f7-list'">
         <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in slotComponents" :key="idx" @command="onCommand" />
@@ -7,10 +7,10 @@
       <generic-widget-component v-else :context="childContext(slotComponent)" v-for="(slotComponent, idx) in slotComponents" :key="idx" @command="onCommand" />
     </template>
   </component>
-  <generic-widget-component v-else-if="componentType && componentType.startsWith('widget:')" :context="childWidgetContext()" @command="onCommand" />
-  <component v-else-if="componentType && componentType.startsWith('oh-')" :is="componentType" :context="context" @command="onCommand" />
-  <div v-else-if="componentType && componentType === 'Label'" :class="config.class" :style="config.style">{{config.text}}</div>
-  <pre v-else-if="componentType && componentType === 'Error'" class="text-color-red" style="white-space: pre-wrap">{{config.error}}</pre>
+  <generic-widget-component v-else-if="componentType && componentType.startsWith('widget:') && visible" :context="childWidgetContext()" @command="onCommand" />
+  <component v-else-if="componentType && componentType.startsWith('oh-') && visible" :is="componentType" :context="context" @command="onCommand" />
+  <div v-else-if="componentType && componentType === 'Label' && visible" :class="config.class" :style="config.style">{{config.text}}</div>
+  <pre v-else-if="componentType && componentType === 'Error' && visible" class="text-color-red" style="white-space: pre-wrap">{{config.error}}</pre>
 </template>
 
 <script>
@@ -27,6 +27,21 @@ export default {
     ...SystemWidgets,
     ...StandardWidgets,
     ...LayoutWidgets
+  },
+  computed: {
+    visible () {
+      if (this.context.editmode) return true
+      if (this.config.visible === undefined) return true
+      if (this.config.visible === false) return false
+      if (this.config.visibleTo) {
+        const user = this.$store.getters.user
+        if (!user) return false
+        if (user.roles && user.roles.some(r => this.config.visibleTo.indexOf('role:' + r) >= 0)) return true
+        if (this.config.visibleTo.indexOf('user:' + user.name) >= 0) return true
+        return false
+      }
+      return true
+    }
   }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
@@ -1,0 +1,69 @@
+import OhLayoutPage from '@/components/widgets/layout/oh-layout-page.vue'
+
+export default {
+  components: {
+    'oh-layout-page': OhLayoutPage,
+    'oh-map-page': () => import('@/components/widgets/map/oh-map-page.vue'),
+    'oh-plan-page': () => import('@/components/widgets/plan/oh-plan-page.vue'),
+    'oh-chart-page': () => import('@/components/widgets/chart/oh-chart-page.vue')
+  },
+  props: ['uid', 'el', 'modalParams'],
+  data () {
+    return {
+      currentTab: 0
+    }
+  },
+  computed: {
+    context () {
+      return {
+        component: Object.assign({}, this.page || this.widget || this.standard, { config: this.modalParams }),
+        store: this.$store.getters.trackedItems,
+        props: this.modalParams
+      }
+    },
+    page () {
+      return (this.uid.indexOf('page:') === 0) ? this.$store.getters.page(this.uid.substring(5)) : null
+    },
+    widget () {
+      return (this.uid.indexOf('widget:') === 0) ? this.$store.getters.widget(this.uid.substring(7)) : null
+    },
+    standard () {
+      return (this.uid.indexOf('oh-') === 0) ? { component: this.uid } : null
+    },
+    ready () {
+      return this.page || this.widget || this.standard
+    },
+    componentType () {
+      if (this.page) {
+        return this.page.component
+      } else if (this.widget || this.standard) {
+        return 'generic-widget-component'
+      }
+      return null
+    },
+    visibleToCurrentUser () {
+      // widgets in modals cannot be restricted (this is by design)
+      if (!this.page || !this.page.config || !this.page.config.visibleTo) return true
+      const user = this.$store.getters.user
+      if (!user) return false
+      if (user.roles && user.roles.some(r => this.page.config.visibleTo.indexOf('role:' + r) >= 0)) return true
+      if (this.page.config.visibleTo.indexOf('user:' + user.name) >= 0) return true
+      return false
+    }
+  },
+  methods: {
+    tabContext (tab) {
+      const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
+      return {
+        component: page,
+        tab: tab,
+        props: tab.config.pageConfig,
+        store: this.$store.getters.trackedItems
+      }
+    },
+    tabComponent (tab) {
+      const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
+      return page.component
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popover.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popover.vue
@@ -10,48 +10,9 @@
 </style>
 
 <script>
-import OhLayoutPage from '@/components/widgets/layout/oh-layout-page.vue'
+import modal from './modal-mixin'
 
 export default {
-  components: {
-    'oh-layout-page': OhLayoutPage,
-    'oh-map-page': () => import('@/components/widgets/map/oh-map-page.vue'),
-    'oh-plan-page': () => import('@/components/widgets/plan/oh-plan-page.vue'),
-    'oh-chart-page': () => import('@/components/widgets/chart/oh-chart-page.vue')
-  },
-  props: ['uid', 'el', 'modalParams'],
-  data () {
-    return {
-    }
-  },
-  computed: {
-    context () {
-      return {
-        component: Object.assign({}, this.page || this.widget || this.standard, { config: this.modalParams }),
-        store: this.$store.getters.trackedItems,
-        props: this.modalParams
-      }
-    },
-    page () {
-      return (this.uid.indexOf('page:') === 0) ? this.$store.getters.page(this.uid.substring(5)) : null
-    },
-    widget () {
-      return (this.uid.indexOf('widget:') === 0) ? this.$store.getters.widget(this.uid.substring(7)) : null
-    },
-    standard () {
-      return (this.uid.indexOf('oh-') === 0) ? { component: this.uid } : null
-    },
-    ready () {
-      return this.page || this.widget || this.standard
-    },
-    componentType () {
-      if (this.page) {
-        return this.page.component
-      } else if (this.widget || this.standard) {
-        return 'generic-widget-component'
-      }
-      return null
-    }
-  }
+  mixins: [modal]
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popup.vue
@@ -4,16 +4,17 @@
       <f7-navbar :title="(page) ? page.config.label : ''" back-link="Back">
       </f7-navbar>
 
-      <f7-toolbar tabbar labels bottom v-if="page && page.component === 'oh-tabs-page'">
+      <f7-toolbar tabbar labels bottom v-if="page && page.component === 'oh-tabs-page' && visibleToCurrentUser">
         <f7-link v-for="(tab, idx) in page.slots.default" :key="idx" tab-link @click="currentTab = idx" :tab-link-active="currentTab === idx" :icon-ios="tab.config.icon" :icon-md="tab.config.icon" :icon-aurora="tab.config.icon" :text="tab.config.title"></f7-link>
       </f7-toolbar>
 
-      <f7-tabs v-if="page && page.component === 'oh-tabs-page'" :class="{notready: !ready}">
+      <f7-tabs v-if="page && page.component === 'oh-tabs-page' && visibleToCurrentUser" :class="{notready: !ready}">
         <f7-tab v-for="(tab, idx) in page.slots.default" :key="idx" :tab-active="currentTab === idx">
           <component v-if="currentTab === idx" :is="tabComponent(tab)" :context="tabContext(tab)" />
         </f7-tab>
       </f7-tabs>
-      <component v-else :is="componentType" :context="context" :class="{notready: !ready}" />
+      <component v-else-if="visibleToCurrentUser" :is="componentType" :context="context" :class="{notready: !ready}" />
+      <empty-state-placeholder v-if="page && !visibleToCurrentUser" icon="multiply_circle_fill" title="page.unavailable.title" text="page.unavailable.text" />
 
     </f7-page>
   </f7-popup>
@@ -25,64 +26,9 @@
 </style>
 
 <script>
-import OhLayoutPage from '@/components/widgets/layout/oh-layout-page.vue'
+import modal from './modal-mixin'
 
 export default {
-  components: {
-    'oh-layout-page': OhLayoutPage,
-    'oh-map-page': () => import('@/components/widgets/map/oh-map-page.vue'),
-    'oh-plan-page': () => import('@/components/widgets/plan/oh-plan-page.vue'),
-    'oh-chart-page': () => import('@/components/widgets/chart/oh-chart-page.vue')
-  },
-  props: ['uid', 'modalParams'],
-  data () {
-    return {
-      currentTab: 0
-    }
-  },
-  computed: {
-    context () {
-      return {
-        component: Object.assign({}, this.page || this.widget || this.standard, { config: this.modalParams }),
-        store: this.$store.getters.trackedItems,
-        config: this.modalParams
-      }
-    },
-    page () {
-      return (this.uid.indexOf('page:') === 0) ? this.$store.getters.page(this.uid.substring(5)) : null
-    },
-    widget () {
-      return (this.uid.indexOf('widget:') === 0) ? this.$store.getters.widget(this.uid.substring(7)) : null
-    },
-    standard () {
-      return (this.uid.indexOf('oh-') === 0) ? { component: this.uid } : null
-    },
-    ready () {
-      return this.page || this.widget || this.standard
-    },
-    componentType () {
-      if (this.page) {
-        return this.page.component
-      } else if (this.widget || this.standard) {
-        return 'generic-widget-component'
-      }
-      return null
-    }
-  },
-  methods: {
-    tabContext (tab) {
-      const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
-      return {
-        component: page,
-        tab: tab,
-        props: tab.config.pageConfig,
-        store: this.$store.getters.trackedItems
-      }
-    },
-    tabComponent (tab) {
-      const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
-      return page.component
-    }
-  }
+  mixins: [modal]
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-sheet.vue
@@ -5,7 +5,9 @@
       <div class="right"><f7-link sheet-close>Close</f7-link></div>
     </f7-toolbar>
 
-    <component :is="componentType" :context="context" :class="{notready: !ready}" />
+    <component v-if="visibleToCurrentUser" :is="componentType" :context="context" :class="{notready: !ready}" />
+    <empty-state-placeholder v-if="page && !visibleToCurrentUser" icon="multiply_circle_fill" title="page.unavailable.title" text="page.unavailable.text" />
+
   </f7-sheet>
 </template>
 
@@ -15,48 +17,9 @@
 </style>
 
 <script>
-import OhLayoutPage from '@/components/widgets/layout/oh-layout-page.vue'
+import modal from './modal-mixin'
 
 export default {
-  components: {
-    'oh-layout-page': OhLayoutPage,
-    'oh-map-page': () => import('@/components/widgets/map/oh-map-page.vue'),
-    'oh-plan-page': () => import('@/components/widgets/plan/oh-plan-page.vue'),
-    'oh-chart-page': () => import('@/components/widgets/chart/oh-chart-page.vue')
-  },
-  props: ['uid', 'modalParams'],
-  data () {
-    return {
-    }
-  },
-  computed: {
-    context () {
-      return {
-        component: Object.assign({}, this.page || this.widget || this.standard, { config: this.modalParams }),
-        store: this.$store.getters.trackedItems,
-        config: this.modalParams
-      }
-    },
-    page () {
-      return (this.uid.indexOf('page:') === 0) ? this.$store.getters.page(this.uid.substring(5)) : null
-    },
-    widget () {
-      return (this.uid.indexOf('widget:') === 0) ? this.$store.getters.widget(this.uid.substring(7)) : null
-    },
-    standard () {
-      return (this.uid.indexOf('oh-') === 0) ? { component: this.uid } : null
-    },
-    ready () {
-      return this.page || this.widget || this.standard
-    },
-    componentType () {
-      if (this.page) {
-        return this.page.component
-      } else if (this.widget || this.standard) {
-        return 'generic-widget-component'
-      }
-      return null
-    }
-  }
+  mixins: [modal]
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
@@ -13,6 +13,8 @@
 .aurora .player-controls
   .button
     height 37px
+  .segmented-highlight
+    display none
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
@@ -12,6 +12,8 @@
   .button
     height 48px
     width 48px
+  .segmented-highlight
+    display none
 .aurora .rollershutter-controls
   .button
     height 37px

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -10,17 +10,19 @@
       </f7-nav-right>
     </f7-navbar>
 
-    <f7-toolbar tabbar labels bottom v-if="page && pageType === 'tabs'">
+    <f7-toolbar tabbar labels bottom v-if="page && pageType === 'tabs' && visibleToCurrentUser">
       <f7-link v-for="(tab, idx) in page.slots.default" :key="idx" tab-link @click="currentTab = idx" :tab-link-active="currentTab === idx" :icon-ios="tab.config.icon" :icon-md="tab.config.icon" :icon-aurora="tab.config.icon" :text="tab.config.title"></f7-link>
     </f7-toolbar>
 
-    <f7-tabs v-if="page && pageType === 'tabs'" :class="{notready: !ready}">
+    <f7-tabs v-if="page && pageType === 'tabs' && visibleToCurrentUser" :class="{notready: !ready}">
       <f7-tab v-for="(tab, idx) in page.slots.default" :key="idx" :tab-active="currentTab === idx">
         <component v-if="currentTab === idx" :is="tabComponent(tab)" :context="tabContext(tab)" @command="onCommand" />
       </f7-tab>
     </f7-tabs>
 
-    <component :is="page.component" v-if="page" :context="context" :class="{notready: !ready}" @command="onCommand" />
+    <component :is="page.component" v-if="page && visibleToCurrentUser" :context="context" :class="{notready: !ready}" @command="onCommand" />
+
+    <empty-state-placeholder v-if="!visibleToCurrentUser" icon="multiply_circle_fill" title="page.unavailable.title" text="page.unavailable.text" />
 
   </f7-page>
 </template>
@@ -82,6 +84,14 @@ export default {
     },
     isAdmin () {
       return this.ready && this.$store.getters.isAdmin
+    },
+    visibleToCurrentUser () {
+      if (!this.page || !this.page.config || !this.page.config.visibleTo) return true
+      const user = this.$store.getters.user
+      if (!user) return false
+      if (user.roles && user.roles.some(r => this.page.config.visibleTo.indexOf('role:' + r) >= 0)) return true
+      if (this.page.config.visibleTo.indexOf('user:' + user.name) >= 0) return true
+      return false
     },
     showBackButton () {
       return this.deep && (!this.page || !this.page.config.sidebar)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -1,10 +1,6 @@
 <template>
   <f7-page name="Model" :stacked="true" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" @click="selectItem(null)">
     <f7-navbar title="Semantic Model" back-link="Settings" back-link-url="/settings/" back-link-force>
-      <f7-nav-right>
-        <!-- <f7-link icon-md="material:done_all" @click="toggleCheck()"
-        :text="(!$theme.md) ? ((showCheckboxes) ? 'Done' : 'Select') : ''"></f7-link> -->
-      </f7-nav-right>
       <f7-subnavbar :inner="false" v-show="initSearchbar">
         <f7-searchbar
           v-if="initSearchbar"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -122,6 +122,8 @@ import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
 import ChartDesigner from '@/components/pagedesigner/chart/chart-designer.vue'
 import ChartWidgetsDefinitions from './chart-widgets-definitions'
 
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
 export default {
   mixins: [PageDesigner],
   components: {
@@ -130,7 +132,8 @@ export default {
     PageSettings,
     WidgetConfigPopup,
     WidgetCodePopup,
-    ChartDesigner
+    ChartDesigner,
+    ConfigSheet
   },
   props: ['createMode', 'uid'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -47,30 +47,6 @@
 
     </f7-tabs>
 
-    <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
-      <f7-page v-if="currentComponent && currentWidget">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit {{currentWidget.label || currentWidget.uid}}</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetConfig">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="currentWidget.props">
-          <f7-col>
-            <config-sheet
-              :parameterGroups="currentWidget.props.parameterGroups || []"
-              :parameters="currentWidget.props.parameters || []"
-              :configuration="currentComponentConfig"
-              @updated="dirty = true"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
-
     <f7-popup ref="slotConfig" class="slotconfig-popup" close-on-escape :opened="widgetSlotConfigOpened" @popup:closed="widgetConfigClosed">
       <f7-page v-if="currentSlot">
         <f7-navbar>
@@ -106,30 +82,8 @@
       </f7-page>
     </f7-popup>
 
-    <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape :opened="widgetCodeOpened" @popup:closed="widgetCodeClosed">
-      <f7-page v-if="currentComponent && widgetCodeOpened">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit Widget Code</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetCode">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <editor class="page-code-editor" mode="text/x-yaml" :value="widgetYaml" @input="(value) => widgetYaml = value" />
-        <pre v-if="widgetYamlError !== 'OK'" class="yaml-message padding-horizontal" :class="['text-color-red']">{{widgetYamlError}}</pre>
-        <div class="code-editor-docs-link"
-          v-if="widgetYamlError === 'OK' && getWidgetDefinition(currentComponent.component) && getWidgetDefinition(currentComponent.component).docLink">
-          <f7-list>
-            <f7-list-button target="_blank" external color="blue"
-            :href="getWidgetDefinition(currentComponent.component).docLink">
-              Apache ECharts Option Reference
-            </f7-list-button>
-          </f7-list>
-        </div>
-      </f7-page>
-    </f7-popup>
+    <widget-config-popup :opened="widgetConfigOpened" :component="currentComponent" :widget="currentWidget" @closed="widgetConfigClosed" @update="updateWidgetConfig" />
+    <widget-code-popup :opened="widgetCodeOpened" :component="currentComponent" :widget-yaml="widgetYaml" @closed="widgetCodeClosed" @update="updateWidgetCode" />
   </f7-page>
 </template>
 
@@ -162,10 +116,11 @@ import YAML from 'yaml'
 import OhChartPage from '@/components/widgets/chart/oh-chart-page.vue'
 
 import PageSettings from '@/components/pagedesigner/page-settings.vue'
+import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
+import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
+
 import ChartDesigner from '@/components/pagedesigner/chart/chart-designer.vue'
 import ChartWidgetsDefinitions from './chart-widgets-definitions'
-
-import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
   mixins: [PageDesigner],
@@ -173,8 +128,9 @@ export default {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     OhChartPage,
     PageSettings,
-    ChartDesigner,
-    ConfigSheet
+    WidgetConfigPopup,
+    WidgetCodePopup,
+    ChartDesigner
   },
   props: ['createMode', 'uid'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -36,45 +36,8 @@
       </f7-tab>
     </f7-tabs>
 
-    <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
-      <f7-page v-if="currentComponent && currentWidget">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit {{currentWidget.label || currentWidget.uid}}</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetConfig">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="currentWidget.props">
-          <f7-col>
-            <config-sheet
-              :parameterGroups="currentWidget.props.parameterGroups || []"
-              :parameters="currentWidget.props.parameters || []"
-              :configuration="currentComponentConfig"
-              @updated="dirty = true"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
-
-    <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape :opened="widgetCodeOpened" @popup:closed="widgetCodeClosed">
-      <f7-page v-if="currentComponent && widgetCodeOpened">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit Widget Code</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetCode">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <editor class="page-code-editor" mode="text/x-yaml" :value="widgetYaml" @input="(value) => widgetYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
-      </f7-page>
-    </f7-popup>
+    <widget-config-popup :opened="widgetConfigOpened" :component="currentComponent" :widget="currentWidget" @closed="widgetConfigClosed" @update="updateWidgetConfig" />
+    <widget-code-popup :opened="widgetCodeOpened" :component="currentComponent" :widget-yaml="widgetYaml" @closed="widgetCodeClosed" @update="updateWidgetCode" />
   </f7-page>
 </template>
 
@@ -116,8 +79,8 @@ import * as StandardWidgets from '@/components/widgets/standard/index'
 import * as LayoutWidgets from '@/components/widgets/layout/index'
 
 import PageSettings from '@/components/pagedesigner/page-settings.vue'
-
-import ConfigSheet from '@/components/config/config-sheet.vue'
+import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
+import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
 
 export default {
   mixins: [PageDesigner],
@@ -125,7 +88,8 @@ export default {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     OhLayoutPage,
     PageSettings,
-    ConfigSheet
+    WidgetConfigPopup,
+    WidgetCodePopup
   },
   props: ['createMode', 'uid'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -22,41 +22,18 @@
           <div>Loading...</div>
         </f7-block>
         <f7-block class="block-narrow" v-if="ready && !previewMode">
-          <f7-col>
-            <f7-list inline-labels>
-              <f7-list-input label="ID" type="text" placeholder="ID" :value="page.uid" @input="page.uid = $event.target.value"
-                required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only" :disabled="!createMode">
-              </f7-list-input>
-              <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" clear-button>
-              </f7-list-input>
-              <f7-list-item title="Show on sidebar">
-                <f7-toggle slot="after" :checked="page.config.sidebar" @toggle:change="page.config.sidebar = $event"></f7-toggle>
-              </f7-list-item>
-              <f7-list-input label="Sidebar order" type="number" placeholder="Assign order index to rearrange pages on sidebar" :value="page.config.order" @input="page.config.order = $event.target.value" clear-button>
-              </f7-list-input>
-            </f7-list>
-          </f7-col>
+          <page-settings :page="page" :createMode="createMode" />
         </f7-block>
 
         <oh-layout-page class="layout-page" v-if="ready" :context="context" :key="pageKey"
           @add-block="addBlock"
           @add-masonry="addMasonry"
         />
-
-        <!-- <f7-actions ref="widgetTypeSelection" id="widget-type-selection" :grid="true">
-          <f7-actions-group>
-            <f7-actions-button v-for="widgetType in widgetTypes" :key="widgetType.type" @click="addWidget(widgetType.type)">
-              <f7-icon :f7="widgetType.icon" slot="media" />
-              <span>{{widgetType.type}}</span>
-            </f7-actions-button>
-          </f7-actions-group>
-        </f7-actions> -->
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
       </f7-tab>
-
     </f7-tabs>
 
     <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
@@ -129,6 +106,8 @@
 </style>
 
 <script>
+import PageDesigner from '../pagedesigner-mixin'
+
 import YAML from 'yaml'
 
 import OhLayoutPage from '@/components/widgets/layout/oh-layout-page.vue'
@@ -136,168 +115,30 @@ import * as SystemWidgets from '@/components/widgets/system/index'
 import * as StandardWidgets from '@/components/widgets/standard/index'
 import * as LayoutWidgets from '@/components/widgets/layout/index'
 
+import PageSettings from '@/components/pagedesigner/page-settings.vue'
+
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
+  mixins: [PageDesigner],
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     OhLayoutPage,
+    PageSettings,
     ConfigSheet
   },
   props: ['createMode', 'uid'],
   data () {
     return {
-      pageReady: false,
-      loading: false,
       page: {
         uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-layout-page',
         config: {},
         slots: { default: [] }
-      },
-      pageKey: this.$f7.utils.id(),
-      pageYaml: null,
-      previewMode: false,
-      currentTab: 'design',
-      clipboard: null,
-      clipboardType: null,
-      currentComponent: null,
-      currentComponentConfig: null,
-      currentWidget: null,
-      widgetConfigOpened: false,
-      widgetCodeOpened: false,
-      widgetYaml: null
-    }
-  },
-  computed: {
-    ready () {
-      return this.pageReady && this.$store.state.components.widgets != null
-    },
-    context () {
-      return {
-        component: this.page,
-        store: this.$store.getters.trackedItems,
-        // states: this.stateTracking.store,
-        editmode: (!this.previewMode) ? {
-          addWidget: this.addWidget,
-          configureWidget: this.configureWidget,
-          editWidgetCode: this.editWidgetCode,
-          cutWidget: this.cutWidget,
-          copyWidget: this.copyWidget,
-          pasteWidget: this.pasteWidget,
-          moveWidgetUp: this.moveWidgetUp,
-          moveWidgetDown: this.moveWidgetDown,
-          removeWidget: this.removeWidget
-        } : null,
-        clipboardtype: this.clipboardType
-      }
-    },
-    yamlError () {
-      if (this.currentTab !== 'code') return null
-      try {
-        YAML.parse(this.pageYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
-      }
-    },
-    widgetYamlError () {
-      if (!this.widgetCodeOpened) return null
-      try {
-        YAML.parse(this.widgetYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
       }
     }
   },
   methods: {
-    onPageAfterIn () {
-      if (window) {
-        window.addEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('startTrackingStates')
-      this.load()
-    },
-    onPageBeforeOut () {
-      if (window) {
-        window.removeEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('stopTrackingStates')
-    },
-    keyDown (ev) {
-      if (ev.ctrlKey || ev.metakKey) {
-        switch (ev.keyCode) {
-          case 82:
-            this.previewMode = !this.previewMode
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-          case 83:
-            this.save(!this.createMode)
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-        }
-      }
-    },
-    load () {
-      if (this.loading) return
-      this.loading = true
-
-      if (this.createMode) {
-        this.loading = false
-        this.pageReady = true
-      } else {
-        this.$oh.api.get('/rest/ui/components/ui:page/' + this.uid).then((data) => {
-          this.$set(this, 'page', data)
-          this.pageReady = true
-          this.loading = false
-        })
-      }
-    },
-    save (stay) {
-      if (!this.page.uid) {
-        this.$f7.dialog.alert('Please give an ID to the page')
-        return
-      }
-      if (!this.page.config.label) {
-        this.$f7.dialog.alert('Please give an label to the page')
-        return
-      }
-      if (!this.createMode && this.uid !== this.page.uid) {
-        this.$f7.dialog.alert('You cannot change the ID of an existing page. Duplicate it with the new ID then delete this one.')
-        return
-      }
-
-      const promise = (this.createMode)
-        ? this.$oh.api.postPlain('/rest/ui/components/ui:page', JSON.stringify(this.page), 'text/plain', 'application/json')
-        : this.$oh.api.put('/rest/ui/components/ui:page/' + this.page.uid, this.page)
-      promise.then((data) => {
-        if (this.createMode) {
-          this.$f7.toast.create({
-            text: 'Page created',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-          this.load()
-        } else {
-          this.$f7.toast.create({
-            text: 'Page updated',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-        }
-        this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
-      }).catch((err) => {
-        this.$f7.toast.create({
-          text: 'Error while saving page: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-      })
-    },
     addWidget (component, widgetType, parentContext, slot) {
       if (!slot) slot = 'default'
       if (!component.slots) component.slots = {}
@@ -351,28 +192,6 @@ export default {
         }).open()
       }
     },
-    widgetConfigClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetConfigOpened = false
-    },
-    updateWidgetConfig () {
-      this.$set(this.currentComponent, 'config', this.currentComponentConfig)
-      this.forceUpdate()
-      this.widgetConfigClosed()
-    },
-    widgetCodeClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetCodeOpened = false
-    },
-    updateWidgetCode () {
-      const updatedWidget = YAML.parse(this.widgetYaml)
-      this.$set(this.currentComponent, 'config', updatedWidget.config)
-      this.$set(this.currentComponent, 'slots', updatedWidget.slots)
-      this.forceUpdate()
-      this.widgetCodeClosed()
-    },
     addBlock (component) {
       component.slots.default.push({
         component: 'oh-block',
@@ -389,83 +208,10 @@ export default {
         }])
       }
     },
-    configureWidget (component, parentContext, forceComponentType) {
-      const componentType = forceComponentType || component.component
-      this.currentComponent = null
-      this.currentWidget = null
-      let widgetDefinition
-      if (componentType.indexOf('widget:') === 0) {
-        this.currentWidget = this.$store.getters.widget(componentType.substring(7))
-      } else {
-        widgetDefinition = Object.values({ ...SystemWidgets, ...LayoutWidgets, ...StandardWidgets }).find((w) => w.widget && w.widget.name === componentType)
-        if (!widgetDefinition) {
-          // widgetDefinition = Object.values(LayoutWidgets).find((w) => w.widget.name === component.component)
-          if (!widgetDefinition) {
-            console.warn('Widget not found: ' + componentType)
-            this.$f7.toast.create({
-              text: `This type of component cannot be configured: ${componentType}.`,
-              destroyOnClose: true,
-              closeTimeout: 3000,
-              closeButton: true,
-              closeButtonText: 'Edit YAML',
-              on: {
-                closeButtonClick: () => {
-                  this.editWidgetCode(component, parentContext)
-                }
-              }
-            }).open()
-            return
-          }
-        }
-        this.currentWidget = widgetDefinition.widget
-      }
-      this.currentComponent = component
-      this.currentComponentConfig = JSON.parse(JSON.stringify(this.currentComponent.config))
-      this.widgetConfigOpened = true
-    },
-    editWidgetCode (component, parentContext, slot) {
-      if (slot && !component.slots) component.slots = {}
-      if (slot && !component.slots[slot]) component.slots[slot] = []
-      this.currentComponent = component
-      this.widgetYaml = YAML.stringify(component)
-      this.widgetCodeOpened = true
-    },
-    cutWidget (component, parentContext) {
-      this.copyWidget(component, parentContext)
-      this.removeWidget(component, parentContext)
-    },
-    copyWidget (component, parentContext) {
-      let newClipboard = JSON.stringify(component)
-      this.$set(this, 'clipboard', newClipboard)
-      this.clipboardType = component.component
-    },
-    pasteWidget (component, parentContext) {
-      if (!this.clipboard) return
-      component.slots.default.push(JSON.parse(this.clipboard))
-      this.forceUpdate()
-    },
-    moveWidgetUp (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos <= 0) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos - 1, 0, component)
-      this.forceUpdate()
-    },
-    moveWidgetDown (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos >= siblings.length - 1) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos + 1, 0, component)
-      this.forceUpdate()
-    },
-    removeWidget (component, parentContext) {
-      parentContext.component.slots.default.splice(parentContext.component.slots.default.indexOf(component), 1)
-      this.forceUpdate()
-    },
-    forceUpdate () {
-      this.pageKey = this.$f7.utils.id()
+    getWidgetDefinition (componentType) {
+      const component = Object.values({ ...SystemWidgets, ...LayoutWidgets, ...StandardWidgets }).find((w) => w.widget && w.widget.name === componentType)
+      if (!component) return null
+      return component.widget
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -74,45 +74,8 @@
       </f7-tab>
     </f7-tabs>
 
-    <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
-      <f7-page v-if="currentComponent && currentWidget">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit {{currentWidget.label || currentWidget.uid}}</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetConfig">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="currentWidget.props">
-          <f7-col>
-            <config-sheet
-              :parameterGroups="currentWidget.props.parameterGroups || []"
-              :parameters="currentWidget.props.parameters || []"
-              :configuration="currentComponentConfig"
-              @updated="dirty = true"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
-
-    <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape :opened="widgetCodeOpened" @popup:closed="widgetCodeClosed">
-      <f7-page v-if="currentComponent && widgetCodeOpened">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit Widget Code</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetCode">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <editor class="page-code-editor" mode="text/x-yaml" :value="widgetYaml" @input="(value) => widgetYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
-      </f7-page>
-    </f7-popup>
+    <widget-config-popup :opened="widgetConfigOpened" :component="currentComponent" :widget="currentWidget" @closed="widgetConfigClosed" @update="updateWidgetConfig" />
+    <widget-code-popup :opened="widgetCodeOpened" :component="currentComponent" :widget-yaml="widgetYaml" @closed="widgetCodeClosed" @update="updateWidgetCode" />
   </f7-page>
 </template>
 
@@ -147,8 +110,8 @@ const ConfigurableWidgets = {
 }
 
 import PageSettings from '@/components/pagedesigner/page-settings.vue'
-
-import ConfigSheet from '@/components/config/config-sheet.vue'
+import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
+import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
 
 export default {
   mixins: [PageDesigner],
@@ -156,11 +119,13 @@ export default {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     'oh-map-page': () => import('@/components/widgets/map/oh-map-page.vue'),
     PageSettings,
-    ConfigSheet
+    WidgetConfigPopup,
+    WidgetCodePopup
   },
   props: ['createMode', 'uid'],
   data () {
     return {
+      forceEditMode: true,
       page: {
         uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-map-page',

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -8,7 +8,6 @@
     </f7-navbar>
     <f7-toolbar tabbar position="top">
       <f7-link @click="currentTab = 'design'; fromYaml()" :tab-link-active="currentTab === 'design'" class="tab-link">Design</f7-link>
-      <!-- <f7-link @click="currentTab = 'preview'" :tab-link-active="currentTab === 'preview'" class="tab-link">Preview</f7-link> -->
       <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
     <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'design'">
@@ -16,6 +15,7 @@
         <f7-toggle :checked="previewMode" @toggle:change="(value) => previewMode = value"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </div>
     </f7-toolbar>
+
     <f7-tabs class="map-editor-tabs">
       <f7-tab id="design" class="map-editor-design-tab" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
         <f7-block v-if="!ready" class="text-align-center">
@@ -23,20 +23,7 @@
           <div>Loading...</div>
         </f7-block>
         <f7-block class="block-narrow" v-if="ready && !previewMode">
-          <f7-col>
-            <f7-list inline-labels>
-              <f7-list-input label="ID" type="text" placeholder="ID" :value="page.uid" @input="page.uid = $event.target.value"
-                required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only" :disabled="!createMode">
-              </f7-list-input>
-              <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" clear-button>
-              </f7-list-input>
-              <f7-list-item title="Show on sidebar">
-                <f7-toggle slot="after" :checked="page.config.sidebar" @toggle:change="page.config.sidebar = $event"></f7-toggle>
-              </f7-list-item>
-              <f7-list-input label="Sidebar order" type="number" placeholder="Assign order index to rearrange pages on sidebar" :value="page.config.order" @input="page.config.order = $event.target.value" clear-button>
-              </f7-list-input>
-            </f7-list>
-          </f7-col>
+          <page-settings :page="page" :createMode="createMode" />
         </f7-block>
 
         <f7-block class="block-narrow" style="padding-bottom: 8rem" v-if="ready && !previewMode">
@@ -74,23 +61,17 @@
               </f7-list-item>
               <f7-list-button color="blue" title="Add marker" @click="addWidget(page, 'oh-map-marker')" />
               <f7-list-button color="blue" title="Add circle marker" @click="addWidget(page, 'oh-map-circle-marker')" />
-              <!-- <f7-list-button color="blue" title="Add marker" @click="addWidget(page, 'oh-map-radius')" /> -->
             </f7-list>
           </f7-col>
         </f7-block>
 
         <oh-map-page class="map-page" v-else-if="ready && previewMode" :context="context" :key="pageKey" />
-
       </f7-tab>
-
-      <!-- <f7-tab id="preview" class="map-editor-preview-tab" @tab:show="() => this.currentTab = 'preview'" :tab-active="currentTab === 'preview'">
-      </f7-tab> -->
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
       </f7-tab>
-
     </f7-tabs>
 
     <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
@@ -153,183 +134,42 @@
 </style>
 
 <script>
+import PageDesigner from '../pagedesigner-mixin'
+
 import YAML from 'yaml'
 
-// import OhMapPage from '@/components/widgets/map/oh-map-page.vue'
 import OhMapMarker from '@/components/widgets/map/oh-map-marker.vue'
 import OhMapCircleMarker from '@/components/widgets/map/oh-map-circle-marker.vue'
 
-// const ConfigurableWidgets = {
-//   'oh-map-marker': () => import('@/components/widgets/map/oh-map-marker.vue'),
-//   'oh-map-circle-marker': () => import('@/components/widgets/map/oh-map-circle-marker.vue')
-// }
 const ConfigurableWidgets = {
   OhMapMarker,
   OhMapCircleMarker
 }
 
+import PageSettings from '@/components/pagedesigner/page-settings.vue'
+
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
+  mixins: [PageDesigner],
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     'oh-map-page': () => import('@/components/widgets/map/oh-map-page.vue'),
+    PageSettings,
     ConfigSheet
   },
   props: ['createMode', 'uid'],
   data () {
     return {
-      pageReady: false,
-      loading: false,
       page: {
         uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-map-page',
         config: {},
         slots: { default: [] }
-      },
-      pageKey: this.$f7.utils.id(),
-      pageYaml: null,
-      previewMode: false,
-      currentTab: 'design',
-      clipboard: null,
-      clipboardType: null,
-      currentComponent: null,
-      currentComponentConfig: null,
-      currentWidget: null,
-      widgetConfigOpened: false,
-      widgetCodeOpened: false,
-      widgetYaml: null
-    }
-  },
-  computed: {
-    ready () {
-      return this.pageReady && this.$store.state.components.widgets != null
-    },
-    context () {
-      return {
-        component: this.page,
-        store: this.$store.getters.trackedItems,
-        // states: this.stateTracking.store,
-        editmode: (!this.previewMode) ? {
-          addWidget: this.addWidget,
-          configureWidget: this.configureWidget,
-          editWidgetCode: this.editWidgetCode,
-          cutWidget: this.cutWidget,
-          copyWidget: this.copyWidget,
-          pasteWidget: this.pasteWidget,
-          moveWidgetUp: this.moveWidgetUp,
-          moveWidgetDown: this.moveWidgetDown,
-          removeWidget: this.removeWidget
-        } : null,
-        clipboardtype: this.clipboardType
-      }
-    },
-    yamlError () {
-      if (this.currentTab !== 'code') return null
-      try {
-        YAML.parse(this.pageYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
-      }
-    },
-    widgetYamlError () {
-      if (!this.widgetCodeOpened) return null
-      try {
-        YAML.parse(this.widgetYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
       }
     }
   },
   methods: {
-    onPageAfterIn () {
-      if (window) {
-        window.addEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('startTrackingStates')
-      this.load()
-    },
-    onPageBeforeOut () {
-      if (window) {
-        window.removeEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('stopTrackingStates')
-    },
-    keyDown (ev) {
-      if (ev.ctrlKey || ev.metakKey) {
-        switch (ev.keyCode) {
-          case 82:
-            this.previewMode = !this.previewMode
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-          case 83:
-            this.save(!this.createMode)
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-        }
-      }
-    },
-    load () {
-      if (this.loading) return
-      this.loading = true
-
-      if (this.createMode) {
-        this.loading = false
-        this.pageReady = true
-      } else {
-        this.$oh.api.get('/rest/ui/components/ui:page/' + this.uid).then((data) => {
-          this.$set(this, 'page', data)
-          this.pageReady = true
-          this.loading = false
-        })
-      }
-    },
-    save (stay) {
-      if (!this.page.uid) {
-        this.$f7.dialog.alert('Please give an ID to the page')
-        return
-      }
-      if (!this.page.config.label) {
-        this.$f7.dialog.alert('Please give an label to the page')
-        return
-      }
-      if (!this.createMode && this.uid !== this.page.uid) {
-        this.$f7.dialog.alert('You cannot change the ID of an existing page. Duplicate it with the new ID then delete this one.')
-        return
-      }
-
-      const promise = (this.createMode)
-        ? this.$oh.api.postPlain('/rest/ui/components/ui:page', JSON.stringify(this.page), 'text/plain', 'application/json')
-        : this.$oh.api.put('/rest/ui/components/ui:page/' + this.page.uid, this.page)
-      promise.then((data) => {
-        if (this.createMode) {
-          this.$f7.toast.create({
-            text: 'Page created',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-          this.load()
-        } else {
-          this.$f7.toast.create({
-            text: 'Page updated',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-        }
-        this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
-      }).catch((err) => {
-        this.$f7.toast.create({
-          text: 'Error while saving page: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-      })
-    },
     markerDefaultIcon (marker) {
       const widgetDefinition = Object.values(ConfigurableWidgets).find((c) => c.widget.name === marker.component)
       if (widgetDefinition) {
@@ -350,105 +190,10 @@ export default {
         this.forceUpdate()
       }
     },
-    widgetConfigClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetConfigOpened = false
-    },
-    updateWidgetConfig () {
-      this.$set(this.currentComponent, 'config', this.currentComponentConfig)
-      this.forceUpdate()
-      this.widgetConfigClosed()
-    },
-    widgetCodeClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetCodeOpened = false
-    },
-    updateWidgetCode () {
-      const updatedWidget = YAML.parse(this.widgetYaml)
-      this.$set(this.currentComponent, 'config', updatedWidget.config)
-      this.$set(this.currentComponent, 'slots', updatedWidget.slots)
-      this.forceUpdate()
-      this.widgetCodeClosed()
-    },
-    configureWidget (component, parentContext, forceComponentType) {
-      const componentType = forceComponentType || component.component
-      this.currentComponent = null
-      this.currentWidget = null
-      let widgetDefinition
-      if (componentType.indexOf('widget:') === 0) {
-        this.currentWidget = this.$store.getters.widget(componentType.substring(7))
-      } else {
-        widgetDefinition = Object.values(ConfigurableWidgets).find((w) => w.widget && w.widget.name === componentType)
-        if (!widgetDefinition) {
-          // widgetDefinition = Object.values(LayoutWidgets).find((w) => w.widget.name === component.component)
-          if (!widgetDefinition) {
-            console.warn('Widget not found: ' + componentType)
-            this.$f7.toast.create({
-              text: `This type of component cannot be configured: ${componentType}.`,
-              destroyOnClose: true,
-              closeTimeout: 3000,
-              closeButton: true,
-              closeButtonText: 'Edit YAML',
-              on: {
-                closeButtonClick: () => {
-                  this.editWidgetCode(component, parentContext)
-                }
-              }
-            }).open()
-            return
-          }
-        }
-        this.currentWidget = widgetDefinition.widget
-      }
-      this.currentComponent = component
-      this.currentComponentConfig = JSON.parse(JSON.stringify(this.currentComponent.config))
-      this.widgetConfigOpened = true
-    },
-    editWidgetCode (component, parentContext, slot) {
-      if (slot && !component.slots) component.slots = {}
-      if (slot && !component.slots[slot]) component.slots[slot] = []
-      this.currentComponent = component
-      this.widgetYaml = YAML.stringify(component)
-      this.widgetCodeOpened = true
-    },
-    cutWidget (component, parentContext) {
-      this.copyWidget(component, parentContext)
-      this.removeWidget(component, parentContext)
-    },
-    copyWidget (component, parentContext) {
-      let newClipboard = JSON.stringify(component)
-      this.$set(this, 'clipboard', newClipboard)
-      this.clipboardType = component.component
-    },
-    pasteWidget (component, parentContext) {
-      if (!this.clipboard) return
-      component.slots.default.push(JSON.parse(this.clipboard))
-      this.forceUpdate()
-    },
-    moveWidgetUp (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos <= 0) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos - 1, 0, component)
-      this.forceUpdate()
-    },
-    moveWidgetDown (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos >= siblings.length - 1) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos + 1, 0, component)
-      this.forceUpdate()
-    },
-    removeWidget (component, parentContext) {
-      parentContext.component.slots.default.splice(parentContext.component.slots.default.indexOf(component), 1)
-      this.forceUpdate()
-    },
-    forceUpdate () {
-      this.pageKey = this.$f7.utils.id()
+    getWidgetDefinition (componentType) {
+      const component = Object.values(ConfigurableWidgets).find((w) => w.widget && w.widget.name === componentType)
+      if (!component) return null
+      return component.widget
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -12,11 +12,9 @@ export default {
       clipboard: null,
       clipboardType: null,
       currentComponent: null,
-      currentComponentConfig: null,
       currentWidget: null,
       widgetConfigOpened: false,
-      widgetCodeOpened: false,
-      widgetYaml: null
+      widgetCodeOpened: false
     }
   },
   computed: {
@@ -27,7 +25,7 @@ export default {
       return {
         component: this.page,
         store: this.$store.getters.trackedItems,
-        editmode: (!this.previewMode) ? {
+        editmode: (!this.previewMode || this.forceEditMode) ? {
           addWidget: this.addWidget,
           configureWidget: this.configureWidget,
           configureSlot: this.configureSlot,
@@ -46,15 +44,6 @@ export default {
       if (this.currentTab !== 'code') return null
       try {
         YAML.parse(this.pageYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
-      }
-    },
-    widgetYamlError () {
-      if (!this.widgetCodeOpened) return null
-      try {
-        YAML.parse(this.widgetYaml, { prettyErrors: true })
         return 'OK'
       } catch (e) {
         return e
@@ -154,8 +143,8 @@ export default {
       this.currentWidget = null
       this.widgetConfigOpened = false
     },
-    updateWidgetConfig () {
-      this.$set(this.currentComponent, 'config', this.currentComponentConfig)
+    updateWidgetConfig (config) {
+      this.$set(this.currentComponent, 'config', config)
       this.forceUpdate()
       this.widgetConfigClosed()
     },
@@ -164,8 +153,8 @@ export default {
       this.currentWidget = null
       this.widgetCodeOpened = false
     },
-    updateWidgetCode () {
-      const updatedWidget = YAML.parse(this.widgetYaml)
+    updateWidgetCode (code) {
+      const updatedWidget = YAML.parse(code)
       this.$set(this.currentComponent, 'config', updatedWidget.config)
       this.$set(this.currentComponent, 'slots', updatedWidget.slots)
       this.forceUpdate()
@@ -200,14 +189,12 @@ export default {
         this.currentWidget = widgetDefinition
       }
       this.currentComponent = component
-      this.currentComponentConfig = JSON.parse(JSON.stringify(this.currentComponent.config))
       this.widgetConfigOpened = true
     },
     editWidgetCode (component, parentContext, slot) {
       if (slot && !component.slots) component.slots = {}
       if (slot && !component.slots[slot]) component.slots[slot] = []
       this.currentComponent = component
-      this.widgetYaml = YAML.stringify(component)
       this.widgetCodeOpened = true
     },
     cutWidget (component, parentContext, slot = 'default') {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -1,0 +1,260 @@
+import YAML from 'yaml'
+
+export default {
+  data () {
+    return {
+      pageReady: false,
+      loading: false,
+      pageKey: this.$f7.utils.id(),
+      pageYaml: null,
+      previewMode: false,
+      currentTab: 'design',
+      clipboard: null,
+      clipboardType: null,
+      currentComponent: null,
+      currentComponentConfig: null,
+      currentWidget: null,
+      widgetConfigOpened: false,
+      widgetCodeOpened: false,
+      widgetYaml: null
+    }
+  },
+  computed: {
+    ready () {
+      return this.pageReady && this.$store.state.components.widgets != null
+    },
+    context () {
+      return {
+        component: this.page,
+        store: this.$store.getters.trackedItems,
+        editmode: (!this.previewMode) ? {
+          addWidget: this.addWidget,
+          configureWidget: this.configureWidget,
+          configureSlot: this.configureSlot,
+          editWidgetCode: this.editWidgetCode,
+          cutWidget: this.cutWidget,
+          copyWidget: this.copyWidget,
+          pasteWidget: this.pasteWidget,
+          moveWidgetUp: this.moveWidgetUp,
+          moveWidgetDown: this.moveWidgetDown,
+          removeWidget: this.removeWidget
+        } : null,
+        clipboardtype: this.clipboardType
+      }
+    },
+    yamlError () {
+      if (this.currentTab !== 'code') return null
+      try {
+        YAML.parse(this.pageYaml, { prettyErrors: true })
+        return 'OK'
+      } catch (e) {
+        return e
+      }
+    },
+    widgetYamlError () {
+      if (!this.widgetCodeOpened) return null
+      try {
+        YAML.parse(this.widgetYaml, { prettyErrors: true })
+        return 'OK'
+      } catch (e) {
+        return e
+      }
+    }
+  },
+  methods: {
+    onPageAfterIn () {
+      if (window) {
+        window.addEventListener('keydown', this.keyDown)
+      }
+      this.$store.dispatch('startTrackingStates')
+      this.load()
+    },
+    onPageBeforeOut () {
+      if (window) {
+        window.removeEventListener('keydown', this.keyDown)
+      }
+      this.$store.dispatch('stopTrackingStates')
+    },
+    keyDown (ev) {
+      if (ev.ctrlKey || ev.metakKey) {
+        switch (ev.keyCode) {
+          case 82:
+            this.previewMode = !this.previewMode
+            ev.stopPropagation()
+            ev.preventDefault()
+            break
+          case 83:
+            this.save(!this.createMode)
+            ev.stopPropagation()
+            ev.preventDefault()
+            break
+        }
+      }
+    },
+    load () {
+      if (this.loading) return
+      this.loading = true
+
+      if (this.createMode) {
+        this.loading = false
+        this.pageReady = true
+      } else {
+        this.$oh.api.get('/rest/ui/components/ui:page/' + this.uid).then((data) => {
+          this.$set(this, 'page', data)
+          this.pageReady = true
+          this.loading = false
+        })
+      }
+    },
+    save (stay) {
+      if (this.currentTab === 'code' && !this.fromYaml()) return
+      if (!this.page.uid) {
+        this.$f7.dialog.alert('Please give an ID to the page')
+        return
+      }
+      if (!this.page.config.label) {
+        this.$f7.dialog.alert('Please give a label to the page')
+        return
+      }
+      if (!this.createMode && this.uid !== this.page.uid) {
+        this.$f7.dialog.alert('You cannot change the ID of an existing page. Duplicate it with the new ID then delete this one.')
+        return
+      }
+
+      const promise = (this.createMode)
+        ? this.$oh.api.postPlain('/rest/ui/components/ui:page', JSON.stringify(this.page), 'text/plain', 'application/json')
+        : this.$oh.api.put('/rest/ui/components/ui:page/' + this.page.uid, this.page)
+      promise.then((data) => {
+        if (this.createMode) {
+          this.$f7.toast.create({
+            text: 'Page created',
+            destroyOnClose: true,
+            closeTimeout: 2000
+          }).open()
+          this.load()
+        } else {
+          this.$f7.toast.create({
+            text: 'Page updated',
+            destroyOnClose: true,
+            closeTimeout: 2000
+          }).open()
+        }
+        this.$f7.emit('sidebarRefresh', null)
+        if (!stay) this.$f7router.back()
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while saving page: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
+    },
+    widgetConfigClosed () {
+      this.currentComponent = null
+      this.currentWidget = null
+      this.widgetConfigOpened = false
+    },
+    updateWidgetConfig () {
+      this.$set(this.currentComponent, 'config', this.currentComponentConfig)
+      this.forceUpdate()
+      this.widgetConfigClosed()
+    },
+    widgetCodeClosed () {
+      this.currentComponent = null
+      this.currentWidget = null
+      this.widgetCodeOpened = false
+    },
+    updateWidgetCode () {
+      const updatedWidget = YAML.parse(this.widgetYaml)
+      this.$set(this.currentComponent, 'config', updatedWidget.config)
+      this.$set(this.currentComponent, 'slots', updatedWidget.slots)
+      this.forceUpdate()
+      this.widgetCodeClosed()
+    },
+    configureWidget (component, parentContext, forceComponentType) {
+      const componentType = forceComponentType || component.component
+      this.currentComponent = null
+      this.currentWidget = null
+      let widgetDefinition
+      if (componentType.indexOf('widget:') === 0) {
+        this.currentWidget = this.$store.getters.widget(componentType.substring(7))
+      } else {
+        // getWidgetDefinition should be defined locally in the page designers SFCs
+        widgetDefinition = this.getWidgetDefinition(componentType)
+        if (!widgetDefinition) {
+          console.warn('Widget not found: ' + componentType)
+          this.$f7.toast.create({
+            text: `This type of component cannot be configured: ${componentType}.`,
+            destroyOnClose: true,
+            closeTimeout: 3000,
+            closeButton: true,
+            closeButtonText: 'Edit YAML',
+            on: {
+              closeButtonClick: () => {
+                this.editWidgetCode(component, parentContext)
+              }
+            }
+          }).open()
+          return
+        }
+        this.currentWidget = widgetDefinition
+      }
+      this.currentComponent = component
+      this.currentComponentConfig = JSON.parse(JSON.stringify(this.currentComponent.config))
+      this.widgetConfigOpened = true
+    },
+    editWidgetCode (component, parentContext, slot) {
+      if (slot && !component.slots) component.slots = {}
+      if (slot && !component.slots[slot]) component.slots[slot] = []
+      this.currentComponent = component
+      this.widgetYaml = YAML.stringify(component)
+      this.widgetCodeOpened = true
+    },
+    cutWidget (component, parentContext, slot = 'default') {
+      this.copyWidget(component, parentContext)
+      this.removeWidget(component, parentContext)
+    },
+    copyWidget (component, parentContext, slot = 'default') {
+      let newClipboard = JSON.stringify(component)
+      this.$set(this, 'clipboard', newClipboard)
+      this.clipboardType = component.component
+    },
+    pasteWidget (component, parentContext, slot = 'default') {
+      if (!this.clipboard) return
+      component.slots[slot].push(JSON.parse(this.clipboard))
+      this.forceUpdate()
+    },
+    moveWidgetUp (component, parentContext, slot = 'default') {
+      let siblings = parentContext.component.slots[slot]
+      let pos = siblings.indexOf(component)
+      if (pos <= 0) return
+      siblings.splice(pos, 1)
+      siblings.splice(pos - 1, 0, component)
+      this.forceUpdate()
+    },
+    moveWidgetDown (component, parentContext, slot = 'default') {
+      let siblings = parentContext.component.slots[slot]
+      let pos = siblings.indexOf(component)
+      if (pos >= siblings.length - 1) return
+      siblings.splice(pos, 1)
+      siblings.splice(pos + 1, 0, component)
+      this.forceUpdate()
+    },
+    removeWidget (component, parentContext, slot = 'default') {
+      parentContext.component.slots[slot].splice(parentContext.component.slots[slot].indexOf(component), 1)
+      this.forceUpdate()
+    },
+    forceUpdate () {
+      this.pageKey = this.$f7.utils.id()
+    },
+    togglePreviewMode (value) {
+      if (value === undefined) value = !this.previewMode
+      if (value === true) {
+        if (this.currentTab === 'code') {
+          if (!this.fromYaml()) return
+        }
+      }
+      this.previewMode = value
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -44,9 +44,15 @@
 
     <!-- skeleton for not ready -->
     <f7-block class="block-narrow">
-      <f7-col v-if="!ready">
-        <f7-block-title>&nbsp;Loading...</f7-block-title>
-        <f7-list contacts-list class="col wide pages-list">
+      <f7-col>
+        <f7-block-title class="searchbar-hide-on-search"><span v-if="ready">{{pages.length}} pages</span><span v-else>Loading...</span></f7-block-title>
+        <div class="padding-left padding-right" v-show="!ready || pages.length > 0">
+          <f7-segmented strong tag="p">
+            <f7-button :active="groupBy === 'alphabetical'" @click="groupBy = 'alphabetical'; $nextTick(() => $refs.listIndex.update())">Alphabetical</f7-button>
+            <f7-button :active="groupBy === 'type'" @click="groupBy = 'type'">By type</f7-button>
+          </f7-segmented>
+        </div>
+        <f7-list v-if="!ready" contacts-list class="col wide pages-list">
           <f7-list-group>
             <f7-list-item
               media-item
@@ -54,22 +60,15 @@
               :key="n"
               :class="`skeleton-text skeleton-effect-blink`"
               title="Title of the page"
-              subtitle="Type of the page"
-              after="status badge"
+              subtitle="Page type"
+              after="The item state"
+              footer="Page UID"
             >
+              <f7-skeleton-block style="width: 32px; height: 32px; border-radius: 50%" slot="media"></f7-skeleton-block>
             </f7-list-item>
           </f7-list-group>
         </f7-list>
-      </f7-col>
-      <f7-col v-else>
-        <f7-block-title class="searchbar-hide-on-search">{{pages.length}} pages</f7-block-title>
-        <div class="padding-left padding-right" v-show="!ready || pages.length > 0">
-          <f7-segmented strong tag="p">
-            <f7-button :active="groupBy === 'alphabetical'" @click="groupBy = 'alphabetical'; $nextTick(() => $refs.listIndex.update())">Alphabetical</f7-button>
-            <f7-button :active="groupBy === 'type'" @click="groupBy = 'type'">By type</f7-button>
-          </f7-segmented>
-        </div>
-        <f7-list
+        <f7-list v-else
           v-show="pages.length > 0"
           class="searchbar-found col pages-list"
           ref="pagesList"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -26,9 +26,17 @@
       </div>
       <div class="right" v-if="$theme.md">
         <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
-        <f7-link icon-md="material:more_vert" icon-color="white" @click="removeSelected"></f7-link>
       </div>
     </f7-toolbar>
+
+    <f7-list-index
+      v-if="ready"
+      ref="listIndex" :key="'pages-index'"
+      v-show="groupBy === 'alphabetical'"
+      list-el=".pages-list"
+      :scroll-list="true"
+      :label="true"
+    ></f7-list-index>
 
     <f7-list class="searchbar-not-found">
       <f7-list-item title="Nothing found"></f7-list-item>
@@ -36,9 +44,9 @@
 
     <!-- skeleton for not ready -->
     <f7-block class="block-narrow">
-      <f7-col v-show="!ready">
+      <f7-col v-if="!ready">
         <f7-block-title>&nbsp;Loading...</f7-block-title>
-        <f7-list media-list class="col wide">
+        <f7-list contacts-list class="col wide pages-list">
           <f7-list-group>
             <f7-list-item
               media-item
@@ -53,34 +61,47 @@
           </f7-list-group>
         </f7-list>
       </f7-col>
-      <f7-col v-if="ready">
+      <f7-col v-else>
         <f7-block-title class="searchbar-hide-on-search">{{pages.length}} pages</f7-block-title>
+        <div class="padding-left padding-right" v-show="!ready || pages.length > 0">
+          <f7-segmented strong tag="p">
+            <f7-button :active="groupBy === 'alphabetical'" @click="groupBy = 'alphabetical'; $nextTick(() => $refs.listIndex.update())">Alphabetical</f7-button>
+            <f7-button :active="groupBy === 'type'" @click="groupBy = 'type'">By type</f7-button>
+          </f7-segmented>
+        </div>
         <f7-list
           v-show="pages.length > 0"
           class="searchbar-found col pages-list"
           ref="pagesList"
-          media-list>
-          <f7-list-item
-            v-for="(page, index) in pages"
-            :key="index"
-            media-item
-            class="pagelist-item"
-            :checkbox="showCheckboxes"
-            :checked="isChecked(page.uid)"
-            @change="(e) => toggleItemCheck(e, page.uid, page)"
-            :link="showCheckboxes ? null : getPageType(page).type + '/' + page.uid"
-            :title="page.config.label"
-            :subtitle="getPageType(page).label"
-            :footer="page.uid"
-          >
-            <div slot="subtitle">
-              <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" ></f7-icon>
-              </f7-chip>
-            </div>
-            <!-- <span slot="media" class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
-            <f7-icon slot="media" color="gray" :f7="getPageIcon(page)" :size="32"></f7-icon>
-          </f7-list-item>
+          :contacts-list="groupBy === 'alphabetical'" media-list>
+          <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
+            <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title></f7-list-item>
+            <f7-list-item
+              v-for="(page, index) in pagesWithInitial"
+              :key="index"
+              media-item
+              class="pagelist-item"
+              :checkbox="showCheckboxes"
+              :checked="isChecked(page.uid)"
+              @change="(e) => toggleItemCheck(e, page.uid, page)"
+              :link="showCheckboxes ? null : getPageType(page).type + '/' + page.uid"
+              :title="page.config.label"
+              :subtitle="getPageType(page).label"
+              :footer="page.uid"
+              :badge="page.config.order"
+            >
+              <div slot="subtitle">
+                <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                  <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" ></f7-icon>
+                </f7-chip>
+                <f7-chip v-for="userrole in page.config.visibleTo || []" :key="userrole" :text="userrole" media-bg-color="green" style="margin-right: 6px">
+                  <f7-icon slot="media" f7="person_crop_circle_fill_badge_checkmark"></f7-icon>
+                </f7-chip>
+              </div>
+              <!-- <span slot="media" class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
+              <f7-icon slot="media" :color="page.config.sidebar ? '' : 'gray'" :f7="getPageIcon(page)" :size="32"></f7-icon>
+            </f7-list-item>
+          </f7-list-group>
         </f7-list>
       </f7-col>
     </f7-block>
@@ -111,6 +132,7 @@ export default {
       pages: [],
       initSearchbar: false,
       selectedItems: [],
+      groupBy: 'alphabetical',
       showCheckboxes: false,
       pageTypes: [
         { type: 'sitemap', label: 'Sitemap', componentType: 'Sitemap', icon: 'menu' },
@@ -122,8 +144,31 @@ export default {
       ]
     }
   },
-  created () {
+  computed: {
+    indexedPages () {
+      if (this.groupBy === 'alphabetical') {
+        return this.pages.reduce((prev, page, i, pages) => {
+          const label = page.config.label || page.uid
+          const initial = label.substring(0, 1).toUpperCase()
+          if (!prev[initial]) {
+            prev[initial] = []
+          }
+          prev[initial].push(page)
 
+          return prev
+        }, {})
+      } else {
+        return this.pages.reduce((prev, page, i, things) => {
+          const type = this.getPageType(page).label
+          if (!prev[type]) {
+            prev[type] = []
+          }
+          prev[type].push(page)
+
+          return prev
+        }, {})
+      }
+    }
   },
   methods: {
     onPageAfterIn () {
@@ -135,6 +180,8 @@ export default {
     load () {
       if (this.loading) return
       this.loading = true
+      this.$set(this, 'selectedItems', [])
+      this.showCheckboxes = false
       var promises = [
         this.$oh.api.get('/rest/ui/components/system:sitemap'),
         this.$oh.api.get('/rest/ui/components/ui:page')
@@ -144,9 +191,10 @@ export default {
         this.pages = pagesAndSitemaps.sort((a, b) => {
           return a.config.label.localeCompare(b.config.label)
         })
+
         this.loading = false
         this.ready = true
-        setTimeout(() => { this.initSearchbar = true })
+        setTimeout(() => { this.initSearchbar = true; this.$refs.listIndex.update() })
       })
     },
     toggleCheck () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -82,45 +82,8 @@
       </f7-tab>
     </f7-tabs>
 
-    <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
-      <f7-page v-if="currentComponent && currentWidget">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit {{currentWidget.label || currentWidget.uid}}</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetConfig">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="currentWidget.props">
-          <f7-col>
-            <config-sheet
-              :parameterGroups="currentWidget.props.parameterGroups || []"
-              :parameters="currentWidget.props.parameters || []"
-              :configuration="currentComponentConfig"
-              @updated="dirty = true"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
-
-    <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape :opened="widgetCodeOpened" @popup:closed="widgetCodeClosed">
-      <f7-page v-if="currentComponent && widgetCodeOpened">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit Widget Code</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetCode">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <editor class="page-code-editor" mode="text/x-yaml" :value="widgetYaml" @input="(value) => widgetYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
-      </f7-page>
-    </f7-popup>
+    <widget-config-popup :opened="widgetConfigOpened" :component="currentComponent" :widget="currentWidget" @closed="widgetConfigClosed" @update="updateWidgetConfig" />
+    <widget-code-popup :opened="widgetCodeOpened" :component="currentComponent" :widget-yaml="widgetYaml" @closed="widgetCodeClosed" @update="updateWidgetCode" />
   </f7-page>
 </template>
 
@@ -154,8 +117,8 @@ const ConfigurableWidgets = {
 }
 
 import PageSettings from '@/components/pagedesigner/page-settings.vue'
-
-import ConfigSheet from '@/components/config/config-sheet.vue'
+import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
+import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
 
 export default {
   mixins: [PageDesigner],
@@ -163,12 +126,14 @@ export default {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     OhPlanPage,
     PageSettings,
-    ConfigSheet
+    WidgetConfigPopup,
+    WidgetCodePopup
   },
   props: ['createMode', 'uid'],
   data () {
     return {
       pageWidgetDefinition: OhPlanPage.widget,
+      forceEditMode: true,
       page: {
         uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-plan-page',

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -8,7 +8,6 @@
     </f7-navbar>
     <f7-toolbar tabbar position="top">
       <f7-link @click="currentTab = 'design'; fromYaml()" :tab-link-active="currentTab === 'design'" class="tab-link">Design</f7-link>
-      <!-- <f7-link @click="currentTab = 'preview'" :tab-link-active="currentTab === 'preview'" class="tab-link">Preview</f7-link> -->
       <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
     <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'design'">
@@ -16,6 +15,7 @@
         <f7-toggle :checked="previewMode" @toggle:change="(value) => previewMode = value"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </div>
     </f7-toolbar>
+
     <f7-tabs class="plan-editor-tabs">
       <f7-tab id="design" class="plan-editor-design-tab" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
         <f7-block v-if="!ready" class="text-align-center">
@@ -23,20 +23,7 @@
           <div>Loading...</div>
         </f7-block>
         <f7-block class="block-narrow" v-if="ready && !previewMode">
-          <f7-col>
-            <f7-list inline-labels>
-              <f7-list-input label="ID" type="text" placeholder="ID" :value="page.uid" @input="page.uid = $event.target.value"
-                required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only" :disabled="!createMode">
-              </f7-list-input>
-              <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" clear-button>
-              </f7-list-input>
-              <f7-list-item title="Show on sidebar">
-                <f7-toggle slot="after" :checked="page.config.sidebar" @toggle:change="page.config.sidebar = $event"></f7-toggle>
-              </f7-list-item>
-              <f7-list-input label="Sidebar order" type="number" placeholder="Assign order index to rearrange pages on sidebar" :value="page.config.order" @input="page.config.order = $event.target.value" clear-button>
-              </f7-list-input>
-            </f7-list>
-          </f7-col>
+          <page-settings :page="page" :createMode="createMode" />
         </f7-block>
 
         <f7-block class="block-narrow" style="padding-bottom: 8rem" v-if="ready && !previewMode">
@@ -87,17 +74,12 @@
         </f7-block>
 
         <oh-plan-page class="plan-page" v-else-if="ready && previewMode" :context="context" :key="pageKey" />
-
       </f7-tab>
-
-      <!-- <f7-tab id="preview" class="plan-editor-preview-tab" @tab:show="() => this.currentTab = 'preview'" :tab-active="currentTab === 'preview'">
-      </f7-tab> -->
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
       </f7-tab>
-
     </f7-tabs>
 
     <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
@@ -160,183 +142,42 @@
 </style>
 
 <script>
+import PageDesigner from '../pagedesigner-mixin'
+
 import YAML from 'yaml'
 
-// import OhplanPage from '@/components/widgets/plan/oh-plan-page.vue'
 import OhPlanPage from '@/components/widgets/plan/oh-plan-page.vue'
 import OhPlanMarker from '@/components/widgets/plan/oh-plan-marker.vue'
 
-// const ConfigurableWidgets = {
-//   'oh-plan-marker': () => import('@/components/widgets/plan/oh-plan-marker.vue'),
-//   'oh-plan-circle-marker': () => import('@/components/widgets/plan/oh-plan-circle-marker.vue')
-// }
 const ConfigurableWidgets = {
   OhPlanMarker
 }
 
+import PageSettings from '@/components/pagedesigner/page-settings.vue'
+
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
+  mixins: [PageDesigner],
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     OhPlanPage,
+    PageSettings,
     ConfigSheet
   },
   props: ['createMode', 'uid'],
   data () {
     return {
-      pageReady: false,
-      loading: false,
       pageWidgetDefinition: OhPlanPage.widget,
       page: {
         uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-plan-page',
         config: {},
         slots: { default: [] }
-      },
-      pageKey: this.$f7.utils.id(),
-      pageYaml: null,
-      previewMode: false,
-      currentTab: 'design',
-      clipboard: null,
-      clipboardType: null,
-      currentComponent: null,
-      currentComponentConfig: null,
-      currentWidget: null,
-      widgetConfigOpened: false,
-      widgetCodeOpened: false,
-      widgetYaml: null
-    }
-  },
-  computed: {
-    ready () {
-      return this.pageReady && this.$store.state.components.widgets != null
-    },
-    context () {
-      return {
-        component: this.page,
-        store: this.$store.getters.trackedItems,
-        // states: this.stateTracking.store,
-        editmode: {
-          addWidget: this.addWidget,
-          configureWidget: this.configureWidget,
-          editWidgetCode: this.editWidgetCode,
-          cutWidget: this.cutWidget,
-          copyWidget: this.copyWidget,
-          pasteWidget: this.pasteWidget,
-          moveWidgetUp: this.moveWidgetUp,
-          moveWidgetDown: this.moveWidgetDown,
-          removeWidget: this.removeWidget
-        },
-        clipboardtype: this.clipboardType
-      }
-    },
-    yamlError () {
-      if (this.currentTab !== 'code') return null
-      try {
-        YAML.parse(this.pageYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
-      }
-    },
-    widgetYamlError () {
-      if (!this.widgetCodeOpened) return null
-      try {
-        YAML.parse(this.widgetYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
       }
     }
   },
   methods: {
-    onPageAfterIn () {
-      if (window) {
-        window.addEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('startTrackingStates')
-      this.load()
-    },
-    onPageBeforeOut () {
-      if (window) {
-        window.removeEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('stopTrackingStates')
-    },
-    keyDown (ev) {
-      if (ev.ctrlKey || ev.metakKey) {
-        switch (ev.keyCode) {
-          case 82:
-            this.previewMode = !this.previewMode
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-          case 83:
-            this.save(!this.createMode)
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-        }
-      }
-    },
-    load () {
-      if (this.loading) return
-      this.loading = true
-
-      if (this.createMode) {
-        this.loading = false
-        this.pageReady = true
-      } else {
-        this.$oh.api.get('/rest/ui/components/ui:page/' + this.uid).then((data) => {
-          this.$set(this, 'page', data)
-          this.pageReady = true
-          this.loading = false
-        })
-      }
-    },
-    save (stay) {
-      if (!this.page.uid) {
-        this.$f7.dialog.alert('Please give an ID to the page')
-        return
-      }
-      if (!this.page.config.label) {
-        this.$f7.dialog.alert('Please give an label to the page')
-        return
-      }
-      if (!this.createMode && this.uid !== this.page.uid) {
-        this.$f7.dialog.alert('You cannot change the ID of an existing page. Duplicate it with the new ID then delete this one.')
-        return
-      }
-
-      const promise = (this.createMode)
-        ? this.$oh.api.postPlain('/rest/ui/components/ui:page', JSON.stringify(this.page), 'text/plain', 'application/json')
-        : this.$oh.api.put('/rest/ui/components/ui:page/' + this.page.uid, this.page)
-      promise.then((data) => {
-        if (this.createMode) {
-          this.$f7.toast.create({
-            text: 'Page created',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-          this.load()
-        } else {
-          this.$f7.toast.create({
-            text: 'Page updated',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-        }
-        this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
-      }).catch((err) => {
-        this.$f7.toast.create({
-          text: 'Error while saving page: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-      })
-    },
     markerDefaultIcon (marker) {
       const widgetDefinition = Object.values(ConfigurableWidgets).find((c) => c.widget.name === marker.component)
       if (widgetDefinition) {
@@ -357,105 +198,10 @@ export default {
         this.forceUpdate()
       }
     },
-    widgetConfigClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetConfigOpened = false
-    },
-    updateWidgetConfig () {
-      this.$set(this.currentComponent, 'config', this.currentComponentConfig)
-      this.forceUpdate()
-      this.widgetConfigClosed()
-    },
-    widgetCodeClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetCodeOpened = false
-    },
-    updateWidgetCode () {
-      const updatedWidget = YAML.parse(this.widgetYaml)
-      this.$set(this.currentComponent, 'config', updatedWidget.config)
-      this.$set(this.currentComponent, 'slots', updatedWidget.slots)
-      this.forceUpdate()
-      this.widgetCodeClosed()
-    },
-    configureWidget (component, parentContext, forceComponentType) {
-      const componentType = forceComponentType || component.component
-      this.currentComponent = null
-      this.currentWidget = null
-      let widgetDefinition
-      if (componentType.indexOf('widget:') === 0) {
-        this.currentWidget = this.$store.getters.widget(componentType.substring(7))
-      } else {
-        widgetDefinition = Object.values(ConfigurableWidgets).find((w) => w.widget && w.widget.name === componentType)
-        if (!widgetDefinition) {
-          // widgetDefinition = Object.values(LayoutWidgets).find((w) => w.widget.name === component.component)
-          if (!widgetDefinition) {
-            console.warn('Widget not found: ' + componentType)
-            this.$f7.toast.create({
-              text: `This type of component cannot be configured: ${componentType}.`,
-              destroyOnClose: true,
-              closeTimeout: 3000,
-              closeButton: true,
-              closeButtonText: 'Edit YAML',
-              on: {
-                closeButtonClick: () => {
-                  this.editWidgetCode(component, parentContext)
-                }
-              }
-            }).open()
-            return
-          }
-        }
-        this.currentWidget = widgetDefinition.widget
-      }
-      this.currentComponent = component
-      this.currentComponentConfig = JSON.parse(JSON.stringify(this.currentComponent.config))
-      this.widgetConfigOpened = true
-    },
-    editWidgetCode (component, parentContext, slot) {
-      if (slot && !component.slots) component.slots = {}
-      if (slot && !component.slots[slot]) component.slots[slot] = []
-      this.currentComponent = component
-      this.widgetYaml = YAML.stringify(component)
-      this.widgetCodeOpened = true
-    },
-    cutWidget (component, parentContext) {
-      this.copyWidget(component, parentContext)
-      this.removeWidget(component, parentContext)
-    },
-    copyWidget (component, parentContext) {
-      let newClipboard = JSON.stringify(component)
-      this.$set(this, 'clipboard', newClipboard)
-      this.clipboardType = component.component
-    },
-    pasteWidget (component, parentContext) {
-      if (!this.clipboard) return
-      component.slots.default.push(JSON.parse(this.clipboard))
-      this.forceUpdate()
-    },
-    moveWidgetUp (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos <= 0) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos - 1, 0, component)
-      this.forceUpdate()
-    },
-    moveWidgetDown (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos >= siblings.length - 1) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos + 1, 0, component)
-      this.forceUpdate()
-    },
-    removeWidget (component, parentContext) {
-      parentContext.component.slots.default.splice(parentContext.component.slots.default.indexOf(component), 1)
-      this.forceUpdate()
-    },
-    forceUpdate () {
-      this.pageKey = this.$f7.utils.id()
+    getWidgetDefinition (componentType) {
+      const component = Object.values(ConfigurableWidgets).find((w) => w.widget && w.widget.name === componentType)
+      if (!component) return null
+      return component.widget
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -120,6 +120,8 @@ import PageSettings from '@/components/pagedesigner/page-settings.vue'
 import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
 import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
 
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
 export default {
   mixins: [PageDesigner],
   components: {
@@ -127,7 +129,8 @@ export default {
     OhPlanPage,
     PageSettings,
     WidgetConfigPopup,
-    WidgetCodePopup
+    WidgetCodePopup,
+    ConfigSheet
   },
   props: ['createMode', 'uid'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -8,13 +8,7 @@
     </f7-navbar>
     <f7-toolbar tabbar position="top">
       <f7-link @click="currentTab = 'design'; fromYaml()" :tab-link-active="currentTab === 'design'" class="tab-link">Design</f7-link>
-      <!-- <f7-link @click="currentTab = 'preview'" :tab-link-active="currentTab === 'preview'" class="tab-link">Preview</f7-link> -->
       <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
-    </f7-toolbar>
-    <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'design'">
-      <!-- <div style="margin-left: auto">
-        <f7-toggle :checked="previewMode" @toggle:change="(value) => previewMode = value"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
-      </div> -->
     </f7-toolbar>
     <f7-tabs class="tabs-editor-tabs">
       <f7-tab id="design" class="tabs-editor-design-tab" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
@@ -23,20 +17,7 @@
           <div>Loading...</div>
         </f7-block>
         <f7-block class="block-narrow" v-if="ready && !previewMode">
-          <f7-col>
-            <f7-list inline-labels>
-              <f7-list-input label="ID" type="text" placeholder="ID" :value="page.uid" @input="page.uid = $event.target.value"
-                required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only" :disabled="!createMode">
-              </f7-list-input>
-              <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" clear-button>
-              </f7-list-input>
-              <f7-list-item title="Show on sidebar">
-                <f7-toggle slot="after" :checked="page.config.sidebar" @toggle:change="page.config.sidebar = $event"></f7-toggle>
-              </f7-list-item>
-              <f7-list-input label="Sidebar order" type="number" placeholder="Assign order index to rearrange pages on sidebar" :value="page.config.order" @input="page.config.order = $event.target.value" clear-button>
-              </f7-list-input>
-            </f7-list>
-          </f7-col>
+          <page-settings :page="page" :createMode="createMode" />
         </f7-block>
 
         <f7-block class="block-narrow" style="padding-bottom: 8rem" v-if="ready">
@@ -78,9 +59,6 @@
 
       </f7-tab>
 
-      <f7-tab id="preview" class="tabs-editor-preview-tab" @tab:show="() => this.currentTab = 'preview'" :tab-active="currentTab === 'preview'">
-
-      </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
@@ -149,173 +127,37 @@
 </style>
 
 <script>
+import PageDesigner from '../pagedesigner-mixin'
+
 import YAML from 'yaml'
 
-// import OhMapPage from '@/components/widgets/map/oh-map-page.vue'
 import OhTab from './oh-tab'
+
+import PageSettings from '@/components/pagedesigner/page-settings.vue'
+
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 const ConfigurableWidgets = { OhTab }
 
 export default {
+  mixins: [PageDesigner],
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
+    PageSettings,
     ConfigSheet
   },
   props: ['createMode', 'uid'],
   data () {
     return {
-      pageReady: false,
-      loading: false,
       page: {
         uid: 'page_' + this.$f7.utils.id(),
         component: 'oh-tabs-page',
         config: {},
         slots: { default: [] }
-      },
-      pageKey: this.$f7.utils.id(),
-      pageYaml: null,
-      previewMode: false,
-      currentTab: 'design',
-      clipboard: null,
-      clipboardType: null,
-      currentComponent: null,
-      currentComponentConfig: null,
-      currentWidget: null,
-      widgetConfigOpened: false,
-      widgetCodeOpened: false,
-      widgetYaml: null
-    }
-  },
-  computed: {
-    ready () {
-      return this.pageReady && this.$store.state.components.widgets != null
-    },
-    context () {
-      return {
-        component: this.page,
-        store: this.$store.getters.trackedItems,
-        // states: this.stateTracking.store,
-        editmode: (!this.previewMode) ? {
-          addWidget: this.addWidget,
-          configureWidget: this.configureWidget,
-          editWidgetCode: this.editWidgetCode,
-          cutWidget: this.cutWidget,
-          copyWidget: this.copyWidget,
-          pasteWidget: this.pasteWidget,
-          moveWidgetUp: this.moveWidgetUp,
-          moveWidgetDown: this.moveWidgetDown,
-          removeWidget: this.removeWidget
-        } : null,
-        clipboardtype: this.clipboardType
-      }
-    },
-    yamlError () {
-      if (this.currentTab !== 'code') return null
-      try {
-        YAML.parse(this.pageYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
-      }
-    },
-    widgetYamlError () {
-      if (!this.widgetCodeOpened) return null
-      try {
-        YAML.parse(this.widgetYaml, { prettyErrors: true })
-        return 'OK'
-      } catch (e) {
-        return e
       }
     }
   },
   methods: {
-    onPageAfterIn () {
-      if (window) {
-        window.addEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('startTrackingStates')
-      this.load()
-    },
-    onPageBeforeOut () {
-      if (window) {
-        window.removeEventListener('keydown', this.keyDown)
-      }
-      this.$store.dispatch('stopTrackingStates')
-    },
-    keyDown (ev) {
-      if (ev.ctrlKey || ev.metakKey) {
-        switch (ev.keyCode) {
-          // case 82:
-          //   this.previewMode = !this.previewMode
-          //   ev.stopPropagation()
-          //   ev.preventDefault()
-          //   break
-          case 83:
-            this.save(!this.createMode)
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
-        }
-      }
-    },
-    load () {
-      if (this.loading) return
-      this.loading = true
-
-      if (this.createMode) {
-        this.loading = false
-        this.pageReady = true
-      } else {
-        this.$oh.api.get('/rest/ui/components/ui:page/' + this.uid).then((data) => {
-          this.$set(this, 'page', data)
-          this.pageReady = true
-          this.loading = false
-        })
-      }
-    },
-    save (stay) {
-      if (!this.page.uid) {
-        this.$f7.dialog.alert('Please give an ID to the page')
-        return
-      }
-      if (!this.page.config.label) {
-        this.$f7.dialog.alert('Please give an label to the page')
-        return
-      }
-      if (!this.createMode && this.uid !== this.page.uid) {
-        this.$f7.dialog.alert('You cannot change the ID of an existing page. Duplicate it with the new ID then delete this one.')
-        return
-      }
-
-      const promise = (this.createMode)
-        ? this.$oh.api.postPlain('/rest/ui/components/ui:page', JSON.stringify(this.page), 'text/plain', 'application/json')
-        : this.$oh.api.put('/rest/ui/components/ui:page/' + this.page.uid, this.page)
-      promise.then((data) => {
-        if (this.createMode) {
-          this.$f7.toast.create({
-            text: 'Page created',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-          this.load()
-        } else {
-          this.$f7.toast.create({
-            text: 'Page updated',
-            destroyOnClose: true,
-            closeTimeout: 2000
-          }).open()
-        }
-        this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
-      }).catch((err) => {
-        this.$f7.toast.create({
-          text: 'Error while saving page: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-      })
-    },
     addWidget (component, widgetType, parentContext, slot) {
       if (!slot) slot = 'default'
       if (!component.slots) component.slots = {}
@@ -329,105 +171,10 @@ export default {
         this.forceUpdate()
       }
     },
-    widgetConfigClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetConfigOpened = false
-    },
-    updateWidgetConfig () {
-      this.$set(this.currentComponent, 'config', this.currentComponentConfig)
-      this.forceUpdate()
-      this.widgetConfigClosed()
-    },
-    widgetCodeClosed () {
-      this.currentComponent = null
-      this.currentWidget = null
-      this.widgetCodeOpened = false
-    },
-    updateWidgetCode () {
-      const updatedWidget = YAML.parse(this.widgetYaml)
-      this.$set(this.currentComponent, 'config', updatedWidget.config)
-      this.$set(this.currentComponent, 'slots', updatedWidget.slots)
-      this.forceUpdate()
-      this.widgetCodeClosed()
-    },
-    configureWidget (component, parentContext, forceComponentType) {
-      const componentType = forceComponentType || component.component
-      this.currentComponent = null
-      this.currentWidget = null
-      let widgetDefinition
-      if (componentType.indexOf('widget:') === 0) {
-        this.currentWidget = this.$store.getters.widget(componentType.substring(7))
-      } else {
-        widgetDefinition = Object.values(ConfigurableWidgets).find((w) => w.widget && w.widget.name === componentType)
-        if (!widgetDefinition) {
-          // widgetDefinition = Object.values(LayoutWidgets).find((w) => w.widget.name === component.component)
-          if (!widgetDefinition) {
-            console.warn('Widget not found: ' + componentType)
-            this.$f7.toast.create({
-              text: `This type of component cannot be configured: ${componentType}.`,
-              destroyOnClose: true,
-              closeTimeout: 3000,
-              closeButton: true,
-              closeButtonText: 'Edit YAML',
-              on: {
-                closeButtonClick: () => {
-                  this.editWidgetCode(component, parentContext)
-                }
-              }
-            }).open()
-            return
-          }
-        }
-        this.currentWidget = widgetDefinition.widget
-      }
-      this.currentComponent = component
-      this.currentComponentConfig = JSON.parse(JSON.stringify(this.currentComponent.config))
-      this.widgetConfigOpened = true
-    },
-    editWidgetCode (component, parentContext, slot) {
-      if (slot && !component.slots) component.slots = {}
-      if (slot && !component.slots[slot]) component.slots[slot] = []
-      this.currentComponent = component
-      this.widgetYaml = YAML.stringify(component)
-      this.widgetCodeOpened = true
-    },
-    cutWidget (component, parentContext) {
-      this.copyWidget(component, parentContext)
-      this.removeWidget(component, parentContext)
-    },
-    copyWidget (component, parentContext) {
-      let newClipboard = JSON.stringify(component)
-      this.$set(this, 'clipboard', newClipboard)
-      this.clipboardType = component.component
-    },
-    pasteWidget (component, parentContext) {
-      if (!this.clipboard) return
-      component.slots.default.push(JSON.parse(this.clipboard))
-      this.forceUpdate()
-    },
-    moveWidgetUp (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos <= 0) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos - 1, 0, component)
-      this.forceUpdate()
-    },
-    moveWidgetDown (component, parentContext) {
-      let siblings = parentContext.component.slots.default
-      let pos = siblings.indexOf(component)
-      if (pos >= siblings.length - 1) return
-      siblings.splice(pos, 1)
-      siblings.splice(pos + 1, 0, component)
-      this.forceUpdate()
-    },
-    removeWidget (component, parentContext) {
-      parentContext.component.slots.default.splice(parentContext.component.slots.default.indexOf(component), 1)
-      this.forceUpdate()
-    },
-    forceUpdate () {
-      this.pageKey = this.$f7.utils.id()
+    getWidgetDefinition (componentType) {
+      const component = Object.values(ConfigurableWidgets).find((w) => w.widget && w.widget.name === componentType)
+      if (!component) return null
+      return component.widget
     },
     toYaml () {
       this.pageYaml = YAML.stringify({

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -63,57 +63,14 @@
         <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
       </f7-tab>
-
     </f7-tabs>
 
-    <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape :opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
-      <f7-page v-if="currentComponent && currentWidget">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit {{currentWidget.label || currentWidget.uid}}</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetConfig">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="currentWidget.props">
-          <f7-col>
-            <config-sheet
-              :parameterGroups="currentWidget.props.parameterGroups || []"
-              :parameters="currentWidget.props.parameters || []"
-              :configuration="currentComponentConfig"
-              @updated="dirty = true"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
-
-    <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape :opened="widgetCodeOpened" @popup:closed="widgetCodeClosed">
-      <f7-page v-if="currentComponent && widgetCodeOpened">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit Widget Code</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetCode">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <editor class="page-code-editor" mode="text/x-yaml" :value="widgetYaml" @input="(value) => widgetYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
-      </f7-page>
-    </f7-popup>
+    <widget-config-popup :opened="widgetConfigOpened" :component="currentComponent" :widget="currentWidget" @closed="widgetConfigClosed" @update="updateWidgetConfig" />
+    <widget-code-popup :opened="widgetCodeOpened" :component="currentComponent" :widget-yaml="widgetYaml" @closed="widgetCodeClosed" @update="updateWidgetCode" />
   </f7-page>
 </template>
 
 <style lang="stylus">
-.sitemap-editor-tabs
-  --f7-grid-gap 0px
-  height calc(100% - var(--f7-toolbar-height))
-  .tab
-    height 100%
 .page-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
@@ -134,8 +91,8 @@ import YAML from 'yaml'
 import OhTab from './oh-tab'
 
 import PageSettings from '@/components/pagedesigner/page-settings.vue'
-
-import ConfigSheet from '@/components/config/config-sheet.vue'
+import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
+import WidgetCodePopup from '@/components/pagedesigner/widget-code-popup.vue'
 
 const ConfigurableWidgets = { OhTab }
 
@@ -144,7 +101,8 @@ export default {
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue'),
     PageSettings,
-    ConfigSheet
+    WidgetConfigPopup,
+    WidgetCodePopup
   },
   props: ['createMode', 'uid'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
@@ -53,6 +53,7 @@
             <f7-list-item
               link="pages/"
               title="Pages"
+              :after="$store.getters.pages.length + sitemapsCount"
               badge-color="blue"
               :footer="objectsSubtitles.pages">
               <f7-icon slot="media" f7="tv" color="gray"></f7-icon>
@@ -149,7 +150,8 @@ export default {
       },
       inboxCount: '',
       thingsCount: '',
-      itemsCount: ''
+      itemsCount: '',
+      sitemapsCount: 0
     }
   },
   methods: {
@@ -173,6 +175,7 @@ export default {
       this.$oh.api.get('/rest/inbox').then((data) => { this.inboxCount = data.filter((e) => e.flag === 'NEW').length.toString() })
       this.$oh.api.get('/rest/things').then((data) => { this.thingsCount = data.length.toString() })
       this.$oh.api.get('/rest/items').then((data) => { this.itemsCount = data.length.toString() })
+      this.$oh.api.get('/rest/ui/components/system:sitemap').then((data) => { this.sitemapsCount = data.length })
     },
     onPageInit () {
       this.loadMenu()

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -27,7 +27,7 @@
     </f7-list>
     <f7-block class="block-narrow">
       <f7-col>
-        <f7-block-title class="searchbar-hide-on-search"><span v-if="ready">{{things.length}} things</span></f7-block-title>
+        <f7-block-title class="searchbar-hide-on-search"><span v-if="ready">{{things.length}} things</span><span v-else>Loading...</span></f7-block-title>
         <div class="padding-left padding-right" v-show="!ready || things.length > 0">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="groupBy = 'alphabetical'; $nextTick(() => $refs.listIndex.update())">Alphabetical</f7-button>


### PR DESCRIPTION
Move duplicated code in page editors and modals
to mixins.

Move the general page settings form to a common
component.

This also introduces two new common config parameters:

- `visibleTo` allows to restrict the visibility of
  pages or widgets to certain users or roles. It
  accepts an array with strings like:
  `["user:user1", "role:administrator"]`
  Multiple entries are "OR"ed - the component will be
  displayed if any matches.
  If the parameter is not present, the component
  is visible by default (even to unauthenticated users).
  This parameter is available to widgets which accept
  expressions in their configuration (typically in
  layout pages).

- `visible` allows to restrict the visibility of
  a widget based on the result of the evaluation of an
  expression. For example:
  `visible: "=items.Item1.state == 'ON'"`
  This allows to build dynamic pages e.g. by setting
  this property on blocks, grid rows or columns, or
  individual widgets which will appear or disappear
  typically based on the state of an item.
  This property is not evaluated for top-level pages or
  widgets that don't support expressions (charts etc.).

Note that these only restrict the visibility and are not
to be considered as security measures.

Allow to specify `visibleTo` as a general page setting.

Signed-off-by: Yannick Schaus <github@schaus.net>