### PR TITLE
Improve bulk operations, consistent delete UX

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -25,8 +25,7 @@
         {{selectedItems.length}} selected
       </div>
       <div class="right" v-if="$theme.md">
-        <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
-        <f7-link icon-md="material:more_vert" icon-color="white" @click="removeSelected"></f7-link>
+        <f7-link v-show="selectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
       </div>
     </f7-toolbar>
 
@@ -66,8 +65,9 @@
             class="widgetlist-item"
             :checkbox="showCheckboxes"
             :checked="isChecked(widget.uid)"
-            @change="(e) => toggleItemCheck(e, widget.uid)"
-            :link="showCheckboxes ? null : widget.uid"
+            @click.ctrl="(e) => ctrlClick(e, widget)"
+            @click.exact="(e) => click(e, widget)"
+            link=""
             :title="widget.uid"
           >
             <div slot="subtitle">
@@ -126,8 +126,19 @@ export default {
     isChecked (item) {
       return this.selectedItems.indexOf(item) >= 0
     },
+    click (event, item) {
+      if (this.showCheckboxes) {
+        this.toggleItemCheck(event, item.uid, item)
+      } else {
+        this.$f7router.navigate(item.uid, { animate: false })
+      }
+    },
+    ctrlClick (event, item) {
+      this.toggleItemCheck(event, item.uid, item)
+      if (!this.selectedItems.length) this.showCheckboxes = false
+    },
     toggleItemCheck (event, item) {
-      console.log('toggle check')
+      if (!this.showCheckboxes) this.showCheckboxes = true
       if (this.isChecked(item)) {
         this.selectedItems.splice(this.selectedItems.indexOf(item), 1)
       } else {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -79,6 +79,13 @@
           <link-details :item="item" :links="links" />
         </f7-col>
       </f7-row>
+      <f7-row v-if="item.editable">
+        <f7-col>
+          <f7-list>
+            <f7-list-button color="red" @click="deleteItem">Remove Item</f7-list-button>
+          </f7-list>
+        </f7-col>
+      </f7-row>
     </f7-block>
   </f7-page>
 </template>
@@ -177,6 +184,17 @@ export default {
         this.item = data
         this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
       })
+    },
+    deleteItem () {
+      this.$f7.dialog.confirm(
+        `Are you sure you want to delete ${this.item.label || this.item.name}?`,
+        'Delete Item',
+        () => {
+          this.$oh.api.delete('/rest/items/' + this.item.name).then(() => {
+            this.$f7router.back('/settings/items/', { force: true })
+          })
+        }
+      )
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -24,7 +24,7 @@
         {{selectedItems.length}} selected
       </div>
       <div class="right" v-if="$theme.md">
-        <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
+        <f7-link v-show="selectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
       </div>
     </f7-toolbar>
 
@@ -70,8 +70,9 @@
               class="itemlist-item"
               :checkbox="showCheckboxes"
               :checked="isChecked(item.name)"
-              @change="(e) => toggleItemCheck(e, item.name)"
-              :link="showCheckboxes ? null : item.name"
+              @click.ctrl="(e) => ctrlClick(e, item)"
+              @click.exact="(e) => click(e, item)"
+              link=""
               :title="(item.label) ? item.label : item.name"
               :footer="(item.label) ? item.name : '\xa0'"
               :subtitle="getItemTypeAndMetaLabel(item)"
@@ -207,8 +208,19 @@ export default {
     isChecked (item) {
       return this.selectedItems.indexOf(item) >= 0
     },
+    click (event, item) {
+      if (this.showCheckboxes) {
+        this.toggleItemCheck(event, item.name, item)
+      } else {
+        this.$f7router.navigate(item.name)
+      }
+    },
+    ctrlClick (event, item) {
+      this.toggleItemCheck(event, item.name, item)
+      if (!this.selectedItems.length) this.showCheckboxes = false
+    },
     toggleItemCheck (event, item) {
-      console.log('toggle check')
+      if (!this.showCheckboxes) this.showCheckboxes = true
       if (this.isChecked(item)) {
         this.selectedItems.splice(this.selectedItems.indexOf(item), 1)
       } else {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -26,7 +26,7 @@
         {{selectedItems.length}} selected
       </div>
       <div class="right" v-if="$theme.md">
-        <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
+        <f7-link v-show="selectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected"></f7-link>
       </div>
     </f7-toolbar>
 
@@ -82,10 +82,11 @@
               media-item
               class="pagelist-item"
               :checkbox="showCheckboxes"
-              :checked="isChecked(page.uid)"
+              :checked="isChecked(((page.component === 'Sitemap') ? 'system:sitemap:' : 'ui:page:') + page.uid)"
               :disabled="showCheckboxes && page.uid === 'overview'"
-              @change="(e) => toggleItemCheck(e, page.uid, page)"
-              :link="showCheckboxes ? null : getPageType(page).type + '/' + page.uid"
+              @click.ctrl="(e) => ctrlClick(e, page)"
+              @click.exact="(e) => click(e, page)"
+              link=""
               :title="page.config.label"
               :subtitle="getPageType(page).label"
               :footer="page.uid"
@@ -216,8 +217,19 @@ export default {
     isChecked (item) {
       return this.selectedItems.indexOf(item) >= 0
     },
+    click (event, item) {
+      if (this.showCheckboxes) {
+        this.toggleItemCheck(event, item.uid, item)
+      } else {
+        this.$f7router.navigate(this.getPageType(item).type + '/' + item.uid)
+      }
+    },
+    ctrlClick (event, item) {
+      this.toggleItemCheck(event, item.uid, item)
+      if (!this.selectedItems.length) this.showCheckboxes = false
+    },
     toggleItemCheck (event, itemName, item) {
-      console.log('toggle check')
+      if (!this.showCheckboxes) this.showCheckboxes = true
       itemName = (item.component === 'Sitemap') ? 'system:sitemap:' + itemName : 'ui:page:' + itemName
       if (this.isChecked(itemName)) {
         this.selectedItems.splice(this.selectedItems.indexOf(itemName), 1)

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -111,6 +111,12 @@
             <semantics-picker v-if="isEditable" :item="rule"></semantics-picker>
             <tag-input :item="rule" :disabled="!isEditable"></tag-input>
           </f7-col>
+          <f7-col v-if="isEditable">
+            <f7-list>
+              <f7-list-button color="red" @click="deleteRule">Remove Rule</f7-list-button>
+            </f7-list>
+          </f7-col>
+
         </f7-block>
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
@@ -332,6 +338,17 @@ export default {
           closeTimeout: 2000
         }).open()
       })
+    },
+    deleteRule () {
+      this.$f7.dialog.confirm(
+        `Are you sure you want to delete ${this.rule.name}?`,
+        'Delete Rule',
+        () => {
+          this.$oh.api.delete('/rest/rules/' + this.rule.uid).then(() => {
+            this.$f7router.back('/settings/rules/', { force: true })
+          })
+        }
+      )
     },
     startEventSource () {
       this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/rules/' + this.ruleId + '/*', null, (event) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -111,7 +111,7 @@
             <semantics-picker v-if="isEditable" :item="rule"></semantics-picker>
             <tag-input :item="rule" :disabled="!isEditable"></tag-input>
           </f7-col>
-          <f7-col v-if="isEditable">
+          <f7-col v-if="isEditable && !createMode">
             <f7-list>
               <f7-list-button color="red" @click="deleteRule">Remove Rule</f7-list-button>
             </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -67,8 +67,13 @@
             <f7-link sheet-close class="padding-right"><f7-icon f7="chevron_down"></f7-icon></f7-link>
           </div>
         </f7-toolbar>
-        <f7-block>
+        <f7-block class="block-narrow">
           <script-general-settings :createMode="newScript" :rule="rule" />
+          <f7-col v-if="isEditable">
+            <f7-list>
+              <f7-list-button color="red" @click="deleteRule">Remove Script</f7-list-button>
+            </f7-list>
+          </f7-col>
         </f7-block>
       </f7-page>
     </f7-sheet>
@@ -311,6 +316,17 @@ export default {
           }).open()
         })
       })
+    },
+    deleteRule () {
+      this.$f7.dialog.confirm(
+        `Are you sure you want to delete ${this.rule.name}?`,
+        'Delete Rule',
+        () => {
+          this.$oh.api.delete('/rest/rules/' + this.rule.uid).then(() => {
+            this.$f7router.back('/settings/scripts/', { force: true })
+          })
+        }
+      )
     },
     showBlocklyCode () {
       try {


### PR DESCRIPTION
- Add bulk operations to the things list, allowing to remove,
disable or enable things
- Add bulk operations to the rules/scripts lists, ability to disable
or enable rules & scripts
- Add ability to delete a rule, script or item from its details
page
- Add ability to start checking objects for a bulk operation
("select mode") with Ctrl+click on desktops. Ctrl+click exits the
select mode automatically when the last checked object is deselected.

Closes #512.
Closes #506.

Signed-off-by: Yannick Schaus <github@schaus.net>