### PR TITLE
Charts: scrollable analyzer legend, calendar

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -281,10 +281,24 @@ export default {
       }
 
       calendarOptions.range = [startTime.toDate(), endTime.subtract(1, 'second').toDate()]
-      calendarOptions.top = 60
-      calendarOptions.bottom = 60
+      calendarOptions.top = 20
+      calendarOptions.bottom = 20
       calendarOptions.left = 60
       calendarOptions.right = 60
+
+      if (document && document.documentElement.classList.contains('theme-dark')) {
+        if (!calendarOptions.itemStyle) calendarOptions.itemStyle = {}
+        if (!calendarOptions.itemStyle.color) calendarOptions.itemStyle.color = '#202020'
+        if (!calendarOptions.itemStyle.borderColor) calendarOptions.itemStyle.borderColor = '#555'
+        if (!calendarOptions.itemStyle) calendarOptions.itemStyle = {}
+        if (!calendarOptions.dayLabel) calendarOptions.dayLabel = {}
+        if (!calendarOptions.dayLabel.color) calendarOptions.dayLabel.color = '#aaa'
+        if (!calendarOptions.monthLabel) calendarOptions.monthLabel = {}
+        if (!calendarOptions.monthLabel.color) calendarOptions.monthLabel.color = '#aaa'
+        if (!calendarOptions.splitLine) calendarOptions.splitLine = {}
+        if (!calendarOptions.splitLine.lineStyle) calendarOptions.splitLine.lineStyle = {}
+        if (!calendarOptions.splitLine.lineStyle.color) calendarOptions.splitLine.lineStyle.color = '#aaa'
+      }
 
       options.calendar = calendarOptions
 

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -24,7 +24,7 @@
           <f7-list-input v-if="supports('encoding')" label="Encoding" type="text" :value="widget.config.encoding" @input="updateParameter('encoding', $event)" clear-button />
           <f7-list-input v-if="supports('service')" label="Service" type="text" :value="widget.config.service" @input="updateParameter('service', $event)" clear-button />
           <f7-list-input v-if="supports('period')" label="Period" type="text" :value="widget.config.period" @input="updateParameter('period', $event)" clear-button />
-          <f7-list-input v-if="supports('height')" label="Height" type="text" :value="widget.config.height" @input="updateParameter('height', $event)" clear-button />
+          <f7-list-input v-if="supports('height')" label="Height" type="number" :value="widget.config.height" @input="updateParameter('height', $event)" clear-button />
           <f7-list-input v-if="supports('sendFrequency')" label="Frequency" type="text" :value="widget.config.sendFrequency" @input="updateParameter('sendFrequency', $event)" clear-button />
           <f7-list-input v-if="supports('frequency')" label="Frequency" type="text" :value="widget.config.frequency" @input="updateParameter('frequency', $event)" clear-button />
           <f7-list-input v-if="supports('minValue')" label="Minimum" type="number" :value="widget.config.minValue" @input="updateParameter('minValue', $event)" clear-button />

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-calendar-axis.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-calendar-axis.js
@@ -12,9 +12,23 @@ export default {
     }
 
     if (!calendar.top) calendar.top = 100
-    if (!calendar.bottom) calendar.bottom = 100
-    if (!calendar.left) calendar.left = 100
-    if (!calendar.right) calendar.right = 100
+    if (!calendar.bottom) calendar.bottom = 50
+    if (!calendar.left) calendar.left = 60
+    if (!calendar.right) calendar.right = 50
+
+    if (document && document.documentElement.classList.contains('theme-dark')) {
+      if (!calendar.itemStyle) calendar.itemStyle = {}
+      if (!calendar.itemStyle.color) calendar.itemStyle.color = '#333'
+      if (!calendar.itemStyle.borderColor) calendar.itemStyle.borderColor = '#555'
+      if (!calendar.itemStyle) calendar.itemStyle = {}
+      if (!calendar.dayLabel) calendar.dayLabel = {}
+      if (!calendar.dayLabel.color) calendar.dayLabel.color = '#aaa'
+      if (!calendar.monthLabel) calendar.monthLabel = {}
+      if (!calendar.monthLabel.color) calendar.monthLabel.color = '#aaa'
+      if (!calendar.splitLine) calendar.splitLine = {}
+      if (!calendar.splitLine.lineStyle) calendar.splitLine.lineStyle = {}
+      if (!calendar.splitLine.lineStyle.color) calendar.splitLine.lineStyle.color = '#aaa'
+    }
 
     return calendar
   }

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/chart-aggregate.js
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/chart-aggregate.js
@@ -153,7 +153,8 @@ export default {
         {
           component: 'oh-chart-legend',
           config: {
-            bottom: 5
+            bottom: 3,
+            type: 'scroll'
           }
         }
       ]

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/chart-time.js
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/chart-time.js
@@ -119,7 +119,8 @@ export default {
       {
         component: 'oh-chart-legend',
         config: {
-          bottom: 5
+          bottom: 3,
+          type: 'scroll'
         }
       }
     ]


### PR DESCRIPTION
Use the scroll option to keep analyzer charts
legend one line only
Fixes #539.

Fixes calendar axes not supporting dark mode by
supplying default colors.

Signed-off-by: Yannick Schaus <github@schaus.net>