### PR TITLE
Don't generate empty tags when clearing semantics in picker

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -56,6 +56,7 @@ export default {
         this.semanticClass = value
       }
       this.item.tags = this.item.tags.filter((t) => !this.semanticType(t) && !this.isSemanticPropertyTag(t))
+      if (!value) return
       this.item.tags.push(this.semanticClass)
       if (this.semanticType(this.semanticClass) === 'Point' && this.semanticProperty.length) {
         this.item.tags.push(this.semanticProperty)


### PR DESCRIPTION
Fixes #690.

Signed-off-by: Yannick Schaus <github@schaus.net>