### PR TITLE
Don't allow adding new bindings if not supported by server

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -54,6 +54,8 @@
         </f7-list>
 
       </f7-col>
+    </f7-block>
+    <f7-block class="block-narrow" v-if="$store.getters.apiEndpoint('extensions')">
       <f7-col v-if="bindings.length">
         <f7-list>
           <f7-list-button color="blue" title="Install More Bindings" href="install-binding" />


### PR DESCRIPTION
This hides the "Install New Bindings" messages if the server doesn't support the `extensions` service.

Signed-off-by: Chris Jackson <chris@cd-jackson.com>

