### PR TITLE
Don't propagate loop to child widgets contexts

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -136,7 +136,6 @@ export default {
         props: this.config,
         vars: this.widgetVars,
         store: this.context.store,
-        loop: this.context.loop,
         config: this.context.config,
         editmode: this.context.editmode,
         clipboardtype: this.context.clipboardtype,


### PR DESCRIPTION
This prevents a loop context from being shared among
multiple instances of the same widget.

To pass elements of the parent loop context to widgets,
use props with an expression when configuring the widget:
```
config:
  prop1: =loop.i
```

Signed-off-by: Yannick Schaus <github@schaus.net>