### PR TITLE
Display config parameters defaults & status info

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -3,6 +3,11 @@
       v-show="(configDescription.visible) ? configDescription.visible(value, configuration, configDescription, parameters) : true">
       <component :is="control" :config-description="configDescription" :value="value" :parameters="parameters" :configuration="configuration" :title="configDescription.title" @input="updateValue" />
       <f7-block-footer slot="after-list" class="param-description">
+        <div v-if="status" class="param-status-info">
+          <f7-chip v-if="status.type !== 'INFORMATION'" :color="status.type === 'WARNING' ? 'orange' : (status.type === 'ERROR') ? 'red' : 'gray'" style="float: right" :text="status.type"></f7-chip>
+          <span v-if="status.statusCode">Status Code: &nbsp;{{status.statusCode}}&nbsp;&nbsp;</span>
+          <span v-if="status.message">{{status.message}}</span>
+        </div>
         <small v-html="configDescription.description"></small>
       </f7-block-footer>
     </f7-list>
@@ -34,7 +39,8 @@ export default {
     'configDescription',
     'value',
     'parameters',
-    'configuration'
+    'configuration',
+    'status'
   ],
   data () {
     return {
@@ -100,6 +106,10 @@ export default {
     margin-bottom 1rem
   p
     margin 0 !important
+  .param-status-info
+    font-weight 500
+    span
+      color var(--f7-block-title-text-color) !important
 .smart-select-popover.popover
   --f7-popover-width 320px
 </style>

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -11,9 +11,10 @@
               v-for="parameter in displayedParameters.filter((p) => !p.groupName)"
               :key="parameter.name"
               :config-description="parameter"
-              :value="configuration[parameter.name]"
+              :value="configurationWithDefaults[parameter.name]"
               :parameters="parameters"
-              :configuration="configuration"
+              :configuration="configurationWithDefaults"
+              :status="parameterStatus(parameter)"
               @update="(value) => updateParameter(parameter, value)"
             />
           </f7-col>
@@ -33,9 +34,10 @@
               v-for="parameter in displayedParameters.filter((p) => p.groupName === group.name)"
               :key="parameter.name"
               :config-description="parameter"
-              :value="configuration[parameter.name]"
+              :value="configurationWithDefaults[parameter.name]"
               :parameters="parameters"
-              :configuration="configuration"
+              :configuration="configurationWithDefaults"
+              :status="parameterStatus(parameter)"
               @update="(value) => updateParameter(parameter, value)"
             />
           </f7-col>
@@ -62,7 +64,7 @@
 
 <script>
 export default {
-  props: ['parameterGroups', 'parameters', 'configuration'],
+  props: ['parameterGroups', 'parameters', 'configuration', 'status'],
   components: {
     'config-parameter': () => import(/* webpackChunkName: "config-parameter" */ './config-parameter.vue')
   },
@@ -72,6 +74,13 @@ export default {
     }
   },
   computed: {
+    configurationWithDefaults () {
+      let conf = Object.assign({}, this.configuration)
+      this.parameters.forEach((p) => {
+        if (conf[p.name] === undefined && p.defaultValue !== undefined) conf[p.name] = p.defaultValue
+      })
+      return conf
+    },
     hasAdvanced () {
       return this.parameters.length > 0 && this.parameters.some((p) => p.advanced)
     },
@@ -93,6 +102,10 @@ export default {
       }
       console.debug(JSON.stringify(this.configuration))
       this.$emit('updated')
+    },
+    parameterStatus (parameter) {
+      if (!this.status || !this.status.length) return null
+      return this.status.find((ps) => ps.parameterName === parameter.name)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -100,6 +100,7 @@
             :parameter-groups="configDescriptions.parameterGroups"
             :parameters="configDescriptions.parameters"
             :configuration="thing.configuration"
+            :status="configStatusInfo"
             @updated="dirty = true"
           />
         </f7-block>
@@ -224,6 +225,7 @@ export default {
       thingType: {},
       channelTypes: {},
       configDescriptions: {},
+      configStatusInfo: [],
       zwaveActions: {},
       thingEnabled: true,
       codePopupOpened: false,
@@ -304,6 +306,11 @@ export default {
             }
 
             if (!this.eventSource) this.startEventSource()
+          })
+
+          // config status unrelated to the other queries, so load it in parallel with the types
+          this.$oh.api.get('/rest/things/' + this.thingId + '/config/status').then(statusData => {
+            this.configStatusInfo = statusData
           })
         })
       })


### PR DESCRIPTION
Pre-fill config parameters controls with the default
value if provided in the config description.

Display thing configuration parameter status info.

Fixes #285.
Fixes #293.

Signed-off-by: Yannick Schaus <github@schaus.net>