### PR TITLE
Fix semantic home page cards with generic equipment

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/en/empty-states.json
@@ -12,7 +12,7 @@
   "things.nobindings.text": "To add things to your system, you first need to install binding add-ons.",
 
   "model.title": "Start modelling your home",
-  "model.text": "Build a model from your items to organize them and relate them to each other semantically.<br><br>Begin with a hierarchy of locations: buildings, outside areas, floors and rooms, as needed. Then, insert equipments and points from your things (or manually).",
+  "model.text": "Build a model from your items to organize them and relate them to each other semantically.<br><br>Begin with a hierarchy of locations: buildings, outside areas, floors and rooms, as needed. Then, insert equipment and points from your things (or manually).",
 
   "items.title": "No items yet",
   "items.text": "Items represent the functional side of your home - you can link them to the channels defined by your things. Start with the Model view to create a clean initial structure.<br><br>You can also define items with configuration files, or with the button below.",

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -5,8 +5,8 @@
         <f7-card-header text-color="white" class="display-block">
           {{title || 'Something'}}
           <div><small>{{subtitle || '&nbsp;'}}</small></div>
-          <div class="location-stats" v-if="items.equipments.length > 0"><small>{{items.equipments.length}} equipment{{items.equipments.length === 1 ? '' : 's'}}</small></div>
-          <div class="location-stats" v-if="items.properties.length > 0"><small>{{items.properties.length}} propert{{items.properties.length === 1 ? 'y' : 'ies'}}</small></div>
+          <div class="location-stats" v-if="items.equipments.length > 0"><small>Equipment: {{items.equipments.length}}</small></div>
+          <div class="location-stats" v-if="items.properties.length > 0"><small>Properties: {{items.properties.length}}</small></div>
         </f7-card-header>
         <f7-link
           card-close
@@ -18,7 +18,7 @@
       </div>
       <div class="card-content-padding" v-if="opened && items.equipments.length > 0 && items.properties.length > 0">
         <f7-segmented round tag="p">
-          <f7-button round outline :active="activeTab === 'equipments'" :color="color" @click="activeTab = 'equipments'">Equipments</f7-button>
+          <f7-button round outline :active="activeTab === 'equipments'" :color="color" @click="activeTab = 'equipments'">Equipment</f7-button>
           <f7-button round outline :active="activeTab === 'properties'" :color="color" @click="activeTab = 'properties'">Properties</f7-button>
         </f7-segmented>
       </div>

--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -3,13 +3,13 @@
     <f7-list-item title="Semantic Class" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-semantics-class" @change="update('class', $event.target.value)">
         <option v-if="!hideNone" :value="''">None</option>
-        <optgroup label="Locations" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Location')">
+        <optgroup label="Location" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Location')">
           <option v-for="type in semanticClasses.Locations" :key="type" :value="type" :selected="type === semanticClass">{{type}}</option>
         </optgroup>
-        <optgroup label="Equipments" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Equipment')">
+        <optgroup label="Equipment" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Equipment')">
           <option v-for="type in semanticClasses.Equipments" :key="type" :value="type" :selected="type === semanticClass">{{type}}</option>
         </optgroup>
-        <optgroup label="Points" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Point')">
+        <optgroup label="Point" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Point')">
           <option v-for="type in semanticClasses.Points" :key="type" :value="type" :selected="type === semanticClass">{{type}}</option>
         </optgroup>
       </select>

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -19,7 +19,7 @@
     <f7-toolbar tabbar labels bottom>
       <f7-link tab-link @click="currentTab = 'overview'" :tab-link-active="currentTab === 'overview'" icon-ios="f7:house_fill" icon-aurora="f7:house_fill" icon-md="material:home" text="Overview"></f7-link>
       <f7-link tab-link @click="currentTab = 'locations'" :tab-link-active="currentTab === 'locations'" icon-ios="f7:placemark_fill" icon-aurora="f7:placemark_fill" icon-md="material:place" text="Locations"></f7-link>
-      <f7-link tab-link @click="currentTab = 'equipments'" :tab-link-active="currentTab === 'equipments'" icon-ios="f7:lightbulb_fill" icon-aurora="f7:lightbulb_fill" icon-md="material:highlight" text="Equipments"></f7-link>
+      <f7-link tab-link @click="currentTab = 'equipments'" :tab-link-active="currentTab === 'equipments'" icon-ios="f7:lightbulb_fill" icon-aurora="f7:lightbulb_fill" icon-md="material:highlight" text="Equipment"></f7-link>
       <f7-link tab-link @click="currentTab = 'properties'" :tab-link-active="currentTab === 'properties'" icon-ios="f7:bolt_fill" icon-aurora="f7:bolt_fill" icon-md="material:flash_on" text="Properties"></f7-link>
     </f7-toolbar>
 
@@ -122,7 +122,7 @@ export default {
         // get the location items
         this.semanticItems.locations = data.filter((item, index, items) => {
           return item.metadata && item.metadata.semantics &&
-            item.metadata.semantics.value.indexOf('Location_') === 0
+            item.metadata.semantics.value.indexOf('Location') === 0
         }).sort((a, b) => {
           const titleA = a.label || a.name
           const titleB = b.label || b.name
@@ -139,7 +139,7 @@ export default {
             equipments: data.filter((item, index, items) => {
               return item.metadata && item.metadata.semantics &&
                 item.metadata.semantics && item.metadata.semantics.config &&
-                item.metadata.semantics.value.indexOf('Equipment_') === 0 &&
+                item.metadata.semantics.value.indexOf('Equipment') === 0 &&
                 item.metadata.semantics.config.hasLocation === l.name
             }).map((item) => {
               return {
@@ -158,9 +158,9 @@ export default {
         this.semanticItems.equipments = data.filter((item, index, items) => {
           return item.metadata && item.metadata.semantics &&
             item.metadata.semantics &&
-            item.metadata.semantics.value.indexOf('Equipment_') === 0
+            item.metadata.semantics.value.indexOf('Equipment') === 0
         }).reduce((prev, item, i, properties) => {
-          const equipmentType = item.metadata.semantics.value.split('_')[1]
+          const equipmentType = item.metadata.semantics.value.split('_')[1] || 'Equipment'
           if (!prev[equipmentType]) prev[equipmentType] = []
           const equipmentWithPoints = {
             item: item,

--- a/bundles/org.openhab.ui/web/src/pages/home/equipments-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/equipments-tab.vue
@@ -2,7 +2,7 @@
   <div v-if="showCards">
     <div class="demo-expandable-cards">
       <equipments-card v-for="(items, equipmentType) in semanticItems.equipments" :key="equipmentType"
-        :title="equipmentType" :items="items" :subtitle="`${items.length} equipment${items.length > 1 ? 's' : ''}`" :color="color(equipmentType)" />
+        :title="equipmentType" :items="items" :subtitle="`${items.length} item${items.length > 1 ? 's' : ''}`" :color="color(equipmentType)" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
Fix bug with cards in the home page's Locations tab
not appearing when there were non-specialized
equipment.

Add a card for non-specialized equipment in the
Equipment tab.

Rename "Equipments" to Equipment, where shown to
the user (#438) - followup PR to do for the references
in the code.

Signed-off-by: Yannick Schaus <github@schaus.net>