### PR TITLE
Don't validate option config parameters

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-options.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-options.vue
@@ -65,7 +65,6 @@ export default {
   },
   methods: {
     updateValue (evt) {
-      this.$f7.input.validateInputs(this.$refs.item.$el)
       let value = (this.inlineList) ? evt : this.$refs.item.f7SmartSelect.getValue()
       if (!this.configDescription.multiple && this.configDescription.type === 'INTEGER') {
         value = parseInt(value)


### PR DESCRIPTION
Config parameters with options don't have to be validated;
they normally are always valid - no empty option is
presented when a value is required etc.

The introduction of validation in #451 broke the control
when options are presented "inline".
See https://github.com/openhab/openhab-core/issues/1763

Signed-off-by: Yannick Schaus <github@schaus.net>