### PR TITLE
Better handling of auto-update value

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
@@ -1,9 +1,9 @@
 <template>
   <div>
     <f7-list>
-      <f7-list-item title="Force auto-update">
-        <f7-toggle slot="after" name="autoupdate" :checked="typeof (metadata.value) === 'string' ? metadata.value === 'true' : metadata.value"
-          @toggle:change="(ev) => metadata.value = ev"></f7-toggle>
+      <f7-list-item title="Force auto-update" checkbox :checked="typeof (metadata.value) === 'string' ? metadata.value === 'true' : metadata.value"
+        :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'"
+        @change="(ev) => metadata.value = new Boolean(ev.target.checked).toString()">
       </f7-list-item>
     </f7-list>
     <f7-block-footer class="param-description">


### PR DESCRIPTION
Includes a indeterminate state when the value
is neither true or false.

Fixes #587.

Signed-off-by: Yannick Schaus <github@schaus.net>