### PR TITLE
[WIP] Format relative URLs for cordova/mobile builds.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
@@ -20,7 +20,7 @@
     @update:center="centerUpdate"
     @update:zoom="zoomUpdate">
       <l-image-overlay
-        :url="config.imageUrl"
+        :url="prepareRequest(config.imageUrl)"
         :bounds="bounds"
       />
       <l-feature-group ref="featureGroup" v-if="context.component.slots && ready">
@@ -216,6 +216,10 @@ export default {
       this.$nextTick(() => {
         this.fitMapBounds()
       })
+    },
+    prepareRequest (url) {
+      // format the URL for codova if not a relative link
+      return !url || url.indexOf('http') === 0 ? url : this.$oh.api.prepareRequest(url)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/js/openhab/cordova/api.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/cordova/api.js
@@ -19,6 +19,7 @@ function prepareRequest (uri) {
 }
 
 export default {
+  prepareRequest,
   get (uri, data) {
     const fullUri = prepareRequest(uri)
     if (fullUri) {

--- a/bundles/org.openhab.ui/web/src/js/openhab/openhab.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/openhab.js
@@ -60,6 +60,9 @@ export default {
     accessToken = token
   },
   api: {
+    prepareRequest (uri) {
+      return uri
+    },
     get (uri, data) {
       return wrapPromise(Framework7.request.promise.json(uri, data))
     },


### PR DESCRIPTION
Signed-off-by: digitaldan <dan@digitaldan.com>

I noticed that when using the cordova version of the app on IOS, my images for pages were not loading. I have these as static files with relative links (much like habpanel) on OH,for example,  `/static/ground_floor.svg` 

This was a quick and dirty fix on my part to see my pages working, so i'm not actually suggesting the current PR for submission, but i am curious if this should be expanded across the whole app (like in a mixin)  to widgets, or is there another/better way? 