### PR TITLE
Oh-Stepper component load default value when not initialized

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-stepper ref="stepper" v-bind="config" :value="value" @stepper:change="onChange"
+  <f7-stepper ref="stepper" v-bind="config" :value="(value)? value : defaultValue" @stepper:change="onChange"
               :manual-input-mode="false" :format-value="formatValue" />
 </template>
 
@@ -10,7 +10,13 @@ import { OhStepperDefinition } from '@/assets/definitions/widgets/system'
 export default {
   mixins: [mixin],
   widget: OhStepperDefinition,
+  data () {
+    return {
+      defaultValue: null
+    }
+  },
   mounted () {
+    this.defaultValue = this.config.value
     delete this.config.value
   },
   computed: {


### PR DESCRIPTION
When an oh-stepper component is created with a simple variable, the value is deleted within the mounted.  See issue #924 

This simple fix checks if the value is null and replaces it with the defaultValue.

I don't know if this is a proper solution, as I think the root of this issue is in the variable initialization but might be a good starting point for this issue.

closes #924 

Signed-off-by: Tom Hoefnagel <hoefnageltom@gmail.com>