### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # Add-on maintainers:
 /bundles/org.openhab.ui.iconset.classic/ @kaikreuzer
-/bundles/org.openhab.ui.basic/ @lolodomo @resetnow
+/bundles/org.openhab.ui.basic/ @openhab/webui-maintainers
 /bundles/org.openhab.ui.cometvisu/ @peuter
 /bundles/org.openhab.ui.cometvisu.php/ @peuter
 /bundles/org.openhab.ui.habot/ @ghys


### PR DESCRIPTION
GitHub will not request reviews from users if they don't have write access to the repo.