### PR TITLE
[mainUI] add support for QR code context in configuration

### DIFF
--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -71,6 +71,7 @@
     "moo": "^0.5.1",
     "nearley": "^2.19.6",
     "pkce-challenge": "^2.1.0",
+    "qrcode": "^1.0.0",
     "sprintf-js": "^1.1.2",
     "template7": "^1.4.2",
     "tern": "^0.23.0",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -81,6 +81,7 @@
     "vue-fragment": "^1.5.1",
     "vue-knob-control": "^1.6.0",
     "vue-magic-grid": "0.0.4",
+    "vue-qrcode": "^0.3.5",
     "vue2-leaflet": "^2.5.2",
     "vuetrend": "^0.3.4",
     "vuex": "^3.5.1",

--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -31,6 +31,7 @@ import ParameterPersistenceService from './controls/parameter-persistenceservice
 import ParameterProps from './controls/parameter-props.vue'
 import ParameterTriggerChannel from './controls/parameter-triggerchannel.vue'
 import ParameterText from './controls/parameter-text.vue'
+import ParameterQrcode from './controls/parameter-qrcode.vue'
 
 export default {
   components: {
@@ -81,8 +82,9 @@ export default {
         return ParameterTriggerChannel
       } else if (configDescription.type === 'TEXT' && configDescription.context === 'persistenceService') {
         return ParameterPersistenceService
+      } else if (configDescription.type === 'TEXT' && configDescription.context === 'qrcode') {
+        return ParameterQrcode
       }
-
       return ParameterText
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-qrcode.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-qrcode.vue
@@ -10,12 +10,10 @@
 </template>
 
 <script>
- import VueQrcode from 'vue-qrcode'
-
 export default {
   props: ['configDescription', 'value'],
   components: {
-      VueQrcode
-    }
+    'vue-qrcode': () => import(/* webpackChunkName: "vue-qrcode" */ 'vue-qrcode')
+  }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-qrcode.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-qrcode.vue
@@ -1,0 +1,21 @@
+<template>
+  <ul>
+    <f7-list-item
+      :floating-label="$theme.md"
+      :title="configDescription.label"
+    >
+        <vue-qrcode :value="value" slot="media"/>
+    </f7-list-item>
+  </ul>
+</template>
+
+<script>
+ import VueQrcode from 'vue-qrcode'
+
+export default {
+  props: ['configDescription', 'value'],
+  components: {
+      VueQrcode
+    }
+}
+</script>


### PR DESCRIPTION
add support for context "QRCode" to binding configuration view. 
it can be used for example for HomeKit pairing. 

it looks like this
![image](https://user-images.githubusercontent.com/11726616/101758844-1df76980-3ad9-11eb-9b06-faec35eeb745.png)


Signed-off-by: Eugen Freiter <freiter@gmx.de>