### PR TITLE
Only show list indexes on mobile devices

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list.vue
@@ -39,6 +39,7 @@
 
     <f7-list-index
       ref="listIndex"
+      v-show="!$device.desktop"
       list-el=".items-list"
       :scroll-list="true"
       :label="true"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -32,7 +32,7 @@
     <f7-list-index
       v-if="ready"
       ref="listIndex" :key="'pages-index'"
-      v-show="groupBy === 'alphabetical'"
+      v-show="groupBy === 'alphabetical' && !$device.desktop"
       list-el=".pages-list"
       :scroll-list="true"
       :label="true"

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -35,6 +35,7 @@
     <f7-list-index
       ref="listIndex"
       v-if="$refs.rulesList"
+      v-show="!$device.desktop"
       :listEl="$refs.rulesList ? $$($refs.rulesList.$el) : undefined"
       :scroll-list="true"
       :label="true"
@@ -168,7 +169,7 @@ export default {
         this.ready = true
         setTimeout(() => {
           this.initSearchbar = true
-          this.$refs.listIndex.update()
+          if (this.$refs.listIndex) this.$refs.listIndex.update()
         })
 
         if (!this.eventSource) this.startEventSource()

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -13,13 +13,6 @@
       </f7-subnavbar>
     </f7-navbar>
 
-    <f7-list-index
-      ref="listIndex"
-      list-el=".binding-list"
-      :scroll-list="true"
-      :label="true"
-    ></f7-list-index>
-
     <empty-state-placeholder v-if="ready && !bindings.length" icon="circle_grid_hex" title="things.nobindings.title" text="things.nobindings.text" />
 
     <f7-block class="block-narrow">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -34,7 +34,7 @@
 
     <f7-list-index
       ref="listIndex"
-      v-show="groupBy === 'alphabetical'"
+      v-show="groupBy === 'alphabetical' && !$device.desktop"
       list-el=".inbox-list"
       :scroll-list="true"
       :label="true"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -34,7 +34,7 @@
 
     <f7-list-index
       ref="listIndex"
-      v-show="groupBy === 'alphabetical'"
+      v-show="groupBy === 'alphabetical' && !$device.desktop"
       list-el=".things-list"
       :scroll-list="true"
       :label="true"


### PR DESCRIPTION
Remove list index in binding selection.

Fixes #755.
Fixes #752.
Fixes #704.

Signed-off-by: Yannick Schaus <github@schaus.net>