### PR TITLE
Use Jenkins Build Status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <img align="right" width="220" src="./logo.png" />
 
-[![Build Status](https://travis-ci.com/openhab/openhab-addons.svg)](https://travis-ci.com/openhab/openhab-webui)
+[![Build Status](https://ci.openhab.org/job/openHAB-WebUI/badge/icon)](https://ci.openhab.org/job/openHAB-WebUI/)
 [![EPL-2.0](https://img.shields.io/badge/license-EPL%202-green.svg)](https://opensource.org/licenses/EPL-2.0)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=2164344)](https://www.bountysource.com/teams/openhab/issues?tracker_ids=2164344)
 


### PR DESCRIPTION
So it shows the actual status instead of some outdated Travis CI status.