### PR TITLE
[Main UI] Sort addons case insensitive

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-add.vue
@@ -79,7 +79,7 @@ export default {
     },
     load () {
       this.$oh.api.get('/rest/addons').then(data => {
-        this.addons = data.filter(addon => !addon.installed && addon.type === this.addonType)
+        this.addons = data.filter(addon => !addon.installed && addon.type === this.addonType).sort((a,b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
         this.ready = true
         setTimeout(() => { this.initSearchbar = true })
         this.startEventSource()

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-list.vue
@@ -112,7 +112,7 @@ export default {
     },
     load () {
       this.$oh.api.get('/rest/addons').then(data => {
-        this.addons = data.filter(addon => addon.installed && addon.type === this.addonType)
+        this.addons = data.filter(addon => addon.installed && addon.type === this.addonType).sort((a,b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
         this.ready = true
         this.startEventSource()
       }).catch((err) => {

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -386,7 +386,7 @@ export default {
       }
     })
     this.$oh.api.get('/rest/addons').then((data) => {
-      this.addons = data
+      this.addons = data.sort((a,b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
       const self = this
       this.autocompleteAddons = this.$f7.autocomplete.create({
         openIn: 'popup',


### PR DESCRIPTION
The list of (installed and uninstalled) addons is not sorted.
As a result it depends on what the rest api returns.
In this case the bindings with lowercase first character are placed after the bindings with uppercase.
To fix this after the filter a sort is added.