### PR TITLE
Fix multiple text parameter dereferencing

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -29,7 +29,7 @@ export default {
       return 'text'
     },
     formattedValue () {
-      if (this.configDescription.multiple) return this.value.join('\n')
+      if (this.configDescription.multiple) return (this.value) ? this.value.join('\n') : ''
       return this.value
     }
   },


### PR DESCRIPTION
Fix #525.

Also should fix https://community.openhab.org/t/chatid-field-is-not-visible-in-the-telegram-bot-thing/108207.

Signed-off-by: Yannick Schaus <github@schaus.net>