### PR TITLE
Don't focus searchbars if no filter when switching tabs

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -154,8 +154,12 @@ export default {
       this.showLinked = val
       const searchbar = this.$refs.searchbar.$el.f7Searchbar
       const filterQuery = searchbar.query
-      searchbar.clear()
-      if (filterQuery) this.$nextTick(() => { searchbar.search(filterQuery) })
+      this.$nextTick(() => {
+        if (filterQuery) {
+          searchbar.clear()
+          searchbar.search(filterQuery)
+        }
+      })
     },
     selectChannel (channel, channelType) {
       if (this.pickerMode) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -202,9 +202,11 @@ export default {
       this.groupBy = groupBy
       const searchbar = this.$refs.searchbar.$el.f7Searchbar
       const filterQuery = searchbar.query
-      searchbar.clear()
       this.$nextTick(() => {
-        if (filterQuery) searchbar.search(filterQuery)
+        if (filterQuery) {
+          searchbar.clear()
+          searchbar.search(filterQuery)
+        }
         if (groupBy === 'alphabetical') this.$refs.listIndex.update()
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -171,9 +171,11 @@ export default {
       this.groupBy = groupBy
       const searchbar = this.$refs.searchbar.$el.f7Searchbar
       const filterQuery = searchbar.query
-      searchbar.clear()
       this.$nextTick(() => {
-        if (filterQuery) searchbar.search(filterQuery)
+        if (filterQuery) {
+          searchbar.clear()
+          searchbar.search(filterQuery)
+        }
         if (groupBy === 'alphabetical') this.$refs.listIndex.update()
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -162,9 +162,11 @@ export default {
       this.groupBy = groupBy
       const searchbar = this.$refs.searchbar.$el.f7Searchbar
       const filterQuery = searchbar.query
-      searchbar.clear()
       this.$nextTick(() => {
-        if (filterQuery) searchbar.search(filterQuery)
+        if (filterQuery) {
+          searchbar.clear()
+          searchbar.search(filterQuery)
+        }
         if (groupBy === 'alphabetical') this.$refs.listIndex.update()
       })
     },


### PR DESCRIPTION
When switching tabs in channels, things, inbox, pages
list, the searchbar.clear() function refocuses the
searchbar which brings up a virtual keyboard on mobile
and/or a backdrop or iOS. Since there's apparently no
way to prevent this behavior, do it only when there's
a value for the searchbar's filter.

Signed-off-by: Yannick Schaus <github@schaus.net>