### PR TITLE
Misc styling fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/model-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/model-card.vue
@@ -9,7 +9,7 @@
               <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.header" :key="'header-' + idx" @command="onCommand" />
             </div>
             <div v-else>
-              {{title}}
+              <div class="title">{{title}}</div>
               <div v-if="subtitle" class="subtitle"><small>{{subtitle || '&nbsp;'}}</small></div>
             </div>
           </slot>
@@ -69,7 +69,10 @@
     .card-background
       transform translateX(0)
 
+  .title
+    max-width calc(340px - 2*var(--f7-card-header-padding-horizontal))
   .subtitle
+    max-width calc(340px - 2*var(--f7-card-header-padding-horizontal))
     font-weight normal
     font-size normal
     line-height 0.7

--- a/bundles/org.openhab.ui/web/src/pages/about.vue
+++ b/bundles/org.openhab.ui/web/src/pages/about.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page name="about" class="page-about" @page:beforein="beforePageIn">
-    <f7-navbar large :title-large="$t('about.title')" title="About" :back-link="$t('dialogs.back')"></f7-navbar>
+    <f7-navbar large :title-large="$t('about.title')" :title="$t('about.title')" :back-link="$t('dialogs.back')"></f7-navbar>
     <f7-block class="block-narrow after-big-title">
       <f7-row>
         <f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -52,7 +52,7 @@
   color var(--f7-navbar-link-color)
   transition color 0.3s
 .home-nav .home-title-large .title-large-text
-  line-height 0.95
+  line-height 0.98
   .today
     position absolute
     font-size 8pt

--- a/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
@@ -116,8 +116,8 @@ export default {
         }, {})
 
         this.model.locations = locations.map(l => this.buildModelCard('location', l, l.item.name, page))
-        this.model.equipment = Object.keys(equipment).sort().map(k => this.buildModelCard('equipment', equipment[k], k, page))
-        this.model.properties = Object.keys(properties).sort().map(k => this.buildModelCard('property', properties[k], k, page))
+        this.model.equipment = Object.keys(equipment).sort((a, b) => this.$t(a).localeCompare(this.$t(b))).map(k => this.buildModelCard('equipment', equipment[k], k, page))
+        this.model.properties = Object.keys(properties).sort((a, b) => this.$t(a).localeCompare(this.$t(b))).map(k => this.buildModelCard('property', properties[k], k, page))
         this.modelReady = true
       })
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -60,7 +60,7 @@
           ref="itemsList"
           media-list
           virtual-list
-          :virtual-list-params="{ items, searchAll, renderExternal, height: $theme.ios ? 78 : $theme.aurora ? 60 : 87}"
+          :virtual-list-params="{ items, searchAll, renderExternal, height: vlData.height }"
         >
           <ul>
             <f7-list-item
@@ -114,6 +114,11 @@
 <script>
 export default {
   data () {
+    let vlHeight
+    if (this.$theme.ios) vlHeight = 78
+    if (this.$theme.aurora) vlHeight = 60
+    if (this.$theme.md) vlHeight = 87
+    if (this.$device.firefox) vlHeight += 1
     return {
       ready: false,
       loading: false,
@@ -121,7 +126,8 @@ export default {
       indexedItems: {},
       initSearchbar: false,
       vlData: {
-        items: []
+        items: [],
+        height: vlHeight
       },
       selectedItems: [],
       showCheckboxes: false,


### PR DESCRIPTION
Fix #619 - virtual list height glitch in Firefox.
(not perfect but will have to do).

Fix #624 - sort equipment/properties cards according to translated title

Wrap card titles to avoid overflow in cases of long translations.

Signed-off-by: Yannick Schaus <github@schaus.net>