### PR TITLE
Migrate to JUnit 5

### DIFF
--- a/bundles/org.openhab.ui.cometvisu/pom.xml
+++ b/bundles/org.openhab.ui.cometvisu/pom.xml
@@ -35,12 +35,12 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.boot</artifactId>
+      <artifactId>org.openhab.core</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core</artifactId>
+      <artifactId>org.openhab.core.io.net</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/bundles/org.openhab.ui.habot/pom.xml
+++ b/bundles/org.openhab.ui.habot/pom.xml
@@ -29,12 +29,7 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.boot</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.ui</artifactId>
+      <artifactId>org.openhab.core.automation</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
@@ -44,12 +39,22 @@
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.model.script</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.semantics</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>
-      <artifactId>org.openhab.core.automation</artifactId>
+      <artifactId>org.openhab.core.ui</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openhab.core.bundles</groupId>
+      <artifactId>org.openhab.core.voice</artifactId>
       <version>${project.version}</version>
     </dependency>
   </dependencies>

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/notification/internal/NotificationService.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/notification/internal/NotificationService.java
@@ -40,7 +40,7 @@ import org.bouncycastle.jce.interfaces.ECPublicKey;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
 import org.jose4j.lang.JoseException;
-import org.openhab.core.config.core.ConfigConstants;
+import org.openhab.core.OpenHAB;
 import org.openhab.ui.habot.notification.internal.webpush.Notification;
 import org.openhab.ui.habot.notification.internal.webpush.PushService;
 import org.openhab.ui.habot.notification.internal.webpush.Subscription;
@@ -174,7 +174,7 @@ public class NotificationService {
         encodedKeys.add(BaseEncoding.base64Url().encode(privateKey));
 
         // write the public key, then the private key in encoded form on separate lines in the file
-        File file = new File(ConfigConstants.getUserDataFolder() + File.separator + VAPID_KEYS_FILE_NAME);
+        File file = new File(OpenHAB.getUserDataFolder() + File.separator + VAPID_KEYS_FILE_NAME);
         file.getParentFile().mkdirs();
         IOUtils.writeLines(encodedKeys, System.lineSeparator(), new FileOutputStream(file));
 
@@ -188,7 +188,7 @@ public class NotificationService {
     private void loadVAPIDKeys() {
         try {
             List<String> encodedKeys = IOUtils.readLines(
-                    new FileInputStream(ConfigConstants.getUserDataFolder() + File.separator + VAPID_KEYS_FILE_NAME));
+                    new FileInputStream(OpenHAB.getUserDataFolder() + File.separator + VAPID_KEYS_FILE_NAME));
             this.publicVAPIDKey = encodedKeys.get(0);
             this.privateVAPIDKey = encodedKeys.get(1);
         } catch (IOException e) {

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/AbstractTrainerTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/AbstractTrainerTest.java
@@ -12,14 +12,14 @@
  */
 package org.openhab.ui.habot.test;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.TreeMap;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.IntentInterpretation;
 import org.openhab.ui.habot.nlp.Skill;
@@ -48,7 +48,7 @@ public class AbstractTrainerTest {
         public final static String CREATE_RULE = "create-rule";
     }
 
-    @Before
+    @BeforeEach
     public void initializeMockSkills() {
         skills = new ArrayList<Skill>();
 

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TokenizerTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TokenizerTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.ui.habot.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.ui.habot.nlp.internal.AlphaNumericTokenizer;
 
 /**

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerDeTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerDeTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.ui.habot.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerEnTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerEnTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.ui.habot.test;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
 /**

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerFrTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerFrTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.ui.habot.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerItTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerItTest.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.ui.habot.test;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 
 /**

--- a/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerNlTest.java
+++ b/bundles/org.openhab.ui.habot/src/test/java/org/openhab/ui/habot/test/TrainerNlTest.java
@@ -12,9 +12,9 @@
  */
 package org.openhab.ui.habot.test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.openhab.ui.habot.nlp.Intent;
 import org.openhab.ui.habot.nlp.internal.IntentTrainer;
 

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <maven.compiler.target>${oh.java.version}</maven.compiler.target>
     <maven.compiler.compilerVersion>${oh.java.version}</maven.compiler.compilerVersion>
 
-    <bnd.version>4.3.0</bnd.version>
+    <bnd.version>5.1.2</bnd.version>
     <karaf.version>4.2.7</karaf.version>
     <sat.version>0.10.0</sat.version>
     <spotless.version>1.30.0</spotless.version>
@@ -319,7 +319,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
+          <version>3.0.0-M5</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
* Migrates all tests to the JUnit 5 Jupiter API
* Updates bnd to 5.1.2
* Updates maven-surefire-plugin to 3.0.0-M5
* Removes org.openhab.core.boot POM dependencies (see https://github.com/openhab/openhab-core/pull/1559)

---

Depends on https://github.com/openhab/openhab-core/pull/1580