### PR TITLE
Disable slider in item action module wizard

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/rule/action-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/action-module-wizard.vue
@@ -49,13 +49,13 @@
       <f7-list-item radio :checked="currentModule.configuration.command === suggestion.command" v-for="suggestion in commandSuggestions" :key="suggestion.command"
         :title="suggestion.label" @click="$set(currentModule.configuration, 'command', suggestion.command)" />
     </f7-list>
-    <f7-block v-if="currentItem && (currentItem.type === 'Dimmer' || currentItem.type === 'Rollershutter' || (currentItem.type === 'Number' && currentItem.stateDescription && currentItem.stateDescription.minimum !== undefined))">
+    <!-- <f7-block v-if="currentItem && (currentItem.type === 'Dimmer' || currentItem.type === 'Rollershutter' || (currentItem.type === 'Number' && currentItem.stateDescription && currentItem.stateDescription.minimum !== undefined))">
       <f7-range :value="currentModule.configuration.command" @range:changed="(val) => $set(currentModule.configuration, 'command', val)"
         :min="(currentItem.stateDescription && currentItem.stateDescription.minimum) ? currentItem.stateDescription.minimum : 0"
         :max="(currentItem.stateDescription && currentItem.stateDescription.maximum) ? currentItem.stateDescription.maximum : 100"
         :step="(currentItem.stateDescription && currentItem.stateDescription.step) ? currentItem.stateDescription.step : 1"
         :scale="true" :label="true" :scaleSubSteps="5" />
-    </f7-block>
+    </f7-block> -->
     <f7-list v-if="currentItem && currentItem.type === 'Color'" media-list>
       <f7-list-input media-item type="colorpicker" label="Pick a color" :color-picker-params="{
           targetEl: '#color-picker-value',

--- a/bundles/org.openhab.ui/web/src/components/rule/trigger-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/trigger-module-wizard.vue
@@ -44,7 +44,7 @@
       <f7-list-item radio v-if="currentItem && currentItem.type === 'Group'" :checked="itemEventType === 'memberUpdated'" name="itemEventType" title="had a member update" @click="updateItemEventType('memberUpdated')" />
       <f7-list-item radio v-if="currentItem && currentItem.type === 'Group'" :checked="itemEventType === 'memberChanged'" name="itemEventType" title="had a member change" @click="updateItemEventType('memberChanged')" />
     </f7-list>
-    <f7-list>
+    <f7-list :key="itemEventType">
       <f7-list-input
         v-if="itemEventType === 'command' || itemEventType === 'memberCommand'"
         label="Command"
@@ -102,7 +102,7 @@
       <f7-list-item radio v-if="currentModule.configuration.thingUID" :checked="thingEventType === 'statusUpdated'" name="thingEventType" title="status was updated" @click="updateThingEventType('statusUpdated')" />
       <f7-list-item radio v-if="currentModule.configuration.thingUID" :checked="thingEventType === 'statusChanged'" name="thingEventType" title="status changed" @click="updateThingEventType('statusChanged')" />
     </f7-list>
-    <f7-list>
+    <f7-list :key="thingEventType">
       <f7-list-item
         v-if="thingEventType === 'statusUpdated'"
         title="to"
@@ -269,15 +269,19 @@ export default {
     },
     updateThingEventType (type) {
       this.thingEventType = type
+      const currentThingUID = this.currentModule.configuration.thingUID
       switch (type) {
         case 'triggerChannelFired':
           this.$emit('typeSelect', 'core.ChannelEventTrigger', true)
+          if (currentThingUID) this.$set(this.currentModule, 'configuration', Object.assign({}, { thingUID: currentThingUID }))
           break
         case 'statusUpdated':
           this.$emit('typeSelect', 'core.ThingStatusUpdateTrigger', true)
+          if (currentThingUID) this.$set(this.currentModule, 'configuration', Object.assign({}, { thingUID: currentThingUID }))
           break
         case 'statusChanged':
           this.$emit('typeSelect', 'core.ThingStatusChangeTrigger', true)
+          if (currentThingUID) this.$set(this.currentModule, 'configuration', Object.assign({}, { thingUID: currentThingUID }))
           break
       }
     },


### PR DESCRIPTION
The rule designer's new action module wizard
has a slider to help set the command for dimmers,
rollershutters & numbers but it doesn't work well
and prevents the input of command values
outside the range, which might prove problematic
(in particular there's no way anymore to set a
rollershutter item to UP/DOWN/STOP...).
So disable it for now.

Also fix bugs with the "thing" trigger wizard.

Signed-off-by: Yannick Schaus <github@schaus.net>