### PR TITLE
Evaluate `oh-time-series` too so one can bind it in widgets

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -130,7 +130,7 @@ export default {
     getSeriesPromises (component) {
       const getter = (data) => seriesComponents[component.component].get(component, data.map((d) => d[1]), this.startTime, this.endTime, this)
 
-      const neededItems = seriesComponents[component.component].neededItems(component).filter(i => !!i)
+      const neededItems = seriesComponents[component.component].neededItems(component, this).filter(i => !!i)
       if (neededItems.length === 0) {
         return Promise.resolve(getter([]))
       }

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-data-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-data-series.js
@@ -1,4 +1,4 @@
-import Framework7 from 'framework7'
+import ComponentId from '../../component-id'
 
 export default {
   neededItems () {
@@ -7,15 +7,12 @@ export default {
   get (component, points, startTime, endTime, chart) {
     if (!component.config || typeof component.config !== 'object') return {}
 
-    if (!component.dataSeriesId) {
-      component.dataSeriesId = Framework7.utils.id()
-    }
-
-    let series = chart.evaluateExpression(component.dataSeriesId, component.config)
+    const dataSeriesId = ComponentId.get(component)
+    let series = chart.evaluateExpression(dataSeriesId, component.config)
 
     if (series.data && Array.isArray(series.data)) {
       series.data = series.data.map((v, index) => {
-        const item = chart.evaluateExpression(component.dataSeriesId + 'data.' + index, v)
+        const item = chart.evaluateExpression(dataSeriesId + 'data.' + index, v)
         return Number.isNaN(item.value) ? {} : item
       })
     }
@@ -23,7 +20,7 @@ export default {
     if (series.axisLine && series.axisLine.lineStyle && series.axisLine.lineStyle.color && Array.isArray(series.axisLine.lineStyle.color)) {
       series.axisLine.lineStyle.color = series.axisLine.lineStyle.color.map((v, index) => {
         if (!Array.isArray(v)) return v
-        return v.map((s, subindex) => chart.evaluateExpression(component.dataSeriesId + 'axisLine.lineStyle.color.' + index + '.' + subindex, s))
+        return v.map((s, subindex) => chart.evaluateExpression(dataSeriesId + 'axisLine.lineStyle.color.' + index + '.' + subindex, s))
       })
     }
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
@@ -1,24 +1,25 @@
+import ComponentId from '../../component-id'
 import MarkArea from './oh-mark-area'
 import Framework7 from 'framework7'
 
 export default {
-  neededItems (component) {
+  neededItems (component, chart) {
     const seriesItem = (!component || !component.config || !component.config.item) ? undefined : component.config.item
     let markAreaItems = []
     if (component.slots && component.slots.markArea) {
       markAreaItems = component.slots.markArea.map(a => a.config.item)
     }
     return [
-      seriesItem,
+      chart.evaluateExpression(ComponentId.get(component) + '.item', seriesItem),
       ...markAreaItems
     ]
   },
   get (component, points, startTime, endTime, chart) {
-    let series = Object.assign({}, component.config)
+    let series = chart.evaluateExpression(ComponentId.get(component), component.config)
     series.data = []
 
-    if (component.config.item) {
-      const itemPoints = points.find(p => p.name === component.config.item).data
+    if (series.item) {
+      const itemPoints = points.find(p => p.name === series.item).data
 
       const formatter = new Intl.NumberFormat('en', { useGrouping: false, maximumFractionDigits: 3 })
       const data = itemPoints.map((p) => {
@@ -26,7 +27,7 @@ export default {
       })
 
       series.data = data
-      series.id = `oh-time-series#${component.config.item}#${Framework7.utils.id()}`
+      series.id = `oh-time-series#${series.item}#${Framework7.utils.id()}`
     }
 
     // other things

--- a/bundles/org.openhab.ui/web/src/components/widgets/component-id.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/component-id.js
@@ -1,15 +1,16 @@
 
+const ids = new WeakMap()
+let index = 1
+
 export default {
-  ids: new WeakMap(),
-  index: 1,
   get (component) {
     if (!component || typeof component !== 'object') return undefined
 
-    let id = this.ids.get(component)
+    let id = ids.get(component)
     if (!id) {
-      id = this.index
-      this.index += 1
-      this.ids.set(component, id)
+      id = index
+      index += 1
+      ids.set(component, id)
     }
 
     return id

--- a/bundles/org.openhab.ui/web/src/components/widgets/component-id.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/component-id.js
@@ -1,0 +1,17 @@
+
+export default {
+  ids: new WeakMap(),
+  index: 1,
+  get (component) {
+    if (!component || typeof component !== 'object') return undefined
+
+    let id = this.ids.get(component)
+    if (!id) {
+      id = this.index
+      this.index += 1
+      this.ids.set(component, id)
+    }
+
+    return id
+  }
+}


### PR DESCRIPTION
Please see [this](https://community.openhab.org/t/main-ui-echarts-gauge-and-pie-poc/113987/18) for details.

Also seen `dataSeriesId` sometimes pops up in yaml editor, polluting yaml, saving ids separately is a better idea, so not changing component itself.

Maybe evaluating `markArea` part of `oh-time-series` would make sense too ...

Signed-off-by: Boris Krivonog <boris.krivonog@inova.si>