### PR TITLE
Show ThingUID instead of ThingTypeUID for scan result

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -31,7 +31,7 @@
                         media-item
                         :title="entry.label"
                         :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
-                        :footer="entry.thingTypeUID">
+                        :footer="entry.thingUID">
           </f7-list-item>
           <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="blue"></f7-list-button>
         </f7-list>


### PR DESCRIPTION
Second (missing) part to https://github.com/openhab/openhab-webui/pull/920

Signed-off-by: Kai Kreuzer <kai@openhab.org>