### PR TITLE
Autocompletion: don't retrigger hinting by default

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -195,7 +195,6 @@ export default {
         if (this.hintContext) cm.state.hintContext = Object.assign({}, this.hintContext)
         cm.setOption('hintOptions', {
           closeOnUnfocus: false,
-          completeSingle: false,
           hint (cm, option) {
             if (self.mode.indexOf('application/vnd.openhab.uicomponent') === 0) {
               return componentsHint(cm, option, self.mode)

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
@@ -175,11 +175,13 @@ function hintConfig (cm, line, parentLineNr) {
       }
     })
     completions = filterPartialCompletions(cm, line, completions)
-    return {
+    const ret = {
       list: completions,
       from: { line: cursor.line, ch: indent + 2 },
       to: { line: cursor.line, ch: line.length }
     }
+    addTooltipHandlers(cm, ret, true)
+    return ret
   }
 }
 
@@ -206,6 +208,7 @@ function hintComponentStructure (cm, line, parentLineNr) {
   }
   ret.from = { line: cursor.line, ch: 0 }
   ret.to = { line: cursor.line, ch: cm.getLine(cursor.line).length }
+  addTooltipHandlers(cm, ret, true)
   return ret
 }
 
@@ -230,6 +233,7 @@ function hintSlots (cm, line, parentLineNr) {
   }
   ret.from = { line: cursor.line, ch: 0 }
   ret.to = { line: cursor.line, ch: cm.getLine(cursor.line).length }
+  addTooltipHandlers(cm, ret, true)
   return ret
 }
 

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-rules.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-rules.js
@@ -114,7 +114,7 @@ function hintConfig (cm, line, parentLineNr) {
         from: { line: cursor.line, ch: 6 },
         to: { line: cursor.line, ch: line.length }
       }
-      addTooltipHandlers(cm, ret)
+      addTooltipHandlers(cm, ret, true)
       return ret
     }
   })

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-things.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-things.js
@@ -54,7 +54,7 @@ function hintThingConfig (cm, line, parentLineNr) {
       from: { line: cursor.line, ch: 6 },
       to: { line: cursor.line, ch: line.length }
     }
-    addTooltipHandlers(cm, ret)
+    addTooltipHandlers(cm, ret, true)
     return ret
   }
 }
@@ -113,7 +113,7 @@ function hintChannelConfig (cm, line, parentLineNr) {
       from: { line: cursor.line, ch: 6 },
       to: { line: cursor.line, ch: line.length }
     }
-    addTooltipHandlers(cm, ret)
+    addTooltipHandlers(cm, ret, true)
     return ret
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
@@ -36,20 +36,23 @@ export function filterPartialCompletions (cm, line, completions, property = 'tex
   return completions.filter((c) => c[property] && c[property].toLowerCase().indexOf(partialCompletion.toLowerCase()) >= 0)
 }
 
-export function addTooltipHandlers (cm, ret) {
+export function addTooltipHandlers (cm, ret, retriggerHint) {
   let tooltip = null
   const cursor = cm.getCursor()
+
+  if (ret.tooltip) return
 
   if (!ret) return
   if (!ret.from) ret.from = cursor
   if (!ret.to) ret.to = cursor
+  ret.tooltip = true
 
   CodeMirror.on(ret, 'close', function () { remove(tooltip) })
   CodeMirror.on(ret, 'update', function () { remove(tooltip) })
   CodeMirror.on(ret, 'pick', function () {
     setTimeout(() => {
       cm.scrollIntoView(cm.getCursor())
-      CodeMirror.commands.autocomplete(cm)
+      if (retriggerHint) CodeMirror.commands.autocomplete(cm)
     }, 100)
   })
   CodeMirror.on(ret, 'select', function (cur, node) {


### PR DESCRIPTION
This prevents infinite loops and other side effects.
Add an option to explicitely retrigger another autocompletion.

Signed-off-by: Yannick Schaus <github@schaus.net>