### PR TITLE
 [MainUI] fix type "number" for list separator in Designer

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -27,7 +27,7 @@
           <f7-list-input v-if="supports('minValue')" label="Minimum" type="number" :value="widget.config.minValue" @input="updateParameter('minValue', $event)" clear-button />
           <f7-list-input v-if="supports('maxValue')" label="Maximum" type="number" :value="widget.config.maxValue" @input="updateParameter('maxValue', $event)" clear-button />
           <f7-list-input v-if="supports('step')" label="Step" type="number" :value="widget.config.step" @input="updateParameter('step', $event)" clear-button />
-          <f7-list-input v-if="supports('separator')" label="Separator" type="number" :value="widget.config.separator" @input="updateParameter('separator', $event)" clear-button />
+          <f7-list-input v-if="supports('separator')" label="Separator" type="text" :value="widget.config.separator" @input="updateParameter('separator', $event)" clear-button />
           <f7-list-item v-if="supports('switchEnabled')" title="Switch enabled">
             <f7-toggle slot="after" :checked="widget.config.switchEnabled" @toggle:change="widget.config.switchEnabled = $event" />
           </f7-list-item>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -98,7 +98,7 @@ export default {
     },
     updateParameter (parameter, $event) {
       let value = $event.target.value
-      if (value && !isNaN(value)) {
+      if (value && $event.target.type === 'number' && !isNaN(value)) {
         value = parseFloat(value)
       }
       this.$set(this.widget.config, parameter, value)


### PR DESCRIPTION
Fixes #949 

After changing the separator type to `text` it works as intended but there was one problem in following use case: when you need a space `' '` as separator character/string, the `updateParameter` method interprets it as a non-NaN value (since `isNaN(' ')` is `false`) and resultet in a `NaN` as input string. (This also occurs on other text inputs when you type a space, like url, refresh, frequency, ...)

I tought about two ways to solve this:
1. Only check for isNaN when `type="number"` (like in the second commit)
2. use `isNaN(parseFloat(value))` instead of `isNaN(value)`, since `parseFloat(' ') === NaN` so the check would work. This way had one problem when the number of space characters is important because `parseFloat('       1') === 1` and this will trim leading whitespaces of the input.