### PR TITLE
Avoid HEAD request

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/openhab/auth.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/auth.js
@@ -88,7 +88,7 @@ export function setAccessToken (token, api) {
   if (!token || !api || requireToken !== undefined) return Promise.resolve()
 
   // determine whether the token is required for user operations
-  return api.head('/rest/sitemaps').then((resp) => {
+  return api.get('/rest/sitemaps').then((resp) => {
     requireToken = false
     return Promise.resolve()
   }).catch((err) => {


### PR DESCRIPTION
Fix #888.
openHAB Cloud doesn't seem to support forwarding HTTP HEAD requests.
So do a GET /rest/sitemaps instead to determine whether the user operations are
allowed anonymously, which is a little bit of overhead but since it's only the _list_
of sitemaps it should be acceptable in most cases.

Signed-off-by: Yannick Schaus <github@schaus.net>