### PR TITLE
Add a "pin" icon to remove the panel breakpoint

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -91,7 +91,7 @@
         </f7-list-item>
       </f7-list>
       <f7-link class="breakpoint-pin" @click="toggleVisibleBreakpoint">
-        <f7-icon slot="media" size="14" :f7="this.visibleBreakpointDisabled ? 'pin_fill' : 'pin'" color="gray"></f7-icon>
+        <f7-icon slot="media" size="14" :f7="this.visibleBreakpointDisabled ? 'pin_slash' : 'pin'" color="gray"></f7-icon>
       </f7-link>
 
       <div slot="fixed" class="account" v-if="ready">

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -90,7 +90,7 @@
           <f7-icon slot="media" ios="f7:question_circle_fill" aurora="f7:question_circle_fill" md="material:help" color="gray"></f7-icon>
         </f7-list-item>
       </f7-list>
-      <f7-link class="breakpointPin" @click="toggleVisibleBreakpoint">
+      <f7-link class="breakpoint-pin" @click="toggleVisibleBreakpoint">
         <f7-icon slot="media" size="14" :f7="this.visibleBreakpointDisabled ? 'pin_fill' : 'pin'" color="gray"></f7-icon>
       </f7-link>
 
@@ -206,14 +206,14 @@
       width 100%
       margin-bottom 0
       height calc(var(--f7-tabbar-labels-height) + var(--f7-safe-area-bottom))
-  .breakpointPin
+  .breakpoint-pin
     position fixed
     top calc(var(--f7-safe-area-top))
     right 0
-    margin 10px
+    margin 12px 10px
     opacity 0
   @media (min-width 960px)
-    .breakpointPin
+    .breakpoint-pin
       opacity 0.75
 
 .theme-dark

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -90,6 +90,9 @@
           <f7-icon slot="media" ios="f7:question_circle_fill" aurora="f7:question_circle_fill" md="material:help" color="gray"></f7-icon>
         </f7-list-item>
       </f7-list>
+      <f7-link class="breakpointPin" @click="toggleVisibleBreakpoint">
+        <f7-icon slot="media" size="14" :f7="this.visibleBreakpointDisabled ? 'pin_fill' : 'pin'" color="gray"></f7-icon>
+      </f7-link>
 
       <div slot="fixed" class="account" v-if="ready">
         <div class="display-flex justify-content-center">
@@ -203,6 +206,15 @@
       width 100%
       margin-bottom 0
       height calc(var(--f7-tabbar-labels-height) + var(--f7-safe-area-bottom))
+  .breakpointPin
+    position fixed
+    top calc(var(--f7-safe-area-top))
+    right 0
+    margin 10px
+    opacity 0
+  @media (min-width 960px)
+    .breakpointPin
+      opacity 0.75
 
 .theme-dark
   .panel-left
@@ -331,6 +343,7 @@ export default {
       sitemaps: null,
       pages: null,
       showSidebar: true,
+      visibleBreakpointDisabled: false,
       loginScreenOpened: false,
       loggedIn: false,
 
@@ -468,12 +481,21 @@ export default {
       } else {
         this.$$('html').removeClass('theme-dark')
       }
+      if (localStorage.getItem('openhab.ui:panel.visibleBreakpointDisabled') === 'true') {
+        this.visibleBreakpointDisabled = true
+        this.$nextTick(() => this.$f7.panel.get('left').disableVisibleBreakpoint())
+      }
     },
     toggleDeveloperSidebar () {
       if (!this.$store.getters.isAdmin) return
       this.showDeveloperSidebar = !this.showDeveloperSidebar
       if (this.showDeveloperSidebar) this.$store.dispatch('startTrackingStates')
       this.$store.commit('setDeveloperSidebar', this.showDeveloperSidebar)
+    },
+    toggleVisibleBreakpoint () {
+      this.$f7.panel.get('left').toggleVisibleBreakpoint()
+      this.visibleBreakpointDisabled = this.$f7.panel.get('left').visibleBreakpointDisabled
+      localStorage.setItem('openhab.ui:panel.visibleBreakpointDisabled', this.visibleBreakpointDisabled)
     },
     keyDown (ev) {
       if (ev.keyCode === 68 && ev.shiftKey && ev.altKey) {
@@ -504,6 +526,8 @@ export default {
   },
   mounted () {
     this.$f7ready((f7) => {
+      localStorage.getItem('openhab.ui:sidebar.noBreakpoint')
+
       this.updateThemeOptions()
       this.$f7.data.themeOptions = this.themeOptions
 

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -526,8 +526,6 @@ export default {
   },
   mounted () {
     this.$f7ready((f7) => {
-      localStorage.getItem('openhab.ui:sidebar.noBreakpoint')
-
       this.updateThemeOptions()
       this.$f7.data.themeOptions = this.themeOptions
 

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -156,7 +156,6 @@ export default {
       this.$store.dispatch('stopTrackingStates')
     },
     onPageInit () {
-      // this.$f7.panel.get('left').enableVisibleBreakpoint()
       if (window.OHApp) {
         if (window.OHApp.pinToHome) this.showPinToHome = true
         if (window.OHApp.exitToApp) this.showExitToApp = true

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -156,7 +156,7 @@ export default {
       this.$store.dispatch('stopTrackingStates')
     },
     onPageInit () {
-      this.$f7.panel.get('left').enableVisibleBreakpoint()
+      // this.$f7.panel.get('left').enableVisibleBreakpoint()
       if (window.OHApp) {
         if (window.OHApp.pinToHome) this.showPinToHome = true
         if (window.OHApp.exitToApp) this.showExitToApp = true

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -279,7 +279,7 @@ export default {
         () => {
           self.$f7.panel.get('left').enableVisibleBreakpoint()
           this.$nextTick(() => {
-            self.$f7.views.main.router.navigate('/', { transition: 'f7-cover-v', clearPreviousHistory: true })
+            self.$f7.views.main.router.navigate('/', { transition: 'f7-circle', clearPreviousHistory: true })
           })
         })
     },


### PR DESCRIPTION
Based on a experiment by @hubsif.
Save and restore the current status in localStorage.

Fixes #523.

Signed-off-by: Yannick Schaus <github@schaus.net>