### PR TITLE
Fix #684 - Allow diacritics in search bars

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -13,7 +13,6 @@
           search-container=".widgets-list"
           search-item=".widgetlist-item"
           search-in=".item-title, .item-subtitle, .item-header, .item-footer"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-add.vue
@@ -2,7 +2,13 @@
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="addonPopupOpened = false" @page:afterout="stopEventSource">
     <f7-navbar :title="'Add ' + addonType + ' add-ons'" back-link="Back">
       <f7-subnavbar :inner="false" v-show="initSearchbar">
-        <f7-searchbar search-container=".addons-list" :init="initSearchbar" v-if="initSearchbar" search-in=".item-title" remove-diacritics :disable-button="!$theme.aurora"></f7-searchbar>
+        <f7-searchbar
+          search-container=".addons-list"
+          :init="initSearchbar"
+          v-if="initSearchbar"
+          search-in=".item-title"
+          :disable-button="!$theme.aurora"
+        ></f7-searchbar>
       </f7-subnavbar>
     </f7-navbar>
     <f7-list class="searchbar-not-found">

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -12,7 +12,6 @@
           :init="initSearchbar"
           search-container=".virtual-list"
           search-in=".item-title, .item-subtitle, .item-footer"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list.vue
@@ -20,7 +20,6 @@
         expandable
         search-container=".contacts-list"
         search-in=".item-title"
-        remove-diacritics
       ></f7-searchbar> -->
       <f7-subnavbar :inner="false" v-show="initSearchbar">
         <f7-searchbar
@@ -29,7 +28,6 @@
           :init="initSearchbar"
           search-container=".contacts-list"
           search-in=".item-title"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -14,7 +14,6 @@
           search-container=".pages-list"
           search-item=".pagelist-item"
           search-in=".item-title, .item-subtitle, .item-header, .item-footer"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -13,7 +13,6 @@
           search-container=".rules-list"
           search-item=".rulelist-item"
           search-in=".item-title, .item-subtitle, .item-header, .item-footer"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/schedule/schedule.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/schedule/schedule.vue
@@ -13,7 +13,6 @@
           search-container=".timeline"
           search-item=".timeline-item-inner"
           search-in=".timeline-item-title"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -8,7 +8,6 @@
           :init="initSearchbar"
           search-container=".binding-list"
           search-in=".item-title, .item-header, .item-footer"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -8,7 +8,6 @@
           :init="initSearchbar"
           search-container=".thing-type-list"
           search-in=".item-title, .item-header, .item-footer"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -13,7 +13,6 @@
           :init="initSearchbar"
           search-container=".contacts-list"
           search-in=".item-inner"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -13,7 +13,6 @@
           :init="initSearchbar"
           search-container=".contacts-list"
           search-in=".item-inner"
-          remove-diacritics
           :disable-button="!$theme.aurora"
         ></f7-searchbar>
       </f7-subnavbar>


### PR DESCRIPTION
Issue #684 resulted from the set option "remove-diacritics" in the f7 searchbar. I removed it and now the search works just fine on all pages that previously ignored unicode characters.

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>