### PR TITLE
Add missing link to f7 input docs

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-input-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-card.md
@@ -50,11 +50,11 @@ Parameters of the card
 
 - `type` <small>TEXT</small> _Type_
 
-  Type of input (see f7-input docs)
+  Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)
 
 - `inputmode` <small>TEXT</small> _Input Mode_
 
-  Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>
+  Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)
 
 - `placeholder` <small>TEXT</small> _Placeholder_
 

--- a/bundles/org.openhab.ui/doc/components/oh-input-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-item.md
@@ -54,11 +54,11 @@ General settings of the list item
 
 - `type` <small>TEXT</small> _Type_
 
-  Type of input (see f7-input docs)
+  Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)
 
 - `inputmode` <small>TEXT</small> _Input Mode_
 
-  Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>
+  Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)
 
 - `placeholder` <small>TEXT</small> _Placeholder_
 

--- a/bundles/org.openhab.ui/doc/components/oh-input.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input.md
@@ -22,11 +22,11 @@ Displays an input field, used to set a variable
 
 - `type` <small>TEXT</small> _Type_
 
-  Type of input (see f7-input docs)
+  Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)
 
 - `inputmode` <small>TEXT</small> _Input Mode_
 
-  Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>
+  Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)
 
 - `placeholder` <small>TEXT</small> _Placeholder_
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
@@ -2,8 +2,8 @@ import { pi, pb, pt } from '../helpers.js'
 
 export default () => [
   pt('name', 'Name', 'Input name'),
-  pt('type', 'Type', 'Type of input (see f7-input docs)'),
-  pt('inputmode', 'Input Mode', 'Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>'),
+  pt('type', 'Type', 'Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)'),
+  pt('inputmode', 'Input Mode', 'Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)'),
   pt('placeholder', 'Placeholder', 'Placeholder text'),
   pb('sendButton', 'Send button', 'Display Send button to update the state with a command (needs a configured item)'),
   pb('clearButton', 'Clear button', 'Display input clear button when applicable'),


### PR DESCRIPTION
The link was missing. Not much more to say about this one.

Also aligned the style of those two links that are just next to each other to look the same.

This is what it looks like:

![image](https://user-images.githubusercontent.com/1475672/108521616-36031a80-72cc-11eb-9de0-e40c71be27f5.png)

This is what it links to: https://framework7.io/docs/inputs.html#supported-inputs

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>