### PR TITLE
[Main UI] Pass access token in header if cookie flag set

### DIFF
--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -21,9 +21,9 @@
   <% if (process.env.TARGET === 'web') { %>
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  <link rel="apple-touch-icon" href="res/icons/apple-touch-icon.png">
-  <link rel="icon" href="res/icons/favicon.png">
-  <link rel="manifest" href="/manifest.json">
+  <link rel="apple-touch-icon" href="res/icons/apple-touch-icon.png" crossorigin="use-credentials">
+  <link rel="icon" href="res/icons/favicon.png" crossorigin="use-credentials">
+  <link rel="manifest" href="/manifest.json" crossorigin="use-credentials">
   <% } %>
   <!-- built styles file will be auto injected -->
 </head>

--- a/bundles/org.openhab.ui/web/src/js/openhab/api.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/api.js
@@ -14,7 +14,11 @@ Framework7.request.setup({
   xhrFields: { withCredentials: true },
   beforeSend (xhr) {
     if (accessToken) {
-      xhr.setRequestHeader('Authorization', 'Bearer ' + accessToken)
+      if (document.cookie.indexOf('X-OPENHAB-AUTH-HEADER') >= 0) {
+        xhr.setRequestHeader('X-OPENHAB-TOKEN', accessToken)
+      } else {
+        xhr.setRequestHeader('Authorization', 'Bearer ' + accessToken)
+      }
     }
   }
 })

--- a/bundles/org.openhab.ui/web/src/pages/developer/api-explorer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/api-explorer.vue
@@ -134,7 +134,11 @@ export default {
           docExpansion: 'none',
           syntaxHighlight: false,
           requestInterceptor: (req) => {
-            req.headers['Authorization'] = 'Bearer ' + tokenResponse.access_token
+            if (document.cookie.indexOf('X-OPENHAB-AUTH-HEADER') >= 0) {
+              req.headers['X-OPENHAB-TOKEN'] = tokenResponse.access_token
+            } else {
+              req.headers['Authorization'] = 'Bearer ' + tokenResponse.access_token
+            }
             return req
           }
         })


### PR DESCRIPTION
This makes a check for the presence of a non-HttpOnly
`X-OPENHAB-AUTH-HEADER` cookie; if found, pass the current
access_token in the `X-OPENHAB-TOKEN` HTTP header instead of
the `Authorization` header as Bearer credentials.

This is explicitely supported by the backend and mitigates
the collisions with authorization schemes set by proxies like
openHAB Cloud.

Signed-off-by: Yannick Schaus <github@schaus.net>