### PR TITLE
[WIP/RfC] Developer Sidebar

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -450,7 +450,6 @@ export default {
     toggleDeveloperSidebar () {
       if (!this.$store.getters.isAdmin) return
       this.showDeveloperSidebar = !this.showDeveloperSidebar
-      this.$store.commit('keepConnectionOpen', this.showDeveloperSidebar)
       if (this.showDeveloperSidebar) this.$store.dispatch('startTrackingStates')
       this.$store.commit('setDeveloperSidebar', this.showDeveloperSidebar)
     },

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -1,0 +1,200 @@
+<template>
+  <f7-page class="developer-sidebar">
+    <f7-navbar title="Developer Sidebar" subtitle="(Shift+Alt+D)" color="black">
+      <f7-subnavbar :inner="false">
+        <f7-searchbar :disable-button="false"></f7-searchbar>
+      </f7-subnavbar>
+    </f7-navbar>
+    <f7-block class="no-margin no-padding after-big-title">
+      <f7-block-title class="padding-horizontal display-flex">
+        <span>Item Monitor</span>
+        <span style="margin-left:auto">
+          <f7-link color="gray" icon-f7="eye" icon-size="14"></f7-link>
+          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
+        </span>
+      </f7-block-title>
+      <f7-list>
+        <ul>
+          <item v-for="item in monitoredItems" :key="item.name" :item="item" :context="context" :no-icon="true" :no-type="true">
+          </item>
+        </ul>
+        <!-- <f7-list-button title="Pick Items" @click="modelPickerOpened = true"></f7-list-button> -->
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding">
+      <f7-block-title class="padding-horizontal display-flex">
+        <span>Rules Monitor</span>
+        <span style="margin-left:auto">
+          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
+        </span>
+      </f7-block-title>
+      <f7-list media-list>
+        <ul>
+          <f7-list-item media-item title="Rule 1" footer="rule1" badge="IDLE" badge-color="green">
+            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+              <f7-link class="margin-right" color="gray" icon-f7="pause_circle" icon-size="18" tooltip="Disable" />
+              <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="Run" />
+              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
+            </div>
+          </f7-list-item>
+          <f7-list-item media-item title="Other Rule" footer="other_rule" badge="DISABLED" badge-color="gray">
+            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+              <f7-link class="margin-right" color="orange" icon-f7="pause_circle" icon-size="18" tooltip="Enable" />
+              <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="Run" />
+              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
+            </div>
+          </f7-list-item>
+        </ul>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding">
+      <f7-block-title class="padding-horizontal display-flex">
+        <span>Things Monitor</span>
+        <span style="margin-left:auto">
+          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
+        </span>
+      </f7-block-title>
+      <f7-list media-list>
+        <ul>
+          <f7-list-item media-item title="Working Thing" footer="The UID of the thing" badge="ONLINE" badge-color="green">
+            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+              <f7-link class="margin-right" color="gray" icon-f7="pause_circle" icon-size="18" tooltip="Disable" />
+              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
+            </div>
+          </f7-list-item>
+          <f7-list-item media-item title="Other Thing" footer="The UID of the thing" badge="DISABLED" badge-color="gray">
+            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+              <f7-link class="margin-right" color="orange" icon-f7="pause_circle" icon-size="18" tooltip="Enable" />
+              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
+            </div>
+          </f7-list-item>
+          <f7-list-item media-item title="Offline Thing" footer="The UID of the thing" badge="ERROR: COMM" badge-color="red">
+            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+              <f7-link class="margin-right" color="gray" icon-f7="pause_circle" icon-size="18" tooltip="Disable" />
+              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
+            </div>
+          </f7-list-item>
+        </ul>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding">
+      <f7-block-title class="padding-horizontal display-flex">
+        <span>Events Monitor</span>
+        <span style="margin-left:auto">
+          <f7-link color="gray" icon-f7="rectangle_compress_vertical" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+        </span>
+      </f7-block-title>
+      <f7-list media-list>
+        <f7-list-item v-for="event in sseEvents" :key="event.time.getTime()" :title="event.topic" :subtitle="event.type" :footer="event.payload">
+        </f7-list-item>
+        <f7-list-button text="Stream Events" @click="startSSE()" v-if="!sseClient" />
+        <f7-list-button color="red" text="Stop Streaming" @click="stopSSE()" v-if="sseClient" />
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding">
+      <f7-block-title class="padding-horizontal display-flex">
+        <span>Pages</span>
+        <span style="margin-left:auto">
+          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
+        </span>
+      </f7-block-title>
+      <f7-list media-list>
+        <ul>
+          <f7-list-item media-item title="Page1" footer="page1">
+            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="after">
+              <f7-link class="margin-right" color="blue" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" />
+              <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="View" />
+              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
+            </div>
+          </f7-list-item>
+        </ul>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding">
+      <f7-block-title class="padding-horizontal">Expression Tester</f7-block-title>
+      <f7-list media-list>
+        <f7-list-input type="text" title="Expression">
+        </f7-list-input>
+        <f7-list-item type="text" title="Result">
+        </f7-list-item>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding">
+      <f7-block-title class="padding-horizontal">Other Tools</f7-block-title>
+      <f7-list>
+        <f7-list-button title="Show Widget in Popup"></f7-list-button>
+        <f7-list-button title="Another Tool"></f7-list-button>
+      </f7-list>
+    </f7-block>
+    <model-picker-popup :value="monitoredItems" :opened="modelPickerOpened" :multiple="true" @closed="modelPickerOpened = false" @input="addItemsFromModel" action-label="Add" />
+  </f7-page>
+</template>
+
+<style lang="stylus">
+.developer-sidebar
+  scrollbar-width none /* Firefox */
+  -ms-overflow-style none  /* IE 10+ */
+
+  &.page
+    background #e7e7e7 !important
+
+  .page-content
+    overflow-x hidden
+.theme-dark
+  .developer-sidebar
+    &.page
+      background #232323 !important
+</style>
+
+<script>
+import Item from '@/components/item/item.vue'
+import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
+
+export default {
+  components: {
+    Item,
+    ModelPickerPopup
+  },
+  data () {
+    return {
+      modelPickerOpened: false,
+      monitoredItems: [],
+      sseClient: null,
+      sseEvents: []
+    }
+  },
+  computed: {
+    context () {
+      return {
+        store: this.$store.getters.trackedItems
+      }
+    }
+  },
+  methods: {
+    itemContext (item) {
+      return {
+
+      }
+    },
+    addItemsFromModel (value) {
+      this.$set(this, 'monitoredItems', value)
+    },
+    startSSE () {
+      this.sseClient = this.$oh.sse.connect('/rest/events', '', (event) => {
+        event.time = new Date()
+        this.sseEvents.unshift(...[event])
+        this.sseEvents.splice(5)
+      })
+    },
+    stopSSE () {
+      this.$oh.sse.close(this.sseClient)
+      this.sseClient = null
+      this.sseEvents = []
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -1,136 +1,148 @@
 <template>
   <f7-page class="developer-sidebar">
     <f7-navbar title="Developer Sidebar" subtitle="(Shift+Alt+D)" color="black">
-      <f7-subnavbar :inner="false">
-        <f7-searchbar :disable-button="false"></f7-searchbar>
+      <f7-subnavbar :inner="false" v-if="!$theme.md">
+        <f7-searchbar custom-search placeholder="Search to Pin" :backdrop="false" :disable-button="false" @searchbar:search="search" @searchbar:clear="clearSearch"></f7-searchbar>
       </f7-subnavbar>
     </f7-navbar>
-    <f7-block class="no-margin no-padding after-big-title">
-      <f7-block-title class="padding-horizontal display-flex">
-        <span>Item Monitor</span>
-        <span style="margin-left:auto">
-          <f7-link color="gray" icon-f7="eye" icon-size="14"></f7-link>
-          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
-          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
-        </span>
-      </f7-block-title>
-      <f7-list>
-        <ul>
-          <item v-for="item in monitoredItems" :key="item.name" :item="item" :context="context" :no-icon="true" :no-type="true">
-          </item>
-        </ul>
-        <!-- <f7-list-button title="Pick Items" @click="modelPickerOpened = true"></f7-list-button> -->
-      </f7-list>
-    </f7-block>
-    <f7-block class="no-margin no-padding">
-      <f7-block-title class="padding-horizontal display-flex">
-        <span>Rules Monitor</span>
-        <span style="margin-left:auto">
-          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
-          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
-        </span>
-      </f7-block-title>
-      <f7-list media-list>
-        <ul>
-          <f7-list-item media-item title="Rule 1" footer="rule1" badge="IDLE" badge-color="green">
-            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
-              <f7-link class="margin-right" color="gray" icon-f7="pause_circle" icon-size="18" tooltip="Disable" />
-              <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="Run" />
-              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
-            </div>
-          </f7-list-item>
-          <f7-list-item media-item title="Other Rule" footer="other_rule" badge="DISABLED" badge-color="gray">
-            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
-              <f7-link class="margin-right" color="orange" icon-f7="pause_circle" icon-size="18" tooltip="Enable" />
-              <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="Run" />
-              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
-            </div>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-block>
-    <f7-block class="no-margin no-padding">
-      <f7-block-title class="padding-horizontal display-flex">
-        <span>Things Monitor</span>
-        <span style="margin-left:auto">
-          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
-          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
-        </span>
-      </f7-block-title>
-      <f7-list media-list>
-        <ul>
-          <f7-list-item media-item title="Working Thing" footer="The UID of the thing" badge="ONLINE" badge-color="green">
-            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
-              <f7-link class="margin-right" color="gray" icon-f7="pause_circle" icon-size="18" tooltip="Disable" />
-              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
-            </div>
-          </f7-list-item>
-          <f7-list-item media-item title="Other Thing" footer="The UID of the thing" badge="DISABLED" badge-color="gray">
-            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
-              <f7-link class="margin-right" color="orange" icon-f7="pause_circle" icon-size="18" tooltip="Enable" />
-              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
-            </div>
-          </f7-list-item>
-          <f7-list-item media-item title="Offline Thing" footer="The UID of the thing" badge="ERROR: COMM" badge-color="red">
-            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
-              <f7-link class="margin-right" color="gray" icon-f7="pause_circle" icon-size="18" tooltip="Disable" />
-              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
-            </div>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-block>
-    <f7-block class="no-margin no-padding">
-      <f7-block-title class="padding-horizontal display-flex">
-        <span>Events Monitor</span>
-        <span style="margin-left:auto">
-          <f7-link color="gray" icon-f7="rectangle_compress_vertical" icon-size="14" @click="modelPickerOpened = true"></f7-link>
-        </span>
-      </f7-block-title>
-      <f7-list media-list>
-        <f7-list-item v-for="event in sseEvents" :key="event.time.getTime()" :title="event.topic" :subtitle="event.type" :footer="event.payload">
-        </f7-list-item>
-        <f7-list-button text="Stream Events" @click="startSSE()" v-if="!sseClient" />
-        <f7-list-button color="red" text="Stop Streaming" @click="stopSSE()" v-if="sseClient" />
-      </f7-list>
-    </f7-block>
-    <f7-block class="no-margin no-padding">
-      <f7-block-title class="padding-horizontal display-flex">
-        <span>Pages</span>
-        <span style="margin-left:auto">
-          <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
-          <f7-link color="gray" icon-f7="multiply" icon-size="14"></f7-link>
-        </span>
-      </f7-block-title>
-      <f7-list media-list>
-        <ul>
-          <f7-list-item media-item title="Page1" footer="page1">
-            <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="after">
-              <f7-link class="margin-right" color="blue" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" />
-              <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="View" />
-              <f7-link color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" />
-            </div>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-block>
-    <f7-block class="no-margin no-padding">
-      <f7-block-title class="padding-horizontal">Expression Tester</f7-block-title>
-      <f7-list media-list>
-        <f7-list-input type="text" title="Expression">
-        </f7-list-input>
-        <f7-list-item type="text" title="Result">
-        </f7-list-item>
-      </f7-list>
-    </f7-block>
-    <f7-block class="no-margin no-padding">
-      <f7-block-title class="padding-horizontal">Other Tools</f7-block-title>
-      <f7-list>
-        <f7-list-button title="Show Widget in Popup"></f7-list-button>
-        <f7-list-button title="Another Tool"></f7-list-button>
-      </f7-list>
-    </f7-block>
-    <model-picker-popup :value="monitoredItems" :opened="modelPickerOpened" :multiple="true" @closed="modelPickerOpened = false" @input="addItemsFromModel" action-label="Add" />
+    <f7-subnavbar :inner="false" v-if="$theme.md">
+      <f7-searchbar custom-search placeholder="Search to Pin" :backdrop="false" :disable-button="false" @searchbar:search="search" @searchbar:clear="clearSearch"></f7-searchbar>
+    </f7-subnavbar>
+    <div v-if="!searching" class="developer-sidebar-content">
+      <f7-segmented strong tag="p" style="margin-right: calc(var(--f7-searchbar-inner-padding-right) + var(--f7-safe-area-right)); margin-left: calc(var(--f7-searchbar-inner-padding-left) + var(--f7-safe-area-left))">
+        <f7-button :active="activeTab === 'pin'" icon-f7="pin_fill" icon-size="18" @click="activeTab = 'pin'"></f7-button>
+        <f7-button :active="activeTab === 'events'" icon-f7="bolt_horizontal_fill" icon-size="18" @click="activeTab = 'events'"></f7-button>
+        <f7-button :active="activeTab === 'tools'" icon-f7="wrench_fill" icon-size="18" @click="activeTab = 'tools'"></f7-button>
+      </f7-segmented>
+      <div v-if="activeTab === 'pin'">
+        <f7-block v-if="!pinnedObjects.items.length && !pinnedObjects.things.length && !pinnedObjects.rules.length && !pinnedObjects.pages.length">
+          <p>Use the search box above or the button below to temporarily pin objects here for quick access.</p>
+          <p><f7-button fill color="blue" @click="modelPickerOpened = true">Add Items from Model</f7-button></p>
+        </f7-block>
+        <f7-block class="no-margin no-padding" v-if="pinnedObjects.items.length">
+          <f7-block-title class="padding-horizontal display-flex">
+            <span>Pinned Items</span>
+            <span style="margin-left:auto">
+              <!-- <f7-link color="gray" icon-f7="eye" icon-size="14"></f7-link> -->
+              <f7-link color="gray" icon-f7="plus" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('items')"></f7-link>
+            </span>
+          </f7-block-title>
+          <f7-list>
+            <ul>
+              <item v-for="item in pinnedObjects.items" :key="item.name" link="" :item="item" :context="context" :no-icon="true" :no-type="true" @click="(evt) => showItem(evt, item)">
+                <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+                  <f7-link class="margin-right itemlist-actions" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/items/' + item.name" :animate="false" />
+                  <f7-link class="itemlist-actions" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" @click="unpin('items', item, 'name')" />
+                </div>
+              </item>
+            </ul>
+            <!-- <f7-list-button title="Pick Items" @click="modelPickerOpened = true"></f7-list-button> -->
+          </f7-list>
+        </f7-block>
+        <f7-block class="no-margin no-padding" v-if="pinnedObjects.things.length">
+          <f7-block-title class="padding-horizontal display-flex">
+            <span>Pinned Things</span>
+            <span style="margin-left:auto">
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('things')"></f7-link>
+            </span>
+          </f7-block-title>
+          <f7-list media-list>
+            <ul>
+              <f7-list-item v-for="thing in pinnedObjects.things" :key="thing.UID" media-item
+                :title="thing.label" :footer="thing.UID">
+                <f7-badge slot="after" :color="thingStatusBadgeColor(thing.statusInfo)" :tooltip="thing.statusInfo.description">{{thingStatusBadgeText(thing.statusInfo)}}</f7-badge>
+                <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+                  <f7-link class="margin-right" :icon-color="(thing.statusInfo.statusDetail === 'DISABLED') ? 'orange' : 'gray'" :tooltip="(thing.statusInfo.statusDetail === 'DISABLED') ? 'Enable' : 'Disable'" icon-f7="pause_circle" icon-size="18" @click="toggleThingDisabled(thing)" />
+                  <f7-link class="margin-right" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/things/' + thing.UID" :animate="false" />
+                  <f7-link color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" @click="unpin('things', thing, 'UID')" />
+                </div>
+              </f7-list-item>
+            </ul>
+          </f7-list>
+        </f7-block>
+        <f7-block class="no-margin no-padding" v-if="pinnedObjects.rules.length">
+          <f7-block-title class="padding-horizontal display-flex">
+            <span>Pinned Rules</span>
+            <span style="margin-left:auto">
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('rules')"></f7-link>
+            </span>
+          </f7-block-title>
+          <f7-list media-list>
+            <ul>
+              <f7-list-item v-for="rule in pinnedObjects.rules" :key="rule.uid" media-item
+                :title="rule.name" :footer="rule.uid">
+                <f7-badge slot="after" :color="ruleStatusBadgeColor(rule.status)" :tooltip="rule.status.description">{{ruleStatusBadgeText(rule.status)}}</f7-badge>
+                <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+                  <f7-link class="margin-right" :icon-color="(rule.status.statusDetail === 'DISABLED') ? 'orange' : 'gray'" :tooltip="(rule.status.statusDetail === 'DISABLED') ? 'Enable' : 'Disable'" icon-f7="pause_circle" icon-size="18" @click="toggleRuleDisabled(rule)" />
+                  <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="Run" @click="runRuleNow(rule)" />
+                  <f7-link class="margin-right" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid" :animate="false" />
+                  <f7-link color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" @click="unpin('rules', rule, 'uid')" />
+                </div>
+              </f7-list-item>
+            </ul>
+          </f7-list>
+        </f7-block>
+        <f7-block class="no-margin no-padding" v-if="pinnedObjects.pages.length">
+          <f7-block-title class="padding-horizontal display-flex">
+            <span>Pinned Pages</span>
+            <span style="margin-left:auto">
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('pages')"></f7-link>
+            </span>
+          </f7-block-title>
+          <f7-list media-list>
+            <ul>
+              <f7-list-item v-for="page in pinnedObjects.pages" :key="page.uid" media-item
+                :title="page.config.label" :footer="page.uid">
+                <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
+                  <!-- <f7-link class="margin-right" color="blue" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" /> -->
+                  <f7-link class="margin-right" color="blue" icon-f7="play" icon-size="18" tooltip="View" :href="'/page/' + page.uid" :animate="false" />
+                  <f7-link class="margin-right" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/pages/' + getPageType(page).type + '/' + page.uid" :animate="false" />
+                  <f7-link color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" @click="unpin('pages', page, 'uid')" />
+                </div>
+              </f7-list-item>
+            </ul>
+          </f7-list>
+        </f7-block>
+      </div>
+
+      <div v-else-if="activeTab === 'events'">
+        <f7-block class="no-margin no-padding">
+          <f7-block-title class="padding-horizontal display-flex">
+            <span>Events Monitor</span>
+            <!-- <span style="margin-left:auto">
+              <f7-link color="gray" icon-f7="rectangle_compress_vertical" icon-size="14" @click="modelPickerOpened = true"></f7-link>
+            </span> -->
+          </f7-block-title>
+          <f7-block>
+            <p v-if="!sseClient"><f7-button fill color="blue" @click="startSSE">Stream Events</f7-button></p>
+            <p v-if="sseClient"><f7-button fill color="red" @click="stopSSE">Stop Streaming</f7-button></p>
+          </f7-block>
+          <f7-list media-list>
+            <f7-list-item v-for="event in sseEvents" :key="event.time.getTime()" :title="event.topic" :subtitle="event.type" :footer="event.payload">
+            </f7-list-item>
+          </f7-list>
+        </f7-block>
+      </div>
+
+      <div v-else-if="activeTab === 'tools'">
+        <f7-block class="no-margin no-padding">
+          <f7-block-title class="padding-horizontal">Widgets Expression Tester</f7-block-title>
+          <f7-list media-list>
+            <f7-list-input type="textarea" title="Expression" placeholder="Try '=2+3' or '=items.MyItem.state'" :value="testExpression" @input="(evt) => testExpression = evt.target.value">
+            </f7-list-input>
+          </f7-list>
+          <f7-block strong v-if="testExpression">
+            <generic-widget-component :context="expressionTesterContext" />
+          </f7-block>
+        </f7-block>
+      </div>
+    </div>
+    <f7-popover ref="itemPopover" class="item-popover">
+      <item-standalone-control v-if="openedItem" :item="openedItem" :context="context" :no-border="true" />
+    </f7-popover>
+    <search-results v-if="searching" :searchResults="searchResults" :pinnedObjects="pinnedObjects" @pin="pin" @unpin="unpin" />
+    <model-picker-popup :value="pinnedObjects.items" :opened="modelPickerOpened" :multiple="true" @closed="modelPickerOpened = false" @input="addItemsFromModel" action-label="Add" />
   </f7-page>
 </template>
 
@@ -139,11 +151,17 @@
   scrollbar-width none /* Firefox */
   -ms-overflow-style none  /* IE 10+ */
 
+  .developer-sidebar-content
+    margin-top var(--f7-subnavbar-height)
+    padding-top 0.3rem
+
   &.page
     background #e7e7e7 !important
 
   .page-content
     overflow-x hidden
+.md .developer-sidebar-content
+  margin-top 0
 .theme-dark
   .developer-sidebar
     &.page
@@ -152,19 +170,52 @@
 
 <script>
 import Item from '@/components/item/item.vue'
+import ItemStandaloneControl from '@/components/item/item-standalone-control.vue'
 import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
+import SearchResults from './search-results.vue'
+
+import RuleStatus from '@/components/rule/rule-status-mixin'
+import ThingStatus from '@/components/thing/thing-status-mixin'
 
 export default {
+  mixins: [RuleStatus, ThingStatus],
   components: {
     Item,
+    ItemStandaloneControl,
+    SearchResults,
     ModelPickerPopup
   },
   data () {
     return {
+      searching: false,
+      activeTab: 'pin',
       modelPickerOpened: false,
       monitoredItems: [],
       sseClient: null,
-      sseEvents: []
+      eventSource: null,
+      searchResults: {
+        items: [],
+        things: [],
+        rules: [],
+        pages: []
+      },
+      pinnedObjects: {
+        items: [],
+        things: [],
+        rules: [],
+        pages: []
+      },
+      sseEvents: [],
+      openedItem: null,
+      pageTypes: [
+        { type: 'sitemap', label: 'Sitemap', componentType: 'Sitemap', icon: 'menu' },
+        { type: 'layout', label: 'Layout', componentType: 'oh-layout-page', icon: 'rectangle_grid_2x2' },
+        { type: 'tabs', label: 'Tabbed', componentType: 'oh-tabs-page', icon: 'squares_below_rectangle' },
+        { type: 'map', label: 'Map', componentType: 'oh-map-page', icon: 'map' },
+        { type: 'plan', label: 'Floor plan', componentType: 'oh-plan-page', icon: 'square_stack_3d_up' },
+        { type: 'chart', label: 'Chart', componentType: 'oh-chart-page', icon: 'graph_square' }
+      ],
+      testExpression: ''
     }
   },
   computed: {
@@ -172,7 +223,31 @@ export default {
       return {
         store: this.$store.getters.trackedItems
       }
+    },
+    expressionTesterContext () {
+      return {
+        component: {
+          component: 'Label',
+          config: {
+            style: {
+              fontFamily: 'monospace'
+            },
+            noBorder: true,
+            noShadow: true,
+            text: this.testExpression.toString()
+          }
+        },
+        editmode: true,
+        vars: {},
+        store: this.$store.getters.trackedItems
+      }
     }
+  },
+  mounted () {
+    this.startEventSource()
+  },
+  beforeDestroy () {
+    this.stopEventSource()
   },
   methods: {
     itemContext (item) {
@@ -181,19 +256,157 @@ export default {
       }
     },
     addItemsFromModel (value) {
-      this.$set(this, 'monitoredItems', value)
+      this.pinnedObjects.items.push(...value)
+    },
+    search (searchbar, query, previousQuery) {
+      if (!query) {
+        this.searching = false
+        return
+      }
+      this.searching = true
+      const promises = [
+        this.$oh.api.get('/rest/items'),
+        this.$oh.api.get('/rest/things'),
+        this.$oh.api.get('/rest/rules'),
+        this.$oh.api.get('/rest/ui/components/ui:page')
+      ]
+
+      Promise.all(promises).then((data) => {
+        const items = data[0].filter((i) => i.name.toLowerCase().indexOf(query.toLowerCase()) >= 0 || (i.label && i.label.toLowerCase().indexOf(query.toLowerCase()) >= 0))
+        const things = data[1].filter((t) => t.UID.toLowerCase().indexOf(query.toLowerCase()) >= 0 || t.label.toLowerCase().indexOf(query.toLowerCase()) >= 0)
+        const rules = data[2].filter((r) => r.uid.toLowerCase().indexOf(query.toLowerCase()) >= 0 || r.name.toLowerCase().indexOf(query.toLowerCase()) >= 0)
+        const pages = data[3].filter((p) => p.uid.toLowerCase().indexOf(query.toLowerCase()) >= 0)
+        this.$set(this, 'searchResults', {
+          items,
+          things,
+          rules,
+          pages
+        })
+      })
+    },
+    clearSearch () {
+      this.searching = false
+      this.$set(this, 'searchResults', { items: [], things: [], rules: [], pages: [] })
+    },
+    pin (type, obj) {
+      this.pinnedObjects[type].push(obj)
+    },
+    unpin (type, obj, keyName) {
+      let index = this.pinnedObjects[type].findIndex((o) => o[keyName] === obj[keyName])
+      if (index >= 0) {
+        this.pinnedObjects[type].splice(index, 1)
+      }
+    },
+    unpinAll (type) {
+      this.$set(this.pinnedObjects, type, [])
+    },
+    getPageType (page) {
+      return this.pageTypes.find(t => t.componentType === page.component)
+    },
+    showItem (evt, item) {
+      evt.cancelBubble = true
+      if (this.$$(evt.target).closest('.itemlist-actions').length) return
+      const itemEl = this.$$(evt.target).closest('.itemlist-item')
+      if (!itemEl.length) return
+      this.openedItem = item
+      this.$nextTick(() => this.$refs.itemPopover.f7Popover.open(itemEl[0]))
+    },
+    toggleThingDisabled (thing) {
+      const enable = (thing.statusInfo.statusDetail === 'DISABLED')
+      this.$oh.api.putPlain('/rest/things/' + thing.UID + '/enable', enable.toString()).then((data) => {
+        this.$f7.toast.create({
+          text: (enable) ? 'Thing enabled' : 'Thing disabled',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while disabling or enabling: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
+    },
+    toggleRuleDisabled (rule) {
+      const enable = (rule.status.statusDetail === 'DISABLED')
+      this.$oh.api.postPlain('/rest/rules/' + rule.uid + '/enable', enable.toString()).then((data) => {
+        this.$f7.toast.create({
+          text: (enable) ? 'Rule enabled' : 'Rule disabled',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while disabling or enabling: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
+    },
+    runRuleNow (rule) {
+      if (this.rule.status === 'RUNNING') return
+      this.$f7.toast.create({
+        text: 'Running rule',
+        destroyOnClose: true,
+        closeTimeout: 2000
+      }).open()
+      this.$oh.api.postPlain('/rest/rules/' + rule.uid + '/runnow', '').catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while running rule: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
     },
     startSSE () {
+      this.$set(this, 'sseEvents', [])
       this.sseClient = this.$oh.sse.connect('/rest/events', '', (event) => {
         event.time = new Date()
         this.sseEvents.unshift(...[event])
-        this.sseEvents.splice(5)
+        this.sseEvents.splice(20)
       })
     },
     stopSSE () {
       this.$oh.sse.close(this.sseClient)
       this.sseClient = null
-      this.sseEvents = []
+    },
+    startEventSource () {
+      this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/rules/*/*,openhab/things/*/*', null, (event) => {
+        const topicParts = event.topic.split('/')
+        switch (topicParts[1]) {
+          case 'things':
+            switch (topicParts[3]) {
+              case 'removed':
+                this.unpin('things', { UID: topicParts[2] }, 'UID')
+                break
+              case 'status':
+                const updatedThing = this.pinnedObjects.things.find((t) => t.UID === topicParts[2])
+                if (!updatedThing) break
+                const newStatus = JSON.parse(event.payload)
+                if (updatedThing) {
+                  if (updatedThing.statusInfo.status !== newStatus.status) updatedThing.statusInfo.status = newStatus.status
+                  if (updatedThing.statusInfo.statusDetail !== newStatus.statusDetail) updatedThing.statusInfo.statusDetail = newStatus.statusDetail
+                  if (updatedThing.statusInfo.description !== newStatus.description) updatedThing.statusInfo.description = newStatus.description
+                }
+            }
+            break
+          case 'rules':
+            switch (topicParts[3]) {
+              case 'removed':
+                this.unpin('rules', { uid: topicParts[2] }, 'uid')
+                break
+              case 'state':
+                const rule = this.pinnedObjects.rules.find((r) => r.uid === topicParts[2])
+                if (!rule) break
+                this.$set(rule, 'status', JSON.parse(event.payload))
+            }
+            break
+        }
+      })
+    },
+    stopEventSource () {
+      this.$oh.sse.close(this.eventSource)
+      this.eventSource = null
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -113,7 +113,7 @@
       <div v-else-if="activeTab === 'events'">
         <f7-block class="no-margin no-padding">
           <f7-block-title class="padding-horizontal display-flex" medium>
-            <span>Events Monitor</span>
+            <span>Event Monitor</span>
             <span style="margin-left:auto">
               <f7-link :color="eventTopicFilter ? 'blue' : 'gray'" :icon-f7="eventTopicFilter ? 'line_horizontal_3_decrease_circle_fill' : 'line_horizontal_3_decrease_circle'" icon-size="14" tooltip="Filter topics" @click="changeEventTopicFilter"></f7-link>
             </span>

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -1,43 +1,58 @@
 <template>
   <div class="after-big-title">
+    <f7-block v-if="loading" class="text-align-center">
+      <f7-preloader></f7-preloader>
+      <div>Loading...</div>
+    </f7-block>
+    <f7-block v-else-if="!searchResults.items.length && !searchResults.things.length && !searchResults.rules.length && !searchResults.pages.length" class="text-align-center">
+      <div>Nothing found</div>
+    </f7-block>
     <f7-block class="no-margin no-padding" v-if="searchResults.items.length">
-      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="square_on_circle" />Items</f7-block-title>
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="square_on_circle" />Items ({{searchResults.items.length}})</f7-block-title>
       <f7-list media-list>
-        <f7-list-item media-item v-for="item in searchResults.items.slice(0, 5)" :key="item.name"
-          :title="item.label || item.name" :footer="(item.label) ? item.name : ''">
+        <f7-list-item media-item v-for="item in filteredSearchResults.items" :key="item.name"
+          :title="item.label || item.name" :footer="(item.label) ? item.name : ''" link="" no-chevron @click="(evt) => togglePin(evt, 'items', item, 'name')">
+          <f7-link slot="after" color="gray" icon-f7="pencil" icon-size="18" tooltip="Details" :href="'/settings/items/' + item.name" :animate="false" />
           <f7-link slot="after" v-if="isPinned('items', item, 'name')" @click="$emit('unpin', 'items', item, 'name')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
           <f7-link slot="after" v-else @click="$emit('pin', 'items', item, 'name')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
         </f7-list-item>
+        <f7-list-button v-if="!showingAll('items')" color="blue" @click="$set(expandedTypes, 'items', true)">Show All</f7-list-button>
       </f7-list>
     </f7-block>
     <f7-block class="no-margin no-padding" v-if="searchResults.things.length">
-      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="lightbulb" />Things</f7-block-title>
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="lightbulb" />Things ({{searchResults.things.length}})</f7-block-title>
       <f7-list media-list>
-        <f7-list-item media-item v-for="thing in searchResults.things.slice(0, 5)" :key="thing.UID"
-          :title="thing.label" :footer="thing.UID">
+        <f7-list-item media-item v-for="thing in filteredSearchResults.things" :key="thing.UID"
+          :title="thing.label" :footer="thing.UID" link="" no-chevron @click="(evt) => togglePin(evt, 'things', thing, 'UID')">
+          <f7-link slot="after" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/things/' + thing.UID" :animate="false" />
           <f7-link slot="after" v-if="isPinned('things', thing, 'UID')" @click="$emit('unpin', 'things', thing, 'UID')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
           <f7-link slot="after" v-else @click="$emit('pin', 'things', thing, 'UID')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
         </f7-list-item>
+        <f7-list-button v-if="!showingAll('things')" color="blue" @click="$set(expandedTypes, 'things', true)">Show All</f7-list-button>
       </f7-list>
     </f7-block>
     <f7-block class="no-margin no-padding" v-if="searchResults.rules.length">
-      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="wand_stars" />Rules</f7-block-title>
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="wand_stars" />Rules ({{searchResults.rules.length}})</f7-block-title>
       <f7-list media-list>
-        <f7-list-item media-item v-for="rule in searchResults.rules.slice(0, 5)" :key="rule.uid"
-          :title="rule.name" :footer="rule.uid">
+        <f7-list-item media-item v-for="rule in filteredSearchResults.rules" :key="rule.uid"
+          :title="rule.name" :footer="rule.uid" link="" no-chevron @click="(evt) => togglePin(evt, 'rules', rule, 'uid')">
+          <f7-link slot="after" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid" :animate="false" />
           <f7-link slot="after" v-if="isPinned('rules', rule, 'uid')" @click="$emit('unpin', 'rules', rule, 'uid')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
           <f7-link slot="after" v-else @click="$emit('pin', 'rules', rule, 'uid')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
         </f7-list-item>
+        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="$set(expandedTypes, 'rules', true)">Show All</f7-list-button>
       </f7-list>
     </f7-block>
     <f7-block class="no-margin no-padding" v-if="searchResults.pages.length">
-      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="tv" />Pages</f7-block-title>
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="tv" />Pages ({{searchResults.pages.length}})</f7-block-title>
       <f7-list media-list>
-        <f7-list-item media-item v-for="page in searchResults.pages.slice(0, 5)" :key="page.uid"
-          :title="page.config.label" :footer="page.uid">
+        <f7-list-item media-item v-for="page in filteredSearchResults.pages" :key="page.uid"
+          :title="page.config.label" :footer="page.uid" link="" no-chevron @click="(evt) => togglePin(evt, 'pages', page, 'uid')">
+          <f7-link slot="after" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/pages/' + getPageType(page).type + '/' + page.uid" :animate="false" />
           <f7-link slot="after" v-if="isPinned('pages', page, 'uid')" @click="$emit('unpin', 'pages', page, 'uid')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
           <f7-link slot="after" v-else @click="$emit('pin', 'pages', page, 'uid')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
         </f7-list-item>
+        <f7-list-button v-if="!showingAll('pages')" color="blue" @click="$set(expandedTypes, 'pages', true)">Show All</f7-list-button>
       </f7-list>
     </f7-block>
 
@@ -46,12 +61,58 @@
 
 <script>
 export default {
-  props: ['searchResults', 'pinnedObjects'],
-  components: {
+  props: ['searchResults', 'pinnedObjects', 'cachedObjects', 'loading'],
+  data () {
+    return {
+      typesIcons: {
+        items: 'square_on_circle',
+        things: 'lightbulb',
+        rules: 'wand_stars',
+        pages: 'tv'
+      },
+      expandedTypes: {},
+      pageTypes: [
+        { type: 'sitemap', label: 'Sitemap', componentType: 'Sitemap', icon: 'menu' },
+        { type: 'layout', label: 'Layout', componentType: 'oh-layout-page', icon: 'rectangle_grid_2x2' },
+        { type: 'tabs', label: 'Tabbed', componentType: 'oh-tabs-page', icon: 'squares_below_rectangle' },
+        { type: 'map', label: 'Map', componentType: 'oh-map-page', icon: 'map' },
+        { type: 'plan', label: 'Floor plan', componentType: 'oh-plan-page', icon: 'square_stack_3d_up' },
+        { type: 'chart', label: 'Chart', componentType: 'oh-chart-page', icon: 'graph_square' }
+      ]
+    }
+  },
+  computed: {
+    filteredSearchResults () {
+      const items = (this.expandedTypes.items) ? this.searchResults.items : this.searchResults.items.slice(0, 5)
+      const things = (this.expandedTypes.things) ? this.searchResults.things : this.searchResults.things.slice(0, 5)
+      const rules = (this.expandedTypes.rules) ? this.searchResults.rules : this.searchResults.rules.slice(0, 5)
+      const pages = (this.expandedTypes.pages) ? this.searchResults.pages : this.searchResults.pages.slice(0, 5)
+      return { items, things, rules, pages }
+    }
+  },
+  watch: {
+    searchResults () {
+      this.$set(this, 'expandedTypes', {})
+    }
   },
   methods: {
     isPinned (type, obj, keyName) {
       return this.pinnedObjects[type].findIndex((o) => o[keyName] === obj[keyName]) >= 0
+    },
+    showingAll (type) {
+      return (this.expandedTypes[type] || this.searchResults[type].length <= 5)
+    },
+    getPageType (page) {
+      return this.pageTypes.find(t => t.componentType === page.component)
+    },
+    togglePin (evt, type, obj, keyName) {
+      evt.cancelBubble = true
+      if (evt.target.tagName.toLowerCase() === 'i') return
+      if (this.isPinned(type, obj, keyName)) {
+        this.$emit('unpin', type, obj, keyName)
+      } else {
+        this.$emit('pin', type, obj, keyName)
+      }
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="after-big-title">
+    <f7-block class="no-margin no-padding" v-if="searchResults.items.length">
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="square_on_circle" />Items</f7-block-title>
+      <f7-list media-list>
+        <f7-list-item media-item v-for="item in searchResults.items.slice(0, 5)" :key="item.name"
+          :title="item.label || item.name" :footer="(item.label) ? item.name : ''">
+          <f7-link slot="after" v-if="isPinned('items', item, 'name')" @click="$emit('unpin', 'items', item, 'name')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
+          <f7-link slot="after" v-else @click="$emit('pin', 'items', item, 'name')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
+        </f7-list-item>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding" v-if="searchResults.things.length">
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="lightbulb" />Things</f7-block-title>
+      <f7-list media-list>
+        <f7-list-item media-item v-for="thing in searchResults.things.slice(0, 5)" :key="thing.UID"
+          :title="thing.label" :footer="thing.UID">
+          <f7-link slot="after" v-if="isPinned('things', thing, 'UID')" @click="$emit('unpin', 'things', thing, 'UID')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
+          <f7-link slot="after" v-else @click="$emit('pin', 'things', thing, 'UID')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
+        </f7-list-item>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding" v-if="searchResults.rules.length">
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="wand_stars" />Rules</f7-block-title>
+      <f7-list media-list>
+        <f7-list-item media-item v-for="rule in searchResults.rules.slice(0, 5)" :key="rule.uid"
+          :title="rule.name" :footer="rule.uid">
+          <f7-link slot="after" v-if="isPinned('rules', rule, 'uid')" @click="$emit('unpin', 'rules', rule, 'uid')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
+          <f7-link slot="after" v-else @click="$emit('pin', 'rules', rule, 'uid')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
+        </f7-list-item>
+      </f7-list>
+    </f7-block>
+    <f7-block class="no-margin no-padding" v-if="searchResults.pages.length">
+      <f7-block-title class="padding-left"><f7-icon class="margin-right" f7="tv" />Pages</f7-block-title>
+      <f7-list media-list>
+        <f7-list-item media-item v-for="page in searchResults.pages.slice(0, 5)" :key="page.uid"
+          :title="page.config.label" :footer="page.uid">
+          <f7-link slot="after" v-if="isPinned('pages', page, 'uid')" @click="$emit('unpin', 'pages', page, 'uid')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
+          <f7-link slot="after" v-else @click="$emit('pin', 'pages', page, 'uid')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
+        </f7-list-item>
+      </f7-list>
+    </f7-block>
+
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['searchResults', 'pinnedObjects'],
+  components: {
+  },
+  methods: {
+    isPinned (type, obj, keyName) {
+      return this.pinnedObjects[type].findIndex((o) => o[keyName] === obj[keyName]) >= 0
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/item-standalone-control.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-standalone-control.vue
@@ -6,7 +6,7 @@
 import itemDefaultStandaloneComponent from '@/components/widgets/standard/default-standalone-item'
 
 export default {
-  props: ['item', 'context'],
+  props: ['item', 'context', 'noBorder'],
   data () {
     return {
       vars: {}
@@ -20,6 +20,11 @@ export default {
         component: itemDefaultStandaloneComponent(this.item),
         store: this.context.store,
         vars: this.vars
+      }
+
+      if (this.noBorder) {
+        ctx.component.config.noBorder = true
+        ctx.component.config.noShadow = true
       }
 
       return ctx

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -1,18 +1,20 @@
 <template>
   <f7-list-item
-  media-item
-  class="itemlist-item"
-  :link="link"
-  :title="(item.label) ? item.label :item.name"
-  :footer="(item.label) ? item.name : '\xa0'"
-  :subtitle="getItemTypeAndMetaLabel(item)"
-  :after="state"
-  v-on="$listeners"
->
-  <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" height="32" width="32" />
-  <span v-else-if="!noIcon" slot="media" class="item-initial">{{item.name[0]}}</span>
-  <f7-icon v-if="!item.editable && !ignoreEditable" slot="after-title" f7="lock_fill" size="1rem" color="gray"></f7-icon>
-</f7-list-item>
+    media-item
+    class="itemlist-item"
+    :link="link"
+    :title="(item.label) ? item.label :item.name"
+    :footer="(item.label) ? item.name : '\xa0'"
+    :subtitle="getItemTypeAndMetaLabel(item)"
+    :after="state"
+    v-on="$listeners"
+  >
+    <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" height="32" width="32" />
+    <span v-else-if="!noIcon" slot="media" class="item-initial">{{item.name[0]}}</span>
+    <f7-icon v-if="!item.editable && !ignoreEditable" slot="after-title" f7="lock_fill" size="1rem" color="gray"></f7-icon>
+    <slot name="footer" v-slot:footer>
+    </slot>
+  </f7-list-item>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -9,15 +9,15 @@
   :after="state"
   v-on="$listeners"
 >
-  <oh-icon v-if="item.category" slot="media" :icon="item.category" height="32" width="32" />
-  <span v-else slot="media" class="item-initial">{{item.name[0]}}</span>
+  <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" height="32" width="32" />
+  <span v-else-if="!noIcon" slot="media" class="item-initial">{{item.name[0]}}</span>
   <f7-icon v-if="!item.editable && !ignoreEditable" slot="after-title" f7="lock_fill" size="1rem" color="gray"></f7-icon>
 </f7-list-item>
 </template>
 
 <script>
 export default {
-  props: ['item', 'context', 'ignoreEditable', 'noState', 'link'],
+  props: ['item', 'context', 'ignoreEditable', 'noState', 'noType', 'noIcon', 'link'],
   computed: {
     state () {
       if (this.noState) return
@@ -27,6 +27,7 @@ export default {
   },
   methods: {
     getItemTypeAndMetaLabel () {
+      if (this.noType) return
       let ret = this.item.type
       if (this.item.metadata && this.item.metadata.semantics) {
         ret += ' · '

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -128,6 +128,9 @@ export default {
       modelItem.checkable = this.multiple
       if (!this.multiple && this.value === item.name) {
         this.selectItem(modelItem)
+      } else if (this.multiple && Array.isArray(this.value) && this.value.findIndex((i) => i.name === item.name) >= 0) {
+        modelItem.checked = true
+        modelItem.disabled = true
       }
 
       return modelItem

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -16,7 +16,7 @@
       />
     <div slot="label" class="semantic-class"> {{className()}}</div>
     <f7-checkbox slot="content-start" v-if="model.checkable"
-      :checked="model.checked === true" @change="check" />
+      :checked="model.checked === true" :disabled="model.disabled" @change="check" />
   </f7-treeview-item>
 </template>
 
@@ -64,6 +64,7 @@ export default {
       if (this.model.checkable && !this.children.length) this.check({ target: { checked: !this.model.checked } })
     },
     check (event) {
+      if (this.model.disabled) return
       this.model.checked = event.target.checked
       this.$emit('checked', this.model, event.target.checked)
     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -51,7 +51,7 @@ export const actionsMixin = {
           }
           let navigateOptions = { props: { deep: true } }
           if (actionPageTransition) navigateOptions.transition = actionPageTransition
-          this.$f7router.navigate('/page/' + actionPage.substring(5), navigateOptions)
+          this.$f7.views.main.router.navigate('/page/' + actionPage.substring(5), navigateOptions)
           break
         case 'command':
           const actionItem = actionConfig[prefix + 'actionItem']
@@ -157,7 +157,7 @@ export const actionsMixin = {
               modalParams: actionModalConfig || {}
             }
           }
-          this.$f7router.navigate(modalRoute, modalProps)
+          this.$f7.views.main.router.navigate(modalRoute, modalProps)
           break
         case 'photos':
           const self = this
@@ -206,14 +206,14 @@ export const actionsMixin = {
               }
             }
           }
-          this.$f7router.navigate(groupPopupRoute, { props: { groupItem: actionGroupItem } })
+          this.$f7.views.main.router.navigate(groupPopupRoute, { props: { groupItem: actionGroupItem } })
           break
         case 'analyze':
         case 'analyzer':
           const actionAnalyzerItems = actionConfig[prefix + 'actionAnalyzerItems']
           const actionAnalyzerChartType = actionConfig[prefix + 'actionAnalyzerChartType']
           const actionAnalyzerCoordSystem = actionConfig[prefix + 'actionAnalyzerCoordSystem']
-          this.$f7router.navigate(`/analyzer/?items=${actionAnalyzerItems.join(',')}&chartType=${actionAnalyzerChartType || ''}&coordSystem=${actionAnalyzerCoordSystem || ''}`)
+          this.$f7.views.main.router.navigate(`/analyzer/?items=${actionAnalyzerItems.join(',')}&chartType=${actionAnalyzerChartType || ''}&coordSystem=${actionAnalyzerCoordSystem || ''}`)
           console.log('Opening the analyzer')
           break
         case 'url':

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -184,12 +184,15 @@ html
 
         .block
           width 720px
+          max-width 100%
 
     .block-narrow .row
         width 720px
+        max-width 100%
 
     .block-narrow .col
         width 720px
+        max-width 100%
         display initial
 
 @media (max-width 1023px)

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -212,7 +212,6 @@ export default [
       {
         path: 'rules/',
         component: RulesListPage,
-        keepAlive: true,
         routes: [
           {
             path: ':ruleId',
@@ -259,7 +258,6 @@ export default [
       {
         path: 'scripts/',
         component: RulesListPage,
-        keepAlive: true,
         options: {
           props: {
             showScripts: true

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -19,7 +19,8 @@ const store = new Vuex.Store({
     apiVersion: null,
     apiEndpoints: null,
     locale: null,
-    runtimeInfo: null
+    runtimeInfo: null,
+    developerSidebar: false
   },
   getters: {
     apiEndpoint: (state) => (type) => (!state.apiEndpoints) ? null : state.apiEndpoints.find((e) => e.type === type)
@@ -30,6 +31,9 @@ const store = new Vuex.Store({
       state.locale = rootResponse.locale
       state.runtimeInfo = rootResponse.runtimeInfo
       state.apiEndpoints = rootResponse.links
+    },
+    setDeveloperSidebar (state, value) {
+      state.developerSidebar = value
     }
   }
   // strict: debug

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -34,6 +34,7 @@ const store = new Vuex.Store({
     },
     setDeveloperSidebar (state, value) {
       state.developerSidebar = value
+      state.states.keepConnectionOpen = value
     }
   }
   // strict: debug

--- a/bundles/org.openhab.ui/web/src/js/store/modules/states.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/states.js
@@ -5,7 +5,8 @@ const state = {
   itemStates: {},
   trackerConnectionId: null,
   trackerEventSource: null,
-  pendingTrackingListUpdate: false
+  pendingTrackingListUpdate: false,
+  keepConnectionOpen: true
 }
 
 let stateTrackingProxy = null
@@ -58,6 +59,7 @@ const actions = {
   },
   startTrackingStates (context) {
     console.debug('Start tracking states')
+    if (context.state.keepConnectionOpen && context.state.trackerEventSource) return
     context.commit('clearTrackingList')
     if (context.state.trackerEventSource) {
       console.debug('Closing existing state tracker connection')
@@ -81,6 +83,7 @@ const actions = {
   },
   stopTrackingStates (context) {
     console.debug('Stop tracking states')
+    if (context.state.keepConnectionOpen) return
     context.commit('clearTrackingList')
     if (context.state.trackerEventSource) {
       this._vm.$oh.sse.close(context.state.trackerEventSource)
@@ -129,6 +132,9 @@ const mutations = {
   },
   clearTrackingList (state, payload) {
     Vue.set(state, 'trackingList', [])
+  },
+  keepConnectionOpen (state, value) {
+    state.keepConnectionOpen = value
   },
   setItemState (state, { itemName, itemState }) {
     Vue.set(state.itemStates, itemName.toString(), itemState)

--- a/bundles/org.openhab.ui/web/src/js/store/modules/states.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/states.js
@@ -6,7 +6,7 @@ const state = {
   trackerConnectionId: null,
   trackerEventSource: null,
   pendingTrackingListUpdate: false,
-  keepConnectionOpen: true
+  keepConnectionOpen: false
 }
 
 let stateTrackingProxy = null

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -27,14 +27,14 @@
           <f7-col width="100" medium="50">
             <f7-block-title>Maintenance Tools</f7-block-title>
             <f7-list media-item>
-              <f7-list-item media-item title="API Explorer" footer="Discover and access the REST API directly" link="api-explorer">
+              <f7-list-item media-item title="Developer Sidebar" class="developer-sidebar-toggle" footer="Show a panel with various tools" link="" no-chevron @click="$f7.emit('toggleDeveloperSidebar')">
                 <f7-icon slot="media" f7="wrench" color="gray"></f7-icon>
-              </f7-list-item>
-              <f7-list-item media-item title="Toggle Developer Sidebar" class="developer-sidebar-toggle" footer="Show a sidebar with various tools" link="" no-chevron @click="$f7.emit('toggleDeveloperSidebar')">
-                <f7-icon slot="media" f7="gear" color="gray"></f7-icon>
                 <div slot="header" style="height: 100%; height: 32px" class="display-flex float-right flex-direction-column justify-content-center">
                   <f7-toggle color="blue" :checked="$store.state.developerSidebar"></f7-toggle>
                 </div>
+              </f7-list-item>
+              <f7-list-item media-item title="API Explorer" footer="Discover and access the REST API directly" link="api-explorer">
+                <f7-icon slot="media" f7="burn" color="gray"></f7-icon>
               </f7-list-item>
             </f7-list>
           </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -30,9 +30,11 @@
               <f7-list-item media-item title="API Explorer" footer="Discover and access the REST API directly" link="api-explorer">
                 <f7-icon slot="media" f7="wrench" color="gray"></f7-icon>
               </f7-list-item>
-              <f7-list-item media-item title="Toggle Developer Sidebar" footer="Show a sidebar with various tools" link="" no-chevron @click="$f7.emit('toggleDeveloperSidebar')">
+              <f7-list-item media-item title="Toggle Developer Sidebar" class="developer-sidebar-toggle" footer="Show a sidebar with various tools" link="" no-chevron @click="$f7.emit('toggleDeveloperSidebar')">
                 <f7-icon slot="media" f7="gear" color="gray"></f7-icon>
-                <f7-toggle slot="header" color="blue" class="float-right" :checked="$store.state.developerSidebar"></f7-toggle>
+                <div slot="header" style="height: 100%; height: 32px" class="display-flex float-right flex-direction-column justify-content-center">
+                  <f7-toggle color="blue" :checked="$store.state.developerSidebar"></f7-toggle>
+                </div>
               </f7-list-item>
             </f7-list>
           </f7-col>
@@ -84,6 +86,9 @@
 </template>
 
 <style lang="stylus">
+@media (max-width 1279px)
+  .developer-sidebar-toggle
+    display none
 
 </style>
 

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -30,6 +30,10 @@
               <f7-list-item media-item title="API Explorer" footer="Discover and access the REST API directly" link="api-explorer">
                 <f7-icon slot="media" f7="wrench" color="gray"></f7-icon>
               </f7-list-item>
+              <f7-list-item media-item title="Toggle Developer Sidebar" footer="Show a sidebar with various tools" link="" no-chevron @click="$f7.emit('toggleDeveloperSidebar')">
+                <f7-icon slot="media" f7="gear" color="gray"></f7-icon>
+                <f7-toggle slot="header" color="blue" class="float-right" :checked="$store.state.developerSidebar"></f7-toggle>
+              </f7-list-item>
             </f7-list>
           </f7-col>
         </f7-row>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -165,8 +165,7 @@ export default {
       this.load()
     },
     onPageAfterIn () {
-      this.$oh.api.get('/rest/links?itemName=' + this.item.name).then((data) => {
-        console.dir(data.filter((l) => l.itemName === this.item.name))
+      this.$oh.api.get('/rest/links?itemName=' + this.itemName).then((data) => {
         this.links = data
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -31,7 +31,8 @@
 
     <f7-list-index
       ref="listIndex"
-      list-el=".rules-list"
+      v-if="$refs.rulesList"
+      :listEl="$refs.rulesList ? $$($refs.rulesList.$el) : undefined"
       :scroll-list="true"
       :label="true"
     ></f7-list-index>
@@ -161,7 +162,10 @@ export default {
 
         this.loading = false
         this.ready = true
-        setTimeout(() => { this.initSearchbar = true; this.$refs.listIndex.update() })
+        setTimeout(() => {
+          this.initSearchbar = true
+          this.$refs.listIndex.update()
+        })
 
         if (!this.eventSource) this.startEventSource()
       }).catch((err, status) => {


### PR DESCRIPTION
This is a proposal of a "developer sidebar" to provide a collection of handy,
always-available tools while heavily working on the configuration.
I'm opening the PR early to gauge interest and allow suggestions on
the features this tool should have.

The developer sidebar is displayed on the right side of the view, outside
the standard page navigation, and available from the developer tools
menu or at any time with the <code>Shift+Alt+D</code> keyboard shortcut, __only__ if
all of these conditions are met:

1. the user has an administrator role;
2. the device is a desktop (or laptop, that is, not a phone or tablet);
3. the width of the screen is >= 1280px.

Example:
![2020-10-24_11-42-18](https://user-images.githubusercontent.com/2004147/97078943-54902800-15f0-11eb-87ac-84a4e85c72ab.gif)

Only the "Item Monitor" and "Events Monitor" tools are (barely) functional
for now, the rest are mockups.
Ideas of tools to include in the sidebar are:
- Search bar to perform a global search among items, things, pages, rules and
quickly navigate to its page (suggested in #224)
- Item monitor: select the items you currently are working on, and show their
states in real time, eventually update their states or send commands, using a
raw input or the standard list control, quickly go edit them;
- Rules monitor: add rules you're currently working on or those you need at
the moment, check their status, disable/enable them, run them, or quickly
go edit them:
- Things monitor: add things you're currently working on or those you need at
the moment, check their status, disable/enable them, or quickly go edit them:
- Events monitor: Stream the events from the event bus, eventually apply
filters;
- Pages (& widgets): add pages or widgets you're currently working on or
those you need at the moment, view them in a popup or navigate, or quickly
go edit them:
- Widget expression tester: Quickly type an expression like in a config parameter
of a widget and check the result;
- ...Other tools (add items etc.?), maybe offer additional tools depending on
the add-ons installed - for example a basic MQTT or HTTP client...

Note: the developer sidebar is resizable! (unlike the menu on the left)
![2020-10-24_12-11-43](https://user-images.githubusercontent.com/2004147/97079193-31ff0e80-15f2-11eb-8dbc-79541836bf2a.gif)


Signed-off-by: Yannick Schaus <github@schaus.net>