### PR TITLE
Fixes sitemap and proxy calls

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ChartRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ChartRenderer.java
@@ -63,7 +63,7 @@ public class ChartRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Chart chart = (Chart) w;
 
         try {

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
@@ -59,7 +59,7 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Colorpicker cp = (Colorpicker) w;
 
         String snippet = getSnippet("colorpicker");

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/FrameRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/FrameRenderer.java
@@ -54,7 +54,7 @@ public class FrameRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         String snippet = getSnippet("frame");
         String label = StringEscapeUtils.escapeHtml(itemUIRegistry.getLabel(w));
         List<String> frameClassList = new ArrayList<>();

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/GroupRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/GroupRenderer.java
@@ -51,7 +51,7 @@ public class GroupRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         String snippet = getSnippet("group");
 
         snippet = preprocessSnippet(snippet, w);

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
@@ -32,8 +32,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is an implementation of the {@link WidgetRenderer} interface, which

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
@@ -94,7 +94,7 @@ public class ImageRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%proxied_url%", proxiedUrl);
         snippet = StringUtils.replace(snippet, "%ignore_refresh%", ignoreRefresh ? "true" : "false");
         snippet = StringUtils.replace(snippet, "%url%", url);
-        
+
         sb.append(snippet);
         return ECollections.emptyEList();
     }

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
@@ -32,6 +32,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is an implementation of the {@link WidgetRenderer} interface, which
@@ -46,6 +48,8 @@ public class ImageRenderer extends AbstractWidgetRenderer {
 
     private static final String URL_NONE_ICON = "images/none.png";
 
+    private final Logger logger = LoggerFactory.getLogger(ImageRenderer.class);
+
     @Activate
     public ImageRenderer(final BundleContext bundleContext, final @Reference TranslationProvider i18nProvider,
             final @Reference ItemUIRegistry itemUIRegistry, final @Reference LocaleProvider localeProvider) {
@@ -58,7 +62,7 @@ public class ImageRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Image image = (Image) w;
         String snippet = (image.getChildren().size() > 0) ? getSnippet("image_link") : getSnippet("image");
 
@@ -72,10 +76,6 @@ public class ImageRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%id%", widgetId);
         snippet = preprocessSnippet(snippet, w);
 
-        String sitemap = null;
-        if (w.eResource() != null) {
-            sitemap = w.eResource().getURI().path();
-        }
         boolean validUrl = isValidURL(image.getUrl());
         String proxiedUrl = "../proxy?sitemap=" + sitemap + "&amp;widgetId=" + widgetId;
         State state = itemUIRegistry.getState(w);
@@ -98,7 +98,7 @@ public class ImageRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%proxied_url%", proxiedUrl);
         snippet = StringUtils.replace(snippet, "%ignore_refresh%", ignoreRefresh ? "true" : "false");
         snippet = StringUtils.replace(snippet, "%url%", url);
-
+        // logger.warn(snippet);
         sb.append(snippet);
         return ECollections.emptyEList();
     }

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
@@ -48,8 +48,6 @@ public class ImageRenderer extends AbstractWidgetRenderer {
 
     private static final String URL_NONE_ICON = "images/none.png";
 
-    private final Logger logger = LoggerFactory.getLogger(ImageRenderer.class);
-
     @Activate
     public ImageRenderer(final BundleContext bundleContext, final @Reference TranslationProvider i18nProvider,
             final @Reference ItemUIRegistry itemUIRegistry, final @Reference LocaleProvider localeProvider) {
@@ -98,7 +96,7 @@ public class ImageRenderer extends AbstractWidgetRenderer {
         snippet = StringUtils.replace(snippet, "%proxied_url%", proxiedUrl);
         snippet = StringUtils.replace(snippet, "%ignore_refresh%", ignoreRefresh ? "true" : "false");
         snippet = StringUtils.replace(snippet, "%url%", url);
-        // logger.warn(snippet);
+        
         sb.append(snippet);
         return ECollections.emptyEList();
     }

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ListRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ListRenderer.java
@@ -52,7 +52,7 @@ public class ListRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         String snippet = getSnippet("list");
         snippet = snippet.replaceAll("%label%", getLabel(w));
 

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/MapviewRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/MapviewRenderer.java
@@ -55,7 +55,7 @@ public class MapviewRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Mapview mapview = (Mapview) w;
         String snippet = getSnippet("mapview");
         snippet = preprocessSnippet(snippet, mapview);

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
@@ -122,7 +122,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
         StringBuilder postChildren = new StringBuilder(parts[1]);
 
         if (parts.length == 2) {
-            processChildren(preChildren, postChildren, children);
+            processChildren(preChildren, postChildren, children, sitemap);
         } else if (parts.length > 2) {
             logger.error("Snippet '{}' contains multiple %children% sections, but only one is allowed!",
                     async ? "layer" : "main");
@@ -130,7 +130,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
         return preChildren.append(postChildren);
     }
 
-    private void processChildren(StringBuilder sb_pre, StringBuilder sb_post, EList<Widget> children)
+    private void processChildren(StringBuilder sb_pre, StringBuilder sb_post, EList<Widget> children, String sitemap)
             throws RenderException {
         // put a single frame around all children widgets, if there are no explicit frames
         if (!children.isEmpty()) {
@@ -158,7 +158,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
             StringBuilder newPre = new StringBuilder();
             StringBuilder newPost = new StringBuilder();
             StringBuilder widgetSB = new StringBuilder();
-            EList<Widget> nextChildren = renderWidget(w, widgetSB);
+            EList<Widget> nextChildren = renderWidget(w, widgetSB, sitemap);
             if (!nextChildren.isEmpty()) {
                 String[] parts = widgetSB.toString().split("%children%");
                 // no %children% placeholder found or at the end
@@ -179,7 +179,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
                             "Snippet for widget '{}' contains multiple %children% sections, but only one is allowed!",
                             widgetType);
                 }
-                processChildren(newPre, newPost, nextChildren);
+                processChildren(newPre, newPost, nextChildren, sitemap);
                 sb_pre.append(newPre);
                 sb_pre.append(newPost);
             } else {
@@ -189,10 +189,10 @@ public class PageRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         for (WidgetRenderer renderer : widgetRenderers) {
             if (renderer.canRender(w)) {
-                return renderer.renderWidget(w, sb);
+                return renderer.renderWidget(w, sb, sitemap);
             }
         }
         return ECollections.emptyEList();

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SelectionRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SelectionRenderer.java
@@ -67,7 +67,7 @@ public class SelectionRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         String snippet = getSnippet("selection");
 
         snippet = preprocessSnippet(snippet, w);

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SetpointRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SetpointRenderer.java
@@ -53,7 +53,7 @@ public class SetpointRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Setpoint sp = (Setpoint) w;
 
         // set defaults for min, max and step

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SliderRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SliderRenderer.java
@@ -56,7 +56,7 @@ public class SliderRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Slider s = (Slider) w;
 
         String snippetName = "slider";

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SwitchRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SwitchRenderer.java
@@ -73,7 +73,7 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Switch s = (Switch) w;
 
         String snippetName = null;

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/TextRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/TextRenderer.java
@@ -27,8 +27,6 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This is an implementation of the {@link WidgetRenderer} interface, which

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/TextRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/TextRenderer.java
@@ -27,6 +27,8 @@ import org.osgi.framework.BundleContext;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is an implementation of the {@link WidgetRenderer} interface, which
@@ -38,6 +40,8 @@ import org.osgi.service.component.annotations.Reference;
 @Component(service = WidgetRenderer.class)
 @NonNullByDefault
 public class TextRenderer extends AbstractWidgetRenderer {
+
+    private final Logger logger = LoggerFactory.getLogger(TextRenderer.class);
 
     @Activate
     public TextRenderer(final BundleContext bundleContext, final @Reference TranslationProvider i18nProvider,
@@ -51,7 +55,7 @@ public class TextRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Text text = (Text) w;
         String snippet = (text.getChildren().size() > 0) ? getSnippet("text_link") : getSnippet("text");
 

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/TextRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/TextRenderer.java
@@ -41,8 +41,6 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 public class TextRenderer extends AbstractWidgetRenderer {
 
-    private final Logger logger = LoggerFactory.getLogger(TextRenderer.class);
-
     @Activate
     public TextRenderer(final BundleContext bundleContext, final @Reference TranslationProvider i18nProvider,
             final @Reference ItemUIRegistry itemUIRegistry, final @Reference LocaleProvider localeProvider) {

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/VideoRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/VideoRenderer.java
@@ -61,7 +61,6 @@ public class VideoRenderer extends AbstractWidgetRenderer {
         String snippet = null;
 
         String widgetId = itemUIRegistry.getWidgetId(w);
-        // String sitemap = w.eResource().getURI().path();
 
         // we handle mjpeg streams as an html image as browser can usually handle this
         String snippetName = (videoWidget.getEncoding() != null
@@ -100,7 +99,6 @@ public class VideoRenderer extends AbstractWidgetRenderer {
             snippet = StringUtils.replace(snippet, "%url%", url);
             snippet = StringUtils.replace(snippet, "%media_type%", mediaType);
         }
-
         sb.append(snippet);
         return ECollections.emptyEList();
     }

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/VideoRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/VideoRenderer.java
@@ -56,12 +56,12 @@ public class VideoRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Video videoWidget = (Video) w;
         String snippet = null;
 
         String widgetId = itemUIRegistry.getWidgetId(w);
-        String sitemap = w.eResource().getURI().path();
+        // String sitemap = w.eResource().getURI().path();
 
         // we handle mjpeg streams as an html image as browser can usually handle this
         String snippetName = (videoWidget.getEncoding() != null

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/WebviewRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/WebviewRenderer.java
@@ -50,7 +50,7 @@ public class WebviewRenderer extends AbstractWidgetRenderer {
     }
 
     @Override
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException {
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException {
         Webview webview = (Webview) w;
         String snippet = getSnippet("webview");
         snippet = preprocessSnippet(snippet, webview);

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/WebAppServlet.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/WebAppServlet.java
@@ -168,7 +168,6 @@ public class WebAppServlet extends BaseServlet {
                 return;
             }
 
-            logger.debug("reading sitemap {}", sitemap.getName());
             if (widgetId == null || widgetId.isEmpty() || widgetId.equals(sitemapName)) {
                 // we are at the homepage, so we render the children of the sitemap root node
                 if (subscriptionId != null) {

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/render/WidgetRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/render/WidgetRenderer.java
@@ -43,7 +43,7 @@ public interface WidgetRenderer {
      *         a "%children%" placeholder for them.
      * @throws RenderException if an error occurs during rendering
      */
-    public EList<Widget> renderWidget(Widget w, StringBuilder sb) throws RenderException;
+    public EList<Widget> renderWidget(Widget w, StringBuilder sb, String sitemap) throws RenderException;
 
     /**
      * Applies a servlet configuration to the renderer


### PR DESCRIPTION
This is a change to the way basic ui looks up sitemap names for Image and Video types(and any other future types that utilize the proxy).

PR for the core.proxy service is here : openhab/openhab-core#2162

Description of issues covered by this :
https://community.openhab.org/t/images-video-sitemaps-and-proxy/115677