### PR TITLE
Refactor grid layout new item positioning

### DIFF
--- a/bundles/org.openhab.ui/doc/components/index.md
+++ b/bundles/org.openhab.ui/doc/components/index.md
@@ -87,6 +87,7 @@ source: https://github.com/openhab/openhab-webui/edit/main/bundles/org.openhab.u
 |--------|------|-------------|
 | [`oh-block`](./oh-block.html) |  [Layout Grid Block](./oh-block.html) | A block in a grid layout |
 | [`oh-grid-col`](./oh-grid-col.html) |  [Layout Grid Column](./oh-grid-col.html) | A column in a grid layout |
+| [`oh-grid-layout`](./oh-grid-layout.html) |  [Fixed Grid Layout](./oh-grid-layout.html) | Arranges widgets on a grid of squares with user-defined sizes |
 | [`oh-grid-row`](./oh-grid-row.html) |  [Layout Grid Row](./oh-grid-row.html) | A row in a grid layout |
 | [`oh-masonry`](./oh-masonry.html) |  [Masonry Layout](./oh-masonry.html) | Arranges widgets automatically depending on the screen size |
 

--- a/bundles/org.openhab.ui/doc/components/oh-grid-layout.md
+++ b/bundles/org.openhab.ui/doc/components/oh-grid-layout.md
@@ -1,0 +1,143 @@
+---
+title: oh-grid-layout - Fixed Grid Layout
+component: oh-grid-layout
+label: Fixed Grid Layout
+description: Arranges widgets on a grid of squares with user-defined sizes
+source: https://github.com/openhab/openhab-webui/edit/main/bundles/org.openhab.ui/doc/components/oh-grid-layout.md
+prev: /docs/ui/components/
+---
+
+# oh-grid-layout - Fixed Grid Layout
+
+<!-- Put a screenshot here if relevant:
+![](./images/oh-grid-layout/header.jpg)
+-->
+
+[[toc]]
+
+<!-- Note: you can overwrite the definition-provided description and add your own intro/additional sections instead -->
+<!-- DO NOT REMOVE the following comments if you intend to keep the definition-provided description -->
+<!-- GENERATED componentDescription -->
+Arranges widgets on a grid of squares with user-defined sizes
+<!-- GENERATED /componentDescription -->
+
+## Configuration
+
+<!-- DO NOT REMOVE the following comments -->
+<!-- GENERATED props -->
+### Layout Settings
+<div class="props">
+<PropGroup name="layout" label="Layout Settings">
+<PropBlock type="INTEGER" name="colNum" label="Number of Columns">
+  <PropDescription>
+    Number of columns across the page (default 16, limited to a minimum widget width of 50px)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="margin" label="Margin">
+  <PropDescription>
+    Margin between items and to screen (default 10)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="verticalCompact" label="Vertical Compact">
+  <PropDescription>
+    Automatically align items from top to bottom (default false)
+  </PropDescription>
+</PropBlock>
+</PropGroup>
+</div>
+
+### Screen Settings
+<div class="props">
+<PropGroup name="screenSettings" label="Screen Settings">
+<PropBlock type="INTEGER" name="screenWidth" label="Screen Width">
+  <PropDescription>
+    Screen width in pixels (default 1280)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="screenHeight" label="Screen Height">
+  <PropDescription>
+    Screen width in pixels (default 720)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="scale" label="Scaling">
+  <PropDescription>
+    Scale content to other screen widths (can lead to unexpected styling issues) (default false)
+  </PropDescription>
+</PropBlock>
+</PropGroup>
+</div>
+
+### Appearance
+<div class="props">
+<PropGroup name="appearance" label="Appearance">
+<PropBlock type="BOOLEAN" name="hideNavbar" label="Hide Navigation bar">
+  <PropDescription>
+    Hide navigation bar on top when page is displayed (You can additionally hide the sidebar using its pin icon) (default false)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="hideSidebarIcon" label="Hide Sidebar Icon">
+  <PropDescription>
+    Don't show a menu icon in the top left corner when the sidebar is closed (default false)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="showFullscreenIcon" label="Show Fullscreen Icon">
+  <PropDescription>
+    Show a fullscreen icon on the top right corner (default false)
+  </PropDescription>
+</PropBlock>
+</PropGroup>
+</div>
+
+
+<!-- GENERATED /props -->
+
+<!-- If applicable describe how properties are forwarded to a underlying component from Framework7, ECharts, etc.:
+### Inherited Properties
+
+-->
+
+<!-- If applicable describe the slots recognized by the component and what they represent:
+### Slots
+
+#### `default`
+
+The contents of the oh-grid-layout.
+
+-->
+
+<!-- Add as many examples as desired - put the YAML in a details container when it becomes too long (~150/200+ lines):
+## Examples
+
+### Example 1
+
+![](./images/oh-grid-layout/example1.jpg)
+
+```yaml
+component: oh-grid-layout
+config:
+  prop1: value1
+  prop2: value2
+```
+
+### Example 2
+
+![](./images/oh-grid-layout/example2.jpg)
+
+::: details YAML
+```yaml
+component: oh-grid-layout
+config:
+  prop1: value1
+  prop2: value2
+slots
+```
+:::
+
+-->
+
+<!-- Try to clean up URLs to the forum (https://community.openhab.org/t/<threadID>[/<postID>] should suffice)
+## Community Resources
+
+- [Community Post 1](https://community.openhab.org/t/12345)
+- [Community Post 2](https://community.openhab.org/t/23456)
+-->

--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -186,15 +186,15 @@ module.exports = {
     ]
   },
   plugins: [
-    new ESLintPlugin({
-      extensions: ['js','vue'],
-    }),
     new webpack.DefinePlugin({
       'process.env.NODE_ENV': JSON.stringify(env),
       'process.env.TARGET': JSON.stringify(target)
     }),
     new VueLoaderPlugin(),
     ...(env === 'production' ? [
+      new ESLintPlugin({
+        extensions: ['js', 'vue']
+      }),
       new OptimizeCSSPlugin({
         cssProcessorOptions: {
           safe: true,

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/layout/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/layout/index.js
@@ -1,6 +1,6 @@
 // definitions for the layout widgets
 
-import { WidgetDefinition, po, pt, pn, pb, pg } from '../helpers'
+import { WidgetDefinition, po, pt, pn, pb, pg } from '../helpers.js'
 
 export function OhBlockDescription () {
   return new WidgetDefinition('oh-block', 'Layout Grid Block', 'A block in a grid layout')
@@ -44,7 +44,7 @@ export function OhMasonryDefinition () {
 }
 
 export function OhGridLayoutDefinition () {
-  return new WidgetDefinition('oh-grid-layout', 'Grid Layout', 'A grid layout')
+  return new WidgetDefinition('oh-grid-layout', 'Fixed Grid Layout', 'Arranges widgets on a grid of squares with user-defined sizes')
     .paramGroup(pg('layout', 'Layout Settings'), [
       pn('colNum', 'Number of Columns', 'Number of columns across the page (default 16, limited to a minimum widget width of 50px)'),
       pn('margin', 'Margin', 'Margin between items and to screen (default 10)'),

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -43,8 +43,8 @@
             </f7-col>
             <f7-col width="50" class="elevation-2 elevation-hover-6 elevation-pressed-1" style="background-color: var(--f7-card-bg-color)">
               <f7-link @click="setLayoutType('fixed')" class="flex-direction-column padding" style="color: var(--f7-theme-color-text-color)">
-                <f7-icon size="70px" f7="rectangle"></f7-icon>
-                <div class="margin-bottom">Fixed</div>
+                <f7-icon size="70px" f7="grid"></f7-icon>
+                <div class="margin-bottom">Fixed Grid</div>
                 <div class="margin-top">Create a panel-like page for a specific screen size. Suitable for e.g. wall mounted tablets.</div>
               </f7-link>
             </f7-col>
@@ -91,6 +91,9 @@
 .layout-editor
   .page-content
     z-index inherit
+  .toolbar-details
+    .tab-link-highlight
+      display none
 </style>
 
 <script>


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/pull/835#discussion_r588900440.
Generate docs for oh-grid-layout.
Minor labels, descriptions, styling fixes.

Move the ESLint plugin to production environments
only (the hot reloading is near unusable in dex mode
with the linting activated on save - the CI & release
builds will still fail but the developer is expected to
rely on an IDE extension or other means to ensure
the code is properly linted during development.

Signed-off-by: Yannick Schaus <github@schaus.net>