### PR TITLE
[WIP]Adds additional CSP contents to enable videojs and our ipcamera binding

### DIFF
--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -11,7 +11,7 @@
     * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content:; media-src * blob:; worker-src * blob:">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
 
   <meta name="theme-color" content="#e64a19">

--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -11,7 +11,7 @@
     * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content:; media-src * blob:; worker-src * blob:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content: blob:">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
 
   <meta name="theme-color" content="#e64a19">


### PR DESCRIPTION
Signed-off-by: Dan Cunningham <dan@digitaldan.com>

 i was not able to load m3u8/ts content from our ipcamera binding  with the new video widget as the CSP policy was blocking the media being loaded as well as blocking a web worker from doing something (might be in the videojs library?) .  

The camera binding runs the HLS stream for cameras on different ports,  so camera 1 might have a http dash stream on 10001, camera2 on 10002, and so on , which the browser will treat as different domains i believe.    I'm no expert on CSP policy so i don't know if the exceptions in this PR create a meaningful security hole.

  I personally would rather have a bit more relaxed CSP policy to load external content since the UI is not normally exposed unauthenticated (by firewall,  the cloud service, etc..) 