### PR TITLE
Improve text parameter autocomplete

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -8,7 +8,7 @@
           <span v-if="status.statusCode">Status Code: &nbsp;{{status.statusCode}}&nbsp;&nbsp;</span>
           <span v-if="status.message">{{status.message}}</span>
         </div>
-        <small v-html="configDescription.description"></small>
+        <small v-html="`${configDescription.required ? '<strong>Required</strong>&nbsp;' : ''}${configDescription.description || ''}`"></small>
       </f7-block-footer>
     </f7-list>
 </template>
@@ -87,7 +87,8 @@ export default {
     }
   },
   mounted () {
-    this.$f7.input.validateInputs(this.$refs.parameter.$el)
+    // Uncomment to perform initial validation on the field
+    // this.$f7.input.validateInputs(this.$refs.parameter.$el)
   },
   methods: {
     updateValue (value) {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -24,19 +24,21 @@ export default {
   },
   mounted () {
     if (this.configDescription.options && this.configDescription.options.length > 0) {
-      const options = this.configDescription.options.map((o) => o.value)
+      const options = this.configDescription.options.map((o) => {
+        return {
+          id: o.value,
+          text: (o.label) ? (o.value !== o.label) ? `${o.label} (${o.value})` : o.label : o.value
+        }
+      })
       const inputControl = this.$refs.input
       if (!inputControl || !inputControl.$el) return
       const inputElement = this.$$(inputControl.$el).find('input')
       this.autoCompleteOptions = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',
+        requestSourceOnOpen: true,
         source (query, render) {
-          if (!query || !query.length) {
-            render((options.length <= 10) ? options : [])
-          } else {
-            render(options.filter((o) => o.toLowerCase().indexOf(query.toLowerCase()) >= 0))
-          }
+          render(options.filter((o) => o.text.toLowerCase().indexOf(query.toLowerCase()) >= 0))
         }
       })
     }


### PR DESCRIPTION
For config parameters with options and limitToOptions=false,
currently implemented as a text field with autocomplete.

Display & allow filtering on the label, and display all
the available options on open.

Fixes #357.

Don't perform the initial validation pass on config sheet.
Add a mention in the description for required fields instead.

Closes #353.

Signed-off-by: Yannick Schaus <github@schaus.net>