### PR TITLE
Introduce Mobile App interface

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -243,6 +243,11 @@ export default {
   },
   data () {
     let theme = localStorage.getItem('openhab.ui:theme')
+
+    if ((!theme || theme === 'auto') && window.OHApp && window.OHApp.preferTheme) {
+      theme = window.OHApp.preferTheme()
+    }
+
     // choose Aurora as default theme for desktops
     if ((!theme || theme === 'auto') && this.$device.desktop) {
       theme = 'aurora'

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -436,7 +436,7 @@ export default {
       })
     },
     updateThemeOptions () {
-      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || (this.$f7.darkTheme ? 'dark' : 'light')
+      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || ((window.OHApp && window.OHApp.preferTheme) ? window.OHApp.preferTheme() : (this.$f7.darkTheme ? 'dark' : 'light'))
       this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((this.$theme.ios || this.$f7.darkTheme || this.themeOptions.dark === 'dark') ? 'light' : 'filled')
       this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
       this.themeOptions.homeBackground = localStorage.getItem('openhab.ui:theme.home.background') || 'default'

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -436,7 +436,7 @@ export default {
       })
     },
     updateThemeOptions () {
-      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || ((window.OHApp && window.OHApp.preferTheme) ? window.OHApp.preferTheme() : (this.$f7.darkTheme ? 'dark' : 'light'))
+      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || ((window.OHApp && window.OHApp.preferDarkMode) ? window.OHApp.preferDarkMode().toString() === 'dark' : (this.$f7.darkTheme ? 'dark' : 'light'))
       this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((this.$theme.ios || this.$f7.darkTheme || this.themeOptions.dark === 'dark') ? 'light' : 'filled')
       this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
       this.themeOptions.homeBackground = localStorage.getItem('openhab.ui:theme.home.background') || 'default'

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -12,8 +12,10 @@
         {{title}}
       </f7-nav-title>
       <f7-nav-right>
-        <f7-link v-if="this.$store.getters.isAdmin" icon-ios="f7:pencil" icon-aurora="f7:pencil" icon-md="material:edit" :href="(homePageComponent) ? '/settings/pages/home/home' : '/settings/pages/home/add'"></f7-link>
-        <f7-link icon-ios="f7:sidebar_right" icon-aurora="f7:sidebar_right" icon-md="material:exit_to_app" panel-open="right"></f7-link>
+        <f7-link v-if="this.$store.getters.isAdmin" icon-ios="f7:pencil" icon-aurora="f7:pencil" icon-md="material:edit" tooltip="Edit Home Page" :href="(homePageComponent) ? '/settings/pages/home/home' : '/settings/pages/home/add'"></f7-link>
+        <f7-link v-if="showPinToHome" icon-ios="f7:pin_fill" icon-aurora="f7:pin_fill" icon-md="material:add_location" tooltip="Pin to Home" @click="pinToHome"></f7-link>
+        <f7-link v-if="showExitToApp" icon-ios="f7:square_arrow_right" icon-aurora="f7:square_arrow_right" icon-md="material:exit_to_app" tooltip="Return to App" @click="exitToApp"></f7-link>
+        <f7-link v-else icon-ios="f7:sidebar_right" icon-aurora="f7:sidebar_right" icon-md="material:exit_to_app" tooltip="Other Apps" panel-open="right"></f7-link>
       </f7-nav-right>
     </f7-navbar>
     <f7-toolbar tabbar labels bottom v-if="tabsVisible">
@@ -82,6 +84,8 @@ export default {
       showSetup: true,
       showTasks: true,
       showCards: false,
+      showPinToHome: false,
+      showExitToApp: false,
       currentTab: 'overview',
       items: []
     }
@@ -143,6 +147,16 @@ export default {
     },
     onPageInit () {
       this.$f7.panel.get('left').enableVisibleBreakpoint()
+      if (window.OHApp) {
+        if (window.OHApp.pinToHome) this.showPinToHome = true
+        if (window.OHApp.exitToApp) this.showExitToApp = true
+      }
+    },
+    pinToHome () {
+      window.OHApp.pinToHome()
+    },
+    exitToApp () {
+      window.OHApp.exitToApp()
     },
     tabVisible (tab) {
       if (!this.tabsVisible) return false


### PR DESCRIPTION
This introduces a few functions allowing apps embedding the web UI
in a WebView to interact with them and adjust part of its rendering.

More precisely, the UI will look for an `OHApp` object
(defined in `window`, for instance with `addJavascriptInterface`
for Android apps):
https://developer.android.com/guide/webapps/webview#BindingJavaScript

The `OHApp` object can define the following functions:

- `string preferTheme()`: if present, will be called during the
  initialization of the app, will force the theme - unless the user
  has made a choice on the About page. These values are allowed:
  `auto`, `ios`, `md` (Material Design/Android), `aurora` (desktop);
- `string preferDarkMode()`: if present, will be called during the
  initialization of the app, will force the color scheme - unless the
  user has made a choice on the About page. These values are
  allowed: `auto`, `light`, `dark`;
- `void pinToHome()`: if present, this will show an icon on the home
  page which will call this function when tapped;
- `void exitToApp()`: if present, this will show an icon on the home
  page which will call this function when tapped. It **replaces** the
  "Other Apps" icon showing the right-side panel.

![image](https://user-images.githubusercontent.com/2004147/100523998-d9a0cb00-31b4-11eb-99bf-c07b923db905.png)

Signed-off-by: Yannick Schaus <github@schaus.net>