### PR TITLE
REST docs: use the redirect URI as client ID

### DIFF
--- a/bundles/org.openhab.ui.restdocs/src/main/resources/swagger/index.html
+++ b/bundles/org.openhab.ui.restdocs/src/main/resources/swagger/index.html
@@ -47,11 +47,10 @@
         onComplete: function(swaggerApi, swaggerUi){
           if(typeof initOAuth == "function") {
             initOAuth({
-              clientId: "your-client-id",
-              clientSecret: "your-client-secret-if-required",
-              realm: "your-realms",
-              appName: "your-app-name", 
-              scopeSeparator: ","
+              clientId: window.location.origin + "/doc/o2c.html",
+              realm: "openhab",
+              appName: "openHAB",
+              scopeSeparator: " "
             });
           }
 


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/1496

Signed-off-by: Yannick Schaus <github@schaus.net>