### PR TITLE
Fix duplicate thing state being printed

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -23,7 +23,7 @@
             <f7-chip class="margin-left"
               :text="thing.statusInfo.status"
               :color="thing.statusInfo.status === 'ONLINE' ? 'green' : 'red'"
-            >{{thing.statusInfo.status}}</f7-chip>
+            ></f7-chip>
             <div v-if="thing.statusInfo.statusDetail !== 'NONE' || thing.statusInfo.description">
               <strong
                 v-if="thing.statusInfo.statusDetail !== 'NONE'"


### PR DESCRIPTION
The `Thing` state is currently printed twice in the thing detail page.
Signed-off-by: Chris Jackson <chris@cd-jackson.com>