### PR TITLE
Allow managed links to non-managed items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
@@ -97,6 +97,7 @@ function hintExpression (cm, line) {
         { text: 'items.', displayText: 'items', description: 'Access to item states' },
         { text: 'props.', displayText: 'props', description: 'Access to the props of the parent root component' },
         { text: 'vars.', displayText: 'vars', description: 'Access to context vars' },
+        { text: 'loop.', displayText: 'loop', description: 'Access to oh-repeater loop variables' },
         { text: 'JSON.', displayText: 'JSON', description: 'Access to the JSON object functions' },
         { text: 'Math.', displayText: 'Math', description: 'Access to the Math object functions' },
         { text: 'Number.', displayText: 'Number', description: 'Access to the Number object functions' },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -32,7 +32,7 @@
         <f7-list>
           <!-- TODO: filter with compatible item types -->
           <item-picker key="itemLink" title="Item to Link" name="item" :value="selectedItemName" :multiple="false"
-            @input="(value) => selectedItemName = value" :editable-only="true"></item-picker>
+            @input="(value) => selectedItemName = value"></item-picker>
         </f7-list>
       </f7-col>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -33,7 +33,7 @@
           </f7-card-content>
           <f7-card-footer v-if="item">
             <f7-button color="red" fill @click="unlinkAndDelete()" v-if="source === 'thing' && item.editable">Unlink &amp; Remove Item</f7-button>
-            <f7-button color="red" @click="unlink()">{{source === 'thing' ? 'Unlink Only' : 'Unlink'}}</f7-button>
+            <f7-button color="red" @click="unlink()">{{source === 'thing' && item.editable ? 'Unlink Only' : 'Unlink'}}</f7-button>
           </f7-card-footer>
         </f7-card>
       </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -31,8 +31,8 @@
             </ul>
           </f7-list>
           </f7-card-content>
-          <f7-card-footer v-if="item && item.editable">
-            <f7-button color="red" fill @click="unlinkAndDelete()" v-if="source === 'thing'">Unlink &amp; Remove Item</f7-button>
+          <f7-card-footer v-if="item">
+            <f7-button color="red" fill @click="unlinkAndDelete()" v-if="source === 'thing' && item.editable">Unlink &amp; Remove Item</f7-button>
             <f7-button color="red" @click="unlink()">{{source === 'thing' ? 'Unlink Only' : 'Unlink'}}</f7-button>
           </f7-card-footer>
         </f7-card>
@@ -159,6 +159,12 @@ export default {
               closeTimeout: 2000
             }).open()
             this.$f7router.back()
+          }).catch((err) => {
+            this.$f7.toast.create({
+              text: 'Link not deleted (links defined in a .items file are not editable from this screen): ' + err,
+              destroyOnClose: true,
+              closeTimeout: 2000
+            }).open()
           })
         })
     },
@@ -184,6 +190,12 @@ export default {
               }).open()
             })
             this.$f7router.back()
+          }).catch((err) => {
+            this.$f7.toast.create({
+              text: 'Link not deleted (links defined in a .items file are not editable from this screen): ' + err,
+              destroyOnClose: true,
+              closeTimeout: 2000
+            }).open()
           })
         })
     },
@@ -209,6 +221,12 @@ export default {
           }).open()
           this.$f7router.back()
         })
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Link not updated (links defined in a .items file are not editable from this screen): ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
       })
     }
   }


### PR DESCRIPTION
Includes both linking and unlinking.
Add error messages when trying to remove a non-managed
link.

Fixes #685.
Fixes #693.
Fixes https://github.com/openhab/openhab-core/issues/2130.

Signed-off-by: Yannick Schaus <github@schaus.net>