### PR TITLE
basic ui: Properly handle escaped characters when parsing quantities

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
@@ -106,11 +106,13 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
         snippet = StringUtils.replace(snippet, "%visibility_class%",
                 itemUIRegistry.getVisiblity(w) ? "" : "mdl-form__row--hidden");
 
-        String state = getState(w);
-        snippet = StringUtils.replace(snippet, "%state%", escapeURL(state));
+        String rawState = getRawState(w);
+        snippet = StringUtils.replace(snippet, "%state%", escapeHtml(rawState));
+        snippet = StringUtils.replace(snippet, "%stateUrlEnc%", escapeURL(rawState));
 
-        String category = getCategory(w);
-        snippet = StringUtils.replace(snippet, "%category%", escapeURL(category));
+        String rawCategory = getRawCategory(w);
+        snippet = StringUtils.replace(snippet, "%category%", escapeHtml(rawCategory));
+        snippet = StringUtils.replace(snippet, "%categoryUrlEnc%", escapeURL(rawCategory));
 
         return snippet;
     }
@@ -276,11 +278,11 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
         return snippet;
     }
 
-    protected @Nullable String getCategory(Widget w) {
+    protected @Nullable String getRawCategory(Widget w) {
         return itemUIRegistry.getCategory(w);
     }
 
-    protected String getState(Widget w) {
+    protected String getRawState(Widget w) {
         State state = itemUIRegistry.getState(w);
         if (state != null) {
             return state.toString();

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
@@ -81,7 +81,7 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
 
         // Should be called before preprocessSnippet
         snippet = StringUtils.replace(snippet, "%state%", hexValue);
-        snippet = StringUtils.replace(snippet, "%icon_state%", escapeURL(hexValue));
+        snippet = StringUtils.replace(snippet, "%stateUrlEnc%", escapeURL(hexValue));
 
         snippet = preprocessSnippet(snippet, w);
         snippet = StringUtils.replace(snippet, "%purelabel%", purelabel);

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SetpointRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SetpointRenderer.java
@@ -75,7 +75,6 @@ public class SetpointRenderer extends AbstractWidgetRenderer {
         String snippet = getSnippet("setpoint");
 
         snippet = preprocessSnippet(snippet, w);
-        snippet = StringUtils.replace(snippet, "%value%", getValue(w));
         snippet = StringUtils.replace(snippet, "%minValue%", minValue.toString());
         snippet = StringUtils.replace(snippet, "%maxValue%", maxValue.toString());
         snippet = StringUtils.replace(snippet, "%step%", step.toString());

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/buttons.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/buttons.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/colorpicker.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/colorpicker.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%icon_state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/group.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/group.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet mdl-form__link %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/mapview.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/mapview.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
     <span class="mdl-form__icon">
-        <img data-icon="%category%" src="../icon/%category%?format=%icon_type%&anyFormat=true" />
+        <img data-icon="%category%" src="../icon/%categoryUrlEnc%?format=%icon_type%&anyFormat=true" />
     </span>
     <span %labelstyle% class="mdl-form__label">
         %label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/rollerblind.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/rollerblind.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/selection.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/selection.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet mdl-form__link %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label_header%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/setpoint.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/setpoint.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/slider.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/slider.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/switch.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/switch.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/text.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/text.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/text_link.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/text_link.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet mdl-form__link %visibility_class%">
 	<span class="mdl-form__icon">
-		<img data-icon="%category%" src="../icon/%category%?state=%state%&format=%icon_type%&anyFormat=true" />
+		<img data-icon="%category%" src="../icon/%categoryUrlEnc%?state=%stateUrlEnc%&format=%icon_type%&anyFormat=true" />
 	</span>
 	<span %labelstyle% class="mdl-form__label">
 		%label%

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/webview.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/webview.html
@@ -1,6 +1,6 @@
 <div class="mdl-form__row mdl-cell mdl-cell--6-col mdl-cell--8-col-tablet %visibility_class%">
     <span class="mdl-form__icon">
-        <img data-icon="%category%" src="../icon/%category%?format=%icon_type%&anyFormat=true" />
+        <img data-icon="%category%" src="../icon/%categoryUrlEnc%?format=%icon_type%&anyFormat=true" />
     </span>
     <span %labelstyle% class="mdl-form__label">
         %label%

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -918,7 +918,7 @@
 		_t.up = _t.parentNode.querySelector(o.setpoint.up);
 		_t.down = _t.parentNode.querySelector(o.setpoint.down);
 
-		_t.value = _t.parentNode.getAttribute("data-value");
+		_t.value = decodeURIComponent(_t.parentNode.getAttribute("data-value"));
 		_t.max = parseFloat(_t.parentNode.getAttribute("data-max"));
 		_t.min = parseFloat(_t.parentNode.getAttribute("data-min"));
 		_t.step = parseFloat(_t.parentNode.getAttribute("data-step"));

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -354,7 +354,7 @@
 				if (state.length < 200) {
 					_t.icon.setAttribute("src",
 						"/icon/" +
-						_t.iconName +
+						encodeURIComponent(_t.iconName) +
 						"?state=" +
 						encodeURIComponent(state) +
 						"&format=" +
@@ -364,7 +364,7 @@
 				} else {
 					_t.icon.setAttribute("src",
 						"/icon/" +
-						_t.iconName +
+						encodeURIComponent(_t.iconName) +
 						"?format=" +
 						smarthome.UI.iconType +
 						"&anyFormat=true"
@@ -918,7 +918,7 @@
 		_t.up = _t.parentNode.querySelector(o.setpoint.up);
 		_t.down = _t.parentNode.querySelector(o.setpoint.down);
 
-		_t.value = decodeURIComponent(_t.parentNode.getAttribute("data-value"));
+		_t.value = _t.parentNode.getAttribute("data-value");
 		_t.max = parseFloat(_t.parentNode.getAttribute("data-max"));
 		_t.min = parseFloat(_t.parentNode.getAttribute("data-min"));
 		_t.step = parseFloat(_t.parentNode.getAttribute("data-step"));


### PR DESCRIPTION
## Description

Quantity values can sometimes contain scientific notation. For example `7E+1 °F` (70 degrees Fahrenheit). The Basic UI backend URL encodes this value before rendering into the data attribute of the setpoint widget, so the value of the raw `data-value` attribute is `7E%2B1+%C2%B0F`.

To calculate the up/down steps, we of course have to parse this value. The current logic hands the URI-encoded blob directly to parseFloat, which (due to the escaping) fails to identify the scientific notation. In the example above, the 70 degrees gets parsed as 7 degrees--obviously an unintended result. This fixes the issue by decoding the escaped characters before attempting to parse the number.

## Changes

- Wrap value parsing in 'decodeURIComponent`

## Testing

I backported this to the `2.5.x` branch and validated on my setup, which consists of several Z-Wave thermostats (that are often set to 70 degrees). Validated that the number is parsed correctly and the up/down arrows behave as expected.

## Additional Notes

Note that the code that results in the state (data-value) attribute getting URL encoded is here: https://github.com/openhab/openhab-webui/blob/2.5.x/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java#L131

Whether or not encoding the state is the correct behavior in this situation I would leave up for debate. Additionally, passing the entire state string (with unit included) to `parseFloat`, does work, but feels somewhat like a hack since we rely on the function to ignore spaces and the unit characters (god forbid a unit abbreviation ever includes a digit or other character that might trip up the parser).

Issues handling scientific notation seem to be part of a wider class of bugs. The behavior is similarly broken in the iOS app (PR forthcoming).