### PR TITLE
Fixes ctrl+save on settings pages

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/services/service-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/services/service-settings.vue
@@ -54,23 +54,23 @@ export default {
         this.$f7.emit('sidebarRefresh', this.config.locale)
       }
       this.$f7router.back()
-    }
-  },
-  onPageAfterIn () {
-    if (window) {
-      window.addEventListener('keydown', this.keyDown)
-    }
-  },
-  onPageBeforeOut () {
-    if (window) {
-      window.removeEventListener('keydown', this.keyDown)
-    }
-  },   
-  keyDown (ev) {
-    if (ev.keyCode === 83 && (ev.ctrlKey || ev.metaKey)) {
-      this.save()
-      ev.stopPropagation()
-      ev.preventDefault()
+    },
+    onPageAfterIn () {
+      if (window) {
+        window.addEventListener('keydown', this.keyDown)
+      }
+    },
+    onPageBeforeOut () {
+      if (window) {
+        window.removeEventListener('keydown', this.keyDown)
+      }
+    },   
+    keyDown (ev) {
+      if (ev.keyCode === 83 && (ev.ctrlKey || ev.metaKey)) {
+        this.save()
+        ev.stopPropagation()
+        ev.preventDefault()
+      }
     }
   }, 
   created () {


### PR DESCRIPTION
When navigating to settings page, i.e. Basic UI, the following is logged:

```
vue.esm.js?a026:628 [Vue warn]: Property or method "onPageAfterIn" is not defined on the instance but referenced during render. Make sure that this property is reactive, either in the data option, or for class-based components, by initializing the property. See: https://vuejs.org/v2/guide/reactivity.html#Declaring-Reactive-Properties.
```

Signed-off-by: Boris Krivonog <boris.krivonog@inova.si>