### PR TITLE
Routable model picker, add to item picker & Blockly

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ohblocks.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ohblocks.js
@@ -1,6 +1,25 @@
 import Blockly from 'blockly'
+import { FieldItemModelPicker } from './ohitemfield'
 
-export default function defineOHBlocks () {
+export default function defineOHBlocks (f7) {
+  Blockly.Blocks['oh_item'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('item')
+        .appendField(new FieldItemModelPicker('MyItem', null, { f7 }), 'itemName')
+      this.setColour(0)
+      this.setInputsInline(true)
+      this.setTooltip('Pick an item from the Model')
+      this.setOutput(true, null)
+    }
+  }
+
+  Blockly.JavaScript['oh_item'] = function (block) {
+    const itemName = block.getFieldValue('itemName')
+    var code = '\'' + itemName + '\''
+    return [code, 0]
+  }
+
   Blockly.Blocks['oh_getitem_state'] = {
     init: function () {
       this.appendValueInput('itemName')

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ohitemfield.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ohitemfield.js
@@ -1,0 +1,45 @@
+import Blockly from 'blockly'
+import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
+
+export class FieldItemModelPicker extends Blockly.FieldTextInput {
+  constructor (optValue, optValidator, optConfig) {
+    super(optValue, optValidator, optConfig)
+    if (optConfig.f7) this.f7 = optConfig.f7
+  }
+
+  static fromJson (options) {
+    return new FieldItemModelPicker(options['options'], undefined, options)
+  }
+
+  showEditor_ (options) {
+    if (this.f7) {
+      const itemsPicked = (value) => {
+        this.value_ = value.name
+        this.setEditorValue_(this.value)
+      }
+      const popup = {
+        component: ModelPickerPopup
+      }
+
+      this.f7.views.main.router.navigate({
+        url: 'pick-from-model',
+        route: {
+          path: 'pick-from-model',
+          popup
+        }
+      }, {
+        props: {
+          value: this.value_,
+          multiple: false
+        }
+      })
+
+      this.f7.once('itemsPicked', itemsPicked)
+      this.f7.once('modelPickerClosed', () => {
+        this.f7.off('itemsPicked', itemsPicked)
+      })
+    }
+  }
+}
+
+Blockly.fieldRegistry.register('oh_item_field', FieldItemModelPicker)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -20,12 +20,9 @@
         </f7-block-footer>
         <f7-list v-if="thingId">
           <ul v-if="parentGroup">
-            <item :item="parentGroup" :link="true" @click="modelPickerOpened = true" />
+            <item :item="parentGroup" :link="true" @click="openModelPicker" />
           </ul>
-          <f7-list-item v-else title="Pick From Model" link @click="modelPickerOpened = true" />
-          <model-picker-popup :value="(parentGroup) ? parentGroup.name : null" popup-title="Parent Group"
-            :allow-empty="true" :groups-only="true" :opened="modelPickerOpened"
-            @input="(item) => parentGroup = item" @closed="modelPickerOpened = false" />
+          <f7-list-item v-else title="Pick From Model" link @click="openModelPicker" />
         </f7-list>
         <f7-block-title v-if="selectedThing.statusInfo">Source Thing</f7-block-title>
         <f7-list v-if="selectedThing.statusInfo" media-list>
@@ -98,7 +95,6 @@ export default {
   mixins: [ThingStatus],
   components: {
     Item,
-    ModelPickerPopup,
     ThingPicker,
     ChannelList,
     ItemForm
@@ -113,8 +109,7 @@ export default {
       selectedThingType: {},
       selectedThingChannelTypes: {},
       newEquipmentItem: {},
-      newPointItems: [],
-      modelPickerOpened: false
+      newPointItems: []
     }
   },
   methods: {
@@ -217,6 +212,35 @@ export default {
         dialog.close()
         console.error(err)
         this.$f7.dialog.alert('An error occurred while creating the items: ' + err)
+      })
+    },
+    pickParentFromModel (value) {
+      this.parentGroup = value
+    },
+    openModelPicker () {
+      const popup = {
+        component: ModelPickerPopup
+      }
+
+      this.$f7router.navigate({
+        url: 'pick-from-model',
+        route: {
+          path: 'pick-from-model',
+          popup
+        }
+      }, {
+        props: {
+          value: (this.parentGroup) ? this.parentGroup.name : null,
+          multiple: false,
+          allowEmpty: true,
+          popupTitle: 'Parent Group',
+          groupsOnly: true
+        }
+      })
+
+      this.$f7.once('itemsPicked', this.pickParentFromModel)
+      this.$f7.once('modelPickerClosed', () => {
+        this.$f7.off('itemsPicked', this.pickParentFromModel)
       })
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -37,8 +37,6 @@
         <oh-layout-page class="layout-page" v-if="ready && previewMode" :context="context" :key="pageKey" />
       </f7-tab>
     </f7-tabs>
-
-    <model-picker-popup :opened="modelPickerOpened" :multiple="modelPickerAllowMultiple" @closed="modelPickerOpened = false" @input="doAddFromModel" action-label="Add" />
   </f7-page>
 </template>
 
@@ -138,7 +136,28 @@ export default {
         const addFromModel = () => {
           this.addFromModelContext = { component, slot, isList, isCells }
           this.modelPickerAllowMultiple = component.component !== 'oh-grid-col'
-          this.modelPickerOpened = true
+          const popup = {
+            component: ModelPickerPopup
+          }
+
+          this.$f7router.navigate({
+            url: 'pick-from-model',
+            route: {
+              path: 'pick-from-model',
+              popup
+            }
+          }, {
+            props: {
+              multiple: this.modelPickerAllowMultiple,
+              popupTitle: 'Add from Model'
+            }
+          })
+
+          this.$f7.once('itemsPicked', this.doAddFromModel)
+          this.$f7.once('modelPickerClosed', () => {
+            this.$f7.off('itemsPicked', this.doAddFromModel)
+          })
+
           this.$nextTick(() => actions.destroy())
         }
         const stdWidgets = (isList) ? StandardListWidgets : (isCells) ? StandardCellWidgets : StandardWidgets

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -295,10 +295,38 @@
           </block>
         </category>
         <category name="openHAB" colour="0">
-          <block type="oh_getitem_state" />
-          <block type="oh_event" />
-          <block type="oh_log" />
-          <block type="oh_print" />
+          <block type="oh_item" />
+          <block type="oh_getitem_state">
+            <value name="itemName">
+              <shadow type="oh_item">
+              </shadow>
+            </value>
+          </block>
+          <block type="oh_event">
+            <value name="value">
+              <shadow type="text">
+                <field name="TEXT">value</field>
+              </shadow>
+            </value>
+            <value name="itemName">
+              <shadow type="oh_item">
+              </shadow>
+            </value>
+          </block>
+          <block type="oh_log">
+            <value name="message">
+              <shadow type="text">
+                <field name="TEXT">abc</field>
+              </shadow>
+            </value>
+          </block>
+          <block type="oh_print">
+            <value name="message">
+              <shadow type="text">
+                <field name="TEXT">abc</field>
+              </shadow>
+            </value>
+          </block>
         </category>
 
         <sep></sep>
@@ -339,7 +367,7 @@ export default {
     }
   },
   mounted () {
-    defineOHBlocks()
+    defineOHBlocks(this.$f7)
     this.workspace = Blockly.inject(this.$refs.blocklyEditor, {
       toolbox: this.$refs.toolbox,
       horizontalLayout: !this.$device.desktop,


### PR DESCRIPTION
Make the model picker popup dialog routable (i.e. responds to
browser-native navigation).

Add an icon to item picker to open the model picker instead
of the standard smart select flat list.

Add a new item field & block to Blockly to easily pick an item
from the model with the dialog. Add "shadow" blocks to openHAB
blocks (can be replaced by the user).

Signed-off-by: Yannick Schaus <github@schaus.net>