### PR TITLE
Rule editor: remove keyboard shortcuts when a module is open

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -368,6 +368,7 @@ export default {
     },
     keyDown (ev) {
       if (ev.ctrlKey || ev.metakKey) {
+        if (this.currentModule) return
         switch (ev.keyCode) {
           case 68:
             this.toggleDisabled()


### PR DESCRIPTION
Fixes #663.

Signed-off-by: Yannick Schaus <github@schaus.net>