### PR TITLE
Redesign thing details page, add YAML editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -88,6 +88,7 @@ import OpenhabDefs from '@/assets/openhab-tern-defs.json'
 
 import componentsHint from '../editor/hint-components'
 import rulesHint from '../editor/hint-rules'
+import thingsHint from '../editor/hint-things'
 
 // Adapted from https://github.com/lkcampbell/brackets-indent-guides (MIT)
 var indentGuidesOverlay = {
@@ -129,7 +130,7 @@ export default {
   components: {
     codemirror
   },
-  props: ['value', 'mode'],
+  props: ['value', 'mode', 'hintContext'],
   data () {
     return {
       code: this.value,
@@ -191,6 +192,7 @@ export default {
         }
         cm.state.$oh = this.$oh
         cm.state.originalMode = this.mode
+        if (this.hintContext) cm.state.hintContext = Object.assign({}, this.hintContext)
         cm.setOption('hintOptions', {
           closeOnUnfocus: false,
           hint (cm, option) {
@@ -198,6 +200,8 @@ export default {
               return componentsHint(cm, option, self.mode)
             } else if (self.mode === 'application/vnd.openhab.rule') {
               return rulesHint(cm, option, self.mode)
+            } else if (self.mode === 'application/vnd.openhab.thing+yaml') {
+              return thingsHint(cm, option, self.mode)
             }
           }
         })

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -195,6 +195,7 @@ export default {
         if (this.hintContext) cm.state.hintContext = Object.assign({}, this.hintContext)
         cm.setOption('hintOptions', {
           closeOnUnfocus: false,
+          completeSingle: false,
           hint (cm, option) {
             if (self.mode.indexOf('application/vnd.openhab.uicomponent') === 0) {
               return componentsHint(cm, option, self.mode)

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-things.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-things.js
@@ -1,0 +1,171 @@
+import { lineIndent, findParent, findParentRoot, isConfig, isChannelsSection } from './yaml-utils'
+import { filterPartialCompletions, addTooltipHandlers, getClassNamesForParameter } from './hint-utils'
+
+function hintOptions (cm, line, parameter) {
+  const cursor = cm.getCursor()
+  const colonPos = line.indexOf(':')
+  let ret = {
+    list: parameter.options.map((o) => {
+      return {
+        text: o.value,
+        description: o.label || o.value
+      }
+    })
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list)
+  ret.from = { line: cursor.line, ch: colonPos + 2 }
+  ret.to = { line: cursor.line, ch: line.length }
+  addTooltipHandlers(cm, ret)
+  return ret
+}
+
+function hintThingConfig (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const colonPos = line.indexOf(':')
+  const afterColon = colonPos > 0 && cursor.ch > colonPos
+  const parameters = cm.state.hintContext.thingType.configParameters
+  if (afterColon) {
+    const parameterName = line.substring(0, colonPos).trim()
+    const parameter = parameters.find((p) => p.name === parameterName)
+    if (parameter) {
+      if (parameter.type === 'BOOLEAN') {
+        if (line.endsWith('true') || line.endsWith('false')) return
+        return {
+          list: [ { text: 'true' }, { text: 'false' } ],
+          from: { line: cursor.line, ch: colonPos + 2 },
+          to: { line: cursor.line, ch: line.length }
+        }
+      } else if (parameter.options) {
+        return hintOptions(cm, line, parameter)
+      }
+    }
+  } else {
+    let completions = parameters.map((p) => {
+      return {
+        text: p.name + ': ',
+        displayText: p.name,
+        description: p.description,
+        className: getClassNamesForParameter(p)
+      }
+    })
+    completions = filterPartialCompletions(cm, line, completions)
+    let ret = {
+      list: completions,
+      from: { line: cursor.line, ch: 6 },
+      to: { line: cursor.line, ch: line.length }
+    }
+    addTooltipHandlers(cm, ret)
+    return ret
+  }
+}
+
+function findChannelTypeUID (cm) {
+  // FIXME: this function will assume the module type will appear directly before
+  // the configuration block, which will usually be the case but it's not guaranteed.
+  // It doesn't parse the YAML properly.
+  const cursor = cm.getCursor()
+  for (let l = cursor.line - 1; l >= 0; l--) {
+    const line = cm.getLine(l)
+    if (line.match(/^ {4}channelTypeUID: /)) {
+      return line.substring(line.indexOf(':') + 1).trim()
+    }
+  }
+}
+
+function hintChannelConfig (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const channelTypeUID = findChannelTypeUID(cm, cursor.line)
+  console.debug(`hinting config for module type: ${channelTypeUID}`)
+  // const indent = lineIndent(cm, parentLineNr)
+  const colonPos = line.indexOf(':')
+  const afterColon = colonPos > 0 && cursor.ch > colonPos
+  const channelType = cm.state.hintContext.channelTypes.find((m) => m.UID === channelTypeUID)
+  if (!channelType) return null
+  const parameters = channelType.parameters
+  if (afterColon) {
+    const parameterName = line.substring(0, colonPos).trim()
+    const parameter = parameters.find((p) => p.name === parameterName)
+    if (parameter) {
+      if (parameter.type === 'BOOLEAN') {
+        if (line.endsWith('true') || line.endsWith('false')) return
+        return {
+          list: [ { text: 'true' }, { text: 'false' } ],
+          from: { line: cursor.line, ch: colonPos + 2 },
+          to: { line: cursor.line, ch: line.length }
+        }
+      } else if (parameter.options) {
+        return hintOptions(cm, line, parameter)
+      }
+    }
+  } else {
+    console.debug(channelType)
+    let completions = parameters.map((p) => {
+      return {
+        text: p.name + ': ',
+        displayText: p.name,
+        description: p.description,
+        className: getClassNamesForParameter(p)
+      }
+    })
+    completions = filterPartialCompletions(cm, line, completions)
+    let ret = {
+      list: completions,
+      from: { line: cursor.line, ch: 6 },
+      to: { line: cursor.line, ch: line.length }
+    }
+    addTooltipHandlers(cm, ret)
+    return ret
+  }
+}
+
+function buildChannelStructure (cm, channelType) {
+  let ret = '  - id: \n    channelTypeUID: ' + channelType.UID + '\n'
+  ret += '    label: \n    description: \n'
+  ret += '    configuration: {}\n'
+  ret += '  '
+  return ret
+}
+
+function hintChannelStructure (cm, line, parentLineNr) {
+  const cursor = cm.getCursor()
+  const thingType = cm.state.hintContext.thingType
+  const bindingId = cm.state.hintContext.thingType.UID.split(':')[0]
+  const channelTypes = cm.state.hintContext.channelTypes.filter((c) => thingType.extensibleChannelTypeIds.map((t) => bindingId + ':' + t).indexOf(c.UID) >= 0)
+  let completions = channelTypes.map((c) => {
+    return {
+      text: buildChannelStructure(cm, c),
+      displayText: `channel: ${c.UID}`,
+      description: `${c.label}${(c.description) ? '<br/><br />' + c.description : ''}`
+    }
+  })
+  let ret = {
+    list: completions,
+    from: { line: cursor.line, ch: 0 },
+    to: { line: cursor.line, ch: cm.getLine(cursor.line).length }
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list)
+  addTooltipHandlers(cm, ret)
+  return ret
+}
+
+export default function hint (cm, option, mode) {
+  const cursor = cm.getCursor()
+  const line = cm.getLine(cursor.line)
+
+  const parentLineNr = findParent(cm, cursor.line)
+  const parentLine = cm.getLine(parentLineNr)
+  console.debug(`parent line (${parentLineNr}): ${parentLine}`)
+
+  let ret
+  if (parentLine && isConfig(parentLine) && lineIndent(cm, parentLineNr) === 0) {
+    ret = hintThingConfig(cm, line, parentLineNr)
+  } else if (parentLine && isConfig(parentLine) && lineIndent(cm, parentLineNr) === 4) {
+    ret = hintChannelConfig(cm, line, parentLineNr)
+  } else if (isChannelsSection(parentLine)) {
+    ret = hintChannelStructure(cm, line, parentLineNr)
+  }
+
+  if (!(ret instanceof Promise)) addTooltipHandlers(cm, ret)
+
+  return ret
+}

--- a/bundles/org.openhab.ui/web/src/components/config/editor/yaml-utils.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/yaml-utils.js
@@ -49,3 +49,8 @@ export function isRuleSection (line) {
   if (!line) return false
   return line.match(/^(triggers|conditions|actions):/)
 }
+
+export function isChannelsSection (line) {
+  if (!line) return false
+  return line.match(/^channels:/)
+}

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -14,7 +14,7 @@
         ></f7-searchbar>
       </f7-col>
     </f7-block>
-    <div style="text-align:right" class="padding-right" v-if="hasAdvanced">
+    <div style="text-align:right" class="padding-right padding-bottom" v-if="hasAdvanced">
       <label @click="toggleAdvanced" class="advanced-label">Show advanced</label> <f7-checkbox name="channel-advanced" :checked="showAdvanced" @change="toggleAdvanced"></f7-checkbox>
     </div>
     <f7-col v-if="thing.channels.length > 0">

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -4,27 +4,26 @@
       <f7-block width="100" class="parameter-group no-margin">
         <f7-row>
           <f7-col>
-            <f7-block-title>General Settings</f7-block-title>
-            <f7-list inline-labels no-hairlines-md>
+            <f7-list inline-labels no-hairlines-md class="no-margin">
               <f7-list-input label="Unique ID" v-if="createMode" type="text" placeholder="Required" :value="thing.ID"
                               @input="changeUID" info="Note: cannot be changed after the creation"
                               required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only">
               </f7-list-input>
               <f7-list-input label="Identifier" type="text" placeholder="Name" :value="thing.UID" disabled>
               </f7-list-input>
-              <f7-list-input label="Label" type="text" placeholder="e.g. My Thing" :value="thing.label"
+              <f7-list-input label="Label" type="text" :disabled="!ready" placeholder="e.g. My Thing" :value="thing.label"
                               @input="thing.label = $event.target.value; $emit('updated')" required validate>
               </f7-list-input>
-              <f7-list-input label="Location" type="text" placeholder="e.g. Kitchen" :value="thing.location"
+              <f7-list-input label="Location" type="text" :disabled="!ready" placeholder="e.g. Kitchen" :value="thing.location"
                               @input="thing.location = $event.target.value; $emit('updated')" clear-button>
               </f7-list-input>
             </f7-list>
-            <f7-block-title v-if="thingType.supportedBridgeTypeUIDs.length">Parent Bridge</f7-block-title>
-            <f7-block-footer v-if="thingType.supportedBridgeTypeUIDs.length && !thing.bridgeUID"
+            <f7-block-title v-if="ready && thingType.supportedBridgeTypeUIDs.length">Parent Bridge</f7-block-title>
+            <f7-block-footer v-if="ready && thingType.supportedBridgeTypeUIDs.length && !thing.bridgeUID"
               class="padding-left padding-right">
               This type of Thing needs to be associated to a working Bridge to function properly.
             </f7-block-footer>
-            <f7-list v-if="thingType.supportedBridgeTypeUIDs.length" inline-labels no-hairlines-md>
+            <f7-list v-if="ready && thingType.supportedBridgeTypeUIDs.length" inline-labels no-hairlines-md>
               <thing-picker
                 title="Bridge" name="bridge" :value="thing.bridgeUID"
                 @input="updateBridge"
@@ -41,7 +40,7 @@
 import ThingPicker from '@/components/config/controls/thing-picker.vue'
 
 export default {
-  props: ['thing', 'thingType', 'createMode'],
+  props: ['thing', 'thingType', 'createMode', 'ready'],
   components: {
     ThingPicker
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
     <f7-navbar :title="createMode ? 'Create New Item': 'Edit Item'" back-link="Cancel">
-      <f7-nav-right>
+      <f7-nav-right v-if="!$theme.aurora || !createMode">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
         <f7-link @click="save()" v-if="!$theme.md">Save</f7-link>
       </f7-nav-right>
@@ -36,6 +36,12 @@
         </f7-list> -->
       </f7-col>
     </f7-block>
+
+    <div v-if="ready && createMode" class="if-aurora display-flex justify-content-center margin padding">
+      <div class="flex-shrink-0">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">Create</f7-button>
+      </div>
+    </div>
   </f7-page>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
     <f7-navbar title="Add Items from Thing" back-link="Back">
-      <f7-nav-right>
+      <f7-nav-right class="if-not-aurora">
         <f7-link @click="add()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
         <f7-link @click="add()" v-if="!$theme.md">Add</f7-link>
       </f7-nav-right>
@@ -69,6 +69,13 @@
         </div>
       </f7-col>
     </f7-block>
+
+    <div v-if="ready && selectedThing.UID" class="if-aurora display-flex justify-content-center margin padding">
+      <div class="flex-shrink-0">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="add">Add to Model</f7-button>
+      </div>
+    </div>
+
   </f7-page>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -24,10 +24,8 @@
               :text="rule.status.status"
               :color="ruleStatusBadgeColor(rule.status)"
             />
-            <div v-if="rule.status.statusDetail !== 'NONE' || rule.status.description">
-              <strong
-                v-if="rule.status.statusDetail !== 'NONE'"
-              >{{rule.status.statusDetail}}</strong>
+            <div>
+              <strong>{{(rule.status.statusDetail !== 'NONE') ? rule.status.statusDetail : '&nbsp;'}}</strong>
               <br>
               <div v-if="rule.status.description">{{rule.status.description}}</div>
             </div>
@@ -44,7 +42,25 @@
           </f7-col>
         </f7-block>
 
-        <f7-block v-if="ready" class="block-narrow">
+        <!-- skeletons -->
+        <f7-block v-if="!ready" class="block-narrow">
+          <f7-col class="skeleton-text skeleton-effect-blink">
+            <f7-list inline-labels no-hairlines-md>
+              <f7-list-input label="Unique ID" type="text" placeholder="Required" value="_______" required validate
+                            :disabled="true" :info="(createMode) ? 'Note: cannot be changed after the creation' : ''"
+                            @input="rule.uid = $event.target.value" :clear-button="createMode">
+              </f7-list-input>
+              <f7-list-input label="Name" type="text" placeholder="Required" required validate
+                            :disabled="true" @input="rule.name = $event.target.value" :clear-button="isEditable">
+              </f7-list-input>
+              <f7-list-input label="Description" type="text" value="__ _____ ___ __ ___"
+                            :disabled="true" @input="rule.description = $event.target.value" :clear-button="isEditable">
+              </f7-list-input>
+            </f7-list>
+          </f7-col>
+        </f7-block>
+
+        <f7-block v-else class="block-narrow">
           <f7-col>
             <f7-list inline-labels no-hairlines-md>
               <f7-list-input label="Unique ID" type="text" placeholder="Required" :value="rule.uid" required validate
@@ -59,6 +75,7 @@
               </f7-list-input>
             </f7-list>
           </f7-col>
+
           <f7-block-footer v-if="!isEditable" class="no-margin padding-left"><f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: this rule is not editable because it has been provisioned from a file.</f7-block-footer>
           <f7-col v-if="isEditable" class="text-align-right justify-content-flex-end">
             <div class="no-padding float-right">
@@ -67,7 +84,7 @@
             </div>
           </f7-col>
           <f7-col class="rule-modules" v-for="section in ['triggers', 'actions', 'conditions']" :key="section">
-            <f7-block-title v-if="isEditable || rule[section].length > 0">{{sectionLabels[section][0]}}</f7-block-title>
+            <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)" v-if="isEditable || rule[section].length > 0">{{sectionLabels[section][0]}}</f7-block-title>
             <f7-list sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, section)">
               <f7-list-item media
                   :title="mod.label || suggestedModuleTitle(mod, null, section)"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -1,28 +1,29 @@
 <template>
-  <f7-page @page:afterin="onPageAfterIn">
+  <f7-page @page:afterin="onPageAfterIn" class="thing-add-page">
     <f7-navbar :title="(ready) ? 'New ' + thingType.label : 'New Thing'" back-link="Back">
-      <f7-nav-right>
+      <f7-nav-right class="if-not-aurora">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
         <f7-link @click="save()" v-if="!$theme.md">Add</f7-link>
       </f7-nav-right>
     </f7-navbar>
 
-    <f7-block v-if="ready" class="block-narrow padding-left padding-right">
+    <f7-block v-if="ready" class="block-narrow">
       <f7-col>
-        <h3>{{thingType.label}}</h3>
-        <div v-html="thingType.description"></div>
+        <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" :ready="true" />
+        <f7-block-title medium>{{thingType.label}}</f7-block-title>
+        <div class="margin thing-type-description" v-html="thingType.description"></div>
       </f7-col>
     </f7-block>
     <!-- skeletons for not ready -->
-    <f7-block v-else class="block-narrow padding-left padding-right skeleton-text skeleton-effect-blink">
+    <f7-block v-else class="block-narrow skeleton-text skeleton-effect-blink">
+      <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" :ready="false" />
       <f7-col>
-        <h3>____ _______</h3>
-        <div>____ ____ ____ _____ ___ __ ____ __ ________ __ ____ ___ ____</div>
+        <f7-block-title>____ _______</f7-block-title>
+        <div class="margin">____ ____ ____ _____ ___ __ ____ __ ________ __ ____ ___ ____</div>
       </f7-col>
     </f7-block>
 
     <f7-block v-if="ready" class="block-narrow">
-      <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" />
       <config-sheet ref="parameters"
         :parameter-groups="thingType.parameterGroups"
         :parameters="thingType.configParameters"
@@ -30,52 +31,24 @@
       />
     </f7-block>
 
+    <div v-if="ready" class="if-aurora display-flex justify-content-center margin">
+      <div class="flex-shrink-0">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">Create Thing</f7-button>
+      </div>
+    </div>
+
   </f7-page>
 </template>
 
 <style lang="stylus">
-code.textual-definition pre {
-  overflow-x: auto;
-  white-space: normal;
-}
-
-pre.textual-definition {
-  padding: 5px;
-}
-
-textarea.textual-definition {
-  position: absolute;
-  top: var(--f7-toolbar-height);
-  left: 5px;
-  right: 5px;
-  bottom: 0;
-  width: calc(100% - 10px);
-  font-family: monospace;
-}
-
-.md .code-popup {
-  margin-bottom: 0 !important;
-}
-
-.ios .code-popup {
-  margin-bottom: 44px !important;
-}
-
-.code-popup {
-  width: 100%;
-  position: fixed;
-  bottom: 0 !important;
-  top: var(--f7-toolbar-height) !important;
-  // margin -2px !important
-  background-color: white !important;
-  border-top: 2px solid #555;
-
-  // z-index 1000 !important
-  code {
-    max-height: 50% !important;
-    overflow-y: auto !important;
-  }
-}
+.thing-add-page
+  .thing-type-description
+    h1
+      font-size 16px
+    h2
+      font-size 12px
+    h3
+      font-size 11px
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" name="channel-add">
     <f7-navbar title="Add Channel" back-link="Cancel">
-      <f7-nav-right>
+      <f7-nav-right class="if-not-aurora">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
         <f7-link @click="save()" v-if="!$theme.md">Done</f7-link>
       </f7-nav-right>
@@ -39,6 +39,13 @@
           />
       </f7-col>
     </f7-block>
+
+    <div v-if="ready && currentChannelType" class="if-aurora display-flex justify-content-center margin padding">
+      <div class="flex-shrink-0">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">Create</f7-button>
+      </div>
+    </div>
+
   </f7-page>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
     <f7-navbar title="Link Channel to Item" back-link="Cancel">
-      <f7-nav-right>
+      <f7-nav-right class="if-not-aurora">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
         <f7-link @click="save()" v-if="!$theme.md">Link</f7-link>
       </f7-nav-right>
@@ -81,7 +81,7 @@
           <f7-link external color="blue" target="_blank" href="https://www.openhab.org/docs/configuration/items.html#profiles">Learn more about profiles.</f7-link>
         </f7-block-footer>
         <f7-list>
-          <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="No Profile (Default)" name="profile-type" />
+          <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="(No Profile)" name="profile-type" />
           <f7-list-item radio v-for="profileType in profileTypes"
             :value="profileType.uid"
             @change="onProfileTypeChange(profileType.uid)"
@@ -97,6 +97,13 @@
           />
       </f7-col>
     </f7-block>
+
+    <div v-if="ready && profileTypes.length" class="if-aurora display-flex justify-content-center padding margin">
+      <div class="flex-shrink-0">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">Link</f7-button>
+      </div>
+    </div>
+
   </f7-page>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -47,7 +47,7 @@
           <div>Loading...</div>
         </f7-block>
         <f7-list v-else>
-          <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="No Profile (Default)" name="profile-type" />
+          <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="(No Profile)" name="profile-type" />
           <f7-list-item radio v-for="profileType in profileTypes"
             :checked="profileType.uid === currentProfileType.uid"
             @change="onProfileTypeChange(profileType.uid)"

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -208,11 +208,9 @@
 </style>
 
 <script>
-import ParameterLocation from '@/components/config/controls/parameter-location.vue'
-
 export default {
   components: {
-    ParameterLocation
+    'parameter-location': () => import('@/components/config/controls/parameter-location.vue')
   },
   data () {
     return {


### PR DESCRIPTION
Merge the 'Info' & 'Config' tabs of the thing details
page into a single 'Thing' tab, and add a 'Code' tab
allowing to edit the relevant parts of the thing in
YAML, with partial autocompletion:

- general parameters: label, location...
- bridge
- configuration parameters
- extensible channels

Remove the unmaintained textual translation button & popup.

Styling tweaks.

Move validation buttons in add/create dialogs from the navbar
to bigger buttons at the bottom of the page:

- add thing
- add channel
- add link
- add item

Change label for no profile from 'No Profile (Default)' to
'(No Profile)'.

Closes #365.

Signed-off-by: Yannick Schaus <github@schaus.net>