### PR TITLE
Avoid the colorpicker entering endless loops

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <item-state-preview v-if="model.item.created !== false" :item="model.item" :context="context" />
+    <item-state-preview v-if="model.item.created !== false" :item="model.item" :context="context" :key="$utils.id()" />
 
     <f7-block-title>Item</f7-block-title>
     <item-details :model="model" :links="links" @item-updated="$emit('item-updated')" @item-created="$emit('item-created')" @item-removed="$emit('item-removed')" @cancel-create="$emit('cancel-create')" />

--- a/bundles/org.openhab.ui/web/src/js/store/modules/states.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/states.js
@@ -111,8 +111,11 @@ const actions = {
       this._vm.$oh.api.postPlain('/rest/events/states/' + context.state.trackerConnectionId, trackingListJson, 'text/plain', 'application/json')
     })
   },
-  sendCommand (context, { itemName, cmd }) {
+  sendCommand (context, { itemName, cmd, updateState }) {
     console.log(`Sending command to ${itemName}: ${cmd}`)
+    if (updateState) {
+      context.commit('setItemState', { itemName, itemState: { state: cmd } })
+    }
     return this._vm.$oh.api.postPlain('/rest/items/' + itemName, cmd, 'text/plain', 'text/plain')
   }
 }


### PR DESCRIPTION
As reported in https://community.openhab.org/t/wiki-building-pages-in-the-oh3-ui-documentation-draft-1-3/104382/58
Sometimes the colorpicker enter infinite loops
sending the same command endlessly, due to
either rounding errors in the HSB components
or other causes.

These fixes should make it better and avoid
these situations.

Add a key to the widget preview in the model
details to avoid reusing widgets when the
configuration differs.

Signed-off-by: Yannick Schaus <github@schaus.net>