### PR TITLE
Rule editor: module type grouping

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -49,7 +49,7 @@ export default {
   computed: {
     control () {
       const configDescription = this.configDescription
-      if (configDescription.options && configDescription.options.length && configDescription.limitToOptions) {
+      if (configDescription.options && configDescription.options.length && configDescription.limitToOptions && !configDescription.context) {
         return ParameterOptions
       } else if (configDescription.type === 'INTEGER') {
         return ParameterInteger

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-thing.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-thing.vue
@@ -1,5 +1,5 @@
 <template>
-  <thing-picker :title="configDescription.label" :value="value" @input="updateValue" />
+  <thing-picker :title="configDescription.label" :value="value" @input="updateValue" :filter-uid="configDescription.options.map((o) => o.value)" />
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/thing-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/thing-picker.vue
@@ -15,7 +15,7 @@
 
 <script>
 export default {
-  props: ['title', 'name', 'value', 'multiple', 'filterType'],
+  props: ['title', 'name', 'value', 'multiple', 'filterType', 'filterUid'],
   data () {
     return {
       ready: false,
@@ -46,6 +46,9 @@ export default {
           this.smartSelectParams.openIn = 'sheet'
           this.smartSelectParams.searchbar = false
         }
+      }
+      if (this.filterUid && this.filterUid.length) {
+        this.things = this.things.filter((t) => this.filterUid.indexOf(t.UID) >= 0)
       }
       this.ready = true
     })


### PR DESCRIPTION
Sort module types in rules editor and group them by scope.
(following the discussion in https://github.com/openhab/openhab-core/issues/1639#issuecomment-692874984)

Fix blank labels when a config parameter with has both options and a
"thing" context.

Signed-off-by: Yannick Schaus <github@schaus.net>