### PR TITLE
Fix thing not saved when modifying channels

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -94,7 +94,7 @@
       </f7-tab>
 
       <f7-tab id="config" :disabled="!(thing.configuration && thingType.configParameters)" @tab:show="() => this.currentTab = 'config'" :tab-active="currentTab === 'config'">
-        <f7-block v-if="currentTab === 'config'" class="block-narrow">
+        <f7-block v-if="thing.UID && thingType.UID" v-show="currentTab === 'config'" class="block-narrow">
           <thing-general-settings :thing="thing" :thing-type="thingType" @updated="thingDirty = true" />
           <config-sheet ref="thingConfiguration"
             :parameter-groups="configDescriptions.parameterGroups"
@@ -244,9 +244,11 @@ export default {
   },
   computed: {
     isExtensible () {
+      if (!this.thingType || !this.thingType.extensibleChannelTypeIds) return false
       return this.thingType.extensibleChannelTypeIds.length > 0
     },
     textualDefinition () {
+      if (!this.thingType || !this.thing) return
       return buildTextualDefinition(this.thing, this.thingType)
     },
     context () {


### PR DESCRIPTION
Reported in https://community.openhab.org/t/oh3-creating-channels-in-mqtt-thing-not-possible/105637.

If the user is in another tab than "Config" of the thing details page, any attempt to save will fail because the config sheet is not present (due to a `v-if="currentTab === 'config'"`) so the attempt to validate the fields leads to an exception.
This makes sure that the config sheet is always in the DOM.

Signed-off-by: Yannick Schaus <github@schaus.net>