### PR TITLE
Photo browser action: allow to parse the array of photos

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -163,7 +163,7 @@ export const actionsMixin = {
           const self = this
           let photos = actionConfig[prefix + 'actionPhotos']
           let photoBrowserConfig = actionConfig[prefix + 'actionPhotoBrowserConfig']
-          if (typeof photos === 'string' && photos.startsWith('{')) photos = JSON.parse(photos)
+          if (typeof photos === 'string' && photos.startsWith('[')) photos = JSON.parse(photos)
           if (typeof photoBrowserConfig === 'string' && photoBrowserConfig.startsWith('{')) photoBrowserConfig = JSON.parse(photoBrowserConfig)
           if (photos && photos.length > 0) {
             const promises = photos.map((el) => {


### PR DESCRIPTION
Fix bug that detects a JSON object instead of
an array.

Signed-off-by: Yannick Schaus <github@schaus.net>