### PR TITLE
Channel list improvements

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
@@ -5,13 +5,15 @@
       :description="group.description"
       :footer="group.description" />
     <f7-list-item
+      v-for="c in group.channels"
+      :key="c.channel.id" :title="c.channel.label || c.channelType.label"
+      v-show="!(pickerMode || multipleLinksMode) || c.channelType.kind !== 'TRIGGER'"
       :accordion-item="!pickerMode && !multipleLinksMode"
       :radio="pickerMode"
       :checkbox="multipleLinksMode"
+      :checked="isSelected(c.channel)"
       name="channel-picker"
       media-item class="channel-item"
-      v-for="c in group.channels"
-      :key="c.channel.id" :title="c.channel.label || c.channelType.label"
       :footer="c.channelType.description"
       :subtitle="c.channel.id + ' (' + getItemType(c.channelType) + ')'"
       :badge="getLinkedItems(c.channel).length || ''" badge-color="blue"
@@ -22,7 +24,7 @@
       <oh-icon v-if="!c.extensible && c.channelType.category" slot="media" :icon="c.channelType.category" height="32" width="32" />
       <span v-else-if="c.extensible && c.channel.label" slot="media" class="item-initial">{{c.channel.label[0]}}</span>
       <span v-else-if="!c.extensible && c.channelType.label" slot="media" class="item-initial">{{c.channelType.label[0]}}</span>
-      <f7-accordion-content v-if="!pickerMode">
+      <f7-accordion-content v-if="!pickerMode" class="searchbar-ignore">
         <slot :channelType="c.channelType" :channelId="c.channel.id" :channel="c.channel" :extensible="c.extensible"></slot>
       </f7-accordion-content>
       <div v-if="multipleLinksMode" slot="root-end">
@@ -41,7 +43,8 @@ export default {
     'thing',
     'pickerMode',
     'multipleLinksMode',
-    'itemTypeFilter'
+    'itemTypeFilter',
+    'selection'
   ],
   data () {
     return {
@@ -72,6 +75,13 @@ export default {
     isItemTypeCompatible (channelType) {
       if (!this.pickerMode || !this.itemTypeFilter) return true
       return this.getItemType(channelType) === this.itemTypeFilter
+    },
+    isSelected (channel) {
+      if (Array.isArray(this.selection)) {
+        return this.selection.indexOf(channel) >= 0
+      } else {
+        return this.selection === channel
+      }
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -1,23 +1,27 @@
 <template>
-  <div class="loading" v-if="!ready">
+  <div class="loading searchbar-ignore" v-if="!ready">
     <div class="list media-list margin-left searchbar-ignore">
       <ul>
-        <li class="item-content skeleton-text">
-          <div class="item-media">
-            <div class="skeleton-block" style="width: 40px; height: 40px; border-radius: 50%"></div>
+        <li class="item-content skeleton-text searchbar-ignore">
+          <div class="item-media searchbar-ignore">
+            <div class="skeleton-block searchbar-ignore" style="width: 40px; height: 40px; border-radius: 50%"></div>
           </div>
-          <div class="item-inner">
-            <div class="item-title-row">
-              <div class="item-title">Item Title</div>
+          <div class="item-inner searchbar-ignore">
+            <div class="item-title-row searchbar-ignore">
+              <div class="item-title searchbar-ignore">Item Title</div>
             </div>
-            <div class="item-subtitle">Item Subtitle</div>
-            <div class="item-text">Item text goes here, and it will be rendered as gray box too.</div>
+            <div class="item-subtitle searchbar-ignore">Item Subtitle</div>
+            <div class="item-text searchbar-ignore">Item text goes here, and it will be rendered as gray box too.</div>
           </div>
         </li>
       </ul>
     </div>
   </div>
   <f7-list media-list v-else inset class="margin-left searchbar-ignore">
+    <f7-list-item v-if="channelKind === 'TRIGGER'"
+      subtitle="This is a trigger channel, use rules to react to events emitted by it.">
+      <f7-icon slot="media" color="gray" f7="bolt_circle_fill"></f7-icon>
+    </f7-list-item>
     <f7-list-group v-if="links">
       <f7-list-item
         v-for="link in links" :key="link.itemName"
@@ -35,12 +39,7 @@
         <!-- <f7-button slot="after-start" color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
       </f7-list-item>
     </f7-list-group>
-    <!-- <f7-list-item class="searchbar-ignore" media-item link
-      color="blue" title="Add Link..." subtitle="Adds another link" @click="addLink()">
-        <f7-icon slot="media" color="green" aurora="f7:plus_circle" ios="f7:plus_circle" md="material:control_point" size="32" width="32"></f7-icon>
-    </f7-list-item> -->
-    <f7-list-item class="searchbar-ignore" link
-      color="blue" subtitle="Add Link to Item..." @click="addLink()">
+    <f7-list-item class="searchbar-ignore" link v-if="channelKind !== 'TRIGGER'" color="blue" subtitle="Add Link to Item..." @click="addLink()">
         <f7-icon slot="media" color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point"></f7-icon>
     </f7-list-item>
     <f7-list-button class="searchbar-ignore" color="blue" :title="(channelType.parameterGroups.length || channelType.parameters.length) ? 'Configure Channel' : 'Channel Details'" @click="configureChannel()"></f7-list-button>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -19,12 +19,12 @@
     </div>
     <f7-col v-if="thing.channels.length > 0">
       <f7-block width="100" class="channel-group no-margin no-padding" ref="channelList">
-        <f7-row>
-          <f7-col class="padding-left padding-right">
-            <f7-segmented strong tag="p">
-              <f7-button @click="showLinked = undefined" small :active="showLinked === undefined" text="All"></f7-button>
-              <f7-button @click="showLinked = true" small :active="showLinked === true" text="Linked"></f7-button>
-              <f7-button @click="showLinked = false" small :active="showLinked === false" text="Unlinked"></f7-button>
+        <f7-row class="searchbar-ignore">
+          <f7-col class="padding-left padding-right searchbar-ignore">
+            <f7-segmented class="searchbar-ignore" strong tag="p">
+              <f7-button class="searchbar-ignore" @click="showLinked = undefined" small :active="showLinked === undefined" text="All"></f7-button>
+              <f7-button class="searchbar-ignore" @click="showLinked = true" small :active="showLinked === true" text="Linked"></f7-button>
+              <f7-button class="searchbar-ignore" @click="showLinked = false" small :active="showLinked === false" text="Unlinked"></f7-button>
             </f7-segmented>
           </f7-col>
         </f7-row>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -14,11 +14,20 @@
         ></f7-searchbar>
       </f7-col>
     </f7-block>
-    <div style="text-align:right" class="padding-right padding-bottom" v-if="hasAdvanced">
+    <div style="text-align:right" class="padding-right" v-if="hasAdvanced">
       <label @click="toggleAdvanced" class="advanced-label">Show advanced</label> <f7-checkbox name="channel-advanced" :checked="showAdvanced" @change="toggleAdvanced"></f7-checkbox>
     </div>
     <f7-col v-if="thing.channels.length > 0">
-      <f7-block width="100" class="channel-group no-margin no-padding">
+      <f7-block width="100" class="channel-group no-margin no-padding" ref="channelList">
+        <f7-row>
+          <f7-col class="padding-left padding-right">
+            <f7-segmented strong tag="p">
+              <f7-button @click="showLinked = undefined" small :active="showLinked === undefined" text="All"></f7-button>
+              <f7-button @click="showLinked = true" small :active="showLinked === true" text="Linked"></f7-button>
+              <f7-button @click="showLinked = false" small :active="showLinked === false" text="Unlinked"></f7-button>
+            </f7-segmented>
+          </f7-col>
+        </f7-row>
         <f7-row v-for="group in channelGroups" :key="group.id">
           <f7-col>
             <!-- <f7-block-title class="channel-group-title">{{group.label}}</f7-block-title>
@@ -30,6 +39,7 @@
               :group="group"
               :thing="thing"
               :picker-mode="pickerMode" :multiple-links-mode="multipleLinksMode" :item-type-filter="itemTypeFilter"
+              :selection="(multipleLinksMode) ? selectedChannels : selectedChannel"
               @selected="selectChannel"
               @channel-opened="channelOpened">
               <template v-slot:default="{ channelId, channelType, channel, extensible }" v-if="!pickerMode && !multipleLinksMode">
@@ -45,6 +55,10 @@
             </channel-group>
           </f7-col>
         </f7-row>
+        <f7-list v-if="multipleLinksMode">
+          <f7-list-button color="blue" @click="toggleAllChecks(true)">Select All</f7-list-button>
+          <f7-list-button color="blue" @click="toggleAllChecks(false)">Unselect All</f7-list-button>
+        </f7-list>
       </f7-block>
     </f7-col>
     <f7-col v-else>
@@ -86,6 +100,7 @@ export default {
   data () {
     return {
       showAdvanced: false,
+      showLinked: undefined,
       openedChannelId: '',
       openedChannel: null,
       selectedChannel: null,
@@ -111,8 +126,10 @@ export default {
             console.warn('Channel type ' + c.channelTypeUID + ' not found for channel ' + c.id)
             return
           }
-          if (this.showAdvanced || !channelType.advanced) {
-            groups[groupIndex].channels.push({ channel: c, channelType: channelType, extensible: this.thingType.extensibleChannelTypeIds.indexOf(c.channelTypeUID.split(':')[1]) >= 0 })
+          if ((this.showAdvanced || !channelType.advanced)) {
+            if ((this.showLinked === undefined || (this.showLinked === true && this.hasLinks(c)) || (this.showLinked === false && !this.hasLinks(c)))) {
+              groups[groupIndex].channels.push({ channel: c, channelType: channelType, extensible: this.thingType.extensibleChannelTypeIds.indexOf(c.channelTypeUID.split(':')[1]) >= 0 })
+            }
           }
           if (channelType.advanced) groups[groupIndex].hasAdvanced = true
         })
@@ -141,6 +158,9 @@ export default {
     isChecked (channel) {
       return this.selectedChannels.indexOf(channel) >= 0
     },
+    hasLinks (channel) {
+      return channel.linkedItems && channel.linkedItems.length > 0
+    },
     toggleItemCheck (channel, channelType) {
       console.log('toggle check')
       if (this.isChecked(channel)) {
@@ -162,6 +182,18 @@ export default {
         }
         this.newItems.push(newItem)
       }
+    },
+    toggleAllChecks (checked) {
+      this.thing.channels.forEach((c) => {
+        const channelType = this.channelTypesMap.get(c.channelTypeUID)
+        if (!channelType) return
+        if (channelType.advanced && !this.showAdvanced) return
+        if (this.showLinked === true && !this.hasLinks(c)) return
+        if (this.showLinked === false && this.hasLinks(c)) return
+        if (this.isChecked(c) === checked) return
+        this.toggleItemCheck(c, channelType)
+      })
+      this.$$(this.$refs.channelList.$el).find('input[type="checkbox"]').forEach((i) => { this.$$(i).prop('checked', checked) })
     },
     newItem (channel) {
       return this.newItems.find((i) => i.channel === channel)


### PR DESCRIPTION
Add `searchbar-ignore` class to link skeletons to prevent
the height of the accordion to be initialized at 0px.
Should fix #401.

Add filters to display only linked or unlinked channels.
Closes #395.

Hide item linking controls for trigger channels.
Closes #390.

Add option to select/unselect all checkboxes when in
multiple links mode. This will take the linked/unlinked
filter into account, and the advanced toggle, but not
the name filter.
Closes #377.

Signed-off-by: Yannick Schaus <github@schaus.net>