### PR TITLE
Fallback to UIDs if things have no label during sorting.

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" class="thing-details-page">
-    <f7-navbar :title="thing.label" back-link="Back" no-hairline>
+    <f7-navbar :title="thing.label || thing.UID" back-link="Back" no-hairline>
       <f7-nav-right v-show="!error">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only></f7-link>
         <f7-link @click="save()" v-if="!$theme.md">Save<span v-if="$device.desktop">&nbsp;(Ctrl-S)</span></f7-link>
@@ -446,10 +446,10 @@ export default {
     deleteThing () {
       let url, message
       if (this.thing.statusInfo.status === 'REMOVING') {
-        message = `${this.thing.label} is currently being removed but the binding has not confirmed it has finished the operation yet. Would you like to force its removal? Warning: this could cause stability issues with the binding!`
+        message = `${this.thing.label || this.thing.UID} is currently being removed but the binding has not confirmed it has finished the operation yet. Would you like to force its removal? Warning: this could cause stability issues with the binding!`
         url = '/rest/things/' + this.thingId + '?force=true'
       } else {
-        message = `Are you sure you want to delete ${this.thing.label}?`
+        message = `Are you sure you want to delete ${this.thing.label || this.thing.UID}?`
         url = '/rest/things/' + this.thingId
       }
       this.$f7.dialog.confirm(

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -79,7 +79,7 @@
               @click.ctrl="(e) => ctrlClick(e, thing)"
               @click.exact="(e) => click(e, thing)"
               link=""
-              :title="thing.label"
+              :title="thing.label || thing.UID"
               :footer="thing.UID"
             >
               <f7-badge slot="after" :color="thingStatusBadgeColor(thing.statusInfo)" :tooltip="thing.statusInfo.description">{{thingStatusBadgeText(thing.statusInfo)}}</f7-badge>
@@ -137,7 +137,7 @@ export default {
     indexedThings () {
       if (this.groupBy === 'alphabetical') {
         return this.things.reduce((prev, thing, i, things) => {
-          const initial = thing.label.substring(0, 1).toUpperCase()
+          const initial = (thing.label || thing.UID).substring(0, 1).toUpperCase()
           if (!prev[initial]) {
             prev[initial] = []
           }
@@ -168,7 +168,7 @@ export default {
     load () {
       this.loading = true
       this.$oh.api.get('/rest/things?summary=true').then((data) => {
-        this.things = data.sort((a, b) => a.label.localeCompare(b.label))
+        this.things = data.sort((a, b) => (a.label || a.UID).localeCompare(b.label || a.UID))
         this.initSearchbar = true
         this.loading = false
         this.ready = true


### PR DESCRIPTION
Fixes #762.
(but there is probably also an issue in the core
that strips the labels sometimes).

Signed-off-by: Yannick Schaus <github@schaus.net>