### PR TITLE
Move the login hint in the sidebar

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
@@ -1,6 +1,6 @@
 {
   "overview.title": "Welcome to openHAB!",
-  "overview.text": "Once your system is configured, create a layout page with the ID <code>\"overview\"</code> to display it here.",
+  "overview.text": "Configure your system, then create a layout page with the ID <code>\"overview\"</code> to display it here.",
 
   "inbox.title": "The Inbox is empty",
   "inbox.text": "Discovery results from your bindings that can be added as things will appear here.<br><br>You can also start a scan for a certain binding or add things manually with the button below.",

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -11,7 +11,7 @@
         <div class="logo-inner"><img src="../res/img/openhab-logo.png" width="100%"></div>
       </f7-link>
       <f7-list v-if="ready">
-        <f7-list-item v-if="!pages || !pages.filter(p => p.config.sidebar).length">
+        <f7-list-item v-if="!pages || !pages.length">
           <span><em>No pages</em></span>
         </f7-list-item>
         <!-- <f7-list-item v-for="sitemap in sitemaps" :animate="false" :key="sitemap.name"

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -4,13 +4,16 @@
   <!-- Left Panel -->
   <f7-panel left :cover="showSidebar" class="sidebar" :visible-breakpoint="1024">
     <f7-page>
-      <f7-list-item link="/" class="logo" panel-close v-if="themeOptions.dark === 'dark'">
-        <img src="../res/img/openhab-logo-white.png" width="100%">
-      </f7-list-item>
-      <f7-list-item link="/" class="logo" panel-close v-else>
-        <img src="../res/img/openhab-logo.png" width="100%">
-      </f7-list-item>
-      <f7-list>
+      <f7-link href="/" class="logo no-ripple" panel-close v-if="themeOptions.dark === 'dark'">
+        <div class="logo-inner"><img src="../res/img/openhab-logo-white.png" width="100%"></div>
+      </f7-link>
+      <f7-link href="/" class="logo no-ripple" panel-close v-else>
+        <div class="logo-inner"><img src="../res/img/openhab-logo.png" width="100%"></div>
+      </f7-link>
+      <f7-list v-if="ready">
+        <f7-list-item v-if="!pages || !pages.filter(p => p.config.sidebar).length">
+          <span><em>No pages</em></span>
+        </f7-list-item>
         <!-- <f7-list-item v-for="sitemap in sitemaps" :animate="false" :key="sitemap.name"
                 :class="{ currentsection: currentUrl.indexOf('/sitemap/' + sitemap.name) >= 0 }"
                 :link="'/sitemap/' + sitemap.name + '/' + sitemap.name"
@@ -82,6 +85,9 @@
 
       <div class="account" v-if="ready">
         <div class="display-flex justify-content-center">
+          <div class="hint-signin" v-if="!$store.getters.user && !$store.getters.pages.length">
+            <em>Sign in as an administrator to access settings<br /><f7-icon f7="arrow_down" size="20"></f7-icon></em>
+          </div>
           <f7-button v-if="!loggedIn" large color="gray" icon-size="36" tooltip="Unlock Administration" icon-f7="lock_shield_fill" @click="authorize()" />
         </div>
         <f7-list v-if="$store.getters.user" media-list>
@@ -155,10 +161,9 @@
     padding-bottom calc(var(--f7-tabbar-labels-height) + var(--f7-safe-area-bottom))
   .logo
     margin-top var(--f7-safe-area-top)
-    list-style none
-    padding 2.5rem 2rem
-    background-color #fff
-    height 50px
+    .logo-inner
+      background-color #fff
+      padding 2.25rem 2rem
   .list
     margin-top 0
   .currentsection
@@ -174,6 +179,11 @@
     position fixed
     bottom calc(var(--f7-safe-area-bottom))
     width 100%
+    .hint-signin
+      position absolute
+      bottom calc(var(--f7-tabbar-labels-height) + var(--f7-safe-area-bottom))
+      width 50%
+      text-align center
     .list
       position absolute
       bottom 0
@@ -191,7 +201,8 @@
     .currentsection
       background-color var(--f7-color-blue-shade)
   .logo
-    background #111111 !important
+    .logo-inner
+      background #111111 !important
 
 .menu-sublinks
   color var(--f7-list-item-footer-text-color)

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -2,7 +2,7 @@
 <f7-app v-if="init" :params="f7params" :class="{ 'theme-dark': this.themeOptions.dark === 'dark', 'theme-filled': this.themeOptions.bars === 'filled' }">
 
   <!-- Left Panel -->
-  <f7-panel left :cover="showSidebar" class="sidebar" :visible-breakpoint="1024">
+  <f7-panel v-show="ready" left :cover="showSidebar" class="sidebar" :visible-breakpoint="1024">
     <f7-page>
       <f7-link href="/" class="logo no-ripple" panel-close v-if="themeOptions.dark === 'dark'">
         <div class="logo-inner"><img src="../res/img/openhab-logo-white.png" width="100%"></div>
@@ -409,6 +409,11 @@ export default {
     }
   },
   created () {
+    this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || 'light'
+    this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')
+    this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
+    this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
+    this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
     // this.loginScreenOpened = true
     const refreshToken = this.getRefreshToken()
     if (refreshToken) {
@@ -426,11 +431,6 @@ export default {
     }
   },
   mounted () {
-    this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || 'light'
-    this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')
-    this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
-    this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
-    this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
     this.$f7ready((f7) => {
       this.$f7.data.themeOptions = this.themeOptions
 

--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -1,8 +1,7 @@
 <template>
 <div>
   <div class="hint-apps" v-if="!overviewPage && !$store.getters.user">
-    <f7-icon class="float-right margin-left" f7="arrow_turn_right_up" size="40"></f7-icon>
-    <p><em class="">Open the apps panel to launch other interfaces</em></p>
+    <p><em><f7-icon class="float-right margin-left margin-bottom" f7="arrow_turn_right_up" size="20" />Open the apps panel to launch other interfaces</em></p>
   </div>
   <f7-block class="block-narrow">
     <habot v-if="showHABot" />
@@ -17,18 +16,13 @@
   </f7-block>
 
   <component :is="overviewPage.component" v-if="overviewPage" :context="overviewPageContext" :class="{notready: !ready}" @command="onCommand" />
-  <div class="empty" v-else>
-    <empty-state-placeholder icon="rocket" title="overview.title" text="overview.text" />
+  <div class="empty-overview" v-else>
+    <empty-state-placeholder icon="house" title="overview.title" text="overview.text" />
     <f7-row class="display-flex justify-content-center">
       <f7-button large fill color="blue" external href="https://next.openhab.org/docs/" target="_blank">Documentation</f7-button>
       <span style="width: 8px"></span>
       <f7-button large color="blue" external href="https://next.openhab.org/docs/tutorial/" target="_blank">Tutorial</f7-button>
     </f7-row>
-
-    <div class="hint-signin" v-if="!$store.getters.user">
-      <p class="padding-left"><em>Click on the shield to sign in as an administrator</em></p>
-      <f7-icon f7="arrow_down_left" size="40"></f7-icon>
-    </div>
   </div>
   <!-- <h2 class="home-header">
     Now
@@ -67,14 +61,8 @@
   width 60%
   p
     text-align right
-.hint-signin
-  position absolute
-  bottom calc(var(--f7-tabbar-labels-height) + var(--f7-safe-area-bottom))
-  width 50%
-  height 10rem
-  left 1rem
-  p
-    margin-left 40px
+.empty-overview
+  padding-top 0.3rem
 </style>
 
 <script>


### PR DESCRIPTION
Displayed only when there are no pages - if there are, it means the admin
user already found the button.
Closes #254.

Change some label texts & empty overview icon.

Make the whole logo area clickable.

Display an indicator when there are no pages to display on the sidebar.

Signed-off-by: Yannick Schaus <github@schaus.net>