### PR TITLE
Add binding configuration link to "choose binding" page

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -50,6 +50,7 @@
             badge-color="red"
             :footer="(binding.description && binding.description.indexOf('<br>') >= 0) ?
                       binding.description.split('<br>')[0] : binding.description">
+            <f7-link slot="after" v-if="binding.configDescriptionURI" :href="`/settings/addons/bindings/${binding.id}/config`" class="margin-left" icon-size="20" icon-f7="gear_alt" color="gray" tooltip="Configure Binding" />
           </f7-list-item>
         </f7-list>
 
@@ -95,6 +96,3 @@ export default {
   }
 }
 </script>
-
-<style>
-</style>


### PR DESCRIPTION
This is the only page where all bindings are shown, including
those not sideloaded and not coming from features/the distro.

Closes #386.

Signed-off-by: Yannick Schaus <github@schaus.net>