### PR TITLE
Fix several issues

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/button.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/button.js
@@ -9,7 +9,8 @@ export default () => [
   pb('raised', 'Raised', 'Makes button raised'),
   pb('outline', 'Outline', 'Makes button outline'),
   pt('active', 'Active', 'Button is active (when part of a f7-segmented').a(),
-  pt('icon', 'Icon', 'Use  <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'),
+  pt('iconF7', 'Icon', 'Framework7 icon to display (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'),
+  pt('iconMaterial', 'Icon', 'Material design icon to display'),
   pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons'),
   pn('iconSize', 'Icon Size', 'Size of the icon in px'),
   pt('tooltip', 'Tooltip', 'Button tooltip text to show on button hover/press').a()

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/link.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/link.js
@@ -2,7 +2,8 @@ import { pt, pn } from '../helpers'
 
 export default () => [
   pt('text', 'Text', 'Link label'),
-  pt('icon', 'Icon', 'Use  <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'),
+  pt('iconF7', 'Icon', 'Framework7 icon to display (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'),
+  pt('iconMaterial', 'Icon', 'Material design icon to display'),
   pt('iconColor', 'Icon Color', 'Color of the icon'),
   pn('iconSize', 'Icon Size', 'Size of the icon in px'),
   pt('badge', 'Badge', 'Text to display in a badge on the opposite side of the item (set either this or "after")').a(),

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -78,7 +78,7 @@
           </f7-list-item>
           <f7-list-item link="/developer/api-explorer" title="API Explorer" view=".view-main" panel-close :animate="false" no-chevron
               :class="{ currentsection: currentUrl.indexOf('/developer/api-explorer') >= 0 }">
-            <f7-icon slot="media" f7="wrench" color="gray"></f7-icon>
+            <f7-icon slot="media" f7="burn" color="gray"></f7-icon>
           </f7-list-item>
           </ul>
         </li>

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-col.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-col.vue
@@ -1,7 +1,7 @@
 <template>
-  <f7-col v-bind="config" v-if="visible">
-    <div width="100%">
-      <f7-menu v-if="context.editmode" class="configure-layout-menu padding-horizontal">
+  <f7-col v-bind="config" v-if="visible" class="oh-col">
+    <div width="100%" v-if="context.editmode">
+      <f7-menu class="configure-layout-menu padding-horizontal">
         <f7-menu-item style="margin-left: auto" icon-f7="rectangle_split_3x1" dropdown>
           <f7-menu-dropdown right>
           <f7-menu-dropdown-item v-if="context.component.slots.default.length > 0" @click="context.editmode.configureWidget(context.component.slots.default[0], context)" href="#" text="Configure Widget"></f7-menu-dropdown-item>
@@ -23,10 +23,6 @@
     <generic-widget-component v-else-if="context.component.slots.default.length" :context="childContext(context.component.slots.default[0])" @command="onCommand" />
   </f7-col>
 </template>
-
-<style>
-
-</style>
 
 <script>
 import mixin from '../widget-mixin'

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-row.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-row.vue
@@ -1,8 +1,8 @@
 <template>
-  <div>
+  <div class="oh-row">
     <hr v-if="context.editmode" style="opacity: 0.5; border-top: 1px #777 dashed" />
-    <div width="100%">
-      <f7-menu v-if="context.editmode" class="configure-layout-menu margin-bottom padding-horizontal">
+    <div width="100%" v-if="context.editmode">
+      <f7-menu class="configure-layout-menu margin-bottom padding-horizontal">
         <f7-menu-item @click="context.editmode.addWidget(context.component, 'oh-grid-col')" icon-f7="plus" text="Add Column" />
         <f7-menu-item style="margin-left: auto" icon-f7="square_split_1x2" dropdown>
           <f7-menu-dropdown right>
@@ -36,8 +36,13 @@
   </div>
 </template>
 
-<style>
-
+<style lang="stylus">
+.oh-row
+  --f7-orig-grid-gap var(--f7-grid-gap)
+  --f7-orig-grid-row-gap var(--f7-grid-row-gap)
+  .oh-col .row:not(.no-gap)
+    --f7-grid-gap var(--f7-orig-grid-gap)
+    --f7-grid-row-gap var(--f7-orig-grid-row-gap)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -106,8 +106,8 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
 
   if (!component.config) component.config = {}
   component.config.item = item.name
-  component.config.title = item.label || item.name
-  if (item.label && itemNameAsFooter) component.config.footer = item.name
+  if (!component.config.title) component.config.title = item.label || item.name
+  if (item.label && itemNameAsFooter && !component.config.footer) component.config.footer = item.name
   component.config.stateAsHeader = true
   if (component.component === 'oh-label-cell') component.config.expandable = false
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -84,7 +84,7 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
       component: 'oh-label-cell'
     }
 
-    if (item.type.indexOf('Number:') === 0) {
+    if (item.type.indexOf('Number') === 0 && (!item.commandDescription || !item.commandDescription.options || stateDescription.readOnly)) {
       component.config = {
         trendItem: item.name,
         action: 'analyze',

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-label-cell.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-label-cell.vue
@@ -9,7 +9,7 @@
             <span>{{config.title || config.header}}</span>
             <f7-badge v-if="config.headerBadge" color="config.headerBadgeColor">{{config.headerBadge}}</f7-badge>
           </div>
-          <div class="state" :style="config.stateStyle">{{config.label || context.store[config.item].displayState || context.store[config.item].state}}</div>
+          <div class="state" :style="config.stateStyle">{{label}}</div>
         </f7-list-item>
       </f7-list>
     </template>
@@ -34,6 +34,11 @@ export default {
   components: {
     OhCell
   },
-  widget: OhLabelCellDefinition
+  widget: OhLabelCellDefinition,
+  computed: {
+    label () {
+      return  this.config.label || this.context.store[this.config.item].displayState || this.context.store[this.config.item].state
+    }
+  }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
@@ -79,7 +79,7 @@ export default function itemDefaultStandaloneComponent (item) {
       component: 'oh-label-card'
     }
 
-    if (item.type.indexOf('Number:') === 0) {
+    if (item.type.indexOf('Number') === 0 && (!item.commandDescription || !item.commandDescription.options || stateDescription.readOnly)) {
       component.config = {
         trendItem: item.name,
         action: 'analyze',

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -91,8 +91,9 @@ export default function itemDefaultListComponent (item, itemNameAsFooter) {
 
   if (!component.config) component.config = {}
   component.config.item = item.name
-  component.config.title = item.label || item.name
-  if (item.category) component.config.icon = 'oh:' + item.category
+  if (!component.config.title) component.config.title = item.label || item.name
+  if (item.category && !component.config.icon) component.config.icon = 'oh:' + item.category
+  if (item.category && ['Switch', 'Rollershutter', 'Contact', 'Dimmer', 'Group'].indexOf(item.type) >= 0) component.config.iconUseState = true
   if (item.label && itemNameAsFooter) component.config.footer = item.name
   if (!item.category) component.config.fallbackIconToInitial = true
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -70,7 +70,7 @@ export default function itemDefaultListComponent (item, itemNameAsFooter) {
       component: 'oh-label-item'
     }
 
-    if (item.type.indexOf('Number:') === 0) {
+    if (item.type.indexOf('Number') === 0 && (!item.commandDescription || !item.commandDescription.options || stateDescription.readOnly)) {
       component.config = {
         action: 'analyze',
         actionAnalyzerItems: [item.name]

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-slider-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-slider-item.vue
@@ -1,5 +1,8 @@
 <template>
   <oh-list-item :context="context" class="slider-listitem">
+    <div slot="after">
+      {{context.store[config.item].displayState || context.store[config.item].state}}
+    </div>
     <div slot="footer" class="padding">
       <generic-widget-component :context="childContext(sliderComponent)" v-on="$listeners" />
     </div>

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-label-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-label-card.vue
@@ -11,7 +11,7 @@
           <f7-icon slot="media" v-else-if="config.icon" :ios="config.icon" :md="config.icon" :aurora="config.icon" :size="config.iconSize || 32" :color="config.iconColor" />
           <div :class="config.class">
             <span :style="{ 'font-size': config.fontSize || '24px', 'font-weight': config.fontWeight || 'normal' }">
-              {{config.label || context.store[config.item].displayState || context.store[config.item].state}}
+              {{label}}
             </span>
           </div>
         </f7-list-item>
@@ -60,6 +60,11 @@ export default {
   components: {
     OhTrend
   },
-  widget: OhLabelCardDefinition
+  widget: OhLabelCardDefinition,
+  computed: {
+    label () {
+      return this.config.label || this.context.store[this.config.item].displayState || this.context.store[this.config.item].state
+    }
+  }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
@@ -1,5 +1,9 @@
 <template>
-  <f7-button v-bind="config" @click="clicked" />
+  <f7-button v-bind="config" @click="clicked">
+    <template v-if="context.component.slots && context.component.slots.default">
+      <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
+    </template>
+  </f7-button>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -24,18 +24,29 @@ export default {
   data () {
     return {
       currentState: this.state,
-      currentIcon: this.icon,
+      currentIcon: this.actualIcon,
       iconUrl: null
     }
   },
+  computed: {
+    actualIcon () {
+      return (this.context) ? this.config.icon : this.icon
+    },
+    actualState () {
+      return (this.context) ? this.config.state : this.state
+    },
+    iconFormat () {
+      return (this.context) ? (this.config.iconFormat || 'svg') : 'svg'
+    }
+  },
   watch: {
-    state (val) {
+    actualState (val) {
       if (val !== this.currentState) {
         this.currentState = val
         this.updateIcon()
       }
     },
-    icon (val) {
+    actualIcon (val) {
       if (val !== this.currentIcon) {
         this.currentIcon = val
         this.updateIcon()
@@ -43,11 +54,14 @@ export default {
     }
   },
   mounted () {
+    this.currentIcon = this.actualIcon
+    this.currentState = this.actualState
     this.updateIcon()
   },
   methods: {
     updateIcon () {
-      this.$oh.media.getIcon((this.context) ? this.config.icon : this.icon, 'svg', (this.context) ? this.config.state : this.currentState).then((url) => {
+      if (!this.currentIcon) return
+      this.$oh.media.getIcon(this.currentIcon, this.iconFormat, this.currentState).then((url) => {
         if (url !== this.iconUrl) {
           this.iconUrl = url
         }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
@@ -1,5 +1,9 @@
 <template>
-  <f7-link v-bind="config" @click="clicked" />
+  <f7-link v-bind="config" @click="clicked">
+    <template v-if="context.component.slots && context.component.slots.default">
+      <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
+    </template>
+  </f7-link>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -54,6 +54,7 @@ export default {
   },
   methods: {
     evaluateExpression (key, value) {
+      if (value === null) return null
       if (typeof value === 'string' && value.startsWith('=')) {
         try {
           // we cache the parsed abstract tree to prevent it from being parsed again at runtime

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -60,12 +60,11 @@
   white-space pre-wrap
 .layout-editor-design-tab
   .layout-page
+    margin-bottom calc(var(--f7-toolbar-height) + 1rem)
     .oh-masonry
       z-index inherit
-      padding-bottom 5rem
 .layout-editor
   .page-content
-    padding-bottom 5rem
     z-index inherit
 </style>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -65,6 +65,7 @@
             <f7-list inline-labels no-hairlines-md>
               <f7-list-input label="Unique ID" type="text" placeholder="Required" :value="rule.uid" required validate
                             :disabled="!createMode" :info="(createMode) ? 'Note: cannot be changed after the creation' : ''"
+                            pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
                             @input="rule.uid = $event.target.value" :clear-button="createMode">
               </f7-list-input>
               <f7-list-input label="Name" type="text" placeholder="Required" :value="rule.name" required validate

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
@@ -4,6 +4,7 @@
       <f7-list class="no-margin" inline-labels no-hairlines-md>
         <f7-list-input label="Unique ID" type="text" placeholder="Required" :value="rule.uid" required validate
                       :disabled="!createMode" :info="(createMode) ? 'Note: cannot be changed after the creation' : ''"
+                      pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
                       @input="rule.uid = $event.target.value" :clear-button="createMode">
         </f7-list-input>
         <f7-list-input label="Name" type="text" placeholder="Required" :value="rule.name" required validate


### PR DESCRIPTION
Fix #520 - don't evaluate null values, move labels to computed properties
Fix #515 - don't overwrite labels, icons in default representations if set in config
Fix #514 - don't inherit layout page no-gap to rows/cols
Fix #513 - fix icon properties in oh-link, oh-button
Close #508 - display error if incorrect format for rules/scripts UIDs (no hard check)
Fix #505 - incorrect bottom margin in layout editor on Firefox
Close #500 - display current value in oh-slider-item
Fix #487 - dynamic icons for default list items (only certain item types)
Allow oh-button & oh-link contents to be customized w/ default slot
Allow oh-icon to receive dynamic updates
Fix wrong API Explorer icon in sidebar

Signed-off-by: Yannick Schaus <github@schaus.net>