### PR TITLE
Upgrade Maven compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
+          <version>3.8.1</version>
           <configuration>
             <compilerId>eclipse</compilerId>
             <compilerArgs>
@@ -246,12 +246,12 @@ Import-Package: \\
             <dependency>
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-compiler-eclipse</artifactId>
-              <version>2.8.5</version>
+              <version>2.8.8</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.16.0</version>
+              <version>3.23.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Upgrades the compiler and its dependencies so the compiler results of Maven builds are more similar to those generated in recent Eclipse versions.