### PR TITLE
Replace tabs with spaces before feeding input to nearley

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-code.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-code.vue
@@ -63,7 +63,7 @@ export default {
     parsedSitemap () {
       try {
         const parser = new Parser(Grammar.fromCompiled(grammar))
-        parser.feed(this.sitemapDsl.trim())
+        parser.feed(this.sitemapDsl.trim().replace(/\t/g, ' '))
         if (!parser.results.length) return { error: 'Unable to parse, check your input' }
         // return parser.results[0].map((i) => i.name).join('\n')
         return parser.results[0]

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
@@ -234,7 +234,7 @@ export default {
     parsedItems () {
       try {
         const parser = new Parser(Grammar.fromCompiled(grammar))
-        parser.feed(this.itemsDsl.trim())
+        parser.feed(this.itemsDsl.trim().replace(/\t/g, ' '))
         if (!parser.results.length) return { error: 'Unable to parse, check your input' }
         // return parser.results[0].map((i) => i.name).join('\n')
         return parser.results[0]


### PR DESCRIPTION
On both textual item definitions and sitemap parsers.
This is easier than supporting tabs in the grammars.
Fixes #325.

Signed-off-by: Yannick Schaus <github@schaus.net>