### PR TITLE
cometvisu: fix nulltype mismatch

### DIFF
--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/EventBroadcaster.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/EventBroadcaster.java
@@ -61,12 +61,10 @@ public interface EventBroadcaster {
     public void registerItems();
 
     /**
-     * lists all client item names and the associated type which must be notified
-     * when the item changes
+     * Lists all client item names and the associated type which must be notified when the item changes.
      *
-     * @param item
-     *            - the item that is listened to
-     * @return
+     * @param item the item that is listened to
+     * @return an unmodifiable map containing the result
      */
-    public Map<String, @Nullable Class<? extends State>> getClientItems(Item item);
+    Map<String, @Nullable Class<? extends State>> getClientItems(Item item);
 }

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ReadResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ReadResource.java
@@ -15,6 +15,7 @@ package org.openhab.ui.cometvisu.internal.backend.rest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -252,6 +253,6 @@ public class ReadResource implements EventBroadcaster, RESTResource {
 
     @Override
     public Map<String, @Nullable Class<? extends State>> getClientItems(Item item) {
-        return items.get(item);
+        return items.getOrDefault(item, Collections.emptyMap());
     }
 }

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/StateEventListener.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/listeners/StateEventListener.java
@@ -44,8 +44,8 @@ public class StateEventListener implements StateChangeListener {
 
     @Override
     public void stateChanged(Item item, State oldState, State newState) {
-        Map<String, Class<? extends State>> clientItems = eventBroadcaster.getClientItems(item);
-        if (clientItems != null && clientItems.size() > 0) {
+        final Map<String, Class<? extends State>> clientItems = eventBroadcaster.getClientItems(item);
+        if (!clientItems.isEmpty()) {
             for (String cvItemName : clientItems.keySet()) {
                 Class<? extends State> stateClass = clientItems.get(cvItemName);
                 StateBean stateBean = new StateBean();
@@ -70,8 +70,8 @@ public class StateEventListener implements StateChangeListener {
         if (item instanceof GroupItem) {
             // group item update could be relevant for the client, although the state of switch group does not change
             // wenn more the one are on, the number-groupFunction changes
-            Map<String, Class<? extends State>> clientItems = eventBroadcaster.getClientItems(item);
-            if (clientItems != null && clientItems.size() > 0) {
+            final Map<String, Class<? extends State>> clientItems = eventBroadcaster.getClientItems(item);
+            if (!clientItems.isEmpty()) {
                 for (String cvItemName : clientItems.keySet()) {
                     Class<? extends State> stateClass = clientItems.get(cvItemName);
                     if (stateClass != null) {


### PR DESCRIPTION
Instead of returning null, we return an empty map so the caller does not need to care about.

This fixed the following problem:

| Description | Resource | Path | Location | Type |
| --- | --- | --- | --- | --- |
| Null type mismatch (type annotations): required '@NonNull Map<@NonNull String,@Nullable Class<? extends @NonNull State>>' but this expression has type '@Nullable Map<@NonNull String,@Nullable Class<? extends @NonNull State>>' | ReadResource.java | /org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest | line 255 | Java Problem |
