### PR TITLE
List available colors for toggle UI items

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-toggle-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-toggle-card.md
@@ -9,7 +9,7 @@ source: https://github.com/openhab/openhab-webui/edit/main/bundles/org.openhab.u
 # oh-toggle-card - Toggle Card
 
 <!-- GENERATED componentDescription -->
-Display a toggle swtich in a card to send ON/OFF commands
+Display a toggle switch in a card to send ON/OFF commands
 <!-- GENERATED /componentDescription -->
 
 ## Configuration
@@ -50,6 +50,6 @@ Parameters of the card
 
 - `color` <small>TEXT</small> _Color_
 
-  Color of the control
+  Color of the control (supported values: red, green, blue, pink, yellow, orange, purple, deeppurple, lightblue, teal, lime, deeporange, gray, white, black)
 
 <!-- GENERATED /props -->

--- a/bundles/org.openhab.ui/doc/components/oh-toggle-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-toggle-item.md
@@ -54,6 +54,6 @@ General settings of the list item
 
 - `color` <small>TEXT</small> _Color_
 
-  Color of the control
+  Color of the control (supported values: red, green, blue, pink, yellow, orange, purple, deeppurple, lightblue, teal, lime, deeporange, gray, white, black)
 
 <!-- GENERATED /props -->

--- a/bundles/org.openhab.ui/doc/components/oh-toggle.md
+++ b/bundles/org.openhab.ui/doc/components/oh-toggle.md
@@ -22,7 +22,7 @@ Toggle control, allows to switch on or off
 
 - `color` <small>TEXT</small> _Color_
 
-  Color of the control
+  Color of the control (supported values: red, green, blue, pink, yellow, orange, purple, deeppurple, lightblue, teal, lime, deeporange, gray, white, black)
 
 - `variable` <small>TEXT</small> _Variable_
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/toggle.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/toggle.js
@@ -2,5 +2,5 @@ import { pi, pt } from '../helpers.js'
 
 export default () => [
   pi('item', 'Item', 'Item to control'),
-  pt('color', 'Color', 'Color of the control')
+  pt('color', 'Color', 'Color of the control (supported values: red, green, blue, pink, yellow, orange, purple, deeppurple, lightblue, teal, lime, deeporange, gray, white, black)')
 ]


### PR DESCRIPTION
Took the values from the css, so kind of reverse engineered.

This is what it looks like:

![image](https://user-images.githubusercontent.com/1475672/108525178-1c63d200-72d0-11eb-8cb5-21e1639f6b14.png)

Also fixed a typo.

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>