### PR TITLE
Show correct alexa metadata categories for group items

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
@@ -35,6 +35,7 @@ const categories = [
   'TV',
   'WEARABLE'
 ]
+
 // Group endpoints are generated from the display categories. Example from the docs: SECURITY_PANEL => Endpoint.SecurityPanel.
 const groupEndpoints = categories
   .map(category => {
@@ -42,9 +43,9 @@ const groupEndpoints = categories
     let capitalizeNext = false
     for (var i = 0; i < category.length; i++) {
       const currentChar = category.charAt(i)
-      if (i == 0) {
+      if (i === 0) {
         convertedChars.push(currentChar.toUpperCase())
-      } else if (currentChar == '_') {
+      } else if (currentChar === '_') {
         capitalizeNext = true
       } else if (capitalizeNext) {
         convertedChars.push(currentChar.toUpperCase())
@@ -95,8 +96,6 @@ const labels = {
   'RangeComponent': [],
   'ToggleComponent': []
 }
-
-
 
 const p = (type, name, label, description, options, advanced) => {
   return {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa.js
@@ -35,6 +35,29 @@ const categories = [
   'TV',
   'WEARABLE'
 ]
+// Group endpoints are generated from the display categories. Example from the docs: SECURITY_PANEL => Endpoint.SecurityPanel.
+const groupEndpoints = categories
+  .map(category => {
+    const convertedChars = []
+    let capitalizeNext = false
+    for (var i = 0; i < category.length; i++) {
+      const currentChar = category.charAt(i)
+      if (i == 0) {
+        convertedChars.push(currentChar.toUpperCase())
+      } else if (currentChar == '_') {
+        capitalizeNext = true
+      } else if (capitalizeNext) {
+        convertedChars.push(currentChar.toUpperCase())
+        capitalizeNext = false
+      } else {
+        convertedChars.push(currentChar.toLocaleLowerCase())
+      }
+    }
+    return 'Endpoint.' + convertedChars.join('')
+  }).reduce((endpoints, endpointName) => {
+    endpoints[endpointName] = []
+    return endpoints
+  }, {})
 
 const labels = {
   'Switchable': [],
@@ -72,6 +95,8 @@ const labels = {
   'RangeComponent': [],
   'ToggleComponent': []
 }
+
+
 
 const p = (type, name, label, description, options, advanced) => {
   return {
@@ -232,6 +257,11 @@ let classes = {}
 for (let l in labels) {
   labels[l].unshift(categoryParameter)
   classes['label:' + l] = labels[l]
+}
+
+for (let l in groupEndpoints) {
+  groupEndpoints[l].unshift(categoryParameter)
+  classes['endpoint:' + l] = groupEndpoints[l]
 }
 
 for (let c in capabilities) {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -16,7 +16,7 @@
             </option>
           </optgroup>
           <optgroup label="Capabilities">
-            <option v-for="cl in orderedClasses.filter((c) => c.indexOf('label:') !== 0 && c.indexOf('endpoint:') === (itemType === 'Group'? 0: -1))"
+            <option v-for="cl in orderedClasses.filter((c) => c.indexOf('label:') !== 0 && c.indexOf('endpoint:') === (itemType === 'Group'? 0 : -1))"
               :value="cl.replace('endpoint:', '')" :key="cl"
               :selected="isSelected(cl.replace('endpoint:', ''))">
               {{cl.replace('endpoint:', '')}}
@@ -47,7 +47,7 @@ export default {
     return {
       itemType: this.item.type,
       classesDefs: Object.keys(AlexaDefinitions),
-      multiple: this.item.type!=='Group' && !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
+      multiple: this.item.type !== 'Group' && !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
       classSelectKey: this.$f7.utils.id()
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div style="text-align:right" class="padding-right">
+    <div style="text-align:right" class="padding-right" v-if="itemType !== 'Group'">
       <label @click="toggleMultiple" style="cursor:pointer">Multiple</label> <f7-checkbox :checked="multiple" @change="toggleMultiple"></f7-checkbox>
     </div>
     <f7-list>
@@ -8,7 +8,7 @@
          :title="(multiple) ? 'Alexa Classes' : 'Alexa Class'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple, scrollToSelectedItem: true }" ref="classes">
         <select name="parameters" @change="updateClasses" :multiple="multiple">
           <option v-if="!multiple" value=""></option>
-          <optgroup label="Labels" v-if="!multiple">
+          <optgroup label="Labels" v-if="!multiple && itemType !== 'Group'">
             <option v-for="cl in orderedClasses.filter((c) => c.indexOf('label:') === 0)"
               :value="cl.replace('label:', '')" :key="cl"
               :selected="isSelected(cl.replace('label:', ''))">
@@ -16,10 +16,10 @@
             </option>
           </optgroup>
           <optgroup label="Capabilities">
-            <option v-for="cl in orderedClasses.filter((c) => c.indexOf('label:') !== 0)"
-              :value="cl" :key="cl"
-              :selected="isSelected(cl)">
-              {{cl}}
+            <option v-for="cl in orderedClasses.filter((c) => c.indexOf('label:') !== 0 && c.indexOf('endpoint:') === (itemType === 'Group'? 0: -1))"
+              :value="cl.replace('endpoint:', '')" :key="cl"
+              :selected="isSelected(cl.replace('endpoint:', ''))">
+              {{cl.replace('endpoint:', '')}}
             </option>
           </optgroup>
         </select>
@@ -39,14 +39,15 @@ import AlexaDefinitions from '@/assets/definitions/metadata/alexa'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['item', 'metadata', 'namespace'],
   components: {
     ConfigSheet
   },
   data () {
     return {
+      itemType: this.item.type,
       classesDefs: Object.keys(AlexaDefinitions),
-      multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
+      multiple: this.item.type!=='Group' && !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
       classSelectKey: this.$f7.utils.id()
     }
   },
@@ -63,7 +64,7 @@ export default {
     parameters () {
       if (!this.classes) return []
       if (!this.multiple) {
-        return AlexaDefinitions['label:' + this.classes] || [...AlexaDefinitions[this.classes]]
+        return AlexaDefinitions['label:' + this.classes] || AlexaDefinitions['endpoint:' + this.classes] || [...AlexaDefinitions[this.classes]]
       }
       const params = []
       this.classes.forEach((c) => {


### PR DESCRIPTION
Aims to solve issue #511. 
For items of type 'Group' disable multiple category selection and show the correct endpoint categories.
Hope this is an acceptable solution. 
Thanks in advance.