### PR TITLE
Add widgetOrder metadata, fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -5,8 +5,9 @@ export default [
   { name: 'widget', label: 'Default Standalone Widget' },
   { name: 'listWidget', label: 'Default List Item Widget' },
   { name: 'cellWidget', label: 'Default Cell Widget' },
+  { name: 'widgetOrder', label: 'Default Widget Order Index' },
   { name: 'autoupdate', label: 'Auto-update' },
-  { name: 'expire', label: 'Expiration timer' },
+  { name: 'expire', label: 'Expiration Timer' },
   { name: 'alexa', label: 'Amazon Alexa' },
   { name: 'homekit', label: 'Apple HomeKit' },
   { name: 'ga', label: 'Google Assistant' }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/visibility.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/visibility.js
@@ -1,0 +1,16 @@
+// Standard visibility settings
+
+import { pg, pt } from './helpers'
+
+export const VisibilityGroup = () => pg('visibility', 'Visibility Options')
+
+export const VisibilityParameters = () => [
+  pt('visible', 'Visible', 'Enter an expression to hide the widget conditionally or false to never display it').g('visibility'),
+  pt('visibleTo', 'Visible only to', 'Role(s) this widget will be visible to (in the code view you can restrict to specific users with the <code>user:userid</code> syntax).' +
+    '<br/><strong>PLEASE NOTE: this should NOT be considered a security feature! Items can still be controlled by other means.</strong>')
+    .g('visibility')
+    .o([
+      { value: 'role:administrator', label: 'Administrators' },
+      { value: 'role:user', label: 'Users' }
+    ], true, true) // limit to options because we don't have a working control for autocompleting a multiple text param
+]

--- a/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
@@ -1,0 +1,33 @@
+export default {
+  props: ['color', 'type', 'header', 'title', 'subtitle', 'items'],
+  data () {
+    return {
+      opened: false,
+      cardId: this.title
+    }
+  },
+  mounted () {
+    window.addEventListener('popstate', this.back)
+  },
+  beforeDestroy () {
+    window.removeEventListener('popstate', this.back)
+  },
+  methods: {
+    cardOpening () {
+      history.pushState({ cardId: this.cardId }, null, window.location.href.split('#card=')[0] + '#' + this.$f7.utils.serializeObject({ card: this.cardId }))
+      setTimeout(() => { this.opened = true })
+    },
+    cardClosed () {
+      if (history.state.cardId && history.state.cardId === this.cardId) history.back()
+      this.opened = false
+    },
+    closeCard () {
+      setTimeout(() => { this.$f7.card.close(this.$refs.card.$el) }, 100)
+    },
+    back (evt) {
+      console.log(evt.state)
+      if (!evt.state || evt.state.cardId === this.cardId) return
+      if (this.opened) this.closeCard()
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/cards/equipments-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipments-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-card expandable class="equipments-card" :animate="$f7.data.themeOptions.expandableCardAnimation !== 'disabled'" card-tablet-fullscreen v-on:card:opened="cardOpening" v-on:card:closed="cardClosed">
+  <f7-card expandable ref="card" class="equipments-card" :animate="$f7.data.themeOptions.expandableCardAnimation !== 'disabled'" card-tablet-fullscreen v-on:card:opened="cardOpening" v-on:card:closed="cardClosed">
     <f7-card-content :padding="false">
       <div :class="`bg-color-${color}`" :style="{height: '150px'}">
         <f7-card-header text-color="white" class="display-block">
@@ -35,24 +35,10 @@
 
 <script>
 import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
+import CardMixin from './card-mixin'
 
 export default {
-  props: ['color', 'type', 'header', 'title', 'subtitle', 'items'],
-  data () {
-    return {
-      opened: false
-    }
-  },
-  methods: {
-    cardOpening () {
-      console.log('card opened')
-      setTimeout(() => { this.opened = true })
-    },
-    cardClosed () {
-      console.log('card closed')
-      this.opened = false
-    }
-  },
+  mixins: [CardMixin],
   computed: {
     listContext () {
       const standaloneEquipments = this.items.filter((i) => i.points.length === 0).map((i) => itemDefaultListComponent(i.item, true))

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-card expandable class="location-card" :animate="$f7.data.themeOptions.expandableCardAnimation !== 'disabled'" card-tablet-fullscreen v-on:card:opened="cardOpening" v-on:card:closed="cardClosed">
+  <f7-card expandable ref="card" class="location-card" :animate="$f7.data.themeOptions.expandableCardAnimation !== 'disabled'" card-tablet-fullscreen v-on:card:opened="cardOpening" v-on:card:closed="cardClosed">
     <f7-card-content :padding="false">
       <div :class="`bg-color-${color}`" :style="{height: '200px'}">
         <f7-card-header text-color="white" class="display-block">
@@ -42,24 +42,17 @@
 
 <script>
 import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
+import CardMixin from './card-mixin'
 
 export default {
+  mixins: [CardMixin],
   props: ['color', 'type', 'header', 'title', 'subtitle', 'items'],
   data () {
     return {
-      opened: false,
       activeTab: (this.items.equipments.length === 0 && this.items.properties.length > 0) ? 'properties' : 'equipments'
     }
   },
   methods: {
-    cardOpening () {
-      console.log('card opened')
-      setTimeout(() => { this.opened = true })
-    },
-    cardClosed () {
-      console.log('card closed')
-      this.opened = false
-    }
   },
   computed: {
     propertiesListContext () {
@@ -71,7 +64,7 @@ export default {
             mediaList: true
           },
           slots: {
-            default: this.items.properties.map(itemDefaultListComponent)
+            default: this.items.properties.map((i) => itemDefaultListComponent(i))
           }
         }
       }

--- a/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-card expandable class="property-card" :animate="$f7.data.themeOptions.expandableCardAnimation !== 'disabled'" card-tablet-fullscreen v-on:card:opened="cardOpening" v-on:card:closed="cardClosed">
+  <f7-card expandable ref="card" class="property-card" :animate="$f7.data.themeOptions.expandableCardAnimation !== 'disabled'" card-tablet-fullscreen v-on:card:opened="cardOpening" v-on:card:closed="cardClosed">
     <f7-card-content :padding="false">
       <div :class="`bg-color-${color}`" :style="{height: '150px'}">
         <f7-card-header text-color="white" class="display-block">
@@ -38,24 +38,10 @@
 
 <script>
 import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
+import CardMixin from './card-mixin'
 
 export default {
-  props: ['color', 'type', 'header', 'title', 'subtitle', 'items'],
-  data () {
-    return {
-      opened: false
-    }
-  },
-  methods: {
-    cardOpening () {
-      console.log('card opened')
-      setTimeout(() => { this.opened = true })
-    },
-    cardClosed () {
-      console.log('card closed')
-      this.opened = false
-    }
-  },
+  mixins: [CardMixin],
   computed: {
     listContext () {
       let pointsByType = []

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -49,7 +49,7 @@ export default {
       })
       const inputControl = this.$refs.input
       if (!inputControl || !inputControl.$el) return
-      const inputElement = this.$$(inputControl.$el).find('input')
+      const inputElement = this.$$(inputControl.$el).find(this.configDescription.multiple ? 'textarea' : 'input')
       this.autoCompleteOptions = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-input
+        label="Order in Lists"
+        name="value"
+        ref="value"
+        type="text"
+        :value="metadata.value"
+        @input="(ev) => metadata.value = ev.target.value"
+        >
+      </f7-list-input>
+    </f7-list>
+    <f7-block-footer class="param-description padding-left">
+      <small>Order index to give to the item's default widget when it is to be displayed in an automatically generated list with other items (semantic cards, group popups...), unless the order is explicitely configured.</small>
+      <br /><br />
+      <small>Lower integer values promote items to the top, higher ones push them to the bottom. Those without an index set will be presented last, in alphabetical order.</small>
+    </f7-block-footer>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['itemName', 'metadata', 'namespace']
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -48,6 +48,12 @@ import ModelTreeview from '@/components/model/model-treeview.vue'
 
 import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
 
+import { compareItems } from '@/components/widgets/widget-order'
+
+function compareModelItems (o1, o2) {
+  return compareItems(o1.item || o1, o2.item || o2)
+}
+
 export default {
   props: ['value', 'opened', 'multiple', 'semanticOnly', 'groupsOnly', 'allowEmpty', 'popupTitle', 'actionLabel'],
   components: {
@@ -154,24 +160,24 @@ export default {
 
         this.rootLocations = this.locations
           .filter((i) => !i.metadata.semantics.config || !i.metadata.semantics.config.isPartOf)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         this.rootLocations.forEach(this.getChildren)
         this.rootEquipments = this.equipments
           .filter((i) => !i.metadata.semantics.config || (!i.metadata.semantics.config.isPartOf && !i.metadata.semantics.config.hasLocation))
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         this.rootEquipments.forEach(this.getChildren)
         this.rootPoints = this.points
           .filter((i) => !i.metadata.semantics.config || (!i.metadata.semantics.config.isPointOf && !i.metadata.semantics.config.hasLocation))
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
 
         if (this.includeNonSemantic && !this.semanticOnly) {
           this.rootGroups = this.items
             .filter((i) => i.type === 'Group' && (!i.metadata || !i.metadata.semantics) && i.groupNames.length === 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
           this.rootGroups.forEach(this.getChildren)
           this.rootItems = this.items
             .filter((i) => i.type !== 'Group' && (!i.metadata || !i.metadata.semantics) && i.groupNames.length === 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         }
 
         this.loading = false
@@ -196,45 +202,45 @@ export default {
       if (parent.class.indexOf('Location') === 0) {
         parent.children.locations = this.locations
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPartOf === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.locations.forEach(this.getChildren)
         parent.children.equipments = this.equipments
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.hasLocation === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.equipments.forEach(this.getChildren)
 
         if (!this.groupsOnly) {
           parent.children.points = this.points
             .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.hasLocation === parent.item.name)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         }
       } else {
         parent.children.equipments = this.equipments
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPartOf === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.equipments.forEach(this.getChildren)
 
         if (!this.groupsOnly) {
           parent.children.points = this.points
             .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPointOf === parent.item.name)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         }
       }
 
       if (this.includeNonSemantic) {
         parent.children.groups = this.items
           .filter((i) => i.type === 'Group' && (!i.metadata) && i.groupNames.indexOf(parent.item.name) >= 0)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.groups.forEach(this.getChildren)
         if (parent.item.metadata) {
           parent.children.items = this.items
             .filter((i) => i.type !== 'Group' && (!i.metadata) && i.groupNames.indexOf(parent.item.name) >= 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         } else {
           if (!this.groupsOnly) {
             parent.children.items = this.items
               .filter((i) => i.type !== 'Group' && i.groupNames.indexOf(parent.item.name) >= 0)
-              .map(this.modelItem)
+              .map(this.modelItem).sort(compareModelItems)
           }
         }
       }

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -88,7 +88,7 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
     if (item.type.indexOf('Number') === 0 && (!item.commandDescription || !item.commandDescription.commandOptions || stateDescription.readOnly)) {
       component.config = {
         trendItem: item.name,
-        action: 'analyze',
+        action: 'analyzer',
         actionAnalyzerItems: [item.name]
       }
     } else if (item.commandDescription && item.commandDescription.commandOptions && !stateDescription.readOnly) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
@@ -83,7 +83,7 @@ export default function itemDefaultStandaloneComponent (item) {
     if (item.type.indexOf('Number') === 0 && (!item.commandDescription || !item.commandDescription.commandOptions || stateDescription.readOnly)) {
       component.config = {
         trendItem: item.name,
-        action: 'analyze',
+        action: 'analyzer',
         actionAnalyzerItems: [item.name]
       }
     } else if (item.commandDescription && item.commandDescription.commandOptions && !stateDescription.readOnly) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -73,7 +73,7 @@ export default function itemDefaultListComponent (item, itemNameAsFooter) {
 
     if (item.type.indexOf('Number') === 0 && (!item.commandDescription || !item.commandDescription.commandOptions || stateDescription.readOnly)) {
       component.config = {
-        action: 'analyze',
+        action: 'analyzer',
         actionAnalyzerItems: [item.name]
       }
     } else if (item.commandDescription && item.commandDescription.commandOptions && !stateDescription.readOnly) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
@@ -1,0 +1,11 @@
+
+export function compareItems (i1, i2) {
+  const order1 = (i1.metadata.widgetOrder) ? i1.metadata.widgetOrder.value : Infinity
+  const order2 = (i2.metadata.widgetOrder) ? i2.metadata.widgetOrder.value : Infinity
+  if (order1 === order2) {
+    const nameOrLabel1 = i1.label || i1.name
+    const nameOrLabel2 = i2.label || i2.name
+    return nameOrLabel1.localeCompare(nameOrLabel2)
+  }
+  return (order1 < order2) ? -1 : 1
+}

--- a/bundles/org.openhab.ui/web/src/pages/group/group-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/group/group-popup.vue
@@ -21,6 +21,7 @@
 <script>
 import itemDefaultStandaloneComponent from '@/components/widgets/standard/default-standalone-item'
 import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
+import { compareItems } from '@/components/widgets/widget-order'
 
 export default {
   props: ['groupItem'],
@@ -88,8 +89,10 @@ export default {
 
     },
     load () {
-      this.$oh.api.get(`/rest/items/${this.groupItem}?metadata=semantics,widget,listWidget`).then((data) => {
+      this.$oh.api.get(`/rest/items/${this.groupItem}?metadata=semantics,widget,listWidget,widgetOrder`).then((data) => {
         this.item = data
+        // array is sorted in-place
+        this.item.members.sort(compareItems)
       })
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/home/equipments-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/equipments-tab.vue
@@ -1,8 +1,11 @@
 <template>
   <div v-if="showCards">
     <div class="demo-expandable-cards">
-      <equipments-card v-for="(items, equipmentType) in semanticItems.equipments" :key="equipmentType"
-        :title="equipmentType" :items="items" :subtitle="`${items.length} item${items.length > 1 ? 's' : ''}`" :color="color(equipmentType)" />
+      <equipments-card v-for="equipmentType in Object.keys(semanticItems.equipments).sort()" :key="equipmentType"
+        :title="equipmentType"
+        :subtitle="`${semanticItems.equipments[equipmentType].length} item${semanticItems.equipments[equipmentType].length > 1 ? 's' : ''}`"
+        :color="color(equipmentType)"
+        :items="semanticItems.equipments[equipmentType]" />
     </div>
   </div>
 </template>

--- a/bundles/org.openhab.ui/web/src/pages/home/properties-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/properties-tab.vue
@@ -1,8 +1,11 @@
 <template>
   <div v-if="showCards">
     <div class="demo-expandable-cards">
-      <property-card v-for="(items, property) in semanticItems.properties" :key="property"
-        :title="property" :items="items" :subtitle="`${items.length} item${items.length > 1 ? 's' : ''}`" :color="color(property)" />
+      <property-card v-for="property in Object.keys(semanticItems.properties).sort()" :key="property"
+        :title="property"
+        :subtitle="`${semanticItems.properties[property].length} item${semanticItems.properties[property].length > 1 ? 's' : ''}`"
+        :color="color(property)"
+        :items="semanticItems.properties[property]" />
     </div>
   </div>
 </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -56,6 +56,7 @@ import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
 import ItemMetadataItemDescription from '@/components/item/metadata/item-metadata-itemdescription.vue'
 import ItemMetadataSynonyms from '@/components/item/metadata/item-metadata-synonyms.vue'
 import ItemMetadataWidget from '@/components/item/metadata/item-metadata-widget.vue'
+import ItemMetadataWidgetOrder from '@/components/item/metadata/item-metadata-widgetorder.vue'
 import ItemMetadataAutoUpdate from '@/components/item/metadata/item-metadata-autoupdate.vue'
 import ItemMetadataExpire from '@/components/item/metadata/item-metadata-expire.vue'
 import ItemMetadataAlexa from '@/components/item/metadata/item-metadata-alexa.vue'
@@ -90,6 +91,8 @@ export default {
         case 'listWidget':
         case 'cellWidget':
           return ItemMetadataWidget
+        case 'widgetOrder':
+          return ItemMetadataWidgetOrder
         case 'autoupdate':
           return ItemMetadataAutoUpdate
         case 'expire':

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -169,6 +169,12 @@ import LinkDetails from '@/components/model/link-details.vue'
 
 import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
 
+import { compareItems } from '@/components/widgets/widget-order'
+
+function compareModelItems (o1, o2) {
+  return compareItems(o1.item || o1, o2.item || o2)
+}
+
 export default {
   components: {
     ModelDetailsPane,
@@ -274,24 +280,24 @@ export default {
 
         this.rootLocations = this.locations
           .filter((i) => !i.metadata.semantics.config || !i.metadata.semantics.config.isPartOf)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         this.rootLocations.forEach(this.getChildren)
         this.rootEquipments = this.equipments
           .filter((i) => !i.metadata.semantics.config || (!i.metadata.semantics.config.isPartOf && !i.metadata.semantics.config.hasLocation))
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         this.rootEquipments.forEach(this.getChildren)
         this.rootPoints = this.points
           .filter((i) => !i.metadata.semantics.config || (!i.metadata.semantics.config.isPointOf && !i.metadata.semantics.config.hasLocation))
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
 
         if (this.includeNonSemantic) {
           this.rootGroups = this.items
             .filter((i) => i.type === 'Group' && (!i.metadata || !i.metadata.semantics) && i.groupNames.length === 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
           this.rootGroups.forEach(this.getChildren)
           this.rootItems = this.items
             .filter((i) => i.type !== 'Group' && (!i.metadata || !i.metadata.semantics) && i.groupNames.length === 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         }
 
         this.loading = false
@@ -340,40 +346,40 @@ export default {
       if (parent.class.indexOf('Location') === 0) {
         parent.children.locations = this.locations
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPartOf === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.locations.forEach(this.getChildren)
         parent.children.equipments = this.equipments
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.hasLocation === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.equipments.forEach(this.getChildren)
 
         parent.children.points = this.points
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.hasLocation === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
       } else {
         parent.children.equipments = this.equipments
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPartOf === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.equipments.forEach(this.getChildren)
 
         parent.children.points = this.points
           .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPointOf === parent.item.name)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
       }
 
       if (this.includeNonSemantic) {
         parent.children.groups = this.items
           .filter((i) => i.type === 'Group' && (!i.metadata) && i.groupNames.indexOf(parent.item.name) >= 0)
-          .map(this.modelItem)
+          .map(this.modelItem).sort(compareModelItems)
         parent.children.groups.forEach(this.getChildren)
         if (parent.item.metadata) {
           parent.children.items = this.items
             .filter((i) => i.type !== 'Group' && (!i.metadata) && i.groupNames.indexOf(parent.item.name) >= 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         } else {
           parent.children.items = this.items
             .filter((i) => i.type !== 'Group' && i.groupNames.indexOf(parent.item.name) >= 0)
-            .map(this.modelItem)
+            .map(this.modelItem).sort(compareModelItems)
         }
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -87,6 +87,8 @@ import itemDefaultStandaloneComponent from '@/components/widgets/standard/defaul
 import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
 import itemDefaultCellComponent from '@/components/widgets/standard/cell/default-cell-item'
 
+import { compareItems } from '@/components/widgets/widget-order'
+
 export default {
   mixins: [PageDesigner],
   components: {
@@ -195,7 +197,7 @@ export default {
       const component = this.addFromModelContext.component
       const slot = this.addFromModelContext.slot
       if (Array.isArray(value)) {
-        value.forEach((i) => {
+        value.sort(compareItems).forEach((i) => {
           component.slots[slot].push(defaultWidgetFn(i))
         })
       } else {


### PR DESCRIPTION
Add a new widgetOrder metadata namespace editor to configure a
*default* index-based widget order. (The cards on the home page
will also feature another, more visual way to influence the order
when they'll be rewritten.)

Expose visible/visibleTo on default widget metadata configuration
pages.
Known bug: counters on home page cards are not accurate when some
items are hidden with visible/visibleTo.

Add a mixin to sort items; use it on cards, model treeview, group
popup, add from model in layout pages.

Close #489.

Fix #533 - wrong call to render properties in location cards.

Fix #498 - make cards routable (has glitches).
(but will be superseded with the cards rewrite).

Fix #542 - allow to unset the options set by the default widget
routines. Fix action name ("analyze" -> "analyzer").

Signed-off-by: Yannick Schaus <github@schaus.net>