### PR TITLE
Allow variables in overview page

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -81,7 +81,8 @@ export default {
     overviewPageContext () {
       return {
         component: this.overviewPage,
-        store: this.context.store
+        store: this.context.store,
+        vars: {}
       }
     }
   },


### PR DESCRIPTION
The variables map was not initialized in the overview
page's context, so attempting to set variables in it
resulted in an error.

Signed-off-by: Yannick Schaus <github@schaus.net>