### PR TITLE
Remove dashboard dependency

### DIFF
--- a/bundles/org.openhab.ui.cometvisu.php/pom.xml
+++ b/bundles/org.openhab.ui.cometvisu.php/pom.xml
@@ -31,11 +31,6 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.openhab.ui.bundles</groupId>
-      <artifactId>org.openhab.ui.dashboard</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.openhab.core.bundles</groupId>
       <artifactId>org.openhab.core.model.sitemap</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
The dashboard no longer exists in OH3 making the release pipeline fail:

See: https://ci.openhab.org/view/Sandbox/job/sandbox-openhab3-release/9/

`[ERROR] Failed to execute goal on project org.openhab.ui.cometvisu.php: Could not resolve dependencies for project org.openhab.ui.bundles:org.openhab.ui.cometvisu.php:jar:3.0.0.M1: Could not find artifact org.openhab.ui.bundles:org.openhab.ui.dashboard:jar:3.0.0.M1 in sandbox-all (https://openhab.jfrog.io/openhab/sandbox-all) -> [Help 1]`
