### PR TITLE
[Main UI] Widget actions: add photos, rule, general improvements

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
@@ -18,9 +18,12 @@ export const actionParams = (groupName, paramPrefix) => {
       { value: 'navigate', label: 'Navigate to page' },
       { value: 'command', label: 'Send command' },
       { value: 'toggle', label: 'Toggle item' },
+      { value: 'options', label: 'Command options' },
+      { value: 'rule', label: 'Run rule' },
       { value: 'popup', label: 'Open popup' },
       { value: 'popover', label: 'Open popover' },
       { value: 'sheet', label: 'Open sheet' },
+      { value: 'photos', label: 'Open photo browser' },
       { value: 'group', label: 'Group details' },
       { value: 'analyzer', label: 'Analyze item(s)' },
       { value: 'url', label: 'External URL' }
@@ -29,9 +32,9 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['url'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pi(paramPrefix + 'actionItem', 'Action Item', 'Item to perform the aciton on')
+    pi(paramPrefix + 'actionItem', 'Action Item', 'Item to perform the action on')
       .v((value, configuration, configDescription, parameters) => {
-        return ['command', 'toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
+        return ['command', 'toggle', 'options'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
     pt(paramPrefix + 'actionCommand', 'Action Command', 'Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different')
       .v((value, configuration, configDescription, parameters) => {
@@ -40,6 +43,14 @@ export const actionParams = (groupName, paramPrefix) => {
     pt(paramPrefix + 'actionCommandAlt', 'Action Toggle Command', 'Command to send to the item when "toggle item" is selected as the action, and the item\'s state is equal to the command above')
       .v((value, configuration, configDescription, parameters) => {
         return ['toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
+    pt(paramPrefix + 'actionOptions', 'Command Options', 'Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['options'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
+    pt(paramPrefix + 'actionRule', 'Rule', 'Rule to run').c('rule')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['rule'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
     pt(paramPrefix + 'actionPage', 'Page', 'Page to navigate to').c('page')
       .v((value, configuration, configDescription, parameters) => {
@@ -65,6 +76,14 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['navigate', 'popup', 'popover', 'sheet'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
+    pt(paramPrefix + 'actionPhotos', 'Images to show', 'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
+    pt(paramPrefix + 'actionPhotoBrowserConfig', 'Photo browser configuration', 'Configuration for the photo browser.<br />Edit in YAML or provide a JSON object, e.g.<br /><code>{ "exposition": false, "type": "popup", "theme": "dark" }</code><br /> See <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photo-browser-parameters">photo browser parameters</a> (not all are supported).')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
     pi(paramPrefix + 'actionGroupPopupItem', 'Group Popup Item', 'Group item whose members to show in a popup')
       .v((value, configuration, configDescription, parameters) => {
         return ['group'].indexOf(configuration[paramPrefix + 'action']) >= 0
@@ -88,6 +107,10 @@ export const actionParams = (groupName, paramPrefix) => {
       { value: 'calendar', label: 'Calendar' }
     ]).v((value, configuration, configDescription, parameters) => {
       return ['analyzer'].indexOf(configuration[paramPrefix + 'action']) >= 0
-    })
+    }),
+    pt(paramPrefix + 'actionFeedback', 'Action feedback', 'Shows a toast popup when the action has been executed. Can either be a text to show or a JSON object including some of the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/toast.html#toast-parameters">supported parameters</a>').a()
+      .v((value, configuration, configDescription, parameters) => {
+        return ['command', 'toggle', 'options', 'rule'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      })
   ]
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
@@ -66,7 +66,9 @@ export default function itemDefaultStandaloneComponent (item) {
         component: 'oh-image-card',
         config: {
           lazy: true,
-          lazyFadeIn: true
+          lazyFadeIn: true,
+          action: 'photos',
+          actionPhotos: [{ item: item.name }]
         }
       }
     }
@@ -86,8 +88,8 @@ export default function itemDefaultStandaloneComponent (item) {
     } else if (item.commandDescription && item.commandDescription.commandOptions && !stateDescription.readOnly) {
       component.config = {
         action: 'options',
-        actionItem: item.name,
-        actionOptions: item.commandDescription.commandOptions.map((o) => (o.label) ? o.command + '=' + o.label : o.command).join(',')
+        actionItem: item.name
+        // command options will be retrieved on click from the API
       }
     } else if (item.type.indexOf('Group') === 0) {
       component.config = {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -53,6 +53,16 @@ export default function itemDefaultListComponent (item, itemNameAsFooter) {
         component: 'oh-player-item'
       }
     }
+
+    if (item.type === 'Image') {
+      component = {
+        component: 'oh-list-item',
+        config: {
+          action: 'photos',
+          actionPhotos: [{ item: item.name }]
+        }
+      }
+    }
   }
 
   if (!component) {
@@ -68,8 +78,8 @@ export default function itemDefaultListComponent (item, itemNameAsFooter) {
     } else if (item.commandDescription && item.commandDescription.commandOptions && !stateDescription.readOnly) {
       component.config = {
         action: 'options',
-        actionItem: item.name,
-        actionOptions: item.commandDescription.commandOptions.map((o) => (o.label) ? o.command + '=' + o.label : o.command).join(',')
+        actionItem: item.name
+        // command options will be retrieved on click from the API
       }
     } else if (item.type.indexOf('Group') === 0) {
       component.config = {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-image-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-image-card.vue
@@ -4,7 +4,7 @@
       <div>{{config.title}}</div>
     </f7-card-header>
     <f7-card-content :padding="false" class="oh-image-card">
-      <f7-list v-if="config.action">
+      <f7-list v-if="config.action" class="image-link">
         <f7-list-item class="oh-image-clickable" link="#" no-chevron @click="performAction">
           <oh-image slot="content-start" :context="childContext(context.component)" />
         </f7-list-item>
@@ -26,6 +26,11 @@
     margin-left 5px
     margin-right 5px
     width calc(100% - 10px)
+  .image-link
+    .item-inner
+      display none
+    .oh-image
+      margin-bottom 5px
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
@@ -4,7 +4,8 @@
 
 <script>
 import mixin from '../widget-mixin'
-import { actionGroup, actionProps, actionsMixin } from '../widget-actions'
+import { actionGroup, actionParams } from '@/assets/definitions/widgets/actions'
+import { actionsMixin } from '../widget-actions'
 
 export default {
   mixins: [mixin, actionsMixin],
@@ -17,7 +18,7 @@ export default {
         actionGroup(null, 'Action to perform when the element is clicked')
       ],
       parameters: [
-        ...actionProps()
+        ...actionParams()
       ]
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
@@ -4,7 +4,8 @@
 
 <script>
 import mixin from '../widget-mixin'
-import { actionGroup, actionProps, actionsMixin } from '../widget-actions'
+import { actionGroup, actionParams } from '@/assets/definitions/widgets/actions'
+import { actionsMixin } from '../widget-actions'
 
 export default {
   mixins: [mixin, actionsMixin],
@@ -17,7 +18,7 @@ export default {
         actionGroup(null, 'Action to perform when the element is clicked')
       ],
       parameters: [
-        ...actionProps()
+        ...actionParams()
       ]
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -4,223 +4,6 @@ import OhPopover from './modals/oh-popover.vue'
 
 import GroupPopup from '@/pages/group/group-popup.vue'
 
-export const actionGroup = (label, description, groupPrefix) => {
-  groupPrefix = (groupPrefix) ? groupPrefix += '_' : ''
-  return {
-    name: groupPrefix + 'actions',
-    label: label || 'Action',
-    description
-  }
-}
-
-export const actionProps = (groupName, paramPrefix) => {
-  paramPrefix = (paramPrefix) ? paramPrefix += '_' : ''
-  if (!groupName) groupName = 'actions'
-  return [
-    {
-      name: paramPrefix + 'action',
-      label: 'Action',
-      groupName,
-      type: 'TEXT',
-      context: 'widgetaction',
-      description: 'Type of action to perform',
-      limitToOptions: true,
-      options: [
-        {
-          value: 'navigate',
-          label: 'Navigate to page'
-        },
-        {
-          value: 'command',
-          label: 'Send command'
-        },
-        {
-          value: 'toggle',
-          label: 'Toggle item'
-        },
-        {
-          value: 'popup',
-          label: 'Open popup'
-        },
-        {
-          value: 'popover',
-          label: 'Open popover'
-        },
-        {
-          value: 'sheet',
-          label: 'Open sheet'
-        },
-        {
-          value: 'group',
-          label: 'Group details'
-        },
-        {
-          value: 'analyzer',
-          label: 'Analyze item(s)'
-        },
-        {
-          value: 'url',
-          label: 'External URL'
-        }
-      ]
-    },
-    {
-      name: paramPrefix + 'actionUrl',
-      label: 'Action URL',
-      groupName,
-      type: 'TEXT',
-      context: 'url',
-      description: 'URL to navigate to',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['url'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-
-    },
-    {
-      name: paramPrefix + 'actionItem',
-      label: 'Action Item',
-      groupName,
-      type: 'TEXT',
-      context: 'item',
-      description: 'Item to perform the action on',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['command', 'toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionCommand',
-      label: 'Action Command',
-      groupName,
-      type: 'TEXT',
-      description: 'Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['command', 'toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionCommandAlt',
-      label: 'Action Toggle Command',
-      groupName,
-      type: 'TEXT',
-      description: 'Command to send to the item when "toggle item" is selected as the action, and the item\'s state is equal to the command above',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionPage',
-      label: 'Page',
-      groupName,
-      type: 'TEXT',
-      context: 'page',
-      description: 'Page to navigate to',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['navigate'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionPageTransition',
-      label: 'Transition Effect',
-      groupName,
-      type: 'TEXT',
-      limitToOptions: true,
-      description: 'Use a specific <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/view.html#custom-page-transitions">page transition animation</a>',
-      options: [
-        { value: 'f7-circle', label: 'Circle' },
-        { value: 'f7-cover', label: 'Cover' },
-        { value: 'f7-cover-v', label: 'Cover from bottom' },
-        { value: 'f7-dive', label: 'Dive' },
-        { value: 'f7-fade', label: 'Fade' },
-        { value: 'f7-flip', label: 'Flip' },
-        { value: 'f7-parallax', label: 'Parallax' },
-        { value: 'f7-push', label: 'Push' }
-      ],
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['navigate'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionModal',
-      label: 'Modal Page or Widget',
-      groupName,
-      type: 'TEXT',
-      context: 'pagewidget',
-      description: 'Page or widget to display in the modal',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['popup', 'popover', 'sheet'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionModalConfig',
-      label: 'Modal component configuration',
-      groupName,
-      context: 'props',
-      type: 'TEXT',
-      description: 'Configuration (prop values) for the target modal page or widget',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['navigate', 'popup', 'popover', 'sheet'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionGroupPopupItem',
-      label: 'Group Popup Item',
-      groupName,
-      type: 'TEXT',
-      context: 'item',
-      description: 'Group item whose members to show in a popup',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['group'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionAnalyzerItems',
-      label: 'Item(s) to Analyze',
-      groupName,
-      context: 'item',
-      type: 'TEXT',
-      multiple: true,
-      description: 'Start analyzing with the specified (set of) item(s)',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['analyzer'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      }
-    },
-    {
-      name: paramPrefix + 'actionAnalyzerChartType',
-      label: 'Chart Type',
-      groupName,
-      type: 'TEXT',
-      limitToOptions: true,
-      description: 'The initial analyzing period - dynamic or a predefined fixed period: day, week, month or year',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['analyzer'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      },
-      options: [
-        { value: '', label: 'Dynamic' },
-        { value: 'day', label: 'Day' },
-        { value: 'isoWeek', label: 'Week (starting on Mondays)' },
-        { value: 'month', label: 'Month' },
-        { value: 'year', label: 'Year' }
-      ]
-    },
-    {
-      name: paramPrefix + 'actionAnalyzerCoordSystem',
-      label: 'Initial Coordinate System',
-      groupName,
-      type: 'TEXT',
-      limitToOptions: true,
-      description: 'The initial coordinate system of the analyzer - time, aggregate or calendar (only time is supported for dynamic periods)',
-      visible: (value, configuration, configDescription, parameters) => {
-        return ['analyzer'].indexOf(configuration[paramPrefix + 'action']) >= 0
-      },
-      options: [
-        { value: 'time', label: 'Time' },
-        { value: 'aggregate', label: 'Aggregate' },
-        { value: 'calendar', label: 'Calendar' }
-      ]
-    }
-  ]
-}
-
 export const actionsMixin = {
   components: {
     OhPopup,
@@ -229,6 +12,22 @@ export const actionsMixin = {
     GroupPopup
   },
   methods: {
+    showActionFeedback (prefix) {
+      let toastConfig = this.config[prefix + 'actionFeedback']
+      if (typeof toastConfig === 'string' && toastConfig.startsWith('{')) toastConfig = JSON.parse(toastConfig)
+      if (typeof toastConfig === 'string') {
+        this.$f7.toast.create({
+          text: toastConfig,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      } else if (typeof toastConfig === 'object') {
+        this.$f7.toast.create(Object.assign({}, toastConfig, {
+          destroyOnClose: true,
+          closeTimeout: (toastConfig.icon || !toastConfig.closeButton) ? 2000 : toastConfig.closeTimeout
+        })).open()
+      }
+    },
     performAction (evt, prefix) {
       if (this.context.editmode) return
       prefix = (prefix) ? prefix += '_' : ''
@@ -251,6 +50,7 @@ export const actionsMixin = {
           const actionItem = this.config[prefix + 'actionItem']
           const actionCommand = this.config[prefix + 'actionCommand']
           this.$store.dispatch('sendCommand', { itemName: actionItem, cmd: actionCommand })
+            .then(() => this.showActionFeedback(prefix))
           break
         case 'toggle':
           const actionToggleItem = this.config[prefix + 'actionItem']
@@ -258,26 +58,65 @@ export const actionsMixin = {
           const actionToggleCommandAlt = this.config[prefix + 'actionCommandAlt']
           const cmd = this.context.store[actionToggleItem].state === actionToggleCommand ? actionToggleCommandAlt : actionToggleCommand
           this.$store.dispatch('sendCommand', { itemName: actionToggleItem, cmd })
+            .then(() => this.showActionFeedback(prefix))
           break
         case 'options':
           const actionCommandOptionsItem = this.config[prefix + 'actionItem']
           const actionCommandOptions = this.config[prefix + 'actionOptions']
-          const actions = actionCommandOptions.split(',').map((o) => {
-            const parts = o.split('=')
-            return {
-              text: parts[1] || parts[0],
-              color: 'blue',
-              onClick: () => {
-                this.$store.dispatch('sendCommand', { itemName: actionCommandOptionsItem, cmd: parts[0] })
-              }
+          const actionsPromise = new Promise((resolve, reject) => {
+            if (actionCommandOptions && typeof actionCommandOptions === 'string') {
+              resolve(actionCommandOptions.split(',').map((o) => {
+                const parts = o.split('=')
+                return {
+                  text: parts[1] || parts[0],
+                  color: 'blue',
+                  onClick: () => {
+                    this.$store.dispatch('sendCommand', { itemName: actionCommandOptionsItem, cmd: parts[0] })
+                      .then(() => this.showActionFeedback(prefix))
+                  }
+                }
+              }))
+            } else if (actionCommandOptions && typeof actionCommandOptions === 'object') {
+              resolve(actionCommandOptions)
+            } else {
+              this.$oh.api.get('/rest/items/' + actionCommandOptionsItem).then((item) => {
+                if (item.commandDescription && item.commandDescription.commandOptions) {
+                  resolve(item.commandDescription.commandOptions.map((cd) => {
+                    return {
+                      text: cd.label || cd.command,
+                      color: 'blue',
+                      onClick: () => {
+                        this.$store.dispatch('sendCommand', { itemName: actionCommandOptionsItem, cmd: cd.command })
+                          .then(() => this.showActionFeedback(prefix))
+                      }
+                    }
+                  }))
+                }
+              })
             }
           })
-          this.$f7.actions.create({
-            buttons: [
-              actions,
-              [{ text: 'Cancel', color: 'red' }]
-            ]
-          }).open()
+
+          actionsPromise.then((actions) => {
+            this.$f7.actions.create({
+              buttons: [
+                actions,
+                [{ text: 'Cancel', color: 'red' }]
+              ]
+            }).open()
+          })
+          break
+        case 'rule':
+          const actionRule = this.config[prefix + 'actionRule']
+          if (!actionRule) break
+          this.$oh.api.postPlain('/rest/rules/' + actionRule + '/runnow', '')
+            .then(() => this.showActionFeedback(prefix))
+            .catch((err) => {
+              this.$f7.toast.create({
+                text: 'Error while running rule: ' + err,
+                destroyOnClose: true,
+                closeTimeout: 2000
+              }).open()
+            })
           break
         case 'popup':
         case 'popover':
@@ -306,6 +145,42 @@ export const actionsMixin = {
             }
           }
           this.$f7router.navigate(modalRoute, modalProps)
+          break
+        case 'photos':
+          const self = this
+          let photos = this.config[prefix + 'actionPhotos']
+          let photoBrowserConfig = this.config[prefix + 'actionPhotoBrowserConfig']
+          if (typeof photos === 'string' && photos.startsWith('{')) photos = JSON.parse(photos)
+          if (typeof photoBrowserConfig === 'string' && photoBrowserConfig.startsWith('{')) photoBrowserConfig = JSON.parse(photoBrowserConfig)
+          if (photos && photos.length > 0) {
+            const promises = photos.map((el) => {
+              if (typeof el === 'string') return Promise.resolve(el)
+              if (typeof el === 'object') {
+                if (el.item) {
+                  return new Promise((resolve, reject) => {
+                    self.$oh.api.getPlain(`/rest/items/${el.item}/state`, 'text/plain').then((data) => {
+                      resolve({
+                        url: data,
+                        caption: el.caption
+                      })
+                    }).catch((err) => {
+                      console.warn('Error while resolving image from item: ' + err)
+                      reject(err)
+                    })
+                  })
+                } else {
+                  return Promise.resolve(el)
+                }
+              }
+            })
+
+            Promise.all(promises).then((resolvedPhotos) => {
+              let photoBrowserParams = Object.assign({}, photoBrowserConfig, { photos: resolvedPhotos })
+              // automatically select the dark theme if not specified
+              if (!photoBrowserParams.theme && self.$f7.darkTheme) photoBrowserParams.theme = 'dark'
+              self.$f7.photoBrowser.create(photoBrowserParams).open()
+            })
+          }
           break
         case 'group':
           const actionGroupItem = this.config[prefix + 'actionGroupPopupItem']

--- a/bundles/org.openhab.ui/web/src/js/store/modules/states.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/states.js
@@ -110,7 +110,7 @@ const actions = {
   },
   sendCommand (context, { itemName, cmd }) {
     console.log(`Sending command to ${itemName}: ${cmd}`)
-    this._vm.$oh.api.postPlain('/rest/items/' + itemName, cmd, 'text/plain', 'text/plain')
+    return this._vm.$oh.api.postPlain('/rest/items/' + itemName, cmd, 'text/plain', 'text/plain')
   }
 }
 


### PR DESCRIPTION
Add 2 new widget actions:

- `rule`: Run a rule immediately (useful for scenes if a supporting item
  is not needed);

- `photos`: Open a photo browser to view images & videos in fullscreen.
  Also make the default widgets (standalone & list item) for
  Image items perform this action.

Other improvements:

- Described the `options` action;
- Allowed the `options` action to retrieve command options from
  the target item's command description dynamically (default
  if explicit options are omitted);
- Default widgets for non-read-only items with command options
  don't specify them in the widget config anymore; this allows
  the list of options to remain current if the options are
  dynamic without reconfiguring the widget;
- Add a `actionFeedback` parameter to actions performing commands or
  running rules to show a toast notification when the action has been
  performed;
- Removed the parameter description leftovers from the actions
  mixin file;
- Styling fixes for clickable oh-image-card


Signed-off-by: Yannick Schaus <github@schaus.net>