### PR TITLE
Auto selects the color default color scheme based on the system preference

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -247,7 +247,7 @@ export default {
         // theme: (document.documentURI && document.documentURI.indexOf('?theme=ios') > 0) ? 'ios'
         //   : (document.documentURI && document.documentURI.indexOf('?theme=md') > 0) ? 'md'
         //     : 'auto', // Automatic theme detection
-        autoDarkTheme: true,
+        autoDarkTheme: !(localStorage.getItem('openhab.ui:theme.dark')),
         // App root data
         data () {
           return {
@@ -414,10 +414,6 @@ export default {
       this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
       this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
       this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
-      // f7 adds theme-dark to the class list if autoDarkTheme is enabled and dark mode is true
-      if (this.themeOptions.dark === 'light') {
-        document.querySelector('html').classList.remove('theme-dark')
-      }
     }
   },
   created () {

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -247,8 +247,8 @@ export default {
         // theme: (document.documentURI && document.documentURI.indexOf('?theme=ios') > 0) ? 'ios'
         //   : (document.documentURI && document.documentURI.indexOf('?theme=md') > 0) ? 'md'
         //     : 'auto', // Automatic theme detection
-        // App root data
         autoDarkTheme: true,
+        // App root data
         data () {
           return {
           }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -414,8 +414,8 @@ export default {
       this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
       this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
       this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
-      // f7 adds theme-dark to the class list if autoDarkTheme is enabled
-      if (this.$f7.darkTheme && this.themeOptions.dark === 'light') {
+      // f7 adds theme-dark to the class list if autoDarkTheme is enabled and dark mode is true
+      if (this.themeOptions.dark === 'light') {
         document.querySelector('html').classList.remove('theme-dark')
       }
     }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -248,6 +248,7 @@ export default {
         //   : (document.documentURI && document.documentURI.indexOf('?theme=md') > 0) ? 'md'
         //     : 'auto', // Automatic theme detection
         // App root data
+        autoDarkTheme: true,
         data () {
           return {
           }
@@ -407,23 +408,19 @@ export default {
         this.$f7.dialog.alert('Error while signing out: ' + err)
       })
     },
-    updateColorTheme () {
-      let colorTheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light'
-      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || colorTheme
+    updateThemeOptions () {
+      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || (this.$f7.darkTheme ? 'dark' : 'light')
+      this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) || (!this.$f7.darkTheme) ? 'filled' : 'light')
+      this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
+      this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
+      this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
+      // f7 adds theme-dark to the class list if autoDarkTheme is enabled
+      if (this.$f7.darkTheme && this.themeOptions.dark === 'light') {
+        document.querySelector('html').classList.remove('theme-dark')
+      }
     }
   },
   created () {
-    if (window.matchMedia) {
-      // see https://github.com/mdn/sprints/issues/858 why we can't use addEventListener here
-      window.matchMedia('(prefers-color-scheme: dark)').addListener(() => {
-        this.updateColorTheme()
-      })
-    }
-    this.updateColorTheme()
-    this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')
-    this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
-    this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
-    this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
     // this.loginScreenOpened = true
     const refreshToken = this.getRefreshToken()
     if (refreshToken) {
@@ -442,6 +439,7 @@ export default {
   },
   mounted () {
     this.$f7ready((f7) => {
+      this.updateThemeOptions()
       this.$f7.data.themeOptions = this.themeOptions
 
       // Init cordova APIs (see cordova-app.js)
@@ -480,6 +478,10 @@ export default {
 
       this.$f7.on('sidebarRefresh', () => {
         this.loadSidebarPages()
+      })
+
+      this.$f7.on('darkThemeChange', () => {
+        this.updateThemeOptions()
       })
     })
   }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -406,19 +406,20 @@ export default {
         this.$f7.preloader.hide()
         this.$f7.dialog.alert('Error while signing out: ' + err)
       })
+    },
+    updateColorTheme () {
+      let colorTheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'light'
+      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || colorTheme
     }
   },
   created () {
-    let colorTheme = 'light'
     if (window.matchMedia) {
-      colorTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
-      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-        if (!localStorage.getItem('openhab.ui:theme.dark')) {
-          this.themeOptions.dark = e.matches ? 'dark' : 'light'
-        }
+      // see https://github.com/mdn/sprints/issues/858 why we can't use addEventListener here
+      window.matchMedia('(prefers-color-scheme: dark)').addListener(() => {
+        this.updateColorTheme()
       })
     }
-    this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || colorTheme
+    this.updateColorTheme()
     this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')
     this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
     this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -409,7 +409,16 @@ export default {
     }
   },
   created () {
-    this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || 'light'
+    let colorTheme = 'light'
+    if (window.matchMedia) {
+      colorTheme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        if (!localStorage.getItem('openhab.ui:theme.dark')) {
+          this.themeOptions.dark = e.matches ? 'dark' : 'light'
+        }
+      })
+    }
+    this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || colorTheme
     this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')
     this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
     this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -100,24 +100,6 @@ export default {
 }
 </script>
 <style>
-.demo-theme-picker {
-  cursor: pointer;
-  padding: 30px;
-  border-radius: 10px;
-  box-shadow: 0px 5px 20px rgba(0,0,0,0.1);
-  border: 1px solid rgba(255,255,255,0.2);
-  box-sizing: border-box;
-  position: relative;
-}
-.demo-theme-picker .checkbox {
-  position: absolute;
-  left: 10px;
-  bottom: 10px;
-}
-.demo-color-picker-button {
-  margin-bottom: 1em;
-  text-transform: capitalize;
-}
 .demo-bars-picker {
   height: 200px;
   border-radius: 10px;

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -8,14 +8,11 @@
       <f7-button round color="blue" raised :fill="theme === 'aurora'" @click="switchTheme('aurora')">Aurora</f7-button>
     </f7-segmented>
     <f7-block-title>Dark mode</f7-block-title>
-    <f7-row>
-      <f7-col width="50" class="bg-color-white demo-theme-picker" @click="setThemeDark('light')">
-        <f7-checkbox checked disabled v-if="darkMode === 'light'" />
-      </f7-col>
-      <f7-col width="50" class="bg-color-black demo-theme-picker" @click="setThemeDark('dark')">
-        <f7-checkbox checked disabled v-if="darkMode === 'dark'" />
-      </f7-col>
-    </f7-row>
+    <f7-segmented>
+      <f7-button round color="blue" raised :fill="darkMode === 'auto'" @click="setThemeDark('auto')">Auto</f7-button>
+      <f7-button round color="blue" raised :fill="darkMode === 'light'" @click="setThemeDark('light')">Light</f7-button>
+      <f7-button round color="blue" raised :fill="darkMode === 'dark'" @click="setThemeDark('dark')">Dark</f7-button>
+    </f7-segmented>
     <f7-block-title>Navigation bars style</f7-block-title>
     <f7-row>
       <f7-col width="50" class="demo-bars-picker demo-bars-picker-fill" @click="setBarsStyle('filled')">
@@ -58,7 +55,8 @@ export default {
       // document.location = document.location.origin + document.location.pathname + '?theme=' + theme
     },
     setThemeDark (value) {
-      localStorage.setItem('openhab.ui:theme.dark', value)
+      value === 'auto'
+        ? localStorage.removeItem('openhab.ui:theme.dark') : localStorage.setItem('openhab.ui:theme.dark', value)
       localStorage.setItem('openhab.ui:theme.bars', 'light') // dark theme with filled bars is ugly, switch to light bars too
       location.reload()
     },
@@ -84,7 +82,7 @@ export default {
       return localStorage.getItem('openhab.ui:theme') || 'auto'
     },
     darkMode () {
-      return localStorage.getItem('openhab.ui:theme.dark') || 'light'
+      return localStorage.getItem('openhab.ui:theme.dark') || 'auto'
     },
     barsStyle () {
       return localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')


### PR DESCRIPTION

Signed-off-by: digitaldan <dan@digitaldan.com>

This is useful on the desktop, and very useful when running on mobile.  Still allows the user to save a permanent preference. 

![theme](https://user-images.githubusercontent.com/1903737/82761509-de249b00-9daf-11ea-9e3c-cc618197e8ce.gif)
