### PR TITLE
Autocomplete for YAML editors

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/button.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/button.js
@@ -1,0 +1,16 @@
+import { pt, pb, pn } from '../helpers'
+
+export default () => [
+  pt('text', 'Text', 'Button label'),
+  pb('round', 'Round', 'Makes button round'),
+  pb('large', 'Large', 'Makes button large'),
+  pb('small', 'Small', 'Makes button small'),
+  pb('fill', 'Fill', 'Makes button filled with color'),
+  pb('raised', 'Raised', 'Makes button raised'),
+  pb('outline', 'Outline', 'Makes button outline'),
+  pt('active', 'Active', 'Button is active (when part of a f7-segmented').a(),
+  pt('icon', 'Icon', 'Use  <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'),
+  pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons'),
+  pn('iconSize', 'Icon Size', 'Size of the icon in px'),
+  pt('tooltip', 'Tooltip', 'Button tooltip text to show on button hover/press').a()
+]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/icon.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/icon.js
@@ -1,0 +1,14 @@
+import { pb, pt } from '../helpers'
+
+export default () => [
+  pb('icon', 'Icon', '<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/configuration/iconsets/classic/">openHAB icon</a>'),
+  pt('width', 'Width', ''),
+  pt('inputmode', 'Input Mode', 'Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>'),
+  pt('placeholder', 'Placeholder', 'Placeholder text'),
+  pb('clearButton', 'Clear button', 'Display input clear button'),
+  pb('outline', 'Outline', 'Makes input outline'),
+  pb('required', 'Required', 'Display an error message if left empty'),
+  pt('item', 'Item', 'Link the input value to the state of this item'),
+  pt('value', 'Value', 'Value when not found in item state or variable'),
+  pt('variable', 'Variable', 'Name of the variable to set when the input changes')
+]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/index.js
@@ -1,0 +1,73 @@
+import { WidgetDefinition, pt, pb } from '../helpers'
+import { actionGroup, actionParams } from '../actions'
+
+const VariableParameter = pt('variable', 'Variable', 'Name of the variable to set on input change')
+const ClearVariableParameter = pb('clearVariable', 'Clear Variable After Action', 'Name of the variable to clear after performing the action')
+
+import ButtonParameters from './button'
+export const OhButtonDefinition = () => new WidgetDefinition('oh-button', 'Button', 'Button performing an action')
+  .paramGroup(actionGroup(), actionParams())
+  .params([...ButtonParameters(), VariableParameter, ClearVariableParameter])
+
+import ColorpickerParameters from './colorpicker'
+export const OhColorpickerDefinition = () => new WidgetDefinition('oh-colorpicker', 'Colorpicker', 'Control to pick a color')
+  .params(ColorpickerParameters())
+
+import GaugeParameters from './gauge'
+export const OhGaugeDefinition = () => new WidgetDefinition('oh-gauge', 'Gauge', 'Circular or semi-circular read-only gauge')
+  .params(GaugeParameters())
+
+import IconParameters from './icon'
+export const OhIconDefinition = () => new WidgetDefinition('oh-icon', 'Icon', 'Display an openHAB icon')
+  .paramGroup(actionGroup(), actionParams())
+  .params(IconParameters())
+
+import ImageParameters from './image'
+export const OhImageDefinition = () => new WidgetDefinition('oh-image', 'Image', 'Displays an image from a URL or an item')
+  .paramGroup(actionGroup(), actionParams())
+  .params(ImageParameters())
+
+import InputParameters from './input'
+export const OhInputDefinition = () => new WidgetDefinition('oh-input', 'Input', 'Displays an input field, used to set of variable')
+  .params(InputParameters())
+
+import KnobParameters from './knob'
+export const OhKnobDefinition = () => new WidgetDefinition('oh-knob', 'Knob', 'Knob control, allow to change a number value on a circular track')
+  .params([...KnobParameters(), VariableParameter])
+
+import LinkParameters from './link'
+export const OhLinkDefinition = () => new WidgetDefinition('oh-link', 'Link', 'Link performing an action')
+  .paramGroup(actionGroup(), actionParams())
+  .params([...LinkParameters(), VariableParameter, ClearVariableParameter])
+
+import ListParameters from './list'
+export const OhListDefinition = () => new WidgetDefinition('oh-list', 'List', 'List control, hosts list items')
+  .params(ListParameters())
+
+import PlayerParameters from './player'
+export const OhPlayerDefinition = () => new WidgetDefinition('oh-player', 'Media player', 'Media player controls, with previous track/pause/play/next buttons')
+  .params(PlayerParameters())
+
+import RollershutterParameters from './rollershutter'
+export const OhRollershutterDefinition = () => new WidgetDefinition('oh-rollershutter', 'Rollershutter', 'Rollershutter control, with up/down/stop buttons')
+  .params(RollershutterParameters())
+
+import SliderParameters from './slider'
+export const OhSliderDefinition = () => new WidgetDefinition('oh-slider', 'Slider', 'Slider control, allows to pick a number value on a scale')
+  .params([...SliderParameters(), VariableParameter])
+
+import StepperParameters from './stepper'
+export const OhStepperDefinition = () => new WidgetDefinition('oh-stepper', 'Stepper', 'Stepper control, allows to input a number or decrement/increment it using buttons')
+  .params([...StepperParameters(), VariableParameter])
+
+import SwiperParameters from './swiper'
+export const OhSwiperDefinition = () => new WidgetDefinition('oh-swiper', 'Swiper', 'Swiper control, allows to display multiple swipeable slides')
+  .params(SwiperParameters())
+
+import ToggleParameters from './toggle'
+export const OhToggleDefinition = () => new WidgetDefinition('oh-toggle', 'Toggle', 'Toggle control, allows to switch on or off')
+  .params([...ToggleParameters(), VariableParameter])
+
+import TrendParameters from './trend'
+export const OhTrendDefinition = () => new WidgetDefinition('oh-trend', 'Trend line', 'Trend line to display the overall recent evoluation of an item')
+  .params(TrendParameters())

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
@@ -1,0 +1,14 @@
+import { pb, pt } from '../helpers'
+
+export default () => [
+  pb('name', 'Name', 'Input name'),
+  pt('type', 'Type', 'Type of input (see f7-input docs)'),
+  pt('inputmode', 'Input Mode', 'Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>'),
+  pt('placeholder', 'Placeholder', 'Placeholder text'),
+  pb('clearButton', 'Clear button', 'Display input clear button'),
+  pb('outline', 'Outline', 'Makes input outline'),
+  pb('required', 'Required', 'Display an error message if left empty'),
+  pt('item', 'Item', 'Link the input value to the state of this item'),
+  pt('value', 'Value', 'Value when not found in item state or variable'),
+  pt('variable', 'Variable', 'Name of the variable to set when the input changes')
+]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/link.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/link.js
@@ -1,0 +1,11 @@
+import { pt, pn } from '../helpers'
+
+export default () => [
+  pt('text', 'Text', 'Link label'),
+  pt('icon', 'Icon', 'Use  <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'),
+  pt('iconColor', 'Icon Color', 'Color of the icon'),
+  pn('iconSize', 'Icon Size', 'Size of the icon in px'),
+  pt('badge', 'Badge', 'Text to display in a badge on the opposite side of the item (set either this or "after")').a(),
+  pt('badgeColor', 'Badge color', 'Color of the badge').a(),
+  pt('tooltip', 'Tooltip', 'Button tooltip text to show on button hover/press').a()
+]

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -1,11 +1,11 @@
 <!-- Adapted from https://github.com/1615450788/vue-cron - license: MIT -->
 
 <template>
-  <f7-popup :id="popupId" class="cron-select" close-on-escape @popup:closed="$emit('closed')" :opened="opened">
+  <f7-popup class="cron-select" close-on-escape @popup:closed="close">
     <f7-page class="cron-select-content">
       <f7-navbar :title="'Cron: ' + cron" :subtitle="translation">
         <f7-nav-right>
-          <f7-link :popup-close="(popupId) ? '#' + popupId : '.cron-select'" @click.native="$emit('input', cron)">Done</f7-link>
+          <f7-link class="popup-close" @click="change">Done</f7-link>
         </f7-nav-right>
       </f7-navbar>
       <f7-toolbar tabbar position="top">
@@ -16,14 +16,7 @@
         <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'month'" @click="currentTab = 'month'">Month</f7-link>
         <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'year'" @click="currentTab = 'year'">Year</f7-link>
       </f7-toolbar>
-      <!-- <f7-toolbar bottom>
-        <div>
-          <h4 class="value">
-            <small>At 12:00 AM, on the weekday nearest day 20 of the month, only in October, only in 2019</small>
-          </h4>
-        </div>
-      </f7-toolbar> -->
-      <f7-tabs type="border-card" v-if="opened">
+      <f7-tabs type="border-card">
         <f7-tab :tab-active="currentTab === 'seconds'">
           <span slot="label">
             <i class="el-icon-date"></i>
@@ -267,7 +260,7 @@ import cronstrue from 'cronstrue'
 
 export default {
   name: 'vueCron',
-  props: ['value', 'opened', 'popupId', 'i18n'],
+  props: ['value'],
   data () {
     return {
       currentTab: 'seconds',
@@ -548,11 +541,10 @@ export default {
       return this.cron
     },
     change () {
-      this.$emit('change', this.cron)
-      this.close()
+      this.$f7.emit('cronEditorUpdate', this.cron)
     },
     close () {
-      this.$emit('close')
+      this.$f7.emit('cronEditorClosed')
     },
     rest (data) {
       for (let i in data) {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/location-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/location-picker.vue
@@ -1,0 +1,96 @@
+<template>
+  <f7-popup ref="mapPicker" class="mappicker-popup" @popup:opened="mapPickerOpened" @popup:closed="mapPickerClosed">
+    <f7-page>
+      <f7-navbar>
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
+        </f7-nav-left>
+        <f7-nav-title>{{title}}</f7-nav-title>
+        <f7-nav-right>
+          <f7-link class="popup-close" @click="updateValue(marker)">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+
+      <l-map
+        v-if="showMap"
+        :zoom="zoom"
+        :center="center"
+        :options="mapOptions"
+        @click="mapClicked"
+        class="oh-map-picker-lmap">
+          <l-tile-layer
+            :url="url"
+            :attribution="attribution"
+          />
+          <l-marker v-if="marker" :lat-lng="marker" />
+      </l-map>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<style lang="stylus">
+.mappicker-popup .oh-map-picker-lmap
+  background-color var(--f7-page-bg-color)
+  &.leaflet-grab
+    cursor crosshair
+.leaflet-dragging .oh-map-picker-lmap.leaflet-grab
+  cursor grabbing !important
+</style>
+
+<script>
+import { latLng, Icon } from 'leaflet'
+import { LMap, LTileLayer, LMarker } from 'vue2-leaflet'
+import 'leaflet/dist/leaflet.css'
+
+delete Icon.Default.prototype._getIconUrl
+Icon.Default.mergeOptions({
+  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
+  iconUrl: require('leaflet/dist/images/marker-icon.png'),
+  shadowUrl: require('leaflet/dist/images/marker-shadow.png')
+})
+
+export default {
+  props: ['value', 'title'],
+  components: {
+    LMap,
+    LTileLayer,
+    LMarker
+  },
+  data () {
+    return {
+      zoom: 4,
+      center: latLng(48, 6),
+      // url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      url: `https://a.basemaps.cartocdn.com/${this.$f7.data.themeOptions.dark}_all/{z}/{x}/{y}.png`,
+      attribution: '&copy; <a class="external" target="_blank" href="http://osm.org/copyright">OpenStreetMap</a>, &copy; <a class="external" target="_blank" href="https://carto.com/attribution/">CARTO</a>',
+      marker: null,
+      showMap: false,
+      mapOptions: {
+        zoomSnap: 0.5
+      }
+    }
+  },
+  methods: {
+    updateValue (marker) {
+      if (marker.lat && marker.lng) {
+        this.$f7.emit('locationUpdate', marker)
+      }
+    },
+    mapPickerClosed () {
+      this.showMap = false
+      this.$f7.emit('locationPickerClosed')
+    },
+    mapClicked (evt) {
+      this.marker = latLng(evt.latlng)
+    },
+    mapPickerOpened () {
+      this.$nextTick(() => {
+        this.zoom = (this.value) ? 13 : 4
+        this.marker = (this.value) ? latLng(this.value.split(',')) : null
+        this.center = (this.value) ? latLng(this.value.split(',')) : latLng(48, 6)
+        this.showMap = true
+      })
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-cronexpression.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-cronexpression.vue
@@ -7,35 +7,53 @@
         :value="value"
         :required="configDescription.required" validate
         :clear-button="!configDescription.required"
-        @input="updateValue"
+        @input="(evt) => updateValue(evt.target.value)"
         :error-message-force="exprError"
         type="text">
         <div class="padding-left" slot="content-end">
-          <f7-button slot="content-end" @click="popupOpened = true"><f7-icon f7="calendar" /> Build</f7-button>
+          <f7-button slot="content-end" @click="openPopup"><f7-icon f7="calendar" /> Build</f7-button>
         </div>
         <div slot="info">{{translation}}</div>
       </f7-list-input>
-      <cron-editor :value="value" :opened="popupOpened" :popup-id="`config-${configDescription.name}-fullscreen`" @closed="popupOpened = false" @input="(value) => { $emit('input', value) }" />
+      <!-- <cron-editor :value="value" :opened="popupOpened" :popup-id="`config-${configDescription.name}-fullscreen`" @closed="popupOpened = false" @input="(value) => { $emit('input', value) }" /> -->
   </ul>
 </template>
 
 <script>
-import CronEditor from './cronexpression-editor.vue'
+import CronEditorPopup from './cronexpression-editor.vue'
 import cronstrue from 'cronstrue'
 
 export default {
   props: ['configDescription', 'value'],
-  components: {
-    CronEditor
-  },
   data () {
     return {
-      popupOpened: false
     }
   },
   methods: {
-    updateValue (event) {
-      this.$emit('input', event.target.value)
+    updateValue (value) {
+      this.$emit('input', value)
+    },
+    openPopup () {
+      const popup = {
+        component: CronEditorPopup
+      }
+
+      this.$f7router.navigate({
+        url: 'widget-code',
+        route: {
+          path: 'widget-code',
+          popup
+        }
+      }, {
+        props: {
+          value: this.value
+        }
+      })
+
+      this.$f7.once('cronEditorUpdate', this.updateValue)
+      this.$f7.once('cronEditorClosed', () => {
+        this.$f7.off('cronEditorUpdate', this.updateValue)
+      })
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-location.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-location.vue
@@ -1,93 +1,29 @@
 <template>
   <ul>
-      <f7-list-input
-        :floating-label="$theme.md"
-        :label="configDescription.label"
-        :name="configDescription.name"
-        :value="value"
-        :required="configDescription.required" validate
-        :clear-button="!configDescription.required"
-        @input="updateValue"
-        type="text">
-        <div class="padding-left" slot="content-end">
-          <f7-button slot="content-end" @click="openMapPicker"><f7-icon f7="placemark" /> Map</f7-button>
-        </div>
-      </f7-list-input>
-      <f7-popup ref="mapPicker" class="mappicker-popup" :opened="mapPickerOpen" @popup:opened="mapPickerOpened" @popup:closed="mapPickerClosed">
-        <f7-page>
-          <f7-navbar>
-            <f7-nav-left>
-              <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-            </f7-nav-left>
-            <f7-nav-title>{{configDescription.label}}</f7-nav-title>
-            <f7-nav-right>
-              <f7-link @click="updateValue(marker)">Done</f7-link>
-            </f7-nav-right>
-          </f7-navbar>
-
-          <l-map
-            v-if="showMap"
-            :zoom="zoom"
-            :center="center"
-            :options="mapOptions"
-            @click="mapClicked"
-            class="oh-map-picker-lmap">
-              <l-tile-layer
-                :url="url"
-                :attribution="attribution"
-              />
-              <l-marker v-if="marker" :lat-lng="marker" />
-          </l-map>
-
-        </f7-page>
-
-      </f7-popup>
+    <f7-list-input
+      :floating-label="$theme.md"
+      :label="configDescription.label"
+      :name="configDescription.name"
+      :value="value"
+      :required="configDescription.required" validate
+      :clear-button="!configDescription.required"
+      @input="updateValue"
+      type="text">
+      <div class="padding-left" slot="content-end">
+        <f7-button slot="content-end" @click="openMapPicker"><f7-icon f7="placemark" /> Map</f7-button>
+      </div>
+    </f7-list-input>
   </ul>
 </template>
 
 <style lang="stylus">
-.mappicker-popup .oh-map-picker-lmap
-  background-color var(--f7-page-bg-color)
-  &.leaflet-grab
-    cursor crosshair
-.leaflet-dragging .oh-map-picker-lmap.leaflet-grab
-  cursor grabbing !important
 </style>
 
 <script>
-import { latLng, Icon } from 'leaflet'
-import { LMap, LTileLayer, LMarker } from 'vue2-leaflet'
-import 'leaflet/dist/leaflet.css'
-
-delete Icon.Default.prototype._getIconUrl
-Icon.Default.mergeOptions({
-  iconRetinaUrl: require('leaflet/dist/images/marker-icon-2x.png'),
-  iconUrl: require('leaflet/dist/images/marker-icon.png'),
-  shadowUrl: require('leaflet/dist/images/marker-shadow.png')
-})
+import LocationPicker from './location-picker.vue'
 
 export default {
   props: ['configDescription', 'value'],
-  components: {
-    LMap,
-    LTileLayer,
-    LMarker
-  },
-  data () {
-    return {
-      mapPickerOpen: false,
-      zoom: 4,
-      center: latLng(48, 6),
-      // url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-      url: `https://a.basemaps.cartocdn.com/${this.$f7.data.themeOptions.dark}_all/{z}/{x}/{y}.png`,
-      attribution: '&copy; <a class="external" target="_blank" href="http://osm.org/copyright">OpenStreetMap</a>, &copy; <a class="external" target="_blank" href="https://carto.com/attribution/">CARTO</a>',
-      marker: null,
-      showMap: false,
-      mapOptions: {
-        zoomSnap: 0.5
-      }
-    }
-  },
   methods: {
     updateValue (event) {
       if (event.lat && event.lng) {
@@ -95,25 +31,29 @@ export default {
       } else {
         this.$emit('input', event.target.value)
       }
-      this.mapPickerOpen = false
-    },
-    mapPickerClosed () {
-      this.showMap = false
-      this.mapPickerOpen = false
-    },
-    mapPickerOpened () {
-      this.$nextTick(() => {
-        this.zoom = (this.value) ? 13 : 4
-        this.marker = (this.value) ? latLng(this.value.split(',')) : null
-        this.center = (this.value) ? latLng(this.value.split(',')) : latLng(48, 6)
-        this.showMap = true
-      })
-    },
-    mapClicked (evt) {
-      this.marker = latLng(evt.latlng)
     },
     openMapPicker () {
-      this.mapPickerOpen = true
+      const popup = {
+        component: LocationPicker
+      }
+
+      this.$f7router.navigate({
+        url: 'pick-location',
+        route: {
+          path: 'pick-location',
+          popup
+        }
+      }, {
+        props: {
+          value: this.value,
+          title: this.configDescription.label
+        }
+      })
+
+      this.$f7.once('locationUpdate', this.updateValue)
+      this.$f7.once('locationPickerClosed', () => {
+        this.$f7.off('locationUpdate', this.updateValue)
+      })
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-props.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-props.vue
@@ -2,38 +2,13 @@
   <ul>
     <f7-list-item :title="configDescription.label" link="#" @click="openPropsSheet">
     </f7-list-item>
-    <f7-popup ref="propSheet" close-on-escape class="widgetprops-popup" :opened="propsSheetOpened" @popup:closed="propsSheetClosed">
-      <f7-page v-if="propsSheetOpened">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$refs.propSheet.f7Popup.close()"></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Set Component Props</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateProps">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="props">
-          <f7-col>
-            <config-sheet
-              :parameterGroups="props.parameterGroups || []"
-              :parameters="props.parameters || []"
-              :configuration="config"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
   </ul>
 </template>
 
 <script>
-// import ConfigSheet from '@/components/config/config-sheet.vue'
+import PropsEditorPopup from './props-editor-popup.vue'
 
 export default {
-  components: {
-    'config-sheet': () => import(/* webpackChunkName: "config-sheet" */ '@/components/config/config-sheet.vue')
-  },
   props: ['configDescription', 'value', 'parameters', 'configuration'],
   data () {
     return {
@@ -81,14 +56,33 @@ export default {
   methods: {
     openPropsSheet () {
       this.config = Object.assign({}, this.value)
-      this.propsSheetOpened = true
+      const popup = {
+        component: PropsEditorPopup
+      }
+
+      this.$f7router.navigate({
+        url: 'configure-props',
+        route: {
+          path: 'configure-props',
+          popup
+        }
+      }, {
+        props: {
+          props: this.props,
+          config: this.config
+        }
+      })
+
+      this.$f7.once('propsEditorUpdate', this.updateProps)
+      this.$f7.once('propsEditorClosed', () => {
+        this.$f7.off('propsEditorUpdate', this.updateProps)
+      })
     },
     propsSheetClosed () {
       this.propsSheetOpened = false
     },
-    updateProps () {
-      this.$emit('input', Object.assign({}, this.config))
-      this.$refs.propSheet.f7Popup.close()
+    updateProps (config) {
+      this.$emit('input', Object.assign({}, config))
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-script.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-script.vue
@@ -4,9 +4,6 @@
          :title="configDescription.label">
         <f7-button slot="after" v-if="$device.desktop" @click="openPopup(true)" icon-material="fullscreen"></f7-button>
         <f7-button slot="after" @click="openPopup(false)">Edit script</f7-button>
-        <!-- <f7-button slot="after" v-if="$device.desktop" @click="fullscreenCodeEditorOpened = true">Fullscreen</f7-button> -->
-        <script-editor-popup v-if="!fullscreen" :title="configDescription.label" :popup-id="`config-${configDescription.name}-window`" :fullscreen="false" :value="value" :opened="codeEditorOpened" @closed="popupClosed"></script-editor-popup>
-        <script-editor-popup v-else :title="configDescription.label" :popup-id="`config-${configDescription.name}-fullscreen`" :fullscreen="true" :value="value" :opened="codeEditorOpened" @closed="popupClosed"></script-editor-popup>
       </f7-list-item>
   </ul>
 </template>
@@ -16,25 +13,39 @@ import ScriptEditorPopup from './script-editor-popup.vue'
 
 export default {
   props: ['configDescription', 'value'],
-  components: {
-    ScriptEditorPopup
-  },
   data () {
     return {
-      codeEditorOpened: false,
-      fullscreenCodeEditorOpened: false,
-      fullscreen: false
     }
   },
   methods: {
-    popupClosed (code) {
-      this.codeEditorOpened = false
-      this.fullScreenCodeEditorOpened = false
+    updateCode (code) {
       this.$emit('input', code)
     },
     openPopup (fullscreen) {
       this.fullscreen = fullscreen
-      this.$nextTick(() => { this.codeEditorOpened = true })
+
+      const popup = {
+        component: ScriptEditorPopup
+      }
+
+      this.$f7router.navigate({
+        url: 'script-edit',
+        route: {
+          path: 'script-edit',
+          popup
+        }
+      }, {
+        props: {
+          title: this.configDescription.label,
+          fullscreen: fullscreen,
+          value: this.value
+        }
+      })
+
+      this.$f7.once('scriptEditorUpdate', this.updateCode)
+      this.$f7.once('scriptEditorClosed', () => {
+        this.$f7.off('scriptEditorUpdate', this.updateCode)
+      })
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -8,9 +8,13 @@
         :value="value"
         :autocomplete="autoCompleteOptions ? 'off' : ''"
         :required="configDescription.required" validate
-        :clear-button="!configDescription.required"
+        :clear-button="!configDescription.required && configDescription.context !== 'password'"
         @input="updateValue"
-        :type="(configDescription.context === 'password') ? 'password' : 'text'" />
+        :type="(configDescription.context === 'password' && !showPassword) ? 'password' : 'text'">
+        <div v-if="configDescription.context === 'password'" class="padding-left" slot="content-end">
+          <f7-link class="margin" color="gray" slot="content-end" @click="showPassword = !showPassword"><f7-icon size="20" :f7="(showPassword) ? 'eye_slash_fill' : 'eye_fill'" /></f7-link>
+        </div>
+      </f7-list-input>
   </ul>
 </template>
 
@@ -19,7 +23,8 @@ export default {
   props: ['configDescription', 'value'],
   data () {
     return {
-      autoCompleteOptions: null
+      autoCompleteOptions: null,
+      showPassword: false
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/props-editor-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/props-editor-popup.vue
@@ -1,0 +1,41 @@
+<template>
+  <f7-popup ref="propSheet" close-on-escape class="widgetprops-popup" @popup:closed="propsSheetClosed">
+    <f7-page>
+      <f7-navbar>
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" class="popup-close"></f7-link>
+        </f7-nav-left>
+        <f7-nav-title>Set Component Props</f7-nav-title>
+        <f7-nav-right>
+          <f7-link class="popup-close" @click="updateProps">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-block v-if="props">
+        <f7-col>
+          <config-sheet
+            :parameterGroups="props.parameterGroups || []"
+            :parameters="props.parameters || []"
+            :configuration="config"
+          />
+        </f7-col>
+      </f7-block>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<script>
+export default {
+  components: {
+    'config-sheet': () => import(/* webpackChunkName: "config-sheet" */ '@/components/config/config-sheet.vue')
+  },
+  props: ['props', 'config'],
+  methods: {
+    propsSheetClosed () {
+      this.$f7.emit('propsEditorClosed')
+    },
+    updateProps () {
+      this.$f7.emit('propsEditorUpdate', this.config)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor-popup.vue
@@ -1,9 +1,9 @@
 <template>
-  <f7-popup :id="popupId" class="editor-popup" :tablet-fullscreen="fullscreen" @popup:opened="() => showEditor = true" @popup:closed="popupClosed" :opened="opened">
+  <f7-popup :id="popupId" class="editor-popup" :tablet-fullscreen="fullscreen" @popup:opened="() => showEditor = true" @popup:closed="popupClosed">
     <f7-page class="code-editor-content">
       <f7-navbar :title="title">
         <f7-nav-right>
-          <f7-link :popup-close="(popupId) ? '#' + popupId : '.editor-popup'">Close</f7-link>
+          <f7-link class="popup-close" @click="update">Close</f7-link>
         </f7-nav-right>
       </f7-navbar>
       <editor v-if="showEditor" v-model="code"></editor>
@@ -30,8 +30,11 @@ export default {
   },
   methods: {
     popupClosed () {
+      this.$f7.emit('scriptEditorClosed')
       this.showEditor = false
-      this.$emit('closed', this.code)
+    },
+    update () {
+      this.$f7.emit('scriptEditorUpdate', this.code)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -149,6 +149,11 @@ export default {
       }
     }
   },
+  beforeDestroy () {
+    if (this.codemirror && this.codemirror.closeHint) {
+      this.codemirror.closeHint()
+    }
+  },
   methods: {
     ternComplete (file, query) {
       // debugger
@@ -185,12 +190,13 @@ export default {
           'Space': autocomplete
         }
         cm.state.$oh = this.$oh
+        cm.state.originalMode = this.mode
         cm.setOption('hintOptions', {
           closeOnUnfocus: false,
           hint (cm, option) {
-            if (self.mode.indexOf('application/vnd.openhab.uicomponent-definition') === 0) {
+            if (self.mode.indexOf('application/vnd.openhab.uicomponent') === 0) {
               return componentsHint(cm, option, self.mode)
-            } else if (self.mode === 'application/vnd.openhab.rule-definition') {
+            } else if (self.mode === 'application/vnd.openhab.rule') {
               return rulesHint(cm, option, self.mode)
             }
           }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -205,7 +205,7 @@ export default {
               e.makePretty()
               found.push({
                 message: message,
-                from: (e.linePos.end) ?  { line: e.linePos.start.line - 1, ch: e.linePos.start.col - 1 } : undefined,
+                from: (e.linePos.end) ? { line: e.linePos.start.line - 1, ch: e.linePos.start.col - 1 } : undefined,
                 to: (e.linePos.end) ? { line: e.linePos.end.line - 1, ch: e.linePos.end.col - 1 } : undefined
               })
             })
@@ -240,7 +240,7 @@ export default {
     }
   },
   mounted () {
-    console.log('codemirror ready: ', this.codemirror)
+    // console.log('codemirror ready: ', this.codemirror)
   }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
@@ -51,7 +51,7 @@ function hintItems (cm, line, replaceAfterColon, addStatePropertySuffix) {
           displayText: item.name,
           description: `${(item.label) ? item.label + ' ' : ''}(${item.type})<br />${item.state}`
         }
-      })
+      }).sort((i1, i2) => i1.text.localeCompare(i2.text))
     }
     ret.list = filterPartialCompletions(cm, line, ret.list)
     if (replaceAfterColon) {

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
@@ -1,0 +1,233 @@
+import { lineIndent, findParent, isConfig, isComponent, isSlots, findComponentType } from './yaml-utils'
+import { cls, filterPartialCompletions, addTooltipHandlers, getClassNamesForParameter } from './hint-utils'
+
+import Vue from 'vue'
+import * as f7vue from 'framework7-vue'
+
+import * as SystemWidgets from '@/components/widgets/system'
+import * as StandardWidgets from '@/components/widgets/standard'
+import * as StandardListWidgets from '@/components/widgets/standard/list'
+import * as StandardCellWidgets from '@/components/widgets/standard/cell'
+import * as LayoutWidgets from '@/components/widgets/layout'
+
+function getWidgetDefinitions () {
+  const ohComponents = Object.values({ ...SystemWidgets, ...LayoutWidgets, ...StandardWidgets, ...StandardListWidgets, ...StandardCellWidgets })
+    .filter((w) => w.widget && typeof w.widget === 'function')
+  const f7Components = Object.values(f7vue).filter((m) => m.name && m.name.indexOf('f7-') === 0)
+  return [...ohComponents.map((c) => c.widget()), ...f7Components]
+}
+
+function hintItems (cm, line, replaceAfterColon, addStatePropertySuffix) {
+  const cursor = cm.getCursor()
+  if (!cm.state.$oh) return
+  return cm.state.$oh.api.get('/rest/items').then((data) => {
+    let ret = {
+      list: data.map((item) => {
+        return {
+          text: item.name,
+          displayText: item.name + ((addStatePropertySuffix ? '.state' : '')),
+          description: `${(item.label) ? item.label + ' ' : ''}(${item.type})<br />${item.state}`
+        }
+      })
+    }
+    ret.list = filterPartialCompletions(cm, line, ret.list)
+    if (replaceAfterColon) {
+      const colonPos = line.indexOf(':')
+      ret.from = { line: cursor.line, ch: colonPos + 2 }
+      ret.to = { line: cursor.line, ch: line.length }
+    }
+    addTooltipHandlers(cm, ret)
+    return ret
+  })
+}
+
+function hintOptions (cm, line, parameter) {
+  const cursor = cm.getCursor()
+  const colonPos = line.indexOf(':')
+  let ret = {
+    list: parameter.options.map((o) => {
+      return {
+        text: o.value,
+        description: o.label || o.value
+      }
+    })
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list)
+  ret.from = { line: cursor.line, ch: colonPos + 2 }
+  ret.to = { line: cursor.line, ch: line.length }
+  return ret
+}
+
+function hintExpression (cm, line) {
+  const cursor = cm.getCursor()
+  if (line[cursor.ch - 1] === ' ' || line[cursor.ch - 1] === '=') {
+    return {
+      list: [
+        { text: 'items.', displayText: 'items', description: 'Access to item states' },
+        { text: 'props.', displayText: 'props', description: 'Access to the props of the parent root component' },
+        { text: 'vars.', displayText: 'vars', description: 'Access to context vars' },
+        { text: 'JSON.', displayText: 'JSON', description: 'Access to the JSON object functions' },
+        { text: 'Math.', displayText: 'Math', description: 'Access to the Math object functions' },
+        { text: 'Number.', displayText: 'Number', description: 'Access to the Number object functions' },
+        { text: 'theme', displayText: 'theme', description: 'The current theme: aurora, ios, or md' },
+        { text: 'themeOptions', displayText: 'themeOptions', description: 'Object with current theme options' },
+        { text: 'device', displayText: 'themeOptions', description: 'Object with information about the current device & browser' }
+      ]
+    }
+  } else if (line[cursor.ch - 1] === '.') {
+    if (line.substring(0, cursor.ch).endsWith('items.')) {
+      return hintItems(cm, line, false, true)
+    }
+  }
+}
+
+function f7ComponentParameters (componentName) {
+  console.debug(f7vue)
+  const Component = Vue.options.components[componentName]
+  if (!Component) return []
+  let f7vueComponent
+
+  for (const m in f7vue) {
+    // eslint-disable-next-line import/namespace
+    if (f7vue[m].name === componentName) f7vueComponent = f7vue[m]
+  }
+  console.debug(f7vueComponent)
+  if (!f7vueComponent) return []
+  const params = []
+  const instance = new Component()
+  for (const propName in f7vueComponent.props) {
+    const prop = f7vueComponent.props[propName]
+    const propType = (Array.isArray(prop.type)) ? prop.type.map((t) => t.name).join(' | ') : prop.type.name
+    const paramType = (propType === 'String') ? 'TEXT' : (propType === 'Number') ? 'INTEGER' : (propType === 'Boolean') ? 'BOOLEAN' : 'UNKNOWN'
+    params.push({
+      name: propName,
+      label: propName,
+      description: propType + '<br />' + ((instance.props[propName] !== undefined) ? `Default value: ${JSON.stringify(instance.props[propName])}` : ''),
+      type: paramType
+    })
+  }
+
+  return params
+}
+
+function hintConfig (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const componentType = findComponentType(cm, parentLineNr)
+  console.debug(`hinting config for component type: ${componentType}`)
+  const indent = lineIndent(cm, parentLineNr)
+  if (!componentType) return
+  const afterColon = line.indexOf(':') > 0 && cursor.ch > line.indexOf(':')
+  const widgetDefinition = getWidgetDefinitions().find((d) => d.name === componentType)
+  const parameters = (componentType.indexOf('f7-') === 0) ? f7ComponentParameters(componentType)
+    : (widgetDefinition && widgetDefinition.props) ? widgetDefinition.props.parameters : []
+  if (afterColon) {
+    if (line.indexOf('=') > 0) {
+      return hintExpression(cm, line)
+    }
+    const parameterName = line.substring(0, line.indexOf(':')).trim()
+    const parameter = parameters.find((p) => p.name === parameterName)
+    if (parameter) {
+      if (parameter.type === 'BOOLEAN') {
+        return { list: [ { text: 'true' }, { text: 'false' } ] }
+      } else if (parameter.context === 'item') {
+        return hintItems(cm, line, true)
+      } else if (parameter.options) {
+        return hintOptions(cm, line, parameter)
+      }
+    }
+  } else {
+    console.debug(widgetDefinition)
+    let completions = parameters.map((p) => {
+      return {
+        text: p.name + ': ',
+        displayText: p.name,
+        description: p.description,
+        className: getClassNamesForParameter(p)
+      }
+    })
+    completions = filterPartialCompletions(cm, line, completions)
+    return {
+      list: completions,
+      from: { line: cursor.line, ch: indent + 2 },
+      to: { line: cursor.line, ch: line.length }
+    }
+  }
+}
+
+function hintComponentStructure (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const indent = (parentLineNr !== undefined) ? lineIndent(cm, parentLineNr) : -2
+  let ret = {
+    list: [
+      {
+        text: ' '.repeat(indent + 2) + 'config:\n' + ' '.repeat(indent + 4),
+        displayText: 'config'
+      },
+      {
+        text: ' '.repeat(indent + 2) + 'slots:\n' + ' '.repeat(indent + 4),
+        displayText: 'slots'
+      },
+      {
+        text: ' '.repeat(indent + 2) + 'slots:\n' +
+          ' '.repeat(indent + 4) + 'default:\n' +
+          ' '.repeat(indent + 6) + '- component: ',
+        displayText: 'default slot'
+      }
+    ]
+  }
+  ret.from = { line: cursor.line, ch: 0 }
+  ret.to = { line: cursor.line, ch: cm.getLine(cursor.line).length }
+  return ret
+}
+
+function hintSlots (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const indent = lineIndent(cm, parentLineNr)
+  const definitions = getWidgetDefinitions()
+  let completions = definitions.map((c) => {
+    return {
+      text: ' '.repeat(indent + 2) + `- component: ${c.name}\n` +
+        // ' '.repeat(indent + 4) + 'config:\n' +
+        ' '.repeat(indent + 4),
+      displayText: c.name,
+      componentName: c.name,
+      className: `${cls}completion ${cls}completion-unknown`,
+      description: c.description || 'A component of type ' + c.name
+    }
+  })
+  completions = filterPartialCompletions(cm, line, completions, 'componentName')
+  let ret = {
+    list: completions
+  }
+  ret.from = { line: cursor.line, ch: 0 }
+  ret.to = { line: cursor.line, ch: cm.getLine(cursor.line).length }
+  return ret
+}
+
+export default function hint (cm, option, mode) {
+  const cursor = cm.getCursor()
+  const line = cm.getLine(cursor.line)
+
+  const parentLineNr = findParent(cm, cursor.line)
+  const parentLine = cm.getLine(parentLineNr)
+  console.debug(`parent line (${parentLineNr}): ${parentLine}`)
+
+  let ret
+  if (parentLine && isConfig(parentLine)) {
+    ret = hintConfig(cm, line, parentLineNr)
+  } else if (isComponent(parentLine) || lineIndent(cm, cursor.line) === 0) {
+    ret = hintComponentStructure(cm, line, parentLineNr)
+  } else {
+    if (parentLine) {
+      const grandparentLineNr = findParent(cm, parentLineNr)
+      const grandparentLine = cm.getLine(grandparentLineNr)
+      if (isSlots(grandparentLine)) {
+        ret = hintSlots(cm, line, parentLineNr)
+      }
+    }
+  }
+
+  if (!(ret instanceof Promise)) addTooltipHandlers(cm, ret)
+
+  return ret
+}

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-rules.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-rules.js
@@ -1,0 +1,177 @@
+import { lineIndent, findParent, findParentRoot, isConfig, isRuleSection } from './yaml-utils'
+import { filterPartialCompletions, addTooltipHandlers, getClassNamesForParameter } from './hint-utils'
+
+function getModuleTypes (cm, section) {
+  if (cm.state['moduleTypes' + section]) return Promise.resolve(cm.state['moduleTypes' + section])
+  return cm.state.$oh.api.get('/rest/module-types' + ((section) ? '?type=' + section : '')).then((data) => {
+    cm.state['moduleTypes' + section] = data
+    return data
+  })
+}
+
+function hintItems (cm, line, replaceAfterColon, addStatePropertySuffix) {
+  const cursor = cm.getCursor()
+  if (!cm.state.$oh) return
+  return cm.state.$oh.api.get('/rest/items').then((data) => {
+    let ret = {
+      list: data.map((item) => {
+        return {
+          text: item.name,
+          displayText: item.name + ((addStatePropertySuffix ? '.state' : '')),
+          description: `${(item.label) ? item.label + ' ' : ''}(${item.type})<br />${item.state}`
+        }
+      })
+    }
+    ret.list = filterPartialCompletions(cm, line, ret.list)
+    if (replaceAfterColon) {
+      const colonPos = line.indexOf(':')
+      ret.from = { line: cursor.line, ch: colonPos + 2 }
+      ret.to = { line: cursor.line, ch: line.length }
+    }
+    addTooltipHandlers(cm, ret)
+    return ret
+  })
+}
+
+function hintOptions (cm, line, parameter) {
+  const cursor = cm.getCursor()
+  const colonPos = line.indexOf(':')
+  let ret = {
+    list: parameter.options.map((o) => {
+      return {
+        text: o.value,
+        description: o.label || o.value
+      }
+    })
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list)
+  ret.from = { line: cursor.line, ch: colonPos + 2 }
+  ret.to = { line: cursor.line, ch: line.length }
+  addTooltipHandlers(cm, ret)
+  return ret
+}
+
+function findModuleType (cm) {
+  // FIXME: this function will assume the module type will appear directly after
+  // the configuration block, which will usually be the case but it's not guaranteed.
+  // It doesn't parse the YAML properly.
+  const cursor = cm.getCursor()
+  for (let l = cursor.line + 1; l < cm.doc.size; l++) {
+    const line = cm.getLine(l)
+    if (line.match(/ {4}type: /)) {
+      return line.split(':')[1].trim()
+    }
+  }
+}
+
+function hintConfig (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const moduleTypeUid = findModuleType(cm, cursor.line)
+  console.debug(`hinting config for module type: ${moduleTypeUid}`)
+  // const indent = lineIndent(cm, parentLineNr)
+  if (!moduleTypeUid) return
+  const sectionRootLineNr = findParentRoot(cm, parentLineNr)
+  const sectionRootLine = cm.getLine(sectionRootLineNr)
+  const section = sectionRootLine.replace('s:', '').trim()
+  console.debug(`section: ${section}`)
+  if (!section) return
+  const afterColon = line.indexOf(':') > 0 && cursor.ch > line.indexOf(':')
+  return getModuleTypes(cm, section).then((moduleTypes) => {
+    const moduleType = moduleTypes.find((m) => m.uid === moduleTypeUid)
+    if (!moduleType) return null
+    const parameters = moduleType.configDescriptions
+    if (afterColon) {
+      const parameterName = line.substring(0, line.indexOf(':')).trim()
+      const parameter = parameters.find((p) => p.name === parameterName)
+      if (parameter) {
+        if (parameter.type === 'BOOLEAN') {
+          return { list: [ { text: 'true' }, { text: 'false' } ] }
+        } else if (parameter.context === 'item') {
+          return hintItems(cm, line, true)
+        } else if (parameter.options) {
+          return hintOptions(cm, line, parameter)
+        }
+      }
+    } else {
+      console.debug(moduleType)
+      let completions = parameters.map((p) => {
+        return {
+          text: p.name + ': ',
+          displayText: p.name,
+          description: p.description,
+          className: getClassNamesForParameter(p)
+        }
+      })
+      completions = filterPartialCompletions(cm, line, completions)
+      let ret = {
+        list: completions,
+        from: { line: cursor.line, ch: 6 },
+        to: { line: cursor.line, ch: line.length }
+      }
+      addTooltipHandlers(cm, ret)
+      return ret
+    }
+  })
+}
+
+function buildModuleStructure (cm, moduleType) {
+  let nextId = 1
+  cm.doc.eachLine((l) => {
+    console.debug(l.text)
+    if (l.text.match(/^[ -]{4}id:/)) {
+      const id = parseInt(l.text.split(':')[1].replace('"', '').trim())
+      if (id >= nextId) nextId = id + 1
+    }
+  })
+  let ret = `  - inputs: {}\n    id: "${nextId}"\n`
+  if (moduleType.configDescriptions.some((p) => p.required)) {
+    ret += '    configuration:\n'
+    for (const configDescription of moduleType.configDescriptions.filter((m) => m.required)) {
+      ret += '      ' + configDescription.name + ': \n'
+    }
+  }
+  ret += '    type: ' + moduleType.uid + '\n  '
+  return ret
+}
+
+function hintModuleStructure (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const section = cm.getLine(parentLineNr).replace('s:', '').trim()
+  return getModuleTypes(cm, section).then((moduleTypes) => {
+    let completions = moduleTypes.map((m) => {
+      return {
+        text: buildModuleStructure(cm, m),
+        displayText: `${section}: ${m.label}`,
+        description: m.uid
+      }
+    })
+    let ret = {
+      list: completions,
+      from: { line: cursor.line, ch: 0 },
+      to: { line: cursor.line, ch: cm.getLine(cursor.line).length }
+    }
+    ret.list = filterPartialCompletions(cm, line, ret.list)
+    addTooltipHandlers(cm, ret)
+    return ret
+  })
+}
+
+export default function hint (cm, option, mode) {
+  const cursor = cm.getCursor()
+  const line = cm.getLine(cursor.line)
+
+  const parentLineNr = findParent(cm, cursor.line)
+  const parentLine = cm.getLine(parentLineNr)
+  console.debug(`parent line (${parentLineNr}): ${parentLine}`)
+
+  let ret
+  if (parentLine && isConfig(parentLine)) {
+    ret = hintConfig(cm, line, parentLineNr)
+  } else if (isRuleSection(parentLine)) {
+    ret = hintModuleStructure(cm, line, parentLineNr)
+  }
+
+  if (!(ret instanceof Promise)) addTooltipHandlers(cm, ret)
+
+  return ret
+}

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-rules.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-rules.js
@@ -16,11 +16,11 @@ function hintItems (cm, line, replaceAfterColon, addStatePropertySuffix) {
     let ret = {
       list: data.map((item) => {
         return {
-          text: item.name,
-          displayText: item.name + ((addStatePropertySuffix ? '.state' : '')),
+          text: item.name + ((addStatePropertySuffix ? '.state' : '')),
+          displayText: item.name,
           description: `${(item.label) ? item.label + ' ' : ''}(${item.type})<br />${item.state}`
         }
-      })
+      }).sort((i1, i2) => i1.text.localeCompare(i2.text))
     }
     ret.list = filterPartialCompletions(cm, line, ret.list)
     if (replaceAfterColon) {

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
@@ -46,7 +46,12 @@ export function addTooltipHandlers (cm, ret) {
 
   CodeMirror.on(ret, 'close', function () { remove(tooltip) })
   CodeMirror.on(ret, 'update', function () { remove(tooltip) })
-  CodeMirror.on(ret, 'pick', function () { cm.scrollIntoView(cm.getCursor()) })
+  CodeMirror.on(ret, 'pick', function () {
+    setTimeout(() => {
+      cm.scrollIntoView(cm.getCursor())
+      CodeMirror.commands.autocomplete(cm)
+    }, 100)
+  })
   CodeMirror.on(ret, 'select', function (cur, node) {
     remove(tooltip)
     var content = cur.description

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
@@ -1,0 +1,70 @@
+import CodeMirror from 'codemirror'
+
+export const cls = 'CodeMirror-Tern-'
+
+function elt (tagname, cls /*, ... elts */) {
+  var e = document.createElement(tagname)
+  if (cls) e.className = cls
+  for (var i = 2; i < arguments.length; ++i) {
+    var elt = arguments[i]
+    if (typeof elt === 'string') elt = document.createTextNode(elt)
+    e.appendChild(elt)
+  }
+  return e
+}
+
+export function makeTooltip (x, y, content, cm) {
+  var node = elt('div', cls + 'tooltip')
+  node.innerHTML = content
+  node.style.left = x + 'px'
+  node.style.top = y + 'px'
+  var container = ((cm.options || {}).hintOptions || {}).container || document.body
+  container.appendChild(node)
+  return node
+}
+
+export function remove (node) {
+  var p = node && node.parentNode
+  if (p) p.removeChild(node)
+}
+
+export function filterPartialCompletions (cm, line, completions, property = 'text') {
+  const cursor = cm.getCursor()
+  const lineBeforeCursor = line.substring(0, cursor.ch)
+  const completionBeginPos = Math.max(lineBeforeCursor.lastIndexOf(' '), lineBeforeCursor.lastIndexOf('.'))
+  const partialCompletion = lineBeforeCursor.substring(completionBeginPos + 1)
+  return completions.filter((c) => c[property] && c[property].toLowerCase().indexOf(partialCompletion.toLowerCase()) >= 0)
+}
+
+export function addTooltipHandlers (cm, ret) {
+  let tooltip = null
+  const cursor = cm.getCursor()
+
+  if (!ret) return
+  if (!ret.from) ret.from = cursor
+  if (!ret.to) ret.to = cursor
+
+  CodeMirror.on(ret, 'close', function () { remove(tooltip) })
+  CodeMirror.on(ret, 'update', function () { remove(tooltip) })
+  CodeMirror.on(ret, 'pick', function () { cm.scrollIntoView(cm.getCursor()) })
+  CodeMirror.on(ret, 'select', function (cur, node) {
+    remove(tooltip)
+    var content = cur.description
+    if (content) {
+      tooltip = makeTooltip(node.parentNode.getBoundingClientRect().right + window.pageXOffset,
+        node.getBoundingClientRect().top + window.pageYOffset, content, cm)
+      tooltip.className += ' ' + cls + 'hint-doc'
+    }
+  })
+}
+
+export function getTypeClasses (type) {
+  return cls + 'completion ' + cls + 'completion-' + type
+}
+
+export function getClassNamesForParameter (param) {
+  if (param.type === 'TEXT') return getTypeClasses('string')
+  if (param.type === 'INTEGER') return getTypeClasses('number')
+  if (param.type === 'BOOLEAN') return getTypeClasses('bool')
+  return getTypeClasses('unknown')
+}

--- a/bundles/org.openhab.ui/web/src/components/config/editor/yaml-utils.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/yaml-utils.js
@@ -1,0 +1,51 @@
+export function lineIndent (cm, linenr) {
+  const line = cm.getLine(linenr)
+  const match = line.match(/^ +/)
+  if (match && match.length === 1) return match[0].length
+  return 0
+}
+
+export function findParent (cm, linenr) {
+  const currentIndent = lineIndent(cm, linenr)
+  for (let l = linenr; l >= 0; l--) {
+    if (lineIndent(cm, l) < currentIndent) return l
+  }
+}
+
+export function findParentRoot (cm, linenr) {
+  for (let l = linenr; l >= 0; l--) {
+    if (lineIndent(cm, l) === 0) return l
+  }
+}
+
+export function findComponentType (cm, linenr) {
+  const currentIndent = lineIndent(cm, linenr)
+  for (let l = linenr - 1; l >= 0; l--) {
+    const line = cm.getLine(l)
+    const indent = lineIndent(cm, l)
+    if (indent === 0 || indent < currentIndent) {
+      const match = line.match(/component: (.*)$/)
+      if (match && match.length === 2) return match[1]
+    }
+  }
+}
+
+export function isConfig (line) {
+  if (!line) return false
+  return line.match(/^ *config(uration)?:/)
+}
+
+export function isSlots (line) {
+  if (!line) return false
+  return line.match(/^ *slots:/)
+}
+
+export function isComponent (line) {
+  if (!line) return false
+  return line.match(/^ *-? ?component:/)
+}
+
+export function isRuleSection (line) {
+  if (!line) return false
+  return line.match(/^(triggers|conditions|actions):/)
+}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
@@ -10,7 +10,7 @@
           <f7-link @click="updateWidgetCode" popup-close>Done</f7-link>
         </f7-nav-right>
       </f7-navbar>
-      <editor class="page-code-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=widget" :value="code" @input="(value) => code = value" />
+      <editor class="page-code-editor" :mode="`application/vnd.openhab.uicomponent+yaml;type=${componentType || 'widget'}`" :value="code" @input="(value) => code = value" />
       <!-- <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre> -->
     </f7-page>
   </f7-popup>
@@ -34,7 +34,7 @@
 import YAML from 'yaml'
 
 export default {
-  props: ['component'],
+  props: ['component', 'componentType'],
   components: {
     'editor': () => import('@/components/config/controls/script-editor.vue')
   },

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
@@ -11,7 +11,7 @@
         </f7-nav-right>
       </f7-navbar>
       <editor class="page-code-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=widget" :value="code" @input="(value) => code = value" />
-      <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
+      <!-- <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre> -->
     </f7-page>
   </f7-popup>
 </template>
@@ -20,8 +20,8 @@
 .widgetcode-popup
   .page-code-editor.vue-codemirror
     display block
-    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-    height calc(80% - 2*var(--f7-navbar-height))
+    top calc(var(--f7-navbar-height))
+    height calc(100% - var(--f7-navbar-height))
     width 100%
   .yaml-message
     display block

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-popup ref="widgetCode" class="widgetcode-popup" close-on-escape @popup:open="widgetCodeOpened" @popup:closed="widgetCodeClosed">
+  <f7-popup ref="widgetCode" class="widgetcode-popup" @popup:open="widgetCodeOpened" @popup:closed="widgetCodeClosed">
     <f7-page v-if="component && code">
       <f7-navbar>
         <f7-nav-left>
@@ -10,7 +10,7 @@
           <f7-link @click="updateWidgetCode" popup-close>Done</f7-link>
         </f7-nav-right>
       </f7-navbar>
-      <editor class="page-code-editor" mode="text/x-yaml" :value="code" @input="(value) => code = value" />
+      <editor class="page-code-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=widget" :value="code" @input="(value) => code = value" />
       <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre>
     </f7-page>
   </f7-popup>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-slot-config-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-slot-config-popup.vue
@@ -1,0 +1,79 @@
+<template>
+  <f7-popup ref="slotConfig" class="slotconfig-popup" @popup:open="ready = true" @popup:closed="widgetSlotConfigClosed">
+    <f7-page v-if="ready">
+      <f7-navbar>
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
+        </f7-nav-left>
+        <f7-nav-title>Edit {{currentSlot}}</f7-nav-title>
+        <f7-nav-right>
+          <f7-link @click="updateWidgetSlotConfig" class="popup-close">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-toolbar tabbar position="top">
+        <f7-link v-for="(slotComponent, idx) in slotConfig" :key="idx" @click="switchTab(idx)" :tab-link-active="currentTab === idx" class="tab-link">{{idx}}</f7-link>
+        <f7-link @click="addComponentToSlot" icon-f7="plus_filled" class="tab-link"></f7-link>
+        <!-- <f7-link @click="currentTab = 'config'" :tab-link-active="currentTab === 'config'" class="tab-link">Config</f7-link>
+        <f7-link @click="currentTab = 'channels'" :tab-link-active="currentTab === 'channels'" class="tab-link">Channels</f7-link> -->
+      </f7-toolbar>
+      <f7-tabs>
+        <f7-tab v-for="(slotComponent, idx) in slotConfig" :key="idx" :tab-active="currentTab === idx">
+          <config-sheet v-if="currentTab === idx && getWidgetDefinition(slotComponent.component)"
+            :parameterGroups="getWidgetDefinition(slotComponent.component).props.parameterGroups || []"
+            :parameters="getWidgetDefinition(slotComponent.component).props.parameters || []"
+            :configuration="slotComponent.config"
+            @updated="dirty = true"
+          />
+          <f7-block v-else strong>
+            This type of component cannot be configured: {{slotComponent.component}}.
+          </f7-block>
+          <f7-list>
+            <f7-list-button color="blue" @click="editWidgetCode(slotComponent)">Edit YAML</f7-list-button>
+            <f7-list-button color="Remove" @click="removeComponentFromSlot(slotComponent, slotConfig); switchTab(slotConfig.length - 1)">Remove</f7-list-button>
+          </f7-list>
+        </f7-tab>
+      </f7-tabs>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<style lang="stylus">
+.slotconfig-popup
+  .page-content
+    overflow-x hidden
+</style>
+
+<script>
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+export default {
+  props: ['currentSlot', 'slotConfig', 'getWidgetDefinition', 'currentSlotDefaultComponentType', 'initialConfig', 'removeComponentFromSlot', 'editWidgetCode'],
+  components: {
+    ConfigSheet
+  },
+  data () {
+    return {
+      ready: false,
+      currentTab: 0
+    }
+  },
+  methods: {
+    switchTab (idx) {
+      this.currentTab = undefined
+      this.$nextTick(() => { this.currentTab = idx }, 500)
+    },
+    widgetSlotConfigOpened () {
+    },
+    widgetSlotConfigClosed () {
+      this.$f7.emit('widgetSlotConfigClosed')
+    },
+    updateWidgetSlotConfig () {
+      this.$f7.emit('widgetSlotConfigUpdate', this.slotConfig)
+    },
+    addComponentToSlot () {
+      this.slotConfig.push({ component: this.currentSlotDefaultComponentType, config: Object.assign({}, this.initialConfig) })
+      this.switchTab(this.slotConfig.length - 1)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -23,8 +23,6 @@ import * as StandardListWidgets from './standard/list'
 import * as StandardCellWidgets from './standard/cell'
 import * as LayoutWidgets from './layout/index'
 
-console.log(SystemWidgets)
-console.log(StandardListWidgets)
 export default {
   mixins: [mixin],
   components: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-cells.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-cells.vue
@@ -68,13 +68,10 @@
 import mixin from '../widget-mixin'
 import OhPlaceholderWidget from './oh-placeholder-widget.vue'
 
-import { OhGridRowDefinition } from '@/assets/definitions/widgets/layout'
-
 export default {
   mixins: [mixin],
   components: {
     OhPlaceholderWidget
-  },
-  widget: OhGridRowDefinition
+  }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/map/index.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/map/index.js
@@ -1,3 +1,2 @@
-export { default as OhMapPage } from './oh-map-page.vue'
 export { default as OhMapMarker } from './oh-map-marker.vue'
 export { default as OhMapCircleMarker } from './oh-map-circle-marker.vue'

--- a/bundles/org.openhab.ui/web/src/components/widgets/map/index.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/map/index.js
@@ -1,0 +1,3 @@
+export { default as OhMapPage } from './oh-map-page.vue'
+export { default as OhMapMarker } from './oh-map-marker.vue'
+export { default as OhMapCircleMarker } from './oh-map-circle-marker.vue'

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
@@ -18,7 +18,6 @@ export default {
   computed: {
     context () {
       const component = this.page || this.widget || this.standard
-      component.config = this.modalParams
       return {
         component: component,
         root: component,

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
@@ -63,6 +63,7 @@ export default {
     },
     tabContext (tab) {
       const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
+      this.$set(this, 'vars', {})
       return {
         component: page,
         tab: tab,

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
@@ -63,7 +63,6 @@ export default {
     },
     tabContext (tab) {
       const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
-      this.$set(this, 'vars', {})
       return {
         component: page,
         tab: tab,

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/modal-mixin.js
@@ -18,9 +18,10 @@ export default {
   computed: {
     context () {
       const component = this.page || this.widget || this.standard
-      const config = Object.assign({}, component.config || {})
+      component.config = this.modalParams
       return {
-        component: Object.assign({}, component, { config }),
+        component: component,
+        root: component,
         store: this.$store.getters.trackedItems,
         props: this.modalParams,
         vars: this.vars
@@ -65,6 +66,7 @@ export default {
       const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
       return {
         component: page,
+        root: page,
         tab: tab,
         props: tab.config.pageConfig,
         store: this.$store.getters.trackedItems

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/index.js
@@ -1,0 +1,2 @@
+export { default as OhPlanPage } from './oh-plan-page.vue'
+export { default as OhPlanMarker } from './oh-plan-marker.vue'

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
@@ -4,10 +4,12 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhButtonDefinition } from '@/assets/definitions/widgets/system'
 import { actionsMixin } from '../widget-actions'
 
 export default {
   mixins: [mixin, actionsMixin],
+  widget: OhButtonDefinition,
   methods: {
     clicked () {
       if (this.config.action || this.config.actionPropsParameterGroup) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-colorpicker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-colorpicker.vue
@@ -10,10 +10,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhColorpickerDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
-  name: 'oh-colorpicker',
   mixins: [mixin],
+  widget: OhColorpickerDefinition,
   data () {
     return {
       colorpicker: null,

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-gauge.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-gauge.vue
@@ -4,9 +4,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhGaugeDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
   mixins: [mixin],
+  widget: OhGaugeDefinition,
   computed: {
     value () {
       if (this.config.variable) return this.context.vars[this.config.variable]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -14,11 +14,13 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhIconDefinition } from '@/assets/definitions/widgets/system'
 import { actionsMixin } from '../widget-actions'
 
 export default {
   mixins: [mixin, actionsMixin],
   props: ['icon', 'width', 'height', 'state'],
+  widget: OhIconDefinition,
   data () {
     return {
       currentState: this.state,

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
@@ -10,9 +10,11 @@
 <script>
 import mixin from '../widget-mixin'
 import { actionsMixin } from '../widget-actions'
+import { OhImageDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
   mixins: [mixin, actionsMixin],
+  widget: OhImageDefinition,
   data () {
     return {
       t: this.$utils.id(),

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -4,9 +4,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhInputDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
   mixins: [mixin],
+  widget: OhInputDefinition,
   computed: {
     value () {
       if (this.config.variable && this.context.vars[this.config.variable] !== undefined) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
@@ -4,6 +4,7 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhKnobDefinition } from '@/assets/definitions/widgets/system'
 
 import KnobControl from 'vue-knob-control'
 
@@ -12,6 +13,7 @@ export default {
   components: {
     KnobControl
   },
+  widget: OhKnobDefinition,
   data () {
     return {
       pendingCommand: null,

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
@@ -4,10 +4,12 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhLinkDefinition } from '@/assets/definitions/widgets/system'
 import { actionsMixin } from '../widget-actions'
 
 export default {
   mixins: [mixin, actionsMixin],
+  widget: OhLinkDefinition,
   methods: {
     clicked () {
       if (this.config.action || this.config.actionPropsParameterGroup) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-list.vue
@@ -18,35 +18,10 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhListDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
   mixins: [mixin],
-  widget: {
-    name: 'oh-list',
-    label: 'List',
-    description: 'A list of vertically arranged items',
-    props: {
-      parameters: [
-        {
-          name: 'simpleList',
-          label: 'Simple list',
-          type: 'BOOLEAN',
-          description: 'Use for simple lists'
-        },
-        {
-          name: 'mediaList',
-          label: 'Media List',
-          type: 'BOOLEAN',
-          description: 'Use for list with rich list items with icons'
-        },
-        {
-          name: 'accordionList',
-          label: 'Accordion List',
-          type: 'BOOLEAN',
-          description: 'Use for lists with accordion (collapsible) items'
-        }
-      ]
-    }
-  }
+  widget: OhListDefinition
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
@@ -19,10 +19,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhPlayerDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
-  name: 'oh-slider',
   mixins: [mixin],
+  widget: OhPlayerDefinition,
   mounted () {
     delete this.config.value
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
@@ -21,10 +21,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhRollershutterDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
-  name: 'oh-rollershutter',
   mixins: [mixin],
+  widget: OhRollershutterDefinition,
   mounted () {
     delete this.config.value
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -4,10 +4,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhSliderDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
-  name: 'oh-slider',
   mixins: [mixin],
+  widget: OhSliderDefinition,
   mounted () {
     delete this.config.value
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -5,10 +5,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhStepperDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
-  name: 'oh-stepper',
   mixins: [mixin],
+  widget: OhStepperDefinition,
   mounted () {
     delete this.config.value
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper-slide.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper-slide.vue
@@ -31,7 +31,6 @@
 </style>
 
 <script>
-
 import mixin from '../widget-mixin'
 
 export default {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
@@ -20,6 +20,7 @@
 <script>
 
 import mixin from '../widget-mixin'
+import { OhSwiperDefinition } from '@/assets/definitions/widgets/system'
 
 import OhSwiperSlide from './oh-swiper-slide.vue'
 import OhPlaceholderWidget from '../layout/oh-placeholder-widget.vue'
@@ -30,33 +31,7 @@ export default {
     OhSwiperSlide,
     OhPlaceholderWidget
   },
-  widget: {
-    name: 'oh-swiper',
-    label: 'Swiper',
-    description: 'Allows to swipe slides',
-    props: {
-      parameters: [
-        {
-          name: 'pagination',
-          label: 'Pagination',
-          type: 'BOOLEAN',
-          description: 'Enable pagination'
-        },
-        {
-          name: 'navigation',
-          label: 'Navigation',
-          type: 'BOOLEAN',
-          description: 'Enable navigation'
-        },
-        {
-          name: 'scrollbar',
-          label: 'Scrollbar',
-          type: 'BOOLEAN',
-          description: 'Enable scrollbar'
-        }
-      ]
-    }
-  },
+  widget: OhSwiperDefinition,
   computed: {
     slides () {
       if (!this.context.component.slots || !this.context.component.slots.default) return []

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-toggle.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-toggle.vue
@@ -4,10 +4,11 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhToggleDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
-  name: 'oh-toggle',
   mixins: [mixin],
+  widget: OhToggleDefinition,
   mounted () {
     delete this.config.value
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-trend.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-trend.vue
@@ -4,10 +4,12 @@
 
 <script>
 import mixin from '../widget-mixin'
+import { OhTrendDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
   mixins: [mixin],
   props: ['width'],
+  widget: OhTrendDefinition,
   data () {
     return {
       trendData: [],

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -28,6 +28,7 @@ export default {
       const sourceConfig = this.context.component.config
       let evalConfig = {}
       if (this.context.component.config) {
+        if (typeof this.context.component.config !== 'object') return {}
         for (const key in this.context.component.config) {
           if (key === 'visible' || key === 'visibleTo') continue
           this.$set(evalConfig, key, this.evaluateExpression(key, sourceConfig[key]))
@@ -87,6 +88,7 @@ export default {
     childContext (component) {
       return {
         component: component,
+        rootcomponent: this.context.root || this.context.component,
         props: this.context.props,
         vars: this.context.vars,
         store: this.context.store,
@@ -109,6 +111,7 @@ export default {
       }
       const widgetContext = {
         component: widget,
+        root: widget,
         props: this.config,
         vars: this.widgetVars,
         store: this.context.store,

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -26,7 +26,7 @@
     <f7-block v-else :key="blockKey + 'b'" class="widget-editor vertical">
       <f7-row resizable>
         <f7-col resizable style="min-width: 20px" class="widget-code">
-          <editor class="widget-component-editor" :mode="'text/x-yaml'" :value="widgetDefinition" @input="(value) => widgetDefinition = value" />
+          <editor class="widget-component-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=widget" :value="widgetDefinition" @input="(value) => widgetDefinition = value" />
         </f7-col>
         <f7-col v-if="ready" resizable style="min-width: 20px" class="widget-preview padding-right margin-bottom">
           <generic-widget-component :key="widgetKey" :context="context" @command="onCommand" />

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -62,27 +62,33 @@
 <style lang="stylus">
 .widget-editor
   margin-top 0 !important
+  margin-bottom 0 !important
   padding 0
   z-index auto !important
-  height calc(100vh - 2*var(--f7-navbar-height) - var(--f7-toolbar-height) - 2.5*var(--f7-block-margin-vertical))
+  top 0
+  height calc(100%)
   .notready
     visibility hidden
   .code-editor-fit
-    top 0
     height calc(100% - var(--f7-grid-gap))
+  .row
+    height 100%
+    .widget-preview
+      height 100%
+      overflow auto
+    .widget-code
+      height 100%
+  .vue-codemirror
+    top 0
+    height 100%
   &.vertical
     .block
       z-index auto !important
-    .row
-      height 100%
-      .widget-preview
-        height 100%
-        overflow auto
-      .widget-code
-        height 100%
   &.horizontal
     .row
       height 50%
+    .vue-codemirror
+      height calc(100% - var(--f7-grid-gap))
 </style>
 
 <script>
@@ -126,7 +132,7 @@ export default {
         if (!this.widgetDefinition) return {}
         return YAML.parse(this.widgetDefinition, { prettyErrors: true })
       } catch (e) {
-        return { component: 'Error', config: { error: e } }
+        return { component: 'Error', config: { error: e.message } }
       }
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -243,6 +243,7 @@ export default {
             destroyOnClose: true,
             closeTimeout: 2000
           }).open()
+          this.$f7router.navigate(this.$f7route.url.replace('/add', '/' + this.widget.uid), { reloadCurrent: true })
           this.load()
         } else {
           this.$f7.toast.create({
@@ -252,7 +253,7 @@ export default {
           }).open()
         }
         this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
+        // if (!stay) this.$f7router.back()
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while saving page: ' + err,

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -118,6 +118,7 @@ export default {
     },
     tabContext (tab) {
       const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
+      this.$set(this, 'vars', {})
       return {
         component: page,
         tab: tab,

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -118,7 +118,6 @@ export default {
     },
     tabContext (tab) {
       const page = this.$store.getters.page(tab.config.page.replace('page:', ''))
-      this.$set(this, 'vars', {})
       return {
         component: page,
         tab: tab,

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -28,7 +28,7 @@
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="metadata-code-editor" mode="text/x-yaml" :value="yaml" @input="(value) => yaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
       </f7-tab>
     </f7-tabs>
 
@@ -39,7 +39,7 @@
 .metadata-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2*var(--f7-navbar-height))
+  height calc(100% - 2*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -39,7 +39,7 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="application/vnd.openhab.uicomponent;type=chart" :value="pageYaml" @input="(value) => pageYaml = value" />
         <!-- <pre v-show="!previewMode" class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
 
         <oh-chart-page class="chart-page" v-if="ready && previewMode" :context="context" :key="pageKey" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -40,7 +40,7 @@
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
-        <pre v-show="!previewMode" class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <!-- <pre v-show="!previewMode" class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
 
         <oh-chart-page class="chart-page" v-if="ready && previewMode" :context="context" :key="pageKey" />
       </f7-tab>
@@ -88,7 +88,7 @@
 .page-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2 * var(--f7-navbar-height))
+  height calc(100% - 3*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -46,41 +46,6 @@
       </f7-tab>
 
     </f7-tabs>
-
-    <f7-popup ref="slotConfig" class="slotconfig-popup" close-on-escape :opened="widgetSlotConfigOpened" @popup:closed="widgetConfigClosed">
-      <f7-page v-if="currentSlot">
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title>Edit {{currentSlot}}</f7-nav-title>
-          <f7-nav-right>
-            <f7-link @click="updateWidgetSlotConfig">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block>
-          <f7-col v-for="(slotComponent, idx) in currentSlotConfig" :key="idx">
-            <config-sheet v-if="getWidgetDefinition(slotComponent.component)"
-              :parameterGroups="getWidgetDefinition(slotComponent.component).props.parameterGroups || []"
-              :parameters="getWidgetDefinition(slotComponent.component).props.parameters || []"
-              :configuration="slotComponent.config"
-              @updated="dirty = true"
-            />
-            <f7-block v-else strong>
-              This type of component cannot be configured: {{slotComponent.component}}.
-            </f7-block>
-            <f7-list>
-              <f7-list-button color="blue" @click="editWidgetCode(slotComponent)">Edit YAML</f7-list-button>
-              <f7-list-button color="Remove" @click="removeComponentFromSlot(slotComponent, currentSlotConfig)">Remove</f7-list-button>
-            </f7-list>
-            <hr />
-          </f7-col>
-          <f7-list>
-            <f7-list-button color="blue" @click="currentSlotConfig.push({ component: currentSlotDefaultComponentType, config: { show: true }})">Add Another</f7-list-button>
-          </f7-list>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
   </f7-page>
 </template>
 
@@ -118,6 +83,8 @@ import ChartDesigner from '@/components/pagedesigner/chart/chart-designer.vue'
 import ChartWidgetsDefinitions from '@/assets/definitions/widgets/chart/index'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
+
+import WidgetSlotConfigPopup from '@/components/pagedesigner/widget-slot-config-popup.vue'
 
 export default {
   mixins: [PageDesigner],
@@ -184,16 +151,43 @@ export default {
       if (this.currentSlotParent.slots[slotName] && this.currentSlotParent.slots[slotName].length > 0) {
         this.currentSlotConfig = JSON.parse(JSON.stringify(this.currentSlotParent.slots[slotName]))
       } else {
-        this.currentSlotConfig = [
+        this.$set(this, 'currentSlotConfig', [
           {
             component: defaultSlotComponentType,
             config: {
               show: true
             }
           }
-        ]
+        ])
       }
-      this.widgetSlotConfigOpened = true
+
+      const popup = {
+        component: WidgetSlotConfigPopup
+      }
+
+      this.$f7router.navigate({
+        url: 'configure-slot',
+        route: {
+          path: 'configure-slot',
+          popup
+        }
+      }, {
+        props: {
+          currentSlot: this.currentSlot,
+          slotConfig: this.currentSlotConfig,
+          getWidgetDefinition: this.getWidgetDefinition,
+          removeComponentFromSlot: this.removeComponentFromSlot,
+          editWidgetCode: this.editWidgetCode,
+          currentSlotDefaultComponentType: this.currentSlotDefaultComponentType,
+          initialConfig: { show: true }
+        }
+      })
+
+      this.$f7.once('widgetSlotConfigUpdate', this.updateWidgetSlotConfig)
+      this.$f7.once('widgetSlotConfigClosed', () => {
+        this.$f7.off('widgetSlotConfigUpdate', this.updateWidgetSlotConfig)
+        this.widgetConfigClosed()
+      })
     },
     removeComponentFromSlot (component, slot) {
       slot.splice(slot.indexOf(component), 1)

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -10,9 +10,9 @@
       <f7-link @click="currentTab = 'design'; fromYaml()" :tab-link-active="currentTab === 'design'" class="tab-link">Design</f7-link>
       <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
-    <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'design'">
+    <f7-toolbar bottom class="toolbar-details">
       <div style="margin-left: auto">
-        <f7-toggle :checked="previewMode" @toggle:change="(value) => previewMode = value"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
+        <f7-toggle :checked="previewMode" @toggle:change="(value) => togglePreviewMode(value)"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </div>
     </f7-toolbar>
     <f7-tabs class="layout-editor-tabs">
@@ -31,8 +31,10 @@
         />
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" class="page-code-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=layout" :value="pageYaml" @input="(value) => pageYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=layout" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
+
+        <oh-layout-page class="layout-page" v-if="ready && previewMode" :context="context" :key="pageKey" />
       </f7-tab>
     </f7-tabs>
 
@@ -49,7 +51,7 @@
 .page-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2*var(--f7-navbar-height))
+  height calc(100% - 3*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -31,7 +31,7 @@
         />
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <editor v-if="currentTab === 'code'" class="page-code-editor" mode="application/vnd.openhab.uicomponent-definition+yaml?type=layout" :value="pageYaml" @input="(value) => pageYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
       </f7-tab>
     </f7-tabs>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -10,9 +10,9 @@
       <f7-link @click="currentTab = 'design'; fromYaml()" :tab-link-active="currentTab === 'design'" class="tab-link">Design</f7-link>
       <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
-    <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'design'">
+    <f7-toolbar bottom class="toolbar-details">
       <div style="margin-left: auto">
-        <f7-toggle :checked="previewMode" @toggle:change="(value) => previewMode = value"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
+        <f7-toggle :checked="previewMode" @toggle:change="(value) => togglePreviewMode(value)"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </div>
     </f7-toolbar>
 
@@ -70,8 +70,10 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
+
+        <oh-map-page class="map-page" v-if="ready && previewMode" :context="context" :key="pageKey + '2'" />
       </f7-tab>
     </f7-tabs>
   </f7-page>
@@ -81,7 +83,7 @@
 .page-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2*var(--f7-navbar-height))
+  height calc(100% - 3*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -70,7 +70,7 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="application/vnd.openhab.uicomponent;type=map" :value="pageYaml" @input="(value) => pageYaml = value" />
         <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
 
         <oh-map-page class="map-page" v-if="ready && previewMode" :context="context" :key="pageKey + '2'" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -238,6 +238,7 @@ export default {
         }
       }, {
         props: {
+          componentType: this.$f7router.currentRoute.params.type,
           component: this.currentComponent
         }
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -75,7 +75,7 @@ export default {
       if (ev.ctrlKey || ev.metakKey) {
         switch (ev.keyCode) {
           case 82:
-            this.previewMode = !this.previewMode
+            this.togglePreviewMode()
             ev.stopPropagation()
             ev.preventDefault()
             break

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -127,6 +127,7 @@ export default {
             destroyOnClose: true,
             closeTimeout: 2000
           }).open()
+          this.$f7router.navigate(this.$f7route.url.replace('/add', '/' + this.page.uid), { reloadCurrent: true })
           this.load()
         } else {
           this.$f7.toast.create({
@@ -136,7 +137,7 @@ export default {
           }).open()
         }
         this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
+        // if (!stay) this.$f7router.back()
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while saving page: ' + err,

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -78,7 +78,7 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="application/vnd.openhab.uicomponent;type=plan" :value="pageYaml" @input="(value) => pageYaml = value" />
         <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
 
         <oh-plan-page class="plan-page" v-if="ready && previewMode" :context="context" :key="pageKey + '2'" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -10,9 +10,9 @@
       <f7-link @click="currentTab = 'design'; fromYaml()" :tab-link-active="currentTab === 'design'" class="tab-link">Design</f7-link>
       <f7-link @click="currentTab = 'code'; toYaml()" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
-    <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'design'">
+    <f7-toolbar bottom class="toolbar-details">
       <div style="margin-left: auto">
-        <f7-toggle :checked="previewMode" @toggle:change="(value) => previewMode = value"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
+        <f7-toggle :checked="previewMode" @toggle:change="(value) => togglePreviewMode(value)"></f7-toggle> Run mode<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </div>
     </f7-toolbar>
 
@@ -78,8 +78,10 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <editor v-if="currentTab === 'code'" :style="{ opacity: previewMode ? '0' : '' }" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
+        <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
+
+        <oh-plan-page class="plan-page" v-if="ready && previewMode" :context="context" :key="pageKey + '2'" />
       </f7-tab>
     </f7-tabs>
   </f7-page>
@@ -89,7 +91,7 @@
 .page-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2*var(--f7-navbar-height))
+  height calc(100% - 3*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -279,6 +279,7 @@ export default {
             closeTimeout: 2000
           }).open()
           this.load()
+          this.$f7router.navigate(this.$f7route.url.replace('/add', '/' + this.sitemap.uid), { reloadCurrent: true })
         } else {
           this.$f7.toast.create({
             text: 'Sitemap updated',
@@ -287,7 +288,7 @@ export default {
           }).open()
         }
         this.$f7.emit('sidebarRefresh', null)
-        if (!stay) this.$f7router.back()
+        // if (!stay) this.$f7router.back()
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while saving sitemap: ' + err,

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -62,7 +62,7 @@
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="page-code-editor" mode="text/x-yaml" :value="pageYaml" @input="(value) => pageYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
       </f7-tab>
     </f7-tabs>
   </f7-page>
@@ -72,7 +72,7 @@
 .page-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2*var(--f7-navbar-height))
+  height calc(100% - 2*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/module-description-suggestions.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/module-description-suggestions.js
@@ -44,7 +44,7 @@ export default {
           return 'When a member of ' + config.itemName + ' received command ' + config.command
         case 'core.GroupStateUpdateTrigger':
           if (!config.groupName) return moduleType.label
-          return 'When ' + config.itemName + ' was updated' +
+          return 'When ' + config.groupName + ' was updated' +
                         ((config.state) ? ' to ' + config.state : '')
         case 'core.GroupStateChangeTrigger':
           if (!config.groupName) return moduleType.label

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -102,73 +102,6 @@
       </f7-tab>
     </f7-tabs>
 
-    <f7-popup ref="modulePopup" class="moduleconfig-popup" close-on-escape :opened="moduleConfigOpened" @popupClosed="moduleConfigClosed">
-      <f7-page>
-        <f7-navbar>
-          <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
-          </f7-nav-left>
-          <f7-nav-title v-if="currentModule && currentModule.new">{{sectionLabels[currentSection][1]}}</f7-nav-title>
-          <f7-nav-title v-else>Edit module</f7-nav-title>
-          <f7-nav-right>
-            <f7-link v-show="currentModuleType" @click="saveModule">Done</f7-link>
-          </f7-nav-right>
-        </f7-navbar>
-        <f7-block v-if="currentModule" class="no-margin no-padding">
-          <f7-col class="margin-top">
-            <f7-list inline-labels no-hairlines-md class="no-margin">
-              <f7-list-input type="text" :placeholder="currentSuggestedModuleTitle" :value="currentModule.label" required
-                            @input="currentModule.label = $event.target.value" clear-button>
-              </f7-list-input>
-              <f7-list-input type="text" :placeholder="currentSuggestedModuleDescription" :value="currentModule.description"
-                            @input="currentModule.description = $event.target.value" clear-button>
-              </f7-list-input>
-            </f7-list>
-          </f7-col>
-          <f7-block-footer class="no-margin padding-left"><small>Tip: leave fields blank to set automatically to the suggested name and description. <f7-link @click="currentModule.label = null; currentModule.description = null">Clear</f7-link></small></f7-block-footer>
-
-          <f7-block-title>Type of {{currentSection.replace(/.$/, '')}}</f7-block-title>
-          <f7-list v-if="!currentModuleType">
-            <ul v-for="(mt, scope) in groupedModuleTypes(currentSection)" :key="scope">
-              <f7-list-item divider :title="scope" />
-              <f7-list-item radio v-for="moduleType in mt"
-                :value="moduleType.uid"
-                @change="currentModule.type = moduleType.uid; currentModuleType = moduleType; $set(currentModule, 'configuration', {})"
-                :checked="currentModule.type === moduleType.uid"
-                :key="moduleType.uid" :title="moduleType.label" name="module-type"></f7-list-item>
-            </ul>
-          </f7-list>
-          <f7-list v-else>
-            <f7-list-item :title="sectionLabels[currentSection][0]" ref="moduleTypeSmartSelect" smart-select :smart-select-params="{ view: $f7.views.main, openIn: 'popup', closeOnSelect: true }">
-              <select name="currentModuleType"
-                @change="currentModuleType = moduleTypes[currentSection].find((t) => t.uid === $refs.moduleTypeSmartSelect.f7SmartSelect.getValue());
-                         currentModule.type = currentModuleType.uid;
-                         currentModule.label = currentModule.description = '';
-                         $set(currentModule, 'configuration', {})">
-                <optgroup v-for="(mt, scope) in groupedModuleTypes(currentSection)" :key="scope" :label="scope">
-                  <option v-for="moduleType in mt"
-                    :value="moduleType.uid" :key="moduleType.uid" :selected="currentModuleType.uid === moduleType.uid">
-                    {{moduleType.label}}
-                  </option>
-                </optgroup>
-              </select>
-            </f7-list-item>
-          </f7-list>
-          <f7-block-title v-if="currentModule && currentModuleType" style="margin-bottom: calc(var(--f7-block-title-margin-bottom) - var(--f7-list-margin-vertical))">Configuration</f7-block-title>
-          <f7-col v-if="currentModule && currentModuleType">
-            <config-sheet :key="currentSection + currentModule.id"
-              :parameterGroups="[]"
-              :parameters="currentModuleType.configDescriptions"
-              :configuration="currentModule.configuration"
-              @updated="dirty = true"
-            />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
-
-    <script-editor-popup v-if="currentModule" title="Edit Script" ref="codePopup" popup-id="edit-rule-script-direct-popup" :value="scriptCode" :fullscreen="false" :opened="codeEditorOpened" @closed="codePopupClosed"></script-editor-popup>
-    <cron-editor popup-id="edit-rule-cron-popup" :value="cronExpression" :opened="cronPopupOpened" @closed="cronPopupOpened = false" @input="(value) => updateCronExpression(value)" />
   </f7-page>
 </template>
 
@@ -206,27 +139,21 @@
 <script>
 import YAML from 'yaml'
 
-// import ConfigParameter from '@/components/config/config-parameter.vue'
-import ConfigSheet from '@/components/config/config-sheet.vue'
 import SemanticsPicker from '@/components/tags/semantics-picker.vue'
 import TagInput from '@/components/tags/tag-input.vue'
-// import RuleConfigureModulePage from './rule-configure-module.vue'
 
+import RuleModulePopup from './rule-module-popup.vue'
 import ScriptEditorPopup from '@/components/config/controls/script-editor-popup.vue'
 import CronEditor from '@/components/config/controls/cronexpression-editor.vue'
 
 import ModuleDescriptionSuggestions from './module-description-suggestions'
-
 import RuleStatus from '@/components/rule/rule-status-mixin'
 
 export default {
   mixins: [ModuleDescriptionSuggestions, RuleStatus],
   components: {
-    ConfigSheet,
     SemanticsPicker,
     TagInput,
-    ScriptEditorPopup,
-    CronEditor,
     'editor': () => import('@/components/config/controls/script-editor.vue')
   },
   props: ['ruleId', 'createMode', 'schedule'],
@@ -242,7 +169,6 @@ export default {
         conditions: [],
         triggers: []
       },
-      moduleConfigOpened: false,
       showModuleControls: false,
       currentSection: 'actions',
       currentTab: 'design',
@@ -459,7 +385,30 @@ export default {
       this.currentSection = section
       this.currentModule = Object.assign({}, mod)
       this.currentModuleType = this.moduleTypes[section].find((m) => m.uid === mod.type)
-      this.$refs.modulePopup.f7Popup.open()
+
+      const popup = {
+        component: RuleModulePopup
+      }
+      this.$f7router.navigate({
+        url: 'module-config',
+        route: {
+          path: 'module-config',
+          popup
+        }
+      }, {
+        props: {
+          currentSection: this.currentSection,
+          ruleModule: this.currentModule,
+          ruleModuleType: this.currentModuleType,
+          moduleTypes: this.moduleTypes
+        }
+      })
+
+      this.$f7.once('ruleModuleConfigUpdate', this.saveModule)
+      this.$f7.once('ruleModuleConfigClosed', () => {
+        this.$f7.off('ruleModuleConfigUpdate', this.saveModule)
+        this.moduleConfigClosed()
+      })
     },
     deleteModule (ev, section, mod) {
       let swipeoutElement = ev.target
@@ -490,26 +439,47 @@ export default {
       this.currentSection = section
       this.currentModule = newModule
       this.currentModuleType = null
-      this.$refs.modulePopup.f7Popup.open()
+
+      const popup = {
+        component: RuleModulePopup
+      }
+      this.$f7router.navigate({
+        url: 'module-config',
+        route: {
+          path: 'module-config',
+          popup
+        }
+      }, {
+        props: {
+          currentSection: this.currentSection,
+          ruleModule: this.currentModule,
+          ruleModuleType: this.currentModuleType,
+          moduleTypes: this.moduleTypes
+        }
+      })
+
+      this.$f7.once('ruleModuleConfigUpdate', this.saveModule)
+      this.$f7.once('ruleModuleConfigClosed', () => {
+        this.$f7.off('ruleModuleConfigUpdate', this.saveModule)
+        this.moduleConfigClosed()
+      })
     },
     reorderModule (ev, section) {
       const newSection = [...this.rule[section]]
       newSection.splice(ev.to, 0, newSection.splice(ev.from, 1)[0])
       this.$set(this.rule, section, newSection)
     },
-    saveModule () {
-      if (!this.currentModule.type) return
-      if (this.currentModule.new) {
-        delete this.currentModule.new
-        this.rule[this.currentSection].push(this.currentModule)
+    saveModule (updatedModule) {
+      if (!updatedModule.type) return
+      if (!updatedModule.label) delete updatedModule.label
+      if (!updatedModule.description) delete updatedModule.description
+      if (updatedModule.new) {
+        delete updatedModule.new
+        this.rule[this.currentSection].push(updatedModule)
       } else {
-        const idx = this.rule[this.currentSection].findIndex((m) => m.id === this.currentModule.id)
-        this.$set(this.rule[this.currentSection], idx, this.currentModule)
+        const idx = this.rule[this.currentSection].findIndex((m) => m.id === updatedModule.id)
+        this.$set(this.rule[this.currentSection], idx, updatedModule)
       }
-      // if (!this.currentModule.label) this.currentModule.label = this.suggestedModuleTitle
-      // if (!this.currentModule.description) this.currentModule.description = this.suggestedModuleDescription
-      this.moduleConfigOpened = false
-      this.$refs.modulePopup.f7Popup.close()
     },
     moduleConfigClosed () {
       this.currentModule = null
@@ -520,25 +490,68 @@ export default {
       this.currentModule = mod
       this.currentModuleType = mod.type
       this.scriptCode = mod.configuration.script
-      setTimeout(() => { this.codeEditorOpened = true })
+
+      const popup = {
+        component: ScriptEditorPopup
+      }
+
+      this.$f7router.navigate({
+        url: 'script-edit',
+        route: {
+          path: 'script-edit',
+          popup
+        }
+      }, {
+        props: {
+          title: 'Edit Script',
+          fullscreen: false,
+          value: this.scriptCode
+        }
+      })
+
+      this.$f7.once('scriptEditorUpdate', this.updateScript)
+      this.$f7.once('scriptEditorClosed', () => {
+        this.$f7.off('scriptEditorUpdate', this.updateScript)
+        this.$nextTick(() => {
+          this.currentModule = null
+          this.currentModuleType = null
+        })
+      })
     },
     buildCronExpression (ev, mod) {
       ev.cancelBubble = true
       this.currentModule = mod
       this.currentModuleType = mod.type
       this.cronExpression = mod.configuration.cronExpression
-      this.cronPopupOpened = true
+      const popup = {
+        component: CronEditor
+      }
+      this.$f7router.navigate({
+        url: 'cron-edit',
+        route: {
+          path: 'cron-edit',
+          popup
+        }
+      }, {
+        props: {
+          value: this.cronExpression
+        }
+      })
+
+      this.$f7.once('cronEditorUpdate', this.updateCronExpression)
+      this.$f7.once('cronEditorClosed', () => {
+        this.$f7.off('cronEditorUpdate', this.updateCronExpression)
+        this.$nextTick(() => {
+          this.currentModule = null
+          this.currentModuleType = null
+        })
+      })
     },
-    codePopupClosed (value) {
-      this.codeEditorOpened = false
+    updateScript (value) {
       if (this.isEditable) this.currentModule.configuration.script = value
-      this.currentModule = null
-      this.currentModuleType = null
     },
     updateCronExpression (value) {
       this.currentModule.configuration.cronExpression = value
-      this.currentModule = null
-      this.currentModuleType = null
     },
     toYaml () {
       this.ruleYaml = YAML.stringify({
@@ -559,36 +572,11 @@ export default {
         this.$f7.dialog.alert(e).open()
         return false
       }
-    },
-    groupedModuleTypes (section) {
-      const moduleTypes = this.moduleTypes[section].filter((t) => t.visibility === 'VISIBLE')
-      let moduleTypesByScope = moduleTypes.reduce((prev, type, i, types) => {
-        const scope = type.uid.split('.')[0]
-        if (!prev[scope]) {
-          prev[scope] = [type]
-        } else {
-          prev[scope] = [...prev[scope], type].sort((t1, t2) => t1.label.localeCompare(t2.label))
-        }
-        return prev
-      }, {})
-      return Object.keys(moduleTypesByScope).sort((s1, s2) => (s1 === 'core') ? -1 : (s2 === 'core') ? 1 : s1.localeCompare(s2))
-        .reduce((prev, key) => {
-          prev[key] = moduleTypesByScope[key]
-          return prev
-        }, {})
     }
   },
   computed: {
     isEditable () {
       return this.rule && this.rule.editable !== false
-    },
-    currentSuggestedModuleTitle () {
-      if (!this.currentModule || !this.currentModuleType) return 'Title'
-      return this.suggestedModuleTitle(this.currentModule, this.currentModuleType)
-    },
-    currentSuggestedModuleDescription () {
-      if (!this.currentModule || !this.currentModuleType) return 'Description'
-      return this.suggestedModuleDescription(this.currentModule, this.currentModuleType)
     },
     yamlError () {
       if (this.currentTab !== 'code') return null

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -97,7 +97,7 @@
         </f7-block>
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="text/x-yaml" :value="ruleYaml" @input="(value) => ruleYaml = value" />
+        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.rule-definition" :value="ruleYaml" @input="(value) => ruleYaml = value" />
         <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
       </f7-tab>
     </f7-tabs>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -16,7 +16,7 @@
           <f7-col v-if="!createMode">
             <div class="float-right align-items-flex-start align-items-center">
               <!-- <f7-toggle class="enable-toggle"></f7-toggle> -->
-              <f7-link :icon-color="(rule.status.statusDetail === 'DISABLED') ? 'orange' : 'gray'" icon-ios="f7:pause_circle" icon-md="f7:pause_circle" icon-aurora="f7:pause_circle" icon-size="32" color="orange" @click="toggleDisabled"></f7-link>
+              <f7-link :icon-color="(rule.status.statusDetail === 'DISABLED') ? 'orange' : 'gray'" :tooltip="((rule.status.statusDetail === 'DISABLED') ? 'Enable' : 'Disable') + (($device.desktop) ? ' (Ctrl-D)' : '')" icon-ios="f7:pause_circle" icon-md="f7:pause_circle" icon-aurora="f7:pause_circle" icon-size="32" color="orange" @click="toggleDisabled"></f7-link>
               <f7-link :tooltip="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" icon-size="32" color="blue" @click="runNow"></f7-link>
             </div>
             Status:
@@ -98,7 +98,7 @@
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
         <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.rule-definition" :value="ruleYaml" @input="(value) => ruleYaml = value" />
-        <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre>
+        <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
       </f7-tab>
     </f7-tabs>
 
@@ -193,7 +193,7 @@
 .rule-code-editor.vue-codemirror
   display block
   top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(80% - 2*var(--f7-navbar-height))
+  height calc(100% - 2*var(--f7-navbar-height))
   width 100%
 .yaml-message
   display block
@@ -415,6 +415,11 @@ export default {
     keyDown (ev) {
       if (ev.ctrlKey || ev.metakKey) {
         switch (ev.keyCode) {
+          case 68:
+            this.toggleDisabled()
+            ev.stopPropagation()
+            ev.preventDefault()
+            break
           case 82:
             this.runNow()
             ev.stopPropagation()

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -97,7 +97,7 @@
         </f7-block>
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
-        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.rule-definition" :value="ruleYaml" @input="(value) => ruleYaml = value" />
+        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.rule" :value="ruleYaml" @input="(value) => ruleYaml = value" />
         <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
       </f7-tab>
     </f7-tabs>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -273,6 +273,7 @@ export default {
             destroyOnClose: true,
             closeTimeout: 2000
           }).open()
+          this.$f7router.navigate(this.$f7route.url.replace('/add', '/' + this.rule.uid), { reloadCurrent: true })
           this.load()
         } else {
           this.$f7.toast.create({
@@ -281,7 +282,7 @@ export default {
             closeTimeout: 2000
           }).open()
         }
-        if (!stay) this.$f7router.back()
+        // if (!stay) this.$f7router.back()
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while saving rule: ' + err,

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -1,0 +1,128 @@
+<template>
+  <f7-popup ref="modulePopup" class="moduleconfig-popup" @popupClosed="moduleConfigClosed">
+    <f7-page>
+      <f7-navbar>
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close></f7-link>
+        </f7-nav-left>
+        <f7-nav-title v-if="ruleModule && ruleModule.new">{{sectionLabels[currentSection][1]}}</f7-nav-title>
+        <f7-nav-title v-else>Edit module</f7-nav-title>
+        <f7-nav-right>
+          <f7-link v-show="currentRuleModuleType" @click="updateModuleConfig" class="popup-close">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-block v-if="ruleModule" class="no-margin no-padding">
+        <f7-col class="margin-top">
+          <f7-list inline-labels no-hairlines-md class="no-margin">
+            <f7-list-input type="text" :placeholder="moduleTitleSuggestion" :value="ruleModule.label" required
+                          @input="ruleModule.label = $event.target.value" clear-button>
+            </f7-list-input>
+            <f7-list-input type="text" :placeholder="moduleDescriptionSuggestion" :value="ruleModule.description"
+                          @input="ruleModule.description = $event.target.value" clear-button>
+            </f7-list-input>
+          </f7-list>
+        </f7-col>
+        <f7-block-footer class="no-margin padding-left"><small>Tip: leave fields blank to set automatically to the suggested name and description. <f7-link @click="ruleModule.label = null; ruleModule.description = null">Clear</f7-link></small></f7-block-footer>
+
+        <f7-block-title>Type of {{currentSection.replace(/.$/, '')}}</f7-block-title>
+        <f7-list v-if="!currentRuleModuleType">
+          <ul v-for="(mt, scope) in groupedModuleTypes(currentSection)" :key="scope">
+            <f7-list-item divider :title="scope" />
+            <f7-list-item radio v-for="moduleType in mt"
+              :value="moduleType.uid"
+              @change="setModuleType(moduleType)"
+              :checked="ruleModule.type === moduleType.uid"
+              :key="moduleType.uid" :title="moduleType.label" name="module-type"></f7-list-item>
+          </ul>
+        </f7-list>
+        <f7-list v-else>
+          <f7-list-item :title="sectionLabels[currentSection][0]" ref="ruleModuleTypeSmartSelect" smart-select :smart-select-params="{ view: $f7.views.main, openIn: 'popup', closeOnSelect: true }">
+            <select name="ruleModuleType"
+              @change="setModuleType(moduleTypes[currentSection].find((t) => t.uid === $refs.ruleModuleTypeSmartSelect.f7SmartSelect.getValue()))">
+              <optgroup v-for="(mt, scope) in groupedModuleTypes(currentSection)" :key="scope" :label="scope">
+                <option v-for="moduleType in mt"
+                  :value="moduleType.uid" :key="moduleType.uid" :selected="currentRuleModuleType.uid === moduleType.uid">
+                  {{moduleType.label}}
+                </option>
+              </optgroup>
+            </select>
+          </f7-list-item>
+        </f7-list>
+        <f7-block-title v-if="ruleModule && currentRuleModuleType" style="margin-bottom: calc(var(--f7-block-title-margin-bottom) - var(--f7-list-margin-vertical))">Configuration</f7-block-title>
+        <f7-col v-if="ruleModule && currentRuleModuleType">
+          <config-sheet :key="currentSection + ruleModule.id"
+            :parameterGroups="[]"
+            :parameters="currentRuleModuleType.configDescriptions"
+            :configuration="ruleModule.configuration"
+            @updated="dirty = true"
+          />
+        </f7-col>
+      </f7-block>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<script>
+import ConfigSheet from '@/components/config/config-sheet.vue'
+
+import ModuleDescriptionSuggestions from './module-description-suggestions'
+
+export default {
+  mixins: [ModuleDescriptionSuggestions],
+  components: {
+    ConfigSheet
+  },
+  props: ['rule', 'ruleModule', 'ruleModuleType', 'moduleTypes', 'currentSection'],
+  data () {
+    return {
+      currentRuleModuleType: this.ruleModuleType,
+      sectionLabels: {
+        triggers: ['When', 'Add Trigger'],
+        actions: ['Then', 'Add Action'],
+        conditions: ['But only if', 'Add Condition']
+      }
+    }
+  },
+  methods: {
+    setModuleType (moduleType) {
+      this.ruleModule.type = moduleType.uid
+      this.$set(this, 'currentRuleModuleType', moduleType)
+      this.$set(this.ruleModule, 'configuration', {})
+      this.ruleModule.label = this.ruleModule.description = ''
+    },
+    moduleConfigClosed () {
+      this.$f7.emit('ruleModuleConfigClosed')
+    },
+    updateModuleConfig () {
+      this.$f7.emit('ruleModuleConfigUpdate', this.ruleModule)
+    },
+    groupedModuleTypes (section) {
+      const moduleTypes = this.moduleTypes[section].filter((t) => t.visibility === 'VISIBLE')
+      let moduleTypesByScope = moduleTypes.reduce((prev, type, i, types) => {
+        const scope = type.uid.split('.')[0]
+        if (!prev[scope]) {
+          prev[scope] = [type]
+        } else {
+          prev[scope] = [...prev[scope], type].sort((t1, t2) => t1.label.localeCompare(t2.label))
+        }
+        return prev
+      }, {})
+      return Object.keys(moduleTypesByScope).sort((s1, s2) => (s1 === 'core') ? -1 : (s2 === 'core') ? 1 : s1.localeCompare(s2))
+        .reduce((prev, key) => {
+          prev[key] = moduleTypesByScope[key]
+          return prev
+        }, {})
+    }
+  },
+  computed: {
+    moduleTitleSuggestion () {
+      if (!this.ruleModule || !this.currentRuleModuleType) return 'Title'
+      return this.suggestedModuleTitle(this.ruleModule, this.currentRuleModuleType)
+    },
+    moduleDescriptionSuggestion () {
+      if (!this.ruleModule || !this.currentRuleModuleType) return 'Description'
+      return this.suggestedModuleDescription(this.ruleModule, this.currentRuleModuleType)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -77,7 +77,7 @@
           <f7-col>
             <f7-block-title>Z-Wave</f7-block-title>
             <f7-list>
-              <f7-list-button color="blue" title="View Network Map" @click="zwaveNetworkPopupOpened = true"></f7-list-button>
+              <f7-list-button color="blue" title="View Network Map" @click="openZWaveNetworkPopup"></f7-list-button>
               <f7-list-button color="blue" v-for="action in zwaveActions" :key="action.name" :title="action.label" @click="doZWaveAction(action)"></f7-list-button>
             </f7-list>
           </f7-col>
@@ -367,6 +367,18 @@ export default {
           save()
         }
       )
+    },
+    openZWaveNetworkPopup () {
+      const popup = {
+        component: ZWaveNetworkPopup
+      }
+      this.$f7router.navigate({
+        url: 'zwave-network',
+        route: {
+          path: 'zwave-network',
+          popup
+        }
+      })
     },
     deleteThing () {
       let url, message

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/zwave/zwave-network-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/zwave/zwave-network-popup.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-popup tablet-fullscreen close-on-escape :opened="opened" @popup:opened="() => showNetwork = true" @popup:closed="$emit('closed')">
+  <f7-popup tablet-fullscreen close-on-escape @popup:opened="() => showNetwork = true" @popup:closed="$emit('closed')">
     <f7-page class="analyzer-content">
       <f7-navbar title="Z-Wave Network Map">
         <f7-nav-right>
@@ -11,20 +11,13 @@
   </f7-popup>
 </template>
 
-<style lang="stylus">
-// .analyzer-content
-//   background white
-</style>
-
 <script>
 export default {
   components: {
     'zwave-network': () => import(/* webpackChunkName: "zwave-network" */ '@/components/thing/zwave/zwave-network.vue')
   },
-  props: ['opened'],
   data () {
     return {
-      popupOpened: false,
       showNetwork: false
     }
   },


### PR DESCRIPTION
Add some autocomplete ("hint" in CodeMirror jargon) logic to YAML
editors for UI components and rules. Might be expanded to other entities
in the future.

Signed-off-by: Yannick Schaus <github@schaus.net>