### PR TITLE
[Main UI/HABPanel] Mobile app interface, part 2

### DIFF
--- a/bundles/org.openhab.ui.habpanel/web/app/menu/menu.controller.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/menu/menu.controller.js
@@ -13,6 +13,14 @@
         vm.editMode = false;
         vm.customWidgetsModels = {};
         vm.customDrawerWidgetsModels = {};
+        vm.canPinToHome = (window.OHApp && typeof window.OHApp.pinToHome === 'function');
+        vm.canExitToApp = (window.OHApp && typeof window.OHApp.exitToApp === 'function');
+        if (window.OHApp && typeof window.OHApp.goFullscreen === 'function') {
+            try {
+                window.OHApp.goFullscreen();
+            } catch (e) {
+            }
+        }
 
         activate();
 
@@ -87,8 +95,19 @@
 
 		vm.goFullscreen = function () {
 			Fullscreen.toggleAll();
-		}
+        }
+        
+        vm.pinToHome = function () {
+            if (window.OHApp && window.OHApp.pinToHome) {
+                window.OHApp.pinToHome();
+            }
+        }
 
+        vm.exitToApp = function () {
+            if (window.OHApp && window.OHApp.exitToApp) {
+                window.OHApp.exitToApp();
+            }
+        }
 
         vm.openDashboardSettings = function(dashboard) {
             $modal.open({

--- a/bundles/org.openhab.ui.habpanel/web/app/menu/menu.html
+++ b/bundles/org.openhab.ui.habpanel/web/app/menu/menu.html
@@ -11,6 +11,16 @@
         ng-hide="lockEditing" ng-click="vm.toggleEditMode()" ng-class="{ 'btn-danger': vm.editMode }">
         <i class="glyphicon glyphicon-cog"></i>
     </a>
+    <a class="btn pull-right" 
+        title="Pin to Home"
+        ng-hide="!vm.canPinToHome" ng-click="vm.pinToHome()">
+        <i class="glyphicon glyphicon-pushpin"></i>
+    </a>
+    <a class="btn pull-right" 
+        title="Return to App"
+        ng-hide="!vm.canExitToApp" ng-click="vm.exitToApp()">
+        <i class="glyphicon glyphicon-log-out"></i>
+    </a>
     <h2 class="dashboard-title">
         <small class="header-clock" ng-if="settings.show_header_clock"><ds-widget-clock show-digital digital-format="settings.header_clock_format || 'shortTime'"></ds-widget-clock></small>
     </h2>

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -471,7 +471,7 @@ export default {
       })
     },
     updateThemeOptions () {
-      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || ((window.OHApp && window.OHApp.preferDarkMode) ? window.OHApp.preferDarkMode().toString() === 'dark' : (this.$f7.darkTheme ? 'dark' : 'light'))
+      this.themeOptions.dark = localStorage.getItem('openhab.ui:theme.dark') || ((window.OHApp && window.OHApp.preferDarkMode) ? window.OHApp.preferDarkMode().toString() : (this.$f7.darkTheme ? 'dark' : 'light'))
       this.themeOptions.bars = localStorage.getItem('openhab.ui:theme.bars') || ((this.$theme.ios || this.$f7.darkTheme || this.themeOptions.dark === 'dark') ? 'light' : 'filled')
       this.themeOptions.homeNavbar = localStorage.getItem('openhab.ui:theme.home.navbar') || 'default'
       this.themeOptions.homeBackground = localStorage.getItem('openhab.ui:theme.home.background') || 'default'
@@ -508,6 +508,12 @@ export default {
   created () {
     // special treatment for this option because it's needed to configure the app initialization
     this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.pagetransition') || 'default'
+    // tell the app to go fullscreen (if the OHApp is supported)
+    if (window.OHApp && typeof window.OHApp.goFullscreen === 'function') {
+      try {
+        window.OHApp.goFullscreen()
+      } catch {}
+    }
     // this.loginScreenOpened = true
     const refreshToken = this.getRefreshToken()
     if (refreshToken) {


### PR DESCRIPTION
This adds support for the "OHApp" mobile app interface to HABPanel, and
fixes setting the main UI's dark mode by the app.
They will also call OHApp.goFullscreen()
on startup if the function exists.

Currently supported in the OHApp interface:
```js
window.OHApp = {
  preferDarkMode() { return 'light' },
  preferTheme() { return 'md' },
  pinToHome() { alert('pinned') },
  exitToApp() { alert('exit') }
  goFullscreen() { console.log('Going fullscreen') }
}
```

Signed-off-by: Yannick Schaus <github@schaus.net>