### PR TITLE
Use summary=true for lists & counters

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -360,9 +360,9 @@ export default {
           Promise.resolve(this.cachedObjects[3])
         ] : [
           this.$oh.api.get('/rest/items'),
-          this.$oh.api.get('/rest/things'),
-          this.$oh.api.get('/rest/rules'),
-          this.$oh.api.get('/rest/ui/components/ui:page')
+          this.$oh.api.get('/rest/things?summary=true'),
+          this.$oh.api.get('/rest/rules?summary=true'),
+          Promise.resolve(this.$store.getters.pages)
         ]
 
       this.searchResultsLoading = true

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -156,7 +156,7 @@ export default {
       this.loading = true
       this.$set(this, 'selectedItems', [])
       this.showCheckboxes = false
-      this.$oh.api.get('/rest/rules' + (this.showScripts ? '?tags=Script' : '')).then(data => {
+      this.$oh.api.get('/rest/rules?summary=true' + (this.showScripts ? '&tags=Script' : '')).then(data => {
         this.rules = data.sort((a, b) => {
           return a.name.localeCompare(b.name)
         })

--- a/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
@@ -209,9 +209,9 @@ export default {
     loadCounters () {
       if (!this.apiEndpoints) return
       if (this.$store.getters.apiEndpoint('inbox')) this.$oh.api.get('/rest/inbox').then((data) => { this.inboxCount = data.filter((e) => e.flag === 'NEW').length.toString() })
-      if (this.$store.getters.apiEndpoint('things')) this.$oh.api.get('/rest/things').then((data) => { this.thingsCount = data.length.toString() })
+      if (this.$store.getters.apiEndpoint('things')) this.$oh.api.get('/rest/things?summary=true').then((data) => { this.thingsCount = data.length.toString() })
       if (this.$store.getters.apiEndpoint('items')) this.$oh.api.get('/rest/items').then((data) => { this.itemsCount = data.length.toString() })
-      if (this.$store.getters.apiEndpoint('ui')) this.$oh.api.get('/rest/ui/components/system:sitemap').then((data) => { this.sitemapsCount = data.length })
+      if (this.$store.getters.apiEndpoint('ui')) this.$oh.api.get('/rest/ui/components/system:sitemap?summary=true').then((data) => { this.sitemapsCount = data.length })
     },
     onPageInit () {
       this.loadMenu()

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -168,7 +168,7 @@ export default {
     },
     load () {
       this.loading = true
-      this.$oh.api.get('/rest/things').then((data) => {
+      this.$oh.api.get('/rest/things?summary=true').then((data) => {
         this.things = data.sort((a, b) => a.label.localeCompare(b.label))
         this.initSearchbar = true
         this.loading = false


### PR DESCRIPTION
Use the summary option added to some API resources in
https://github.com/openhab/openhab-core/pull/1827
when displaying counters or lists that don't
need the entire object.

Signed-off-by: Yannick Schaus <github@schaus.net>