### PR TITLE
Fix #717 - Alexa documentation link

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -29,7 +29,7 @@
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
     </div>
     <p class="padding">
-      <f7-link color="blue" external target="_blank" href="https://www.openhab.org/link/alexa">Alexa Integration Documentation</f7-link>
+      <f7-link color="blue" external target="_blank" href="https://www.openhab.org/docs/ecosystem/alexa/">Alexa Integration Documentation</f7-link>
     </p>
   </div>
 </template>


### PR DESCRIPTION
Just a change of the link to the correct value.

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>