### PR TITLE
add missing page check in page-view

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -1,10 +1,10 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" hide-bars-on-scroll :style="pageStyle">
-    <f7-navbar v-if="!page.config.hideNavbar" :back-link="(showBackButton) ? $t('page.navbar.back') : undefined">
+    <f7-navbar v-if="!page || !page.config.hideNavbar" :back-link="(showBackButton) ? $t('page.navbar.back') : undefined">
       <f7-nav-left v-if="!showBackButton">
         <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
       </f7-nav-left>
-      <f7-nav-title>{{ (ready) ? page.config.label : '' }}</f7-nav-title>
+      <f7-nav-title>{{ (page) ? page.config.label : '' }}</f7-nav-title>
       <f7-nav-right>
         <f7-link v-if="isAdmin" icon-md="material:edit" :href="'/settings/pages/' + pageType + '/' + uid">
           {{ $theme.md ? '' : $t('page.navbar.edit') }}
@@ -14,27 +14,25 @@
 
     <f7-link v-else-if="!page.config.hideSidebarIcon" class="sidebar-icon" icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
 
-    <f7-link v-if="$fullscreen.support && page.config.showFullscreenIcon" class="fullscreen-icon" :icon-f7="fullscreen ? 'rectangle_arrow_up_right_arrow_down_left_slash' : 'rectangle_arrow_up_right_arrow_down_left'" @click="toggleFullscreen" />
+    <f7-link v-if="page && $fullscreen.support && page.config.showFullscreenIcon" class="fullscreen-icon" :icon-f7="fullscreen ? 'rectangle_arrow_up_right_arrow_down_left_slash' : 'rectangle_arrow_up_right_arrow_down_left'" @click="toggleFullscreen" />
 
     <f7-toolbar tabbar labels bottom v-if="page && pageType === 'tabs' && visibleToCurrentUser">
       <f7-link v-for="(tab, idx) in page.slots.default" :key="idx" tab-link @click="onTabChange(idx)" :tab-link-active="currentTab === idx" :icon-ios="tab.config.icon" :icon-md="tab.config.icon" :icon-aurora="tab.config.icon" :text="tab.config.title" />
     </f7-toolbar>
 
-    <f7-tabs v-if="page && pageType === 'tabs' && visibleToCurrentUser" :class="{notready: !ready}">
+    <f7-tabs v-if="page && pageType === 'tabs' && visibleToCurrentUser">
       <f7-tab v-for="(tab, idx) in page.slots.default" :key="idx" :tab-active="currentTab === idx">
         <component v-if="currentTab === idx" :is="tabComponent(tab)" :context="tabContext(tab)" @command="onCommand" />
       </f7-tab>
     </f7-tabs>
 
-    <component :is="page.component" v-else-if="page && visibleToCurrentUser" :context="context" :class="{notready: !ready}" @command="onCommand" />
+    <component :is="page.component" v-else-if="page && visibleToCurrentUser" :context="context" @command="onCommand" />
 
     <empty-state-placeholder v-if="!visibleToCurrentUser" icon="multiply_circle_fill" title="page.unavailable.title" text="page.unavailable.text" />
   </f7-page>
 </template>
 
 <style lang="stylus">
-.notready
-  visibility hidden
 .sidebar-icon
   position fixed
   top 8px
@@ -60,9 +58,7 @@ export default {
   data () {
     return {
       currentTab: 0,
-      // ready: false,
       loading: false,
-      // page: {}
       fullscreen: this.$fullscreen.getState()
     }
   },
@@ -101,11 +97,8 @@ export default {
           return 'unknown'
       }
     },
-    ready () {
-      return this.page
-    },
     isAdmin () {
-      return this.ready && this.$store.getters.isAdmin
+      return this.page && this.$store.getters.isAdmin
     },
     visibleToCurrentUser () {
       if (!this.page || !this.page.config || !this.page.config.visibleTo) return true


### PR DESCRIPTION
This fixes a [bug raised in the community forums](https://community.openhab.org/t/openhab-3-ui-not-loading-items-on-browser-refresh-on-pages/118979).

I couldn't help it and again did some additional cleanup 😬 :

Having both `page` and `ready` for the same seemed confusing somewhat inconsistent in lines like this:
```js
    <f7-tabs v-if="page && pageType === 'tabs' && visibleToCurrentUser" :class="{notready: !ready}">
```

Additionally, I completely removed the notready css, as it actually only gets rendered when it is ready (`v-if="page ...`).