### PR TITLE
Allow customisation of location-card badges.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
@@ -73,14 +73,14 @@ export default {
       }
     },
     map () {
-      return this.query.map((item) => this.store[item.name].state).filter((state) => Number.isFinite(Number.parseFloat(state.split(' ')[0])))
+      return this.query.map((item) => this.store[item.name].state).filter((state) => Number.isFinite(Number.parseFloat(state)))
     },
     mapAux () {
-      return this.queryAux.map((item) => this.store[item.name].state).filter((state) => Number.isFinite(Number.parseFloat(state.split(' ')[0])))
+      return this.queryAux.map((item) => this.store[item.name].state).filter((state) => Number.isFinite(Number.parseFloat(state)))
     },
     reduce () {
       const ret = this.map.reduce((avg, state, arr, { length }) => {
-        const value = Number.parseFloat(state.split(' ')[0])
+        const value = Number.parseFloat(state)
         if (Number.isFinite(value)) {
           return avg + value / length
         }
@@ -92,7 +92,7 @@ export default {
     reduceAux () {
       if (this.type !== 'temperature') return undefined
       const ret = this.mapAux.reduce((avg, state, arr, { length }) => {
-        const value = Number.parseFloat(state.split(' ')[0])
+        const value = Number.parseFloat(state)
         if (Number.isFinite(value)) {
           return avg + value / length
         }

--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/status-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/status-badge.vue
@@ -34,9 +34,10 @@
 
 <script>
 import { findEquipment, allEquipmentPoints, findPoints } from '../glance-helpers'
+import expr from 'expression-eval'
 
 export default {
-  props: ['element', 'type', 'customConfig', 'invertColor', 'store'],
+  props: ['element', 'type', 'badgeOverrides', 'invertColor', 'store'],
   data () {
     return {
       badgeConfigs: {
@@ -57,6 +58,12 @@ export default {
   },
   computed: {
     config () {
+      if (this.badgeOverrides) {
+        const override = this.badgeOverrides[this.type]
+        if (override && override.badge) {
+          return Object.assign(this.badgeConfigs[this.type], override.badge)
+        }
+      }
       return this.badgeConfigs[this.type]
     },
     query () {
@@ -171,6 +178,13 @@ export default {
       return this.query.map((item) => this.store[item.name].state)
     },
     reduce () {
+      if (this.badgeOverrides) {
+        const override = this.badgeOverrides[this.type]
+        if (override && override.expression) {
+          const ast = expr.parse(override.expression)
+          return this.map.filter((state) => expr.eval(ast, { state: state, Number: Number })).length
+        }
+      }
       switch (this.type) {
         case 'lights':
           return this.map.filter((state) => state === 'ON' || (state.split(',').length === 3 && state.split(',')[2] !== '0') || (state.indexOf(',') < 0 && Number.parseInt(state) > 0)).length

--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/status-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/status-badge.vue
@@ -198,7 +198,7 @@ export default {
       if (this.badgeOverrides && !this.exprAst) {
         const override = this.badgeOverrides[this.type]
         if (override && override.expression) {
-            this.exprAst = expr.parse(override.expression)
+          this.exprAst = expr.parse(override.expression)
         }
       }
       return this.exprAst

--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/status-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/status-badge.vue
@@ -53,7 +53,8 @@ export default {
         screens: { icon: 'f7:tv' },
         projectors: { icon: 'f7:videocam_fill' },
         speakers: { icon: 'f7:speaker_2_fill' }
-      }
+      },
+      exprAst: null
     }
   },
   computed: {
@@ -178,12 +179,9 @@ export default {
       return this.query.map((item) => this.store[item.name].state)
     },
     reduce () {
-      if (this.badgeOverrides) {
-        const override = this.badgeOverrides[this.type]
-        if (override && override.expression) {
-          const ast = expr.parse(override.expression)
-          return this.map.filter((state) => expr.eval(ast, { state: state, Number: Number })).length
-        }
+      const ast = this.overrideExpression()
+      if (ast) {
+        return this.map.filter((state) => expr.eval(ast, { state: state, Number: Number })).length
       }
       switch (this.type) {
         case 'lights':
@@ -193,6 +191,17 @@ export default {
         default:
           return this.map.filter((state) => state === 'ON' || state === 'OPEN').length
       }
+    }
+  },
+  methods: {
+    overrideExpression () {
+      if (this.badgeOverrides && !this.exprAst) {
+        const override = this.badgeOverrides[this.type]
+        if (override && override.expression) {
+            this.exprAst = expr.parse(override.expression)
+        }
+      }
+      return this.exprAst
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -10,7 +10,7 @@
       <div class="location-stats margin-top" :class="config.invertText ? 'invert-text' : ''" v-if="!config.disableBadges">
         <span v-for="badgeType in ['alarms', 'lights', 'windows', 'doors', 'garagedoors', 'blinds', 'presence', 'lock', 'climate', 'screens', 'projectors', 'speakers']" :key="badgeType">
           <status-badge v-if="!config.badges || !config.badges.length || config.badges.indexOf(badgeType) >= 0"
-                        :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" />
+            :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" :badgeOverrides="badgeOverrides"/>
         </span>
       </div>
       <div class="location-stats margin-top-half" v-if="!config.disableBadges">
@@ -66,9 +66,10 @@ export default {
       activeTab: (this.element.equipment.length === 0 && this.element.properties.length > 0) ? 'properties' : 'equipment'
     }
   },
-  methods: {
-  },
   computed: {
+    badgeOverrides () {
+      return this.config.badges || this.context.badgeOverrides
+    },
     propertiesListContext () {
       return {
         store: this.$store.getters.trackedItems,

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -10,7 +10,7 @@
       <div class="location-stats margin-top" :class="config.invertText ? 'invert-text' : ''" v-if="!config.disableBadges">
         <span v-for="badgeType in ['alarms', 'lights', 'windows', 'doors', 'garagedoors', 'blinds', 'presence', 'lock', 'climate', 'screens', 'projectors', 'speakers']" :key="badgeType">
           <status-badge v-if="!config.badges || !config.badges.length || config.badges.indexOf(badgeType) >= 0"
-            :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" :badgeOverrides="badgeOverrides"/>
+                        :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" :badgeOverrides="badgeOverrides" />
         </span>
       </div>
       <div class="location-stats margin-top-half" v-if="!config.disableBadges">

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -118,7 +118,7 @@ export default {
           component: (this.type === 'locations') ? 'oh-location-card' : (this.type === 'equipment') ? 'oh-equipment-card' : 'oh-property-card',
           config: {}
         },
-        store: this.$store.getters.trackedItems,
+        store: this.$store.getters.trackedItems
       }
       const page = this.page
       const type = this.type

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -113,13 +113,19 @@ export default {
       return excludedIdx >= 0
     },
     cardContext (element) {
-      return {
+      let context = {
         component: element.card || {
           component: (this.type === 'locations') ? 'oh-location-card' : (this.type === 'equipment') ? 'oh-equipment-card' : 'oh-property-card',
           config: {}
         },
-        store: this.$store.getters.trackedItems
+        store: this.$store.getters.trackedItems,
       }
+      const page = this.page
+      const type = this.type
+      if (page && page.slots && page.slots[type] && page.slots[type][0] && page.slots[type][0].config && page.slots[type][0].config.badges) {
+        context.badgeOverrides = page.slots[type][0].config.badges
+      }
+      return context
     },
     parentLocationName (item) {
       if (item.metadata.semantics.config && item.metadata.semantics.config.isPartOf) {


### PR DESCRIPTION
Was using OH 3 before https://github.com/openhab/openhab-webui/pull/771 was merged - at that time blinds badges were displayed on location card(s) when rollershutters were closed (in my case position > 0) - and after fix was merged, really still cannot get used seeing badge when blinds are open (up) :)

So instead of arguing what is better, let's make it configurable so each can decide what suits best.

For example - Living Room, 3 blinds, 2 closed - default configuration:

<img src="https://user-images.githubusercontent.com/3818211/107160729-5233bd00-6998-11eb-8dbc-8c18876f9b78.png" width="300" >

If we want to see blind's badge when `position > 0` we can write

```
config:
  label: Home Page
locations:
  - component: oh-locations-tab
    config:
      cardOrder:
       ...
      excludedCards: []
    slots:
      gGF_Living:
        - component: oh-location-card
          config:
            badges:
              blinds:
                expression: Number.parseInt(state) > 0          
```

result

<img width="300" src="https://user-images.githubusercontent.com/3818211/107160858-25cc7080-6999-11eb-87c7-c3dfda3d9f57.png">

We can override icon too

```
        - component: oh-location-card
          config:
            badges:
              blinds:
                expression: Number.parseInt(state) > 0       
                badge:
                  icon: f7:logo_windows
```

<img width="300" src="https://user-images.githubusercontent.com/3818211/107160940-9c696e00-6999-11eb-8355-e27f2c6e68cf.png">

Badges can be overridden per card (as above example) or for all cards

```
config:
  label: Home Page
locations:
  - component: oh-locations-tab
    config:
      badges:
        blinds:
          badge:
            icon: f7:logo_windows
          expression: Number.parseInt(state) > 0
```

If both are specified, per-card definition takes precedence.

All badges can be overridden, i.e. both lights&blinds

```
config:
  label: Home Page
locations:
  - component: oh-locations-tab
    config:
      badges:
        blinds:
          expression: Number.parseInt(state) > 0
        lights:
          badge:
            icon: f7:sun_max
```

result

<img width="300" src="https://user-images.githubusercontent.com/3818211/107161165-27973380-699b-11eb-8d0d-eafface30da7.png">

I look forward to any feedback or comments.

Signed-off-by: Boris Krivonog <boris.krivonog@inova.si>