### PR TITLE
Fix some misc minor issues

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -51,7 +51,7 @@ A regular or expandable cell
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="color" label="Highlight Color">

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -51,7 +51,7 @@ A cell expanding to a color picker
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="color" label="Highlight Color">

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-item.md
@@ -46,7 +46,7 @@ Display a color picker in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-input-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-card.md
@@ -72,7 +72,7 @@ Display an input in a card
 </PropBlock>
 <PropBlock type="TEXT" name="inputmode" label="Input Mode">
   <PropDescription>
-    Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>
+    Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="placeholder" label="Placeholder">

--- a/bundles/org.openhab.ui/doc/components/oh-input-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-item.md
@@ -46,7 +46,7 @@ Display an input field in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">
@@ -77,7 +77,7 @@ Display an input field in a list
 </PropBlock>
 <PropBlock type="TEXT" name="inputmode" label="Input Mode">
   <PropDescription>
-    Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>
+    Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="placeholder" label="Placeholder">

--- a/bundles/org.openhab.ui/doc/components/oh-input.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input.md
@@ -40,7 +40,7 @@ Displays an input field, used to set a variable
 </PropBlock>
 <PropBlock type="TEXT" name="inputmode" label="Input Mode">
   <PropDescription>
-    Type of data that might be entered: see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>
+    Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="placeholder" label="Placeholder">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -51,7 +51,7 @@ A cell expanding to a knob control
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="color" label="Highlight Color">

--- a/bundles/org.openhab.ui/doc/components/oh-label-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-card.md
@@ -237,7 +237,7 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -51,7 +51,7 @@ A cell with a big label to show a short item state value
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="color" label="Highlight Color">

--- a/bundles/org.openhab.ui/doc/components/oh-label-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-item.md
@@ -57,7 +57,7 @@ Display the state of an item in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-list-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-list-item.md
@@ -46,7 +46,7 @@ A list item
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -51,7 +51,7 @@ A marker on a floor plan
 <PropGroup name="icon" label="Icon">
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="iconUseState" label="Icon depends on state">

--- a/bundles/org.openhab.ui/doc/components/oh-player-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-player-item.md
@@ -46,7 +46,7 @@ Display player controls in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
@@ -51,7 +51,7 @@ A cell expanding to rollershutter controls
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="color" label="Highlight Color">

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-item.md
@@ -46,7 +46,7 @@ Display rollershutter controls in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-card.md
@@ -87,7 +87,7 @@ Display a slider in a card to control an item
 </PropBlock>
 <PropBlock type="BOOLEAN" name="label" label="Display Label">
   <PropDescription>
-    Display a label above the slider knob
+    Display a label above the slider knob while sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="scale" label="Display Scale">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -51,7 +51,7 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="color" label="Highlight Color">
@@ -97,7 +97,7 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="BOOLEAN" name="label" label="Display Label">
   <PropDescription>
-    Display a label above the slider knob
+    Display a label above the slider knob while sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="scale" label="Display Scale">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-item.md
@@ -46,7 +46,7 @@ Display a slider control in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">
@@ -92,7 +92,7 @@ Display a slider control in a list
 </PropBlock>
 <PropBlock type="BOOLEAN" name="label" label="Display Label">
   <PropDescription>
-    Display a label above the slider knob
+    Display a label above the slider knob while sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="scale" label="Display Scale">

--- a/bundles/org.openhab.ui/doc/components/oh-slider.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider.md
@@ -55,7 +55,7 @@ Slider control, allows to pick a number value on a scale
 </PropBlock>
 <PropBlock type="BOOLEAN" name="label" label="Display Label">
   <PropDescription>
-    Display a label above the slider knob
+    Display a label above the slider knob while sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="scale" label="Display Scale">

--- a/bundles/org.openhab.ui/doc/components/oh-stepper-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper-item.md
@@ -46,7 +46,7 @@ Display a stepper control in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-toggle-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-toggle-card.md
@@ -18,7 +18,7 @@ prev: /docs/ui/components/
 <!-- Note: you can overwrite the definition-provided description and add your own intro/additional sections instead -->
 <!-- DO NOT REMOVE the following comments if you intend to keep the definition-provided description -->
 <!-- GENERATED componentDescription -->
-Display a toggle switch in a card to send ON/OFF commands
+Display a toggle swtich in a card to send ON/OFF commands
 <!-- GENERATED /componentDescription -->
 
 ## Configuration

--- a/bundles/org.openhab.ui/doc/components/oh-toggle-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-toggle-item.md
@@ -46,7 +46,7 @@ Display a toggle switch in a list
 </PropBlock>
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
-    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>) or <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)
+    Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
@@ -6,7 +6,7 @@ export default () => [
   pd('max', 'Max', 'Maximum value'),
   pd('step', 'Step', 'Minimum interval between values'),
   pd('vertical', 'Vertical', 'Display the slider vertically'),
-  pb('label', 'Display Label', 'Display a label above the slider knob'),
+  pb('label', 'Display Label', 'Display a label above the slider knob while sliding'),
   pb('scale', 'Display Scale', 'Display a scale on the slider'),
   pn('scaleSteps', 'Scale steps', 'Number of (major) scale markers'),
   pn('scaleSubSteps', 'Scale sub-steps', 'Number of scale minor markers between each major marker'),

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-layout.vue
@@ -117,7 +117,7 @@ export default {
   },
   created () {
     this.colNum = this.config.colNum || 16
-    this.margin = this.config.margin || 10
+    this.margin = this.config.margin >= 0 ? this.config.margin : 10
 
     if (this.config.layoutType === 'fixed') {
       this.style.width = this.screenWidth = this.config.screenWidth || 1280

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-page @page:init="load" @page:reinit="load" @page:afterout="stopEventSource">
+  <f7-page @page:beforein="load" @page:afterout="stopEventSource">
     <f7-navbar title="Items" back-link="Settings" back-link-url="/settings/" back-link-force>
       <f7-nav-right>
         <f7-link icon-md="material:done_all" @click="toggleCheck()"


### PR DESCRIPTION
> Fix zero margin not applied in oh-grid-layout

Fixes zero margin issue reported in [comment in #835](https://github.com/openhab/openhab-webui/pull/835#issuecomment-803290075)

> Make slider label help more descriptive

I had to lookup the f7 docs to find out where this "label" actually sits. Perhaps this small addition also helps others like it would help me 😉.

> Fix load issue in item-list-vlist

Fixes an issue introduced with #954: I repeatedly hit the issue that when returning from metadata to item-details, the whole site would not react due to the item-list-vlist page being pre-loaded in background and not having $refs defined and thus hitting an exception - though not always 🤔. I didn't really track it down to the root, just fixed it by having it only load before the page is actually shown, which made it disappear.