### PR TITLE
Script editor: Basic hints for unknown modes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -62,6 +62,7 @@ import 'codemirror/addon/edit/closebrackets.js'
 // for autocomplete
 import 'codemirror/addon/hint/show-hint.js'
 import 'codemirror/addon/hint/show-hint.css'
+import 'codemirror/addon/hint/anyword-hint.js'
 import 'codemirror/addon/dialog/dialog.js'
 import 'codemirror/addon/dialog/dialog.css'
 import 'codemirror/addon/tern/tern.js'
@@ -94,6 +95,7 @@ import OpenhabDefs from '@/assets/openhab-tern-defs.json'
 import componentsHint from '../editor/hint-components'
 import rulesHint from '../editor/hint-rules'
 import thingsHint from '../editor/hint-things'
+import pythonHint from '../editor/hint-python'
 
 // Adapted from https://github.com/lkcampbell/brackets-indent-guides (MIT)
 var indentGuidesOverlay = {
@@ -257,6 +259,7 @@ export default {
         if (this.hintContext) cm.state.hintContext = Object.assign({}, this.hintContext)
         cm.setOption('hintOptions', {
           closeOnUnfocus: false,
+          completeSingle: self.mode && self.mode.indexOf('yaml') > 0,
           hint (cm, option) {
             if (self.mode.indexOf('application/vnd.openhab.uicomponent') === 0) {
               return componentsHint(cm, option, self.mode)
@@ -264,6 +267,10 @@ export default {
               return rulesHint(cm, option, self.mode)
             } else if (self.mode === 'application/vnd.openhab.thing+yaml') {
               return thingsHint(cm, option, self.mode)
+            } else if (self.mode === 'application/python') {
+              return pythonHint(cm, option, self.mode)
+            } else {
+              return _CodeMirror.hint.anyword(cm, option, self.mode)
             }
           }
         })

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-python.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-python.js
@@ -1,0 +1,103 @@
+/* This code is adapted from https://github.com/mildsunrise/CodeMirror/blob/master/addon/hint/python-hint.js */
+
+import CodeMirror from 'codemirror'
+
+function forEach (arr, f) {
+  for (var i = 0, e = arr.length; i < e; ++i) f(arr[i])
+}
+
+function arrayContains (arr, item) {
+  if (!Array.prototype.indexOf) {
+    var i = arr.length
+    while (i--) {
+      if (arr[i] === item) {
+        return true
+      }
+    }
+    return false
+  }
+  return arr.indexOf(item) !== -1
+}
+
+function scriptHint (editor, _keywords, getToken) {
+  // Find the token at the cursor
+  var cur = editor.getCursor(), token = getToken(editor, cur), tprop = token
+  // If it's not a 'word-style' token, ignore the token.
+
+  if (!/^[\w$_]*$/.test(token.string)) {
+    token = tprop = { start: cur.ch,
+      end: cur.ch,
+      string: '',
+      state: token.state,
+      className: token.string === ':' ? 'python-type' : null }
+  }
+
+  let context
+  if (!context) context = []
+  context.push(tprop)
+
+  var completionList = getCompletions(token, context)
+  completionList = completionList.sort()
+  // prevent autocomplete for last word, instead show dropdown with one word
+  if (completionList.length === 1) {
+    completionList.push(' ')
+  }
+
+  return { list: completionList,
+    from: CodeMirror.Pos(cur.line, token.start),
+    to: CodeMirror.Pos(cur.line, token.end) }
+}
+
+CodeMirror.pythonHint = function (editor) {
+  const scriptHints = scriptHint(editor, pythonKeywordsU, function (e, cur) { return e.getTokenAt(cur) })
+  const otherHints = CodeMirror.hint.anyword(editor)
+  return {
+    from: otherHints.from,
+    to: otherHints.to,
+    list: Array.from(new Set([...scriptHints.list, ...otherHints.list])).sort()
+  }
+}
+
+export default CodeMirror.pythonHint
+
+var pythonKeywords = 'and del from not while as elif global or with assert else if pass yield' +
+'break except import print class exec in raise continue finally is return def for lambda try'
+var pythonKeywordsL = pythonKeywords.split(' ')
+var pythonKeywordsU = pythonKeywords.toUpperCase().split(' ')
+
+var pythonBuiltins = 'abs divmod input open staticmethod all enumerate int ord str ' +
+'any eval isinstance pow sum basestring execfile issubclass print super' +
+'bin file iter property tuple bool filter len range type' +
+'bytearray float list raw_input unichr callable format locals reduce unicode' +
+'chr frozenset long reload vars classmethod getattr map repr xrange' +
+'cmp globals max reversed zip compile hasattr memoryview round __import__' +
+'complex hash min set apply delattr help next setattr buffer' +
+'dict hex object slice coerce dir id oct sorted intern '
+var pythonBuiltinsL = pythonBuiltins.split(' ').join('() ').split(' ')
+var pythonBuiltinsU = pythonBuiltins.toUpperCase().split(' ').join('() ').split(' ')
+
+function getCompletions (token, context) {
+  var found = [], start = token.string
+  function maybeAdd (str) {
+    if (str.indexOf(start) === 0 && !arrayContains(found, str)) found.push(str)
+  }
+
+  function gatherCompletions (_obj) {
+    forEach(pythonBuiltinsL, maybeAdd)
+    forEach(pythonBuiltinsU, maybeAdd)
+    forEach(pythonKeywordsL, maybeAdd)
+    forEach(pythonKeywordsU, maybeAdd)
+  }
+
+  if (context) {
+    // If this is a property, see if it belongs to some object we can
+    // find in the current environment.
+    var obj = context.pop(), base
+
+    if (obj.type === 'variable') { base = obj.string } else if (obj.type === 'variable-3') { base = ':' + obj.string }
+
+    while (base != null && context.length) { base = base[context.pop().string] }
+    if (base != null) gatherCompletions(base)
+  }
+  return found
+}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-code.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-code.vue
@@ -1,35 +1,49 @@
 <template>
-  <div class="row">
-    <div class="col">
-      <editor class="sitemap-parser" :value="sitemapDsl" @input="updateSitemap" />
-      <div v-if="parsedSitemap.error" class="sitemap-results error">
-        <pre><code class="text-color-red">{{parsedSitemap.error}}</code></pre>
+  <f7-block class="sitemap-code">
+    <div class="row sitemap-parser resizable">
+      <div class="col">
+        <editor :value="sitemapDsl" @input="updateSitemap" mode="application/vnd.openhab.sitemap+dsl" />
       </div>
-      <div v-else class="sitemap-results">
-        <pre><code class="text-color-teal">Your sitemap definition looks valid.</code></pre>
-        <pre><code>{{parsedSitemap}}</code></pre>
-      </div>
+      <span class="resize-handler"></span>
     </div>
-  </div>
+    <div class="row sitemap-results resizable">
+      <div class="col">
+        <div v-if="parsedSitemap.error" class="error">
+          <pre><code class="text-color-red">{{parsedSitemap.error}}</code></pre>
+        </div>
+        <div v-else>
+          <pre><code class="text-color-teal">Your sitemap definition looks valid.</code></pre>
+          <pre><code>{{parsedSitemap}}</code></pre>
+        </div>
+      </div>
+      <span class="resize-handler"></span>
+    </div>
+  </f7-block>
 </template>
 
 <style lang="stylus">
-.sitemap-parser.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(50% - 2*var(--f7-navbar-height))
-  width 100%
-.sitemap-results
-  position absolute
-  top 50%
-  height 50%
-  overflow-y auto
-  width 100%
-  &.error
+.sitemap-code
+  margin-top 0 !important
+  margin-bottom 0 !important
+  padding 0
+  z-index auto !important
+  top 0
+  height calc(100%)
+  .sitemap-parser
+    height 50%
+    width 100%
+    .vue-codemirror
+      top 0
+      height calc(100% - var(--f7-grid-gap))
+  .sitemap-results
+    height 50%
+    width 100%
+    overflow-y auto
+    .error
+      pre
+        padding 0 1rem
     pre
       padding 0 1rem
-  pre
-    padding 0 1rem
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
@@ -6,102 +6,110 @@
         <f7-link @click="add()" v-if="!$theme.md">Add</f7-link>
       </f7-nav-right>
     </f7-navbar>
-    <div class="row" v-if="ready">
-      <div class="col">
-        <editor class="items-parser" :value="itemsDsl" @input="(value) => itemsDsl = value" />
-        <div v-if="parsedItems.error" class="items-results error">
-          <div v-if="!itemsDsl">
-            <empty-state-placeholder icon="text_badge_plus" title="items.add.title" text="items.add.text" />
-          </div>
-          <pre v-else><code>{{parsedItems.error}}</code></pre>
+    <f7-block class="items-add-from-textual-definition">
+      <div class="row items-parser resizable" v-if="ready">
+        <div class="col">
+          <editor class="editor" :value="itemsDsl" @input="(value) => itemsDsl = value" mode="application/vnd.openhab.items+dsl" />
         </div>
-        <div v-else class="items-results">
-          <div class="card data-table data-table-init">
-            <table>
-              <thead>
-                <tr>
-                  <th class="label-cell">Type</th>
-                  <th class="label-cell">Name</th>
-                  <th class="label-cell">Label</th>
-                  <th class="label-cell">Icon</th>
-                  <th class="label-cell">Groups</th>
-                  <th class="label-cell">Tags</th>
-                  <th class="numerical-cell">Link(s)</th>
-                  <th class="numerical-cell">Metadata</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr v-for="(item, idx) in parsedItems" :key="idx" class="background-yellow">
-                  <td class="label-cell">{{item.type}}</td>
-                  <td class="label-cell">
-                    {{item.name}}
-                    <f7-icon v-if="item.existing && item.existing.editable" f7="exclamationmark_octagon_fill" color="yellow" size="22" tooltip="Item already exists" />
-                    <f7-icon v-if="item.existing && !item.existing.editable" f7="multiply_circle_fill" color="red" size="22" tooltip="Item already exists and is not editable" />
-                  </td>
-                  <td class="label-cell">{{item.label}}</td>
-                  <td class="label-cell"><oh-icon v-if="item.category" :icon="item.category" :width="20" :height="20" /></td>
-                  <td class="label-cell">{{(item.groupNames) ? item.groupNames.join(', ') : ''}}</td>
-                  <td class="label-cell" v-if="item.tags">
-                    <f7-chip class="margin-right" v-for="tag in item.tags" :key="tag" :text="tag" media-bg-color="blue">
-                      <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" ></f7-icon>
-                    </f7-chip>
-                  </td>
-                  <td class="label-cell" v-else></td>
-                  <!-- links -->
-                  <td class="label-cell" v-if="item.links">
-                    <div class="margin-right" v-for="(link, lidx) in item.links" :key="lidx">
-                      <div v-if="link.value">
-                        <div><em>{{link.value}}</em></div>
-                        <small>{{link.config.map((c) => c.key + '=' + c.value).join(', ')}}</small>
-                      </div>
-                      <em v-else>{{link}}</em>
-                    </div>
-                  </td>
-                  <td class="label-cell" v-else></td>
-                  <!-- metadata -->
-                  <td class="label-cell" v-if="item.metadata">
-                    <div class="margin-right" v-for="(metadata, lidx) in item.metadata" :key="lidx">
-                      <div v-if="metadata.value.value">
-                        <div>{{metadata.key}}="{{metadata.value.value}}"</div>
-                        <small>{{metadata.value.config.map((c) => c.key + '=' + c.value).join(', ')}}</small>
-                      </div>
-                      <div v-else>{{metadata.key}}="{{metadata.value}}"</div>
-                    </div>
-                  </td>
-                  <td class="label-cell" v-else></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-        </div>
+        <span class="resize-handler"></span>
       </div>
-    </div>
+      <div class="row items-results resizable" v-if="ready">
+        <div class="col">
+          <div v-if="parsedItems.error" class="error">
+            <div v-if="!itemsDsl">
+              <empty-state-placeholder icon="text_badge_plus" title="items.add.title" text="items.add.text" />
+            </div>
+            <pre v-else><code>{{parsedItems.error}}</code></pre>
+          </div>
+          <div v-if="!parsedItems.error" class="items-table">
+            <div class="card data-table data-table-init">
+              <table>
+                <thead>
+                  <tr>
+                    <th class="label-cell">Type</th>
+                    <th class="label-cell">Name</th>
+                    <th class="label-cell">Label</th>
+                    <th class="label-cell">Icon</th>
+                    <th class="label-cell">Groups</th>
+                    <th class="label-cell">Tags</th>
+                    <th class="numerical-cell">Link(s)</th>
+                    <th class="numerical-cell">Metadata</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="(item, idx) in parsedItems" :key="idx" class="background-yellow">
+                    <td class="label-cell">{{item.type}}</td>
+                    <td class="label-cell">
+                      {{item.name}}
+                      <f7-icon v-if="item.existing && item.existing.editable" f7="exclamationmark_octagon_fill" color="yellow" size="22" tooltip="Item already exists" />
+                      <f7-icon v-if="item.existing && !item.existing.editable" f7="multiply_circle_fill" color="red" size="22" tooltip="Item already exists and is not editable" />
+                    </td>
+                    <td class="label-cell">{{item.label}}</td>
+                    <td class="label-cell"><oh-icon v-if="item.category" :icon="item.category" :width="20" :height="20" /></td>
+                    <td class="label-cell">{{(item.groupNames) ? item.groupNames.join(', ') : ''}}</td>
+                    <td class="label-cell" v-if="item.tags">
+                      <f7-chip class="margin-right" v-for="tag in item.tags" :key="tag" :text="tag" media-bg-color="blue">
+                        <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" ></f7-icon>
+                      </f7-chip>
+                    </td>
+                    <td class="label-cell" v-else></td>
+                    <!-- links -->
+                    <td class="label-cell" v-if="item.links">
+                      <div class="margin-right" v-for="(link, lidx) in item.links" :key="lidx">
+                        <div v-if="link.value">
+                          <div><em>{{link.value}}</em></div>
+                          <small>{{link.config.map((c) => c.key + '=' + c.value).join(', ')}}</small>
+                        </div>
+                        <em v-else>{{link}}</em>
+                      </div>
+                    </td>
+                    <td class="label-cell" v-else></td>
+                    <!-- metadata -->
+                    <td class="label-cell" v-if="item.metadata">
+                      <div class="margin-right" v-for="(metadata, lidx) in item.metadata" :key="lidx">
+                        <div v-if="metadata.value.value">
+                          <div>{{metadata.key}}="{{metadata.value.value}}"</div>
+                          <small>{{metadata.value.config.map((c) => c.key + '=' + c.value).join(', ')}}</small>
+                        </div>
+                        <div v-else>{{metadata.key}}="{{metadata.value}}"</div>
+                      </div>
+                    </td>
+                    <td class="label-cell" v-else></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+        <span class="resize-handler"></span>
+      </div>
+    </f7-block>
   </f7-page>
 </template>
 
 <style lang="stylus">
-.items-parser.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height))
-  height calc(50% - var(--f7-navbar-height))
-  width 100%
-.items-results
-  position absolute
-  top 50%
-  height 50%
-  overflow-y auto
-  width 100%
-  &.error
-    pre
-      padding 0 1rem
-.parse-results
-  position relative
-  left 0
-  width 100%
-  pre
-    font-size 12px
-    height calc(100% - var(--f7-navbar-height) + var(--f7-toolbar-height) - 100px)
-    overflow auto
+.items-add-from-textual-definition
+  margin-top 0 !important
+  margin-bottom 0 !important
+  padding 0
+  z-index auto !important
+  top 0
+  height calc(100%)
+  .items-parser
+    height 50%
+    width 100%
+    .editor.vue-codemirror
+      top 0
+      height calc(100% - var(--f7-grid-gap))
+  .items-results
+    height 50%
+    width 100%
+    overflow-y auto
+    .error
+      pre
+        padding 1rem
+        font-size 12px
+        overflow auto
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -10,12 +10,12 @@
       <f7-link @click="currentTab = 'tree'" :tab-link-active="currentTab === 'tree'" class="tab-link">Design</f7-link>
       <f7-link @click="currentTab = 'code'" :tab-link-active="currentTab === 'code'" class="tab-link">Code</f7-link>
     </f7-toolbar>
-    <f7-toolbar bottom class="toolbar-details" v-show="currentTab === 'tree'">
+    <f7-toolbar bottom class="toolbar-details" v-if="currentTab === 'tree'">
       <f7-link :disabled="selectedWidget != null" class="left" @click="selectedWidget = null">Clear</f7-link>
       <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up"></f7-link>
     </f7-toolbar>
     <f7-tabs class="sitemap-editor-tabs">
-      <f7-tab id="tree" @tab:show="() => this.currentTab = 'tree'" :tab-active="currentTab === 'tree'">
+      <f7-tab class="design" id="tree" @tab:show="() => this.currentTab = 'tree'" :tab-active="currentTab === 'tree'">
         <f7-block v-if="!ready" class="text-align-center">
           <f7-preloader></f7-preloader>
           <div>Loading...</div>
@@ -98,10 +98,13 @@
 
 <style lang="stylus">
 .sitemap-editor-tabs
-  --f7-grid-gap 0px
-  height calc(100% - var(--f7-toolbar-height))
+  height calc(100%)
+  overflow hidden
   .tab
     height 100%
+  .design
+    --f7-grid-gap 0px
+    height calc(100% - var(--f7-toolbar-height))
 
 .sitemap-tree-wrapper
   padding 0


### PR DESCRIPTION
(Slightly) less basic hints for Python

Make "add from textual definition" & sitemap code editor
splits resizable (closes #783).

Signed-off-by: Yannick Schaus <github@schaus.net>