### PR TITLE
Upgrade Travis CI to use Ubuntu 20.04 and fix warnings/caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,12 @@
-sudo: required
-dist: bionic
+os: linux
+dist: focal
 
 language: java
-
 jdk: openjdk11
 
 cache:
   directories:
   - $HOME/.m2
-  - $HOME/.p2
   - bundles/org.openhab.ui.basic/npm_cache
   - bundles/org.openhab.ui.homebuilder/npm_cache
 


### PR DESCRIPTION
Upgrades the Travis CI build environment to Ubuntu 20.04 (Focal Fossa).

Also fixes the following Travis configuration validation warnings:

* deprecated key sudo (The key `sudo` has no effect anymore.)
* missing os, using the default linux

Also updates the caching config:

* `$HOME/.p2` has no content since the bnd migration