### PR TITLE
Misc style fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -106,7 +106,7 @@
     <!-- <f7-view url="/panel-right/"></f7-view> -->
   </f7-panel>
 
-  <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="this.themeOptions.pageTransitionAnimation !== 'disabled'"></f7-view>
+  <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'"></f7-view>
 
   <f7-login-screen id="my-login-screen" :opened="loginScreenOpened">
     <f7-view name="login" v-if="$device.cordova">
@@ -410,13 +410,15 @@ export default {
     },
     updateThemeOptions () {
       this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || (this.$f7.darkTheme ? 'dark' : 'light')
-      this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) || (!this.$f7.darkTheme) ? 'filled' : 'light')
+      this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((this.$theme.ios || this.$f7.darkTheme || this.themeOptions.dark === 'dark') ? 'light' : 'filled')
       this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
+      this.themeOptions.homeBackground = localStorage.getItem('openhab.ui:theme.home.background') || 'default'
       this.themeOptions.expandableCardAnimation = localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
-      this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
     }
   },
   created () {
+    // special treatment for this option because it's needed to configure the app initialization
+    this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.pagetransition') || 'default'
     // this.loginScreenOpened = true
     const refreshToken = this.getRefreshToken()
     if (refreshToken) {

--- a/bundles/org.openhab.ui/web/src/components/cards/equipments-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipments-card.vue
@@ -13,7 +13,7 @@
           color="white"
           class="card-opened-fade-in"
           :style="{position: 'absolute', right: '15px', top: '15px'}"
-          icon-f7="close_round_fill"
+          icon-f7="multiply_circle_fill"
         ></f7-link>
       </div>
       <div class="card-content-padding" v-if="opened">

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -14,7 +14,7 @@
           color="white"
           class="card-opened-fade-in"
           :style="{position: 'absolute', right: '15px', top: '15px'}"
-          icon-f7="close_round_fill"
+          icon-f7="multiply_circle_fill"
         ></f7-link>
       </div>
       <div class="card-content-padding" v-if="opened && items.equipments.length > 0 && items.properties.length > 0">

--- a/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
@@ -13,7 +13,7 @@
           color="white"
           class="card-opened-fade-in"
           :style="{position: 'absolute', right: '15px', top: '15px'}"
-          icon-f7="close_round_fill"
+          icon-f7="multiply_circle_fill"
         ></f7-link>
       </div>
       <!-- <div class="card-content-padding" v-if="opened">

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -15,11 +15,11 @@
     </f7-segmented>
     <f7-block-title>Navigation bars style</f7-block-title>
     <f7-row>
-      <f7-col width="50" class="demo-bars-picker demo-bars-picker-fill" @click="setBarsStyle('filled')">
+      <f7-col width="50" class="nav-bars-picker nav-bars-picker-fill" @click="setBarsStyle('filled')">
         <div class="demo-navbar"></div>
         <f7-checkbox checked disabled v-if="barsStyle === 'filled'" />
       </f7-col>
-      <f7-col width="50" class="demo-bars-picker demo-bars-picker-empty" @click="setBarsStyle('light')">
+      <f7-col width="50" class="nav-bars-picker nav-bars-picker-empty" @click="setBarsStyle('light')">
         <div class="demo-navbar"></div>
         <f7-checkbox checked disabled v-if="barsStyle === 'light'" />
       </f7-col>
@@ -32,6 +32,10 @@
           <f7-list-item>
             <span>Simple navigation bar on home page</span>
             <f7-toggle :checked="homePageNavbarStyle === 'simple'" @toggle:change="setHomePageNavbarStyle"></f7-toggle>
+          </f7-list-item>
+          <f7-list-item>
+            <span>Standard home page background color</span>
+            <f7-toggle :checked="homePageBackground === 'standard'" @toggle:change="setHomePageBackground"></f7-toggle>
           </f7-list-item>
           <f7-list-item>
             <span>Disable card expansion animations</span>
@@ -51,13 +55,16 @@ export default {
   methods: {
     switchTheme (theme) {
       localStorage.setItem('openhab.ui:theme', theme)
+      localStorage.removeItem('openhab.ui:theme.bars') // reset the bars to their default when switching themes
       location.reload()
-      // document.location = document.location.origin + document.location.pathname + '?theme=' + theme
     },
     setThemeDark (value) {
-      value === 'auto'
-        ? localStorage.removeItem('openhab.ui:theme.dark') : localStorage.setItem('openhab.ui:theme.dark', value)
-      localStorage.setItem('openhab.ui:theme.bars', 'light') // dark theme with filled bars is ugly, switch to light bars too
+      if (value === 'auto') {
+        localStorage.removeItem('openhab.ui:theme.dark')
+      } else {
+        localStorage.setItem('openhab.ui:theme.dark', value)
+      }
+      localStorage.removeItem('openhab.ui:theme.bars') // reset the bars to their default when switching dark mode
       location.reload()
     },
     setBarsStyle (value) {
@@ -68,12 +75,16 @@ export default {
       localStorage.setItem('openhab.ui:theme.home.navbar', (value) ? 'simple' : 'default')
       location.reload()
     },
+    setHomePageBackground (value) {
+      localStorage.setItem('openhab.ui:theme.home.background', (value) ? 'standard' : 'default')
+      location.reload()
+    },
     setExpandableCardAnimation (value) {
       localStorage.setItem('openhab.ui:theme.home.cardanimation', (value) ? 'disabled' : 'default')
       location.reload()
     },
     setPageTransitionAnimation (value) {
-      localStorage.setItem('openhab.ui:theme.home.pagetransition', (value) ? 'disabled' : 'default')
+      localStorage.setItem('openhab.ui:theme.pagetransition', (value) ? 'disabled' : 'default')
       location.reload()
     }
   },
@@ -85,80 +96,82 @@ export default {
       return localStorage.getItem('openhab.ui:theme.dark') || 'auto'
     },
     barsStyle () {
-      return localStorage.getItem('openhab.ui:theme.bars') || ((!this.$theme.ios) ? 'filled' : 'light')
+      return localStorage.getItem('openhab.ui:theme.bars') || ((this.$theme.ios || this.$f7.darkTheme || this.darkMode === 'dark') ? 'light' : 'filled')
     },
     homePageNavbarStyle () {
       return localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
+    },
+    homePageBackground () {
+      return localStorage.getItem('openhab.ui:theme.home.background') || 'default'
     },
     expandableCardsAnimation () {
       return localStorage.getItem('openhab.ui:theme.home.cardanimation') || 'default'
     },
     pageTransitionAnimation () {
-      return localStorage.getItem('openhab.ui:theme.home.pagetransition') || 'default'
+      return localStorage.getItem('openhab.ui:theme.pagetransition') || 'default'
     }
   }
 }
 </script>
-<style>
-.demo-bars-picker {
-  height: 200px;
-  border-radius: 10px;
-  box-shadow: 0px 5px 20px rgba(0,0,0,0.1);
-  cursor: pointer;
-  position: relative;
-  overflow: hidden;
-  background: var(--f7-page-bg-color);
-  border: 1px solid rgba(255,255,255,0.2);
-}
-.demo-bars-picker .checkbox {
-  position: absolute;
-  left: 10px;
-  bottom: 10px;
-}
+<style lang="stylus">
+.nav-bars-picker
+  height 200px;
+  border-radius 10px;
+  box-shadow 0px 5px 20px rgba(0,0,0,0.1);
+  cursor pointer;
+  position relative;
+  overflow hidden;
+  background var(--f7-page-bg-color);
+  border 1px solid rgba(255,255,255,0.2);
 
-.demo-bars-picker .demo-navbar {
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 30px;
-  top: 0;
-  border-bottom: 1px solid transparent;
-}
-.demo-bars-picker .demo-navbar:before {
-  content: '';
-  position: absolute;
-  left: 10px;
-  width: 20px;
-  height: 10px;
-  top: 50%;
-  margin-top: -5px;
-}
-.demo-bars-picker .demo-navbar:after {
-  content: '';
-  position: absolute;
-  right: 10px;
-  width: 20px;
-  height: 10px;
-  top: 50%;
-  margin-top: -5px;
-}
-.demo-bars-picker-empty .demo-navbar {
-  background: #f7f7f8;
-  border-color: rgba(0,0,0,0.1);
-}
-.theme-dark .demo-bars-picker-empty .demo-navbar {
-  background: #1b1b1b;
-  border-color: #282829;
-}
-.demo-bars-picker-empty .demo-navbar:before,
-.demo-bars-picker-empty .demo-navbar:after {
-  background: var(--f7-theme-color);
-}
-.demo-bars-picker-fill .demo-navbar {
-  background: var(--f7-theme-color);
-}
-.demo-bars-picker-fill .demo-navbar:before,
-.demo-bars-picker-fill .demo-navbar:after {
-  background: #fff;
-}
+.nav-bars-picker .checkbox
+  position absolute;
+  left 10px;
+  bottom 10px;
+
+.nav-bars-picker .demo-navbar
+  position absolute;
+  left 0;
+  width 100%;
+  height 30px;
+  top 0;
+  border-bottom 1px solid transparent;
+
+.nav-bars-picker .demo-navbar:before
+  content '';
+  position absolute;
+  left 10px;
+  width 20px;
+  height 10px;
+  top 50%;
+  margin-top -5px;
+
+.nav-bars-picker .demo-navbar:after
+  content '';
+  position absolute;
+  right 10px;
+  width 20px;
+  height 10px;
+  top 50%;
+  margin-top -5px;
+
+.nav-bars-picker-empty .demo-navbar
+  background #f7f7f8;
+  border-color rgba(0,0,0,0.1);
+
+.theme-dark .nav-bars-picker-empty .demo-navbar
+  background #1b1b1b;
+  border-color #282829;
+
+.nav-bars-picker-empty .demo-navbar:before,
+.nav-bars-picker-empty .demo-navbar:after
+  background var(--f7-theme-color);
+
+.nav-bars-picker-fill .demo-navbar
+  background var(--f7-theme-color);
+
+.nav-bars-picker-fill .demo-navbar:before,
+.nav-bars-picker-fill .demo-navbar:after
+  background #fff;
+
 </style>

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -1,18 +1,39 @@
 <template>
   <f7-block>
     <f7-block-title class="padding-left">Theme</f7-block-title>
-    <f7-segmented>
-      <f7-button round color="blue" raised :fill="theme === 'auto'" @click="switchTheme('auto')">Auto</f7-button>
-      <f7-button round color="blue" raised :fill="theme === 'md'" @click="switchTheme('md')">MD</f7-button>
-      <f7-button round color="blue" raised :fill="theme === 'ios'" @click="switchTheme('ios')">iOS</f7-button>
-      <f7-button round color="blue" raised :fill="theme === 'aurora'" @click="switchTheme('aurora')">Aurora</f7-button>
-    </f7-segmented>
+    <f7-row>
+      <f7-col width="25" class="theme-picker auto" @click="switchTheme('auto')">
+        <span class="text-color-gray">Auto</span>
+        <f7-checkbox checked disabled v-if="theme === 'auto'" />
+      </f7-col>
+      <f7-col width="25" class="theme-picker" @click="switchTheme('md')">
+        <span><f7-icon f7="logo_android" size="20" color="gray" /></span>
+        <f7-checkbox checked disabled v-if="theme === 'md'" />
+      </f7-col>
+      <f7-col width="25" class="theme-picker" @click="switchTheme('ios')">
+        <span><f7-icon f7="logo_ios" size="25" color="gray" /></span>
+        <f7-checkbox checked disabled v-if="theme === 'ios'" />
+      </f7-col>
+      <f7-col width="25" class="theme-picker" @click="switchTheme('aurora')">
+        <span><f7-icon f7="desktopcomputer" size="20" color="gray" /></span>
+        <f7-checkbox checked disabled v-if="theme === 'aurora'" />
+      </f7-col>
+    </f7-row>
     <f7-block-title>Dark mode</f7-block-title>
-    <f7-segmented>
-      <f7-button round color="blue" raised :fill="darkMode === 'auto'" @click="setThemeDark('auto')">Auto</f7-button>
-      <f7-button round color="blue" raised :fill="darkMode === 'light'" @click="setThemeDark('light')">Light</f7-button>
-      <f7-button round color="blue" raised :fill="darkMode === 'dark'" @click="setThemeDark('dark')">Dark</f7-button>
-    </f7-segmented>
+    <f7-row>
+      <f7-col width="33" class="theme-picker auto" @click="setThemeDark('auto')">
+        <span class="text-color-gray">Auto</span>
+        <f7-checkbox checked disabled v-if="darkMode === 'auto'" />
+      </f7-col>
+      <f7-col width="33" class="bg-color-white theme-picker" @click="setThemeDark('light')">
+        <span class="text-color-gray">Light</span>
+        <f7-checkbox checked disabled v-if="darkMode === 'light'" />
+      </f7-col>
+      <f7-col width="33" class="bg-color-black theme-picker" @click="setThemeDark('dark')">
+        <span class="text-color-gray">Dark</span>
+        <f7-checkbox checked disabled v-if="darkMode === 'dark'" />
+      </f7-col>
+    </f7-row>
     <f7-block-title>Navigation bars style</f7-block-title>
     <f7-row>
       <f7-col width="50" class="nav-bars-picker nav-bars-picker-fill" @click="setBarsStyle('filled')">
@@ -114,64 +135,87 @@ export default {
 }
 </script>
 <style lang="stylus">
+.theme-picker
+  cursor pointer
+  height 100px
+  padding 40px 20px
+  border-radius 10px
+  box-shadow 0px 5px 20px rgba(0,0,0,0.1)
+  border 1px solid rgba(255,255,255,0.2)
+  box-sizing border-box
+  position relative
+  display flex
+  align-content center
+  font-size 16px
+  span
+    width 100%
+    text-align center
+  i.f7-icons
+    width 100%
+    text-align center
+  .checkbox
+    position absolute
+    left 10px
+    bottom 10px
+
 .nav-bars-picker
-  height 200px;
-  border-radius 10px;
-  box-shadow 0px 5px 20px rgba(0,0,0,0.1);
-  cursor pointer;
-  position relative;
-  overflow hidden;
-  background var(--f7-page-bg-color);
-  border 1px solid rgba(255,255,255,0.2);
+  height 200px
+  border-radius 10px
+  box-shadow 0px 5px 20px rgba(0,0,0,0.1)
+  cursor pointer
+  position relative
+  overflow hidden
+  background var(--f7-page-bg-color)
+  border 1px solid rgba(255,255,255,0.2)
 
 .nav-bars-picker .checkbox
-  position absolute;
-  left 10px;
-  bottom 10px;
+  position absolute
+  left 10px
+  bottom 10px
 
 .nav-bars-picker .demo-navbar
-  position absolute;
-  left 0;
-  width 100%;
-  height 30px;
-  top 0;
-  border-bottom 1px solid transparent;
+  position absolute
+  left 0
+  width 100%
+  height 30px
+  top 0
+  border-bottom 1px solid transparent
 
 .nav-bars-picker .demo-navbar:before
-  content '';
-  position absolute;
-  left 10px;
-  width 20px;
-  height 10px;
-  top 50%;
-  margin-top -5px;
+  content ''
+  position absolute
+  left 10px
+  width 20px
+  height 10px
+  top 50%
+  margin-top -5px
 
 .nav-bars-picker .demo-navbar:after
-  content '';
-  position absolute;
-  right 10px;
-  width 20px;
-  height 10px;
-  top 50%;
-  margin-top -5px;
+  content ''
+  position absolute
+  right 10px
+  width 20px
+  height 10px
+  top 50%
+  margin-top -5px
 
 .nav-bars-picker-empty .demo-navbar
-  background #f7f7f8;
-  border-color rgba(0,0,0,0.1);
+  background #f7f7f8
+  border-color rgba(0,0,0,0.1)
 
 .theme-dark .nav-bars-picker-empty .demo-navbar
-  background #1b1b1b;
-  border-color #282829;
+  background #1b1b1b
+  border-color #282829
 
 .nav-bars-picker-empty .demo-navbar:before,
 .nav-bars-picker-empty .demo-navbar:after
-  background var(--f7-theme-color);
+  background var(--f7-theme-color)
 
 .nav-bars-picker-fill .demo-navbar
-  background var(--f7-theme-color);
+  background var(--f7-theme-color)
 
 .nav-bars-picker-fill .demo-navbar:before,
 .nav-bars-picker-fill .demo-navbar:after
-  background #fff;
+  background #fff
 
 </style>

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/oh-chart-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/oh-chart-page.vue
@@ -32,11 +32,11 @@
   width 100%
   height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height)) !important
   &.with-tabbar
-    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-safe-area-bottom) - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
   &.with-toolbar
-    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-toolbar-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-safe-area-bottom) - var(--f7-navbar-height) - var(--f7-toolbar-height)) !important
   &.with-sheet
-    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-sheet-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-safe-area-bottom) - var(--f7-navbar-height) - var(--f7-sheet-height)) !important
   .echarts
     width calc(100% - 20px)
     height 100%

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/oh-chart-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/oh-chart-page.vue
@@ -28,15 +28,15 @@
   position absolute
   background-color white
   overflow-x hidden
-  top calc(var(--f7-navbar-height))
+  top calc(var(--f7-safe-area-top) + var(--f7-navbar-height))
   width 100%
-  height calc(100% - var(--f7-navbar-height)) !important
+  height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height)) !important
   &.with-tabbar
-    height calc(100% - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
   &.with-toolbar
-    height calc(100% - var(--f7-navbar-height) - var(--f7-toolbar-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-toolbar-height)) !important
   &.with-sheet
-    height calc(100% - var(--f7-navbar-height) - var(--f7-sheet-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-sheet-height)) !important
   .echarts
     width calc(100% - 20px)
     height 100%

--- a/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-page.vue
@@ -24,10 +24,10 @@
 .oh-map-page-lmap
   position absolute
   background-color var(--f7-page-bg-color)
-  top calc(var(--f7-navbar-height))
-  height calc(100% - var(--f7-navbar-height)) !important
+  top calc(var(--f7-safe-area-top) + var(--f7-navbar-height))
+  height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height)) !important
   &.with-tabbar
-    height calc(100% - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
@@ -43,10 +43,10 @@
 .oh-plan-page-lmap
   position absolute
   background-color var(--f7-page-bg-color)
-  top calc(var(--f7-navbar-height))
-  height calc(100% - var(--f7-navbar-height)) !important
+  top calc(var(--f7-safe-area-top) + var(--f7-navbar-height))
+  height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height)) !important
   &.with-tabbar
-    height calc(100% - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
+    height calc(100% - var(--f7-safe-area-top) - var(--f7-navbar-height) - var(--f7-tabbar-labels-height)) !important
   &.oh-plan-white-background, &.oh-plan-blackwhite-background
     background-color white
 .theme-dark

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
@@ -10,11 +10,11 @@
 .player-controls
   .button
     height 48px
+  .segmented-highlight
+    display none
 .aurora .player-controls
   .button
     height 37px
-  .segmented-highlight
-    display none
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -113,6 +113,27 @@ export const actionProps = (groupName, paramPrefix) => {
       }
     },
     {
+      name: paramPrefix + 'actionPageTransition',
+      label: 'Transition Effect',
+      groupName,
+      type: 'TEXT',
+      limitToOptions: true,
+      description: 'Use a specific <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/view.html#custom-page-transitions">page transition animation</a>',
+      options: [
+        { value: 'f7-circle', label: 'Circle' },
+        { value: 'f7-cover', label: 'Cover' },
+        { value: 'f7-cover-v', label: 'Cover from bottom' },
+        { value: 'f7-dive', label: 'Dive' },
+        { value: 'f7-fade', label: 'Fade' },
+        { value: 'f7-flip', label: 'Flip' },
+        { value: 'f7-parallax', label: 'Parallax' },
+        { value: 'f7-push', label: 'Push' }
+      ],
+      visible: (value, configuration, configDescription, parameters) => {
+        return ['navigate'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }
+    },
+    {
       name: paramPrefix + 'actionModal',
       label: 'Modal Page or Widget',
       groupName,
@@ -197,12 +218,15 @@ export const actionsMixin = {
       switch (action) {
         case 'navigate':
           const actionPage = this.config[prefix + 'actionPage']
+          const actionPageTransition = this.config[prefix + 'actionPageTransition']
           console.log('Navigating to ' + actionPage)
           if (actionPage.indexOf('page:') !== 0) {
             console.log('Action target is not of the format page:uid')
             return
           }
-          this.$f7router.navigate('/page/' + actionPage.substring(5), { props: { deep: true } })
+          let navigateOptions = { props: { deep: true } }
+          if (actionPageTransition) navigateOptions.transition = actionPageTransition
+          this.$f7router.navigate('/page/' + actionPage.substring(5), navigateOptions)
           break
         case 'command':
           const actionItem = this.config[prefix + 'actionItem']

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -1,7 +1,6 @@
 /* iOS Cordova Tweak */
-.device-cordova.device-ios {
-  height: 100vh;
-}
+.device-cordova.device-ios
+  height 100vh
 
 /* Disable Android Chrome pull-to-refresh */
 html
@@ -20,141 +19,122 @@ html
     transition-duration 1ms
 
 /* Custom color theme properties */
-:root {
-  --f7-theme-color: #e64a19;
-  --f7-theme-color-rgb: 230, 74, 25;
-  --f7-theme-color-shade: #c13e15;
-  --f7-theme-color-tint: #ea673e;
-}
+:root
+  --f7-theme-color #e64a19
+  --f7-theme-color-rgb 230, 74, 25
+  --f7-theme-color-shade #c13e15
+  --f7-theme-color-tint #ea673e
 
 :root.theme-filled,
-:root .theme-filled {
-  .subnavbar:not(.toolbar-bottom) {
-    --f7-bars-bg-color: var(--f7-theme-color);
-    --f7-bars-bg-color-rgb: var(--f7-theme-color-rgb);
-    --f7-bars-translucent-opacity: 0.9;
-    --f7-bars-text-color: #fff;
-    --f7-bars-link-color: #fff;
-    --f7-navbar-subtitle-text-color: rgba(255,255,255,0.85);
-    --f7-bars-border-color: transparent;
-  }
-  .toolbar:not(.toolbar-bottom) {
-  --f7-bars-bg-color: var(--f7-theme-color);
-  --f7-bars-bg-color-rgb: var(--f7-theme-color-rgb);
-  --f7-bars-translucent-opacity: 0.9;
-  --f7-bars-text-color: #fff;
-  --f7-bars-link-color: #fff;
-  --f7-bars-border-color: transparent;
-  }
-  .tabbar:not(.toolbar-bottom) {
-    --f7-bars-bg-color: var(--f7-theme-color);
-    --f7-bars-bg-color-rgb: var(--f7-theme-color-rgb);
-    --f7-bars-translucent-opacity: 0.9;
-    --f7-bars-text-color: #fff;
-    --f7-bars-link-color: #fff;
-    --f7-navbar-subtitle-text-color: rgba(255,255,255,0.85);
-    --f7-bars-border-color: transparent;
-    --f7-tabbar-link-active-color: #fff;
-    --f7-tabbar-link-inactive-color: rgba(255,255,255,0.54);
-    --f7-tabbar-link-active-border-color: #fff;
-  }
-  .navbar {
-    --f7-bars-bg-color: var(--f7-theme-color);
-    --f7-bars-bg-color-rgb: var(--f7-theme-color-rgb);
-    --f7-bars-text-color: #fff;
-    --f7-bars-translucent-opacity: 0.9;
-    --f7-bars-link-color: #fff;
-    --f7-navbar-large-title-text-color: #fff;
-    --f7-bars-border-color: transparent;
-    
-    &.navbar-large-transparent .title-large-text {
-      --f7-navbar-large-title-text-color: #000;
-    }
-    &.navbar-large-transparent:not(.navbar-large-collapsed) {
-      --f7-bars-link-color: var(--f7-theme-color);
-    }
-  }
-  --f7-navbar-subtitle-text-color: rgba(255,255,255,0.85);
-  --f7-navbar-border-color: transparent;
-  --f7-searchbar-input-bg-color: #fff;
-  --f7-sheet-border-color: transparent;
+:root .theme-filled
+  .subnavbar:not(.toolbar-bottom)
+    --f7-bars-bg-color var(--f7-theme-color)
+    --f7-bars-bg-color-rgb var(--f7-theme-color-rgb)
+    --f7-bars-translucent-opacity 0.9
+    --f7-bars-text-color #fff
+    --f7-bars-link-color #fff
+    --f7-navbar-subtitle-text-color rgba(255,255,255,0.85)
+    --f7-bars-border-color transparent
 
-  .navbar-large-transparent {
-    --f7-navbar-large-title-text-color: #000;
+  .toolbar:not(.toolbar-bottom)
+  --f7-bars-bg-color var(--f7-theme-color)
+  --f7-bars-bg-color-rgb var(--f7-theme-color-rgb)
+  --f7-bars-translucent-opacity 0.9
+  --f7-bars-text-color #fff
+  --f7-bars-link-color #fff
+  --f7-bars-border-color transparent
 
-    --r: 230;
-    --g: 74;
-    --b: 25;
-    --progress: var(--f7-navbar-large-collapse-progress);
-    // --f7-bars-link-color: rgb(
+  .tabbar:not(.toolbar-bottom)
+    --f7-bars-bg-color var(--f7-theme-color)
+    --f7-bars-bg-color-rgb var(--f7-theme-color-rgb)
+    --f7-bars-translucent-opacity 0.9
+    --f7-bars-text-color #fff
+    --f7-bars-link-color #fff
+    --f7-navbar-subtitle-text-color rgba(255,255,255,0.85)
+    --f7-bars-border-color transparent
+    --f7-tabbar-link-active-color #fff
+    --f7-tabbar-link-inactive-color rgba(255,255,255,0.54)
+    --f7-tabbar-link-active-border-color #fff
+
+  .navbar
+    --f7-bars-bg-color var(--f7-theme-color)
+    --f7-bars-bg-color-rgb var(--f7-theme-color-rgb)
+    --f7-bars-text-color #fff
+    --f7-bars-translucent-opacity 0.9
+    --f7-bars-link-color #fff
+    --f7-navbar-large-title-text-color #fff
+    --f7-bars-border-color transparent
+
+    &.navbar-large-transparent .title-large-text
+      --f7-navbar-large-title-text-color #000
+
+    &.navbar-large-transparent:not(.navbar-large-collapsed)
+      --f7-bars-link-color var(--f7-theme-color)
+
+  --f7-navbar-subtitle-text-color rgba(255,255,255,0.85)
+  --f7-navbar-border-color transparent
+  --f7-searchbar-input-bg-color #fff
+  --f7-sheet-border-color transparent
+
+  .navbar-large-transparent
+    --f7-navbar-large-title-text-color #000
+
+    --r 230
+    --g 74
+    --b 25
+    --progress var(--f7-navbar-large-collapse-progress)
+    // --f7-bars-link-color rgb(
     //   calc(var(--r) + (255 - var(--r)) * var(--progress)),
     //   calc(var(--g) + (255 - var(--g)) * var(--progress)),
     //   calc(var(--b) + (255 - var(--b)) * var(--progress))
-    // );
-  }
-}
+    // )
 
 .md
-  --f7-page-bg-color: #fafafa
-  --f7-page-bg-color-rgb: rgb(250, 250, 250)
+  --f7-page-bg-color #fafafa
+  --f7-page-bg-color-rgb rgb(250, 250, 250)
   .list-card
     box-shadow var(--f7-elevation-1)
 
-.home-tabs {
-  --f7-theme-color: #2196f3;
-}
+.home-tabs
+  --f7-theme-color #2196f3
 
-.navbar-large-hidden {
-  --f7-navbar-large-collapse-progress: 1
+.navbar-large-hidden
+  --f7-navbar-large-collapse-progress 1
   opacity 0
-}
-.navbar-large-hidden:not(.navbar-large-collapsed) .navbar-bg {
+
+.navbar-large-hidden:not(.navbar-large-collapsed) .navbar-bg
   opacity 0
-}
 
-.toolbar.toolbar-bottom, .tabbar.tabbar-bottom {
-  --f7-theme-color: #2196f3;
-  }
+.toolbar.toolbar-bottom, .tabbar.tabbar-bottom
+  --f7-theme-color #2196f3
 
-.home-tabs {
-  --f7-theme-color: #2196f3;
-  --f7-bars-bg-color: rgb(247, 247, 248);
-  --f7-bars-text-color: #000;
-  --f7-tabbar-link-inactive-color: rgba(0, 0, 0, 0.54);
-  --f7-tabbar-link-active-color: var(--f7-theme-color);
-  text-transform: none;
-}
+.home-tabs
+  --f7-theme-color #2196f3
+  --f7-bars-bg-color rgb(247, 247, 248)
+  --f7-bars-text-color #000
+  --f7-tabbar-link-inactive-color rgba(0, 0, 0, 0.54)
+  --f7-tabbar-link-active-color var(--f7-theme-color)
+  text-transform none
 
-.md .title-large-text {
+.md .title-large-text
   font-weight bold !important
-}
 
-.theme-dark .home-tabs {
-  --f7-bars-bg-color: rgb(32, 32, 33);
-  --f7-bars-text-color: #fff;
-  --f7-bars-link-color: #fff;
-  --f7-tabbar-link-inactive-color: rgba(255,255,255,0.54);
-}
+.theme-dark .home-tabs
+  --f7-bars-bg-color rgb(32, 32, 33)
+  --f7-bars-text-color #fff
+  --f7-bars-link-color #fff
+  --f7-tabbar-link-inactive-color rgba(255,255,255,0.54)
 
-.ios .contextual-toolbar {
-//   --f7-theme-color: #2196f3;
-//   --f7-bars-bg-color: rgb(247, 247, 248);
-//   --f7-bars-text-color: #000;
-//   --f7-tabbar-link-inactive-color: rgba(0, 0, 0, 0.54);
-//   --f7-tabbar-link-active-color: var(--f7-theme-color);
-// //  --f7-bars-link-color: var(--f7-theme-color);
-//   text-transform: none;
 
-   .delete {
-     --f7-bars-link-color: #ff3b30;
-   }
-}
-.md .contextual-toolbar {
-  --f7-theme-color: #474747;
-  --f7-bars-bg-color: #474747;
-  --f7-bars-text-color: #fff;
-  height: var(--f7-navbar-height);
-}
+.ios .contextual-toolbar
+   .delete
+     --f7-bars-link-color #ff3b30
+
+.md .contextual-toolbar
+  --f7-theme-color #474747
+  --f7-bars-bg-color #474747
+  --f7-bars-text-color #fff
+  height var(--f7-navbar-height)
 
 .panel-left .page-content::-webkit-scrollbar
   width 0
@@ -162,89 +142,58 @@ html
 .page-home
   .page-content::-webkit-scrollbar
     width 0
-  // &.page-with-card-opened
-  //   .page-content
-  //     overflow auto
-  // .toolbar-hidden + .page-content
-  //   overflow hidden !important
-
-// .tabbar-labels .tabbar-label {
-//     line-height: 1;
-//     margin: 0;
-//     text-overflow: ellipsis;
-//     white-space: nowrap;
-//     font-size: var(--f7-tabbar-label-font-size) !important;
-//     text-transform: var(--f7-tabbar-label-text-transform) !important;
-//     font-weight: var(--f7-tabbar-label-font-weight) !important;
-//     letter-spacing: var(--f7-tabbar-label-letter-spacing) !important;
-// }
 
 /* Left Panel right border when it is visible by breakpoint */
-.panel-left.panel-in-breakpoint:before {
-  position: absolute;
-  right: 0;
-  top: 0;
-  height: 100%;
-  width: 1px;
-  background: rgba(0,0,0,0.1);
-  content: '';
-  z-index: 6000;
-}
+.panel-left.panel-in-breakpoint:before
+  position absolute
+  right 0
+  top 0
+  height 100%
+  width 1px
+  background rgba(0,0,0,0.1)
+  content ''
+  z-index 6000
 
 /* Hide navbar link which opens left panel when it is visible by breakpoint */
-.panel-left.panel-in-breakpoint ~ .view .navbar .panel-open[data-panel="left"] {
-  display: none;
-}
+.panel-left.panel-in-breakpoint ~ .view .navbar .panel-open[data-panel="left"]
+  display none
 
 /*
   Extra borders for main view and left panel for iOS theme when it behaves as panel (before breakpoint size)
 */
 .ios .panel-left:not(.panel-in-breakpoint).panel-active ~ .view-main:before,
-.ios .panel-left:not(.panel-in-breakpoint).panel-closing ~ .view-main:before {
-  position: absolute;
-  left: 0;
-  top: 0;
-  height: 100%;
-  width: 1px;
-  background: rgba(0,0,0,0.1);
-  content: '';
-  z-index: 6000;
-}
+.ios .panel-left:not(.panel-in-breakpoint).panel-closing ~ .view-main:before
+  position absolute
+  left 0
+  top 0
+  height 100%
+  width 1px
+  background rgba(0,0,0,0.1)
+  content ''
+  z-index 6000
 
-/* Your app styles here */
+@media (min-width 1024px)
+    .block-narrow
+        display flex
+        flex-direction column
+        align-items center
+        justify-content center
 
-@media (min-width: 1024px) {
-    .block-narrow {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-    }
+    .block-narrow .row
+        width 720px
 
-    .block-narrow .row {
-        width: 720px;
-    }
+    .block-narrow .col
+        width 720px
+        display initial
 
-    .block-narrow .col {
-        width: 720px;
-        display: initial;
-    }
-}
+@media (max-width 1023px)
+  .block-narrow
+    padding-left var(--f7-safe-area-left)
+    padding-right var(--f7-safe-area-right)
 
-@media (max-width: 1023px) {
-  .block-narrow {
-    padding-left: var(--f7-safe-area-left);
-    padding-right: var(--f7-safe-area-right);
-  }
-}
+.md .panel-in-breakpoint
+  box-shadow 0 1px 10px 0 rgba(0, 0, 0, 0.3)
 
-.md .panel-in-breakpoint {
-  box-shadow: 0 1px 10px 0 rgba(0, 0, 0, 0.3);
-}
-
-// .page-content {
-//   margin-top: 1rem;
-// }
 .page-content
   .block:first-child
     margin-top 1rem
@@ -272,34 +221,31 @@ html
     padding-left calc(var(--f7-safe-area-left) + var(--f7-card-header-padding-horizontal))
 
 /* Demo Expandable Cards */
-@media (min-width: 768px) {
-  .demo-expandable-cards {
-    display: flex;
-    flex-wrap: wrap;
-  }
-  .demo-expandable-cards .card {
-    flex-shrink: 10;
-    min-width: 0;
-  }
-}
-@media (min-width: 768px) and (max-width: 1023px) {
-  .demo-expandable-cards .card {
-    width 340px
-  }
-  // .demo-expandable-cards .card {
-  //   width: calc((100% - var(--f7-card-expandable-margin-horizontal) * 3) / 2);
-  // }
-  .demo-expandable-cards .card:nth-child(n),
-  .demo-expandable-cards .card:nth-child(n + 1) {
-    margin-left: 0;
-  }
-  .demo-expandable-cards .card:nth-child(n + 3) {
-    margin-top: 0;
-  }
-}
+@media (min-width 768px)
+  .demo-expandable-cards
+    display flex
+    flex-wrap wrap
 
-@media (min-width: 1024px)
-  .demo-expandable-cards 
+  .demo-expandable-cards .card
+    flex-shrink 10
+    min-width 0
+
+@media (min-width 768px) and (max-width 1023px)
+  .demo-expandable-cards .card
+    width 340px
+
+  // .demo-expandable-cards .card
+  //   width calc((100% - var(--f7-card-expandable-margin-horizontal) * 3) / 2)
+  //
+  .demo-expandable-cards .card:nth-child(n),
+  .demo-expandable-cards .card:nth-child(n + 1)
+    margin-left 0
+
+  .demo-expandable-cards .card:nth-child(n + 3)
+    margin-top 0
+
+@media (min-width 1024px)
+  .demo-expandable-cards
     margin-top 2rem
     .card
       width 340px
@@ -312,7 +258,6 @@ html
   .demo-expandable-cards .card:nth-child(n + 3)
     margin-top 0
 
-
   // hide scrollbar
   .card-expandable.card-opened .card-content
       overflow-y scroll
@@ -322,16 +267,6 @@ html
   .card-expandable.card-opened .card-content::-webkit-scrollbar /* WebKit */
       width 0
       height 0
-
-
-.view-master-detail .navbar-master-detail .link.back,
-.view-master-detail .page-master-detail .navbar .link.back
-  display none
-
-// .ios .card-expandable
-//   background-color var(--f7-page-bg-color)
-//   .list
-//     background-color white
 
 // Remove the borders and background for admin links in sidebar
 .list.admin-links
@@ -356,19 +291,18 @@ html
   text-align center
   line-height 32px
 
-#framework7-root:not(.theme-dark) .page-home,
-#framework7-root:not(.theme-dark) .page-about,
+#framework7-root:not(.theme-dark) .page-home:not(.standard-background),
+#framework7-root:not(.theme-dark) .page-about:not(.standard-background),
 //#framework7-root:not(.theme-dark) .page-settings
   --f7-page-bg-color #fff
 
-// disable blur on card backdrop (poor performance)
-.card-backdrop {
-  background: rgba(0,0,0,0.2);
-}
-.card-backdrop-in {
-  animation: card-backdrop-fade-in 400ms forwards;
-  pointer-events: auto;
-}
-.card-backdrop-out {
-  animation: card-backdrop-fade-out 400ms forwards;
-}
+// disable blur on card backdrop (poor performance - update: seems fixed)
+// .card-backdrop
+//   background rgba(0,0,0,0.2)
+
+// .card-backdrop-in
+//   animation card-backdrop-fade-in 400ms forwards
+//   pointer-events auto
+
+// .card-backdrop-out
+//   animation card-backdrop-fade-out 400ms forwards

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-page stacked name="HomePage" class="page-home" @page:init="onPageInit" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
+  <f7-page stacked name="HomePage" class="page-home" :class="{ 'standard-background': $f7.data.themeOptions.homeBackground === 'standard' }" @page:init="onPageInit" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar :large="$f7.data.themeOptions.homeNavbar !== 'simple'" :large-transparent="$f7.data.themeOptions.homeNavbar !== 'simple'" class="home-nav">
       <f7-nav-left>
         <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left"></f7-link>


### PR DESCRIPTION
Better filled bars defaults

Add per-device option to set the home page background
to the standard color (i.e. gray in light mode, no effect
in dark mode)

Consider safe area (fullscreen iOS) for map, plans, charts

Convert CSS remains to stylus, cleanups, fixes

Add page transition effect option for navigation
widget actions
(https://framework7.io/docs/view.html#custom-page-transitions)

Signed-off-by: Yannick Schaus <github@schaus.net>