### PR TITLE
Wrap list items in list card in widget editor preview, fixes #923

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -137,8 +137,7 @@ export default {
           ? {
             component: 'oh-list-card',
             config: {
-              mediaList: true,
-              footer: 'Detected list item as root component, wrapping in list card for preview'
+              mediaList: true
             },
             slots: {
               default: [this.widget]

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -105,6 +105,8 @@ import { strOptions } from 'yaml/types'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import DirtyMixin from '@/pages/settings/dirty-mixin'
 
+import * as StandardListWidgets from '@/components/widgets/standard/list'
+
 strOptions.fold.lineWidth = 0
 
 export default {
@@ -124,13 +126,25 @@ export default {
       vars: {},
       blockKey: this.$f7.utils.id(),
       widgetKey: this.$f7.utils.id(),
-      widgetPropsOpened: false
+      widgetPropsOpened: false,
+      standardListWidgets: Object.values(StandardListWidgets).filter((c) => c.widget && typeof c.widget === 'function').map((c) => c.widget().name)
     }
   },
   computed: {
     context () {
       return {
-        component: this.widget,
+        component: !this.widget.component || this.standardListWidgets.includes(this.widget.component) || this.widget.component.startsWith('f7-list-item')
+          ? {
+            component: 'oh-list-card',
+            config: {
+              mediaList: true,
+              footer: 'Detected list item as root component, wrapping in list card for preview'
+            },
+            slots: {
+              default: [this.widget]
+            }
+          }
+          : this.widget,
         store: this.$store.getters.trackedItems,
         props: this.props,
         vars: this.vars


### PR DESCRIPTION
Result looks like this:

![wrapped_list_item](https://user-images.githubusercontent.com/2242688/111202569-4c974b80-85c4-11eb-9af5-285495211061.png)

It shows some additional information in the list card footer, so developers are made aware about what's happening behind the scenes. Can be omitted.

Roughly based on code in `item-metadata-widget`.