### PR TITLE
Fix #722 #711 - Show current GA metadata when editing

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -34,6 +34,9 @@ export default {
     }
   },
   computed: {
+    classes () {
+      return this.metadata.value
+    },
     parameters () {
       if (!this.metadata.value) return []
       return [...GoogleDefinitions[this.metadata.value]]


### PR DESCRIPTION
Fixes #722 (which is a duplicate of #711, sorry for that), Fixes #711. See the referenced issue(s) for details.

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>