### PR TITLE
Fix points names in Add Points to Model scenario

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -64,7 +64,7 @@
               (you will be able to configure the links individually later if needed).
             </f7-block-footer>
             <channel-list :thing="selectedThing" :thingType="selectedThingType" :channelTypes="selectedThingChannelTypes"
-              :multiple-links-mode="true" :new-items-prefix="(createEquipment) ? newEquipmentItem.name : (parentGroup) ? parentGroup : ''"
+              :multiple-links-mode="true" :new-items-prefix="(createEquipment) ? newEquipmentItem.name : (parentGroup) ? parentGroup.name : ''"
               @selected="(channel) => toggleSelect(channel)" :new-items="newPointItems" />
         </div>
       </f7-col>


### PR DESCRIPTION
Fix a bug introduced with #275 when points being added to the model without an
equipment would not have their default name properly computed.

Signed-off-by: Yannick Schaus <github@schaus.net>