### PR TITLE
[Main UI] Include bridgeID in thingUID on manual creation

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -47,7 +47,7 @@ export default {
   methods: {
     computedThingUid () {
       return (this.thing.bridgeUID)
-        ? [this.thing.thingTypeUID, this.thing.bridgeUID.substring(this.thing.bridgeUID.lastIndexOf(':')), this.thing.ID].join(':')
+        ? [this.thing.thingTypeUID, this.thing.bridgeUID.substring(this.thing.bridgeUID.lastIndexOf(':') + 1), this.thing.ID].join(':')
         : [this.thing.thingTypeUID, this.thing.ID].join(':')
     },
     changeUID (event) {

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -44,8 +44,6 @@ export default {
   components: {
     ThingPicker
   },
-  computed: {
-  },
   methods: {
     computedThingUid () {
       return (this.thing.bridgeUID)

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -26,7 +26,7 @@
             <f7-list v-if="thingType.supportedBridgeTypeUIDs.length" inline-labels no-hairlines-md>
               <thing-picker
                 title="Bridge" name="bridge" :value="thing.bridgeUID"
-                @input="(value) => { thing.bridgeUID = value; $emit('updated') }"
+                @input="updateBridge"
                 :filterType="thingType.supportedBridgeTypeUIDs" />
             </f7-list>
           </f7-col>
@@ -44,10 +44,22 @@ export default {
   components: {
     ThingPicker
   },
+  computed: {
+  },
   methods: {
+    computedThingUid () {
+      return (this.thing.bridgeUID)
+        ? [this.thing.thingTypeUID, this.thing.bridgeUID.substring(this.thing.bridgeUID.lastIndexOf(':')), this.thing.ID].join(':')
+        : [this.thing.thingTypeUID, this.thing.ID].join(':')
+    },
     changeUID (event) {
       this.thing.ID = event.target.value
-      this.thing.UID = this.thing.thingTypeUID + ':' + this.thing.ID
+      if (this.createMode) this.thing.UID = this.computedThingUid()
+    },
+    updateBridge (value) {
+      this.thing.bridgeUID = value
+      this.$emit('updated')
+      if (this.createMode) this.thing.UID = this.computedThingUid()
     }
   }
 }


### PR DESCRIPTION
This will include the ID of the bridge in the ThingUID if it is specified during the
manual creation of the thing.

The thingUID format will therefore be `binding:thingType:bridgeID:thingID` if a bridge is specified during the creation, otherwise it will be `binding:thingType:thingID`. This is consistent with the naming convention adopted when creating things by other means (files, inbox).

Note that the thingUID is immutable once the thing has been created, so the bridge ID part will be false or missing when the bridge is altered or assigned after the creation. Relying on the thingUID to determine the bridge should be discouraged.
See openhab/openhab-addons#7496 (comment)

Fixes #290.

Signed-off-by: Yannick Schaus <github@schaus.net>