### PR TITLE
Fix #720 - Add thermostatTemperatureSetpointHigh and ...Low to Metadadata UI list

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
@@ -13,33 +13,38 @@ const p = (type, name, label, description, options, advanced) => {
   }
 }
 
-const tfaAckParameter = p('BOOLEAN', 'tfaAck', 'TFA Ack Needed')
-const tfaPinParameter = p('TEXT', 'tfaPin', 'TFA Pin')
+const tfaAckParameter = p('BOOLEAN', 'tfaAck', 'Two-Factor-Authentication Ack Needed')
+const tfaPinParameter = p('TEXT', 'tfaPin', 'Two-Factor-Authentication Pin')
 const nameParameter = p('TEXT', 'name', 'Name', 'Custom name (use of the synonyms is preferred)', null, true)
-const roomHintParameter = p('TEXT', 'roomHint', 'Room Hint', null, null, true)
+const roomHintParameter = p('TEXT', 'roomHint', 'Room Hint', 'Suggested name for the room where this device is installed', null, true)
+const structureHintParameter = p('TEXT', 'structureHint', 'Structure Hint', 'Suggested name for the structure where this device is installed', null, true)
 const invertedParameter = p('BOOLEAN', 'inverted', 'Inverted')
-const speedParameter = p('TEXT', 'speed', 'Speed', 'Mappings between items states and Google modes')
+const speedParameter = p('TEXT', 'speeds', 'Speeds', 'Mappings between items states and Google modes (comma separated), e.g. "0=away:zero,50=default:standard:one,100=high:two"')
+const langParameter = p('TEXT', 'lang', 'Language', 'Language used for parsing text in the other parameters, e.g. "en"')
 const orderedParameter = p('BOOLEAN', 'ordered', 'Ordered')
 const useFahrenheitParameter = p('BOOLEAN', 'useFahrenheit', 'Use Fahrenheit')
-const thermostatModesParameter = p('TEXT', 'modes', 'Thermostat Modes', 'Mappings between items states and Google modes')
+const thermostatModesParameter = p('TEXT', 'modes', 'Thermostat Modes', 'Mappings between items states and Google modes (comma separated), e.g. "off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto"')
+const thermostatTemperatureRangeParameter = p('TEXT', 'thermostatTemperatureRange', 'Temperature Range', 'The temperature range your thermostat supports (comma separated), e.g. "10,30"')
+const protocolsParameter = p('TEXT', 'protocols', 'Protocols', 'List of supported protocols (comma separated), e.g. "hls,dash,smooth_stream,progressive_mp4"')
+const tokenNeededParameter = p('BOOLEAN', 'token', 'Authentification Token Needed')
 
 const classes = {
   'Light': [],
-  'Switch': [],
-  'Outlet': [],
-  'CoffeeMaker': [],
-  'WaterHeater': [],
-  'Fireplace': [],
-  'Valve': [],
-  'Sprinkler': [],
-  'Vacuum': [],
+  'Switch': [ invertedParameter ],
+  'Outlet': [ invertedParameter ],
+  'Coffee_Maker': [ invertedParameter ],
+  'WaterHeater': [ invertedParameter ],
+  'Fireplace': [ invertedParameter ],
+  'Valve': [ invertedParameter ],
+  'Sprinkler': [ invertedParameter ],
+  'Vacuum': [ invertedParameter ],
   'Scene': [],
-  'Lock': [],
-  'SecuritySystem': [],
+  'Lock': [ invertedParameter ],
+  'SecuritySystem': [ invertedParameter ],
   'Speaker': [],
-  'Fan': [ speedParameter, orderedParameter ],
-  'Hood': [ speedParameter, orderedParameter ],
-  'AirPurifier': [ speedParameter, orderedParameter ],
+  'Fan': [ speedParameter, langParameter, orderedParameter ],
+  'Hood': [ speedParameter, langParameter, orderedParameter ],
+  'AirPurifier': [ speedParameter, langParameter, orderedParameter ],
   'Awning': [ invertedParameter ],
   'Blinds': [ invertedParameter ],
   'Curtain': [ invertedParameter ],
@@ -49,18 +54,18 @@ const classes = {
   'Pergola': [ invertedParameter ],
   'Shutter': [ invertedParameter ],
   'Window': [ invertedParameter ],
-  'Thermostat': [ useFahrenheitParameter, thermostatModesParameter ],
+  'Thermostat': [ useFahrenheitParameter, thermostatModesParameter, thermostatTemperatureRangeParameter ],
   'thermostatTemperatureAmbient': [],
   'thermostatHumidityAmbient': [],
   'thermostatTemperatureSetpoint': [],
   'thermostatTemperatureSetpointHigh': [],
   'thermostatTemperatureSetpointLow': [],
   'thermostatMode': [],
-  'Camera': []
+  'Camera': [ protocolsParameter, tokenNeededParameter ]
 }
 
 for (let c in classes) {
-  classes[c] = [...classes[c], tfaAckParameter, tfaPinParameter, nameParameter, roomHintParameter]
+  classes[c] = [...classes[c], tfaAckParameter, tfaPinParameter, nameParameter, roomHintParameter, structureHintParameter]
 }
 
 export default classes

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
@@ -53,6 +53,8 @@ const classes = {
   'thermostatTemperatureAmbient': [],
   'thermostatHumidityAmbient': [],
   'thermostatTemperatureSetpoint': [],
+  'thermostatTemperatureSetpointHigh': [],
+  'thermostatTemperatureSetpointLow': [],
   'thermostatMode': [],
   'Camera': []
 }


### PR DESCRIPTION
Fixes various problems with the google assistant metadata UI, including #720. I took all the data directly from the [source](https://github.com/openhab/openhab-google-assistant/blob/master/functions/devices.js), not relying on the [documentation ](https://www.openhab.org/docs/ecosystem/google-assistant/) (because it is wrong in some minor places).

- Add `thermostatTemperatureSetpointHigh` and `thermostatTemperatureSetpointLow` (fixes #720) ![image](https://user-images.githubusercontent.com/1475672/103240655-3a0c5f00-4951-11eb-92ce-a95520dd9ae5.png)
- Rename `CoffeeMaker` to `Coffee_Maker` (yes, it has to be this inconsistent to work unfortunately, thanks Google...) ![image](https://user-images.githubusercontent.com/1475672/103240644-337de780-4951-11eb-9284-13846ac14b0d.png)
- Add `protocols` and `tokens` parameters for `Camera` ![image](https://user-images.githubusercontent.com/1475672/103240666-4395c700-4951-11eb-900e-198fb2912dac.png)
- Rename wrongly named parameter `speed` to `speeds` and add parameter `lang` (Fan) 
![image](https://user-images.githubusercontent.com/1475672/103240792-97a0ab80-4951-11eb-9f84-d2efe0f9f9b1.png)
- Add advanced parameter `structureHint` (all items) because it is implemented in the assistant binding and roomHint is also in the UI already 
![image](https://user-images.githubusercontent.com/1475672/103240867-cd459480-4951-11eb-8233-c2d3a8d3b158.png)
- Add parameter `inverted` for Switch, Outlet, CoffeeMaker, WaterHeater, Fireplace, Valve, Sprinkler, Vacuum, Lock, SecuritySystem 
![image](https://user-images.githubusercontent.com/1475672/103240889-d898c000-4951-11eb-8aae-8e76a78b265a.png)
- Add parameter `thermostatTemperatureRange` (Thermostat) 
![image](https://user-images.githubusercontent.com/1475672/103240898-dfbfce00-4951-11eb-9606-3dfee80df165.png)
- Added some examples in the descriptions of the parameters (see screenshots above)

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>