### PR TITLE
Array.prototype.flat doesn't exist on older browsers, added fallback

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/app.js
+++ b/bundles/org.openhab.ui/web/src/js/app.js
@@ -1,3 +1,5 @@
+import './compatibility'
+
 // Import Vue
 import Vue from 'vue'
 

--- a/bundles/org.openhab.ui/web/src/js/compatibility.js
+++ b/bundles/org.openhab.ui/web/src/js/compatibility.js
@@ -1,0 +1,9 @@
+
+if (!Array.prototype.flat) {
+  // eslint-disable-next-line no-extend-native
+  Array.prototype.flat = function (depth = 1) {
+    return this.reduce(function (flat, toFlatten) {
+      return flat.concat((Array.isArray(toFlatten) && (depth > 1)) ? toFlatten.flat(depth - 1) : toFlatten)
+    }, [])
+  }
+}


### PR DESCRIPTION
Added a fallback implementation for missing `Array.prototype.flat` on older browsers.

Fixes https://github.com/openhab/openhab-webui/issues/647.

Discussion on https://community.openhab.org/t/oh3-mainui-on-smart-tvs/116209

Signed-off-by: Boris Krivonog <boris.krivonog@inova.si>