### PR TITLE
Validate parameters immediately & before save

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -1,5 +1,5 @@
 <template>
-    <f7-list class="config-parameter" :no-hairlines-md="configDescription.type !== 'BOOLEAN' && (!configDescription.options || !configDescription.options.length) && ['item'].indexOf(configDescription.context) < 0"
+    <f7-list ref="parameter" class="config-parameter" :no-hairlines-md="configDescription.type !== 'BOOLEAN' && (!configDescription.options || !configDescription.options.length) && ['item'].indexOf(configDescription.context) < 0"
       v-show="(configDescription.visible) ? configDescription.visible(value, configuration, configDescription, parameters) : true">
       <component :is="control" :config-description="configDescription" :value="value" :parameters="parameters" :configuration="configuration" :title="configDescription.title" @input="updateValue" />
       <f7-block-footer slot="after-list" class="param-description">
@@ -85,6 +85,9 @@ export default {
 
       return ParameterText
     }
+  },
+  mounted () {
+    this.$f7.input.validateInputs(this.$refs.parameter.$el)
   },
   methods: {
     updateValue (value) {

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-block v-if="parameters" class="config-sheet">
+  <f7-block v-if="parameters" class="config-sheet" ref="sheet">
     <div style="text-align:right" class="padding-right" v-if="hasAdvanced">
       <label @click="toggleAdvanced" class="advanced-label">Show advanced</label> <f7-checkbox :checked="showAdvanced" @change="toggleAdvanced"></f7-checkbox>
     </div>
@@ -90,6 +90,9 @@ export default {
     }
   },
   methods: {
+    isValid () {
+      return this.$f7.input.validateInputs(this.$refs.sheet.$el)
+    },
     toggleAdvanced (event) {
       this.showAdvanced = !this.showAdvanced // event.target.checked
     },

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -7,12 +7,13 @@
             <f7-block-title>General Settings</f7-block-title>
             <f7-list inline-labels no-hairlines-md>
               <f7-list-input label="Unique ID" v-if="createMode" type="text" placeholder="Required" :value="thing.ID"
-                              @input="changeUID" info="Note: cannot be changed after the creation">
+                              @input="changeUID" info="Note: cannot be changed after the creation"
+                              required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only">
               </f7-list-input>
               <f7-list-input label="Identifier" type="text" placeholder="Name" :value="thing.UID" disabled>
               </f7-list-input>
               <f7-list-input label="Label" type="text" placeholder="e.g. My Thing" :value="thing.label"
-                              @input="thing.label = $event.target.value; $emit('updated')">
+                              @input="thing.label = $event.target.value; $emit('updated')" required validate>
               </f7-list-input>
               <f7-list-input label="Location" type="text" placeholder="e.g. Kitchen" :value="thing.location"
                               @input="thing.location = $event.target.value; $emit('updated')" clear-button>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -23,7 +23,7 @@
 
     <f7-block v-if="ready" class="block-narrow">
       <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" />
-      <config-sheet
+      <config-sheet ref="parameters"
         :parameter-groups="thingType.parameterGroups"
         :parameters="thingType.configParameters"
         :configuration="thing.configuration"
@@ -128,6 +128,11 @@ export default {
         this.$f7.dialog.alert('Please give a name')
         return
       }
+      if (!this.$refs.parameters.isValid()) {
+        this.$f7.dialog.alert('Please review the configuration and correct validation errors')
+        return
+      }
+
       this.thing.UID = this.thingTypeId + ':' + this.thing.ID
 
       this.$oh.api.post('/rest/things', this.thing).then(() => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -64,9 +64,9 @@
         </div>
       </f7-col>
 
-      <f7-block v-if="!itemTypeCompatible()" class="text-color-red">
+      <!-- <f7-block v-if="!itemTypeCompatible()" class="text-color-red">
         The channel and the item type are not compatible.
-      </f7-block>
+      </f7-block> -->
 
       <f7-block v-if="!ready" class="text-align-center">
         <f7-preloader></f7-preloader>
@@ -90,7 +90,7 @@
       </f7-col>
       <f7-col v-if="profileTypeConfiguration != null">
         <f7-block-title>Profile Configuration</f7-block-title>
-          <config-sheet
+          <config-sheet ref="profileConfiguration"
             :parameter-groups="profileTypeConfiguration.parameterGroups"
             :parameters="profileTypeConfiguration.parameters"
             :configuration="configuration"
@@ -109,7 +109,6 @@ import ItemForm from '@/components/item/item-form.vue'
 
 import Item from '@/components/item/item.vue'
 
-import { Categories } from '@/assets/categories.js'
 import * as Types from '@/assets/item-types.js'
 import * as SemanticClasses from '@/assets/semantics.js'
 
@@ -242,6 +241,10 @@ export default {
       }
       if (!link.channelUID) {
         this.$f7.dialog.alert('Please configure the channel to link')
+        return
+      }
+      if (this.$refs.profileConfiguration && !this.$refs.profileConfiguration.isValid()) {
+        this.$f7.dialog.alert('Please review the profile configuration and correct validation errors')
         return
       }
       // temporarily disabled

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -57,7 +57,7 @@
       </f7-col>
       <f7-col v-if="profileTypeConfiguration != null">
         <f7-block-title>Profile Configuration</f7-block-title>
-          <config-sheet
+          <config-sheet ref="profileConfiguration"
             :parameter-groups="profileTypeConfiguration.parameterGroups"
             :parameters="profileTypeConfiguration.parameters"
             :configuration="link.configuration"
@@ -191,6 +191,10 @@ export default {
       const link = this.link
       if (this.currentProfileType) {
         link.configuration.profile = this.currentProfileType.uid
+      }
+      if (this.$refs.profileConfiguration && !this.$refs.profileConfiguration.isValid()) {
+        this.$f7.dialog.alert('Please review the profile configuration and correct validation errors')
+        return
       }
 
       // delete then recreate the link

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -96,7 +96,7 @@
       <f7-tab id="config" :disabled="!(thing.configuration && thingType.configParameters)" @tab:show="() => this.currentTab = 'config'" :tab-active="currentTab === 'config'">
         <f7-block v-if="currentTab === 'config'" class="block-narrow">
           <thing-general-settings :thing="thing" :thing-type="thingType" @updated="thingDirty = true" />
-          <config-sheet
+          <config-sheet ref="thingConfiguration"
             :parameter-groups="configDescriptions.parameterGroups"
             :parameters="configDescriptions.parameters"
             :configuration="thing.configuration"
@@ -328,6 +328,10 @@ export default {
         endpoint = '/rest/things/' + this.thingId
         payload = this.thing
         successMessage = 'Thing updated'
+      }
+      if (!this.$refs.thingConfiguration.isValid()) {
+        this.$f7.dialog.alert('Please review the configuration and correct validation errors')
+        return
       }
       this.$oh.api.put(endpoint, payload).then(data => {
         // this.$set(this, 'thing', data)


### PR DESCRIPTION
Perform the validation of all configuration parameters
when they are displayed (for instance this will show the
"Please fill out this field" message on all required
parameters immediately when the sheet is displayed).

Validate ID and label inputs on general thing settings.

Validate configuration on thing creation or update, and
profile configuration on link add/edit, and refuse to
save if there are invalid parameters.
Closes #267.

Signed-off-by: Yannick Schaus <github@schaus.net>