### PR TITLE
Replace double percent sign in chart unit, fixes #870, fixes #928

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -317,13 +317,14 @@ export default {
           // dynamically add value axes according to unit if determined
           const seriesOptions = this.seriesOptions[item.name]
           if (!seriesOptions.discrete && (seriesOptions.type === 'line' || seriesOptions.type === 'bar')) {
-            const unit = (item.transformedState && item.transformedState.split(' ').length === 2)
+            let unit = (item.transformedState && item.transformedState.split(' ').length === 2)
               ? item.transformedState.split(' ')[1]
               : (item.state.split(' ').length === 2)
                 ? item.state.split(' ')[1]
                 : (item.stateDescription && item.stateDescription.pattern && item.stateDescription.pattern.split(' ').length === 2)
                   ? item.stateDescription.pattern.split(' ')[1]
                   : undefined
+            if (unit) unit = unit.replace(/^%%/, '%')
             let unitAxis = this.valueAxesOptions.findIndex((a) => a.unit === unit)
             if (unitAxis >= 0) {
               this.$set(seriesOptions, 'valueAxisIndex', unitAxis)


### PR DESCRIPTION
Pragmatic fix of double percent sign in charts. Does not address the general unit detection flaws mentioned in [comment in #928](https://github.com/openhab/openhab-webui/issues/928#issuecomment-803126163)