### PR TITLE
Blockly editor for scripts (experimental)

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -4587,6 +4587,120 @@
         "file-uri-to-path": "1.0.0"
       }
     },
+    "blockly": {
+      "version": "3.20200924.4",
+      "resolved": "https://registry.npmjs.org/blockly/-/blockly-3.20200924.4.tgz",
+      "integrity": "sha512-KDPVLJSguxwKXL6GVdVaYRINoxtojTsQ4lOhuWS9LkzyMhmQVZKMgFzlQum5rE5+hlhzj1BqqUQHe8JbfvL+dQ==",
+      "dev": true,
+      "requires": {
+        "jsdom": "15.2.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+          "dev": true
+        },
+        "cssstyle": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+          "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+          "dev": true,
+          "requires": {
+            "cssom": "0.3.8"
+          },
+          "dependencies": {
+            "cssom": {
+              "version": "0.3.8",
+              "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+              "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+              "dev": true
+            }
+          }
+        },
+        "jsdom": {
+          "version": "15.2.1",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.1.tgz",
+          "integrity": "sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==",
+          "dev": true,
+          "requires": {
+            "abab": "2.0.2",
+            "acorn": "7.4.1",
+            "acorn-globals": "4.3.4",
+            "array-equal": "1.0.0",
+            "cssom": "0.4.4",
+            "cssstyle": "2.3.0",
+            "data-urls": "1.1.0",
+            "domexception": "1.0.1",
+            "escodegen": "1.12.0",
+            "html-encoding-sniffer": "1.0.2",
+            "nwsapi": "2.2.0",
+            "parse5": "5.1.0",
+            "pn": "1.1.0",
+            "request": "2.88.0",
+            "request-promise-native": "1.0.7",
+            "saxes": "3.1.11",
+            "symbol-tree": "3.2.4",
+            "tough-cookie": "3.0.1",
+            "w3c-hr-time": "1.0.1",
+            "w3c-xmlserializer": "1.1.2",
+            "webidl-conversions": "4.0.2",
+            "whatwg-encoding": "1.0.5",
+            "whatwg-mimetype": "2.3.0",
+            "whatwg-url": "7.1.0",
+            "ws": "7.3.1",
+            "xml-name-validator": "3.0.0"
+          }
+        },
+        "nwsapi": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
+          "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+          "dev": true
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+          "dev": true
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "2.1.0",
+            "psl": "1.4.0",
+            "punycode": "2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+          "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "4.7.0",
+            "tr46": "1.0.1",
+            "webidl-conversions": "4.0.2"
+          }
+        },
+        "ws": {
+          "version": "7.3.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+          "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+          "dev": true
+        }
+      }
+    },
     "bluebird": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
@@ -14745,6 +14859,15 @@
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
+    "saxes": {
+      "version": "3.1.11",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz",
+      "integrity": "sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==",
+      "dev": true,
+      "requires": {
+        "xmlchars": "2.2.0"
+      }
+    },
     "schema-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -17377,6 +17500,17 @@
         "browser-process-hrtime": "0.1.3"
       }
     },
+    "w3c-xmlserializer": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-1.1.2.tgz",
+      "integrity": "sha512-p10l/ayESzrBMYWRID6xbuCKh2Fp77+sA0doRuGn4tTIMrrZVeqfpKjXHY+oDh3K4nLdPgNwMTVP6Vp4pvqbNg==",
+      "dev": true,
+      "requires": {
+        "domexception": "1.0.1",
+        "webidl-conversions": "4.0.2",
+        "xml-name-validator": "3.0.0"
+      }
+    },
     "walker": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.7.tgz",
@@ -18367,6 +18501,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
+    },
+    "xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
     "xtend": {

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -102,6 +102,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-dynamic-import-node-babel-7": "^2.0.7",
     "babel-plugin-transform-vue-jsx": "^4.0.1",
+    "blockly": "^3.20200924.4",
     "chalk": "^2.4.2",
     "copy-webpack-plugin": "^4.6.0",
     "cross-env": "^5.2.1",

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ohblocks.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ohblocks.js
@@ -1,0 +1,67 @@
+import Blockly from 'blockly'
+
+export default function defineOHBlocks () {
+  Blockly.Blocks['oh_getitem_state'] = {
+    init: function () {
+      this.appendValueInput('itemName')
+        .appendField('get item state')
+        .setCheck('String')
+      this.setInputsInline(true)
+      this.setOutput(true, 'String')
+      this.setColour(0)
+      this.setTooltip('Get an item state from the item registry')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_getitem_state'] = function (block) {
+    const itemName = Blockly.JavaScript.valueToCode(block, 'itemName', Blockly.JavaScript.ORDER_ATOMIC)
+    var code = 'itemRegistry.getItem(' + itemName + ').getState()'
+    return [code, 0]
+  }
+
+  Blockly.Blocks['oh_sendcommand'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('send command')
+      this.appendValueInput('command')
+        // .setCheck('String')
+      this.appendDummyInput()
+        .appendField('to')
+      this.appendValueInput('itemName')
+        // .setCheck('String')
+      this.setInputsInline(true)
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setColour(0)
+      this.setTooltip('Send a command to an item')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_sendcommand'] = function (block) {
+    const itemName = Blockly.JavaScript.valueToCode(block, 'itemName', Blockly.JavaScript.ORDER_ATOMIC)
+    const command = Blockly.JavaScript.valueToCode(block, 'command', Blockly.JavaScript.ORDER_ATOMIC)
+    var code = 'events.sendCommand(' + itemName + ', ' + command + ');\n'
+    return code
+  }
+
+  Blockly.Blocks['oh_print'] = {
+    init: function () {
+      this.appendValueInput('message')
+        // .setCheck('String')
+        .appendField('print')
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setColour(0)
+      this.setTooltip('Print a message on the console')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_print'] = function (block) {
+    const message = Blockly.JavaScript.valueToCode(block, 'message', Blockly.JavaScript.ORDER_ATOMIC)
+    var code = 'print(' + message + ');\n'
+    return code
+  }
+}

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -316,6 +316,8 @@
   width 100%
   .blockly
     height 100%
+    .blocklyMainBackground
+      stroke inherit
 .blocklyDropDownDiv
   z-index 9000
 </style>
@@ -338,7 +340,10 @@ export default {
   mounted () {
     defineOHBlocks()
     this.workspace = Blockly.inject(this.$refs.blocklyEditor, {
-      toolbox: this.$refs.toolbox
+      toolbox: this.$refs.toolbox,
+      horizontalLayout: !this.$device.desktop,
+      theme: (this.$f7.data.themeOptions.dark === 'dark') ? 'dark' : undefined,
+      trashcan: false
     })
     const xml = Blockly.Xml.textToDom(this.blocks)
     Blockly.Xml.domToWorkspace(xml, this.workspace)

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -1,0 +1,356 @@
+<template>
+  <div class="blockly-editor">
+     <div class="blockly" ref="blocklyEditor" />
+
+      <xml xmlns="https://developers.google.com/blockly/xml" ref="toolbox" style="display: none">
+        <category name="Logic" colour="%{BKY_LOGIC_HUE}">
+          <block type="controls_if"></block>
+          <block type="logic_compare"></block>
+          <block type="logic_operation"></block>
+          <block type="logic_negate"></block>
+          <block type="logic_boolean"></block>
+          <block type="logic_null"></block>
+          <block type="logic_ternary"></block>
+        </category>
+        <category name="Loops" colour="%{BKY_LOOPS_HUE}">
+          <block type="controls_repeat_ext">
+            <value name="TIMES">
+              <shadow type="math_number">
+                <field name="NUM">10</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="controls_whileUntil"></block>
+          <block type="controls_for">
+            <value name="FROM">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+            <value name="TO">
+              <shadow type="math_number">
+                <field name="NUM">10</field>
+              </shadow>
+            </value>
+            <value name="BY">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="controls_forEach"></block>
+          <block type="controls_flow_statements"></block>
+        </category>
+        <category name="Math" colour="%{BKY_MATH_HUE}">
+          <block type="math_number">
+            <field name="NUM">123</field>
+          </block>
+          <block type="math_arithmetic">
+            <value name="A">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+            <value name="B">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_single">
+            <value name="NUM">
+              <shadow type="math_number">
+                <field name="NUM">9</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_trig">
+            <value name="NUM">
+              <shadow type="math_number">
+                <field name="NUM">45</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_constant"></block>
+          <block type="math_number_property">
+            <value name="NUMBER_TO_CHECK">
+              <shadow type="math_number">
+                <field name="NUM">0</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_round">
+            <value name="NUM">
+              <shadow type="math_number">
+                <field name="NUM">3.1</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_on_list"></block>
+          <block type="math_modulo">
+            <value name="DIVIDEND">
+              <shadow type="math_number">
+                <field name="NUM">64</field>
+              </shadow>
+            </value>
+            <value name="DIVISOR">
+              <shadow type="math_number">
+                <field name="NUM">10</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_constrain">
+            <value name="VALUE">
+              <shadow type="math_number">
+                <field name="NUM">50</field>
+              </shadow>
+            </value>
+            <value name="LOW">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+            <value name="HIGH">
+              <shadow type="math_number">
+                <field name="NUM">100</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_random_int">
+            <value name="FROM">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+            <value name="TO">
+              <shadow type="math_number">
+                <field name="NUM">100</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="math_random_float"></block>
+          <block type="math_atan2">
+            <value name="X">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+            <value name="Y">
+              <shadow type="math_number">
+                <field name="NUM">1</field>
+              </shadow>
+            </value>
+          </block>
+        </category>
+        <category name="Text" colour="%{BKY_TEXTS_HUE}">
+          <block type="text"></block>
+          <block type="text_join"></block>
+          <block type="text_append">
+            <value name="TEXT">
+              <shadow type="text"></shadow>
+            </value>
+          </block>
+          <block type="text_length">
+            <value name="VALUE">
+              <shadow type="text">
+                <field name="TEXT">abc</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="text_isEmpty">
+            <value name="VALUE">
+              <shadow type="text">
+                <field name="TEXT"></field>
+              </shadow>
+            </value>
+          </block>
+          <block type="text_indexOf">
+            <value name="VALUE">
+              <block type="variables_get">
+                <field name="VAR">{textVariable}</field>
+              </block>
+            </value>
+            <value name="FIND">
+              <shadow type="text">
+                <field name="TEXT">abc</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="text_charAt">
+            <value name="VALUE">
+              <block type="variables_get">
+                <field name="VAR">{textVariable}</field>
+              </block>
+            </value>
+          </block>
+          <block type="text_getSubstring">
+            <value name="STRING">
+              <block type="variables_get">
+                <field name="VAR">{textVariable}</field>
+              </block>
+            </value>
+          </block>
+          <block type="text_changeCase">
+            <value name="TEXT">
+              <shadow type="text">
+                <field name="TEXT">abc</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="text_trim">
+            <value name="TEXT">
+              <shadow type="text">
+                <field name="TEXT">abc</field>
+              </shadow>
+            </value>
+          </block>
+        </category>
+        <category name="Lists" colour="%{BKY_LISTS_HUE}">
+          <block type="lists_create_with">
+            <mutation items="0"></mutation>
+          </block>
+          <block type="lists_create_with"></block>
+          <block type="lists_repeat">
+            <value name="NUM">
+              <shadow type="math_number">
+                <field name="NUM">5</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="lists_length"></block>
+          <block type="lists_isEmpty"></block>
+          <block type="lists_indexOf">
+            <value name="VALUE">
+              <block type="variables_get">
+                <field name="VAR">{listVariable}</field>
+              </block>
+            </value>
+          </block>
+          <block type="lists_getIndex">
+            <value name="VALUE">
+              <block type="variables_get">
+                <field name="VAR">{listVariable}</field>
+              </block>
+            </value>
+          </block>
+          <block type="lists_setIndex">
+            <value name="LIST">
+              <block type="variables_get">
+                <field name="VAR">{listVariable}</field>
+              </block>
+            </value>
+          </block>
+          <block type="lists_getSublist">
+            <value name="LIST">
+              <block type="variables_get">
+                <field name="VAR">{listVariable}</field>
+              </block>
+            </value>
+          </block>
+          <block type="lists_split">
+            <value name="DELIM">
+              <shadow type="text">
+                <field name="TEXT">,</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="lists_sort"></block>
+        </category>
+        <category name="Color" colour="%{BKY_COLOUR_HUE}">
+          <block type="colour_picker"></block>
+          <block type="colour_random"></block>
+          <block type="colour_rgb">
+            <value name="RED">
+              <shadow type="math_number">
+                <field name="NUM">100</field>
+              </shadow>
+            </value>
+            <value name="GREEN">
+              <shadow type="math_number">
+                <field name="NUM">50</field>
+              </shadow>
+            </value>
+            <value name="BLUE">
+              <shadow type="math_number">
+                <field name="NUM">0</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="colour_blend">
+            <value name="COLOUR1">
+              <shadow type="colour_picker">
+                <field name="COLOUR">#ff0000</field>
+              </shadow>
+            </value>
+            <value name="COLOUR2">
+              <shadow type="colour_picker">
+                <field name="COLOUR">#3333ff</field>
+              </shadow>
+            </value>
+            <value name="RATIO">
+              <shadow type="math_number">
+                <field name="NUM">0.5</field>
+              </shadow>
+            </value>
+          </block>
+        </category>
+        <category name="openHAB" colour="0">
+          <block type="oh_getitem_state" />
+          <block type="oh_sendcommand" />
+          <block type="oh_print" />
+        </category>
+
+        <sep></sep>
+        <category name="Variables" colour="%{BKY_VARIABLES_HUE}" custom="VARIABLE"></category>
+        <category name="Functions" colour="%{BKY_PROCEDURES_HUE}" custom="PROCEDURE"></category>
+      </xml>
+
+  </div>
+</template>
+
+<style lang="stylus">
+.blockly-editor
+  display block
+  top calc(100%)
+  height calc(100%)
+  width 100%
+  .blockly
+    height 100%
+.blocklyDropDownDiv
+  z-index 9000
+</style>
+
+<script>
+import Blockly from 'blockly'
+import Vue from 'vue'
+
+import defineOHBlocks from '@/assets/definitions/blockly/ohblocks'
+
+Vue.config.ignoredElements = ['field', 'block', 'category', 'xml', 'mutation', 'value', 'sep']
+
+export default {
+  props: ['blocks'],
+  data () {
+    return {
+      workspace: null
+    }
+  },
+  mounted () {
+    defineOHBlocks()
+    this.workspace = Blockly.inject(this.$refs.blocklyEditor, {
+      toolbox: this.$refs.toolbox
+    })
+    const xml = Blockly.Xml.textToDom(this.blocks)
+    Blockly.Xml.domToWorkspace(xml, this.workspace)
+  },
+  methods: {
+    getBlocks () {
+      const xml = Blockly.Xml.workspaceToDom(this.workspace)
+      return Blockly.Xml.domToText(xml)
+    },
+    getCode () {
+      return Blockly.JavaScript.workspaceToCode(this.workspace)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -327,7 +327,7 @@ export default {
       }
     },
     convertToBlockly () {
-      if (this.script || this.isBlockly) return
+      if (this.script || this.isBlockly || this.mode !== 'application/javascript') return
       this.$set(this.currentModule.configuration, 'blockSource', '<xml xmlns="https://developers.google.com/blockly/xml"></xml>')
     },
     updateScript (value) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -25,7 +25,7 @@
         <f7-link v-if="isScriptRule" class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up"></f7-link>
       </span>
     </f7-toolbar>
-    <editor v-if="ready && !newScript && !isBlockly" class="rule-script-editor" :mode="mode" :value="script" @input="(value) => { script = value; dirty = true }" :tern-autocompletion-hook="true" />
+    <editor v-if="ready && !newScript && (!isBlockly || blocklyCodePreview)" class="rule-script-editor" :mode="mode" :value="script" @input="updateScript" :tern-autocompletion-hook="true" />
     <blockly-editor ref="blocklyEditor" v-else-if="ready && !newScript && isBlockly" :blocks="currentModule.configuration.blockSource"></blockly-editor>
     <script-general-settings v-else-if="createMode" :createMode="true" :rule="rule" />
     <f7-block class="block-narrow" v-if="newScript">
@@ -36,9 +36,9 @@
             :value="mode" :checked="mode === language.contentType" @change="mode = language.contentType"
             v-for="language in languages" :key="language.contentType"
             :title="language.name" :after="language.version" :footer="language.contentType"></f7-list-item>
-          <f7-list-item media-item radio radio-icon="start"
+          <!-- <f7-list-item media-item radio radio-icon="start"
             :value="mode" :checked="mode === 'application/vnd.openhab.blockly.rule'" @change="mode = 'application/vnd.openhab.blockly.rule'"
-            :title="'Blockly editor'"></f7-list-item>
+            :title="'Blockly editor'"></f7-list-item> -->
         </f7-list>
       </f7-col>
     </f7-block>
@@ -47,6 +47,17 @@
         <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="createScript">Create Script</f7-button>
       </div>
     </div>
+
+    <f7-fab v-show="isBlockly && !blocklyCodePreview" position="right-bottom" slot="fixed" color="blue" @click="showBlocklyCode">
+      <f7-icon f7="doc_text"></f7-icon>
+    </f7-fab>
+    <f7-fab v-show="isBlockly && blocklyCodePreview" position="right-bottom" slot="fixed" color="blue" @click="blocklyCodePreview = false">
+      <f7-icon f7="ticket"></f7-icon>
+    </f7-fab>
+    <f7-fab v-show="!script && mode === 'application/javascript' && !isBlockly" position="right-bottom" slot="fixed" color="blue" @click="convertToBlockly" tooltip="Convert to Blockly">
+      <f7-icon f7="ticket_fill"></f7-icon>
+    </f7-fab>
+
     <f7-sheet ref="detailsSheet" class="script-details-sheet" :backdrop="false" :close-on-escape="true" :opened="detailsOpened" @sheet:closed="detailsOpened = false">
       <f7-page>
         <f7-toolbar tabbar bottom>
@@ -105,7 +116,8 @@ export default {
       mode: '',
       eventSource: null,
       keyHandler: null,
-      detailsOpened: false
+      detailsOpened: false,
+      blocklyCodePreview: false
     }
   },
   computed: {
@@ -240,8 +252,13 @@ export default {
         }
       }
       if (this.isBlockly) {
-        this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
-        this.script = this.$refs.blocklyEditor.getCode()
+        try {
+          this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
+          this.script = this.$refs.blocklyEditor.getCode()
+        } catch (e) {
+          this.$f7.dialog.alert(e)
+          return
+        }
       }
       this.currentModule.configuration.script = this.script
       return this.$oh.api.put('/rest/rules/' + this.rule.uid, this.rule).then((data) => {
@@ -299,6 +316,35 @@ export default {
         })
       })
     },
+    showBlocklyCode () {
+      try {
+        this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
+        this.script = this.$refs.blocklyEditor.getCode()
+        this.currentModule.configuration.blockSource = (this.script) ? this.$refs.blocklyEditor.getBlocks() : undefined
+        if (this.isBlockly) this.blocklyCodePreview = true
+      } catch (e) {
+        this.$f7.dialog.alert(e)
+      }
+    },
+    convertToBlockly () {
+      if (this.script || this.isBlockly) return
+      this.$set(this.currentModule.configuration, 'blockSource', '<xml xmlns="https://developers.google.com/blockly/xml"></xml>')
+    },
+    updateScript (value) {
+      if (this.isBlockly) {
+        this.$f7.toast.create({
+          text: 'Cannot update the code of a Blockly script',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        const script = String(this.script)
+        this.script = null
+        this.$nextTick(() => { this.$set(this, 'script', script) })
+      } else {
+        this.script = value
+        this.dirty = true
+      }
+    },
     startEventSource () {
       this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/rules/' + this.ruleId + '/*', null, (event) => {
         console.log(event)
@@ -317,6 +363,19 @@ export default {
     keyDown (ev) {
       if (ev.ctrlKey || ev.metakKey) {
         switch (ev.keyCode) {
+          case 66:
+            if (this.isBlockly) {
+              if (this.blocklyCodePreview) {
+                this.blocklyCodePreview = false
+              } else {
+                this.showBlocklyCode()
+              }
+            } else {
+              this.convertToBlockly()
+            }
+            ev.stopPropagation()
+            ev.preventDefault()
+            break
           case 68:
             this.toggleDisabled()
             ev.stopPropagation()


### PR DESCRIPTION
Allow to create new ECMAScript-based scripts with a
Blockly editor: https://developers.google.com/blockly.

The undocumented "blockSource" configuration parameter
is added to the script action module and will trigger
the display of the Blockly editor instead of the code
editor if present.

3 openHAB-related blocks have been added to the standard
toolbox: get item state, send command, print.

![image](https://user-images.githubusercontent.com/2004147/97811766-e5b07000-1c7c-11eb-8cb8-b7098a69ba05.png)

![image](https://user-images.githubusercontent.com/2004147/97811771-f1039b80-1c7c-11eb-8211-7bb2e7c07e0b.png)



Signed-off-by: Yannick Schaus <github@schaus.net>