### PR TITLE
Show ThingUID instead of ThingTypeUID for discovery result

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -81,7 +81,7 @@
                           @click.exact="(e) => click(e, entry)"
                           :title="entry.label"
                           :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
-                          :footer="entry.thingTypeUID"
+                          :footer="entry.thingUID"
                           :badge="(entry.flag === 'IGNORED') ? 'IGNORED' : ''"
             >
               <!-- <f7-button icon-f7="add_round" color="blue" slot="after"></f7-button>


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/10154#issuecomment-779422785

Signed-off-by: Kai Kreuzer <kai@openhab.org>