### PR TITLE
Add stylesheet configuration to widgets

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -28,6 +28,7 @@
         "nearley": "^2.19.6",
         "pkce-challenge": "^2.1.0",
         "qrcode": "^1.0.0",
+        "scope-css": "^1.2.1",
         "sprintf-js": "^1.1.2",
         "template7": "^1.4.2",
         "tern": "^0.23.0",
@@ -2901,13 +2902,21 @@
       },
       "engines": {
         "node": ">= 10.0"
+      },
+      "peerDependencies": {
+        "lodash": "^4.17.11"
       }
     },
     "node_modules/@bundle-stats/utils/node_modules/core-js": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
       "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/@cnakazawa/watch": {
       "version": "1.0.3",
@@ -3141,37 +3150,55 @@
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/actions/-/actions-1.10.8.tgz",
       "integrity": "sha512-VS0OynDh5LfPPpnIx9tsMEdn42z+qn8Fwk+mxxs2erZDeOy6JanQ4LP562ZzvyoujmvvlvRXenjgAlGnI7rKLA==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/auto-scroll": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/auto-scroll/-/auto-scroll-1.10.8.tgz",
       "integrity": "sha512-ro/F9j1g4vwbq3m7Heg4brEHkkCvHBl2dqJTamPnReKH4vCldNCzwM8gsh+om73BS5mMsyiQiuHbkpzhWr7SdQ==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/auto-start": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/auto-start/-/auto-start-1.10.8.tgz",
       "integrity": "sha512-Ggm8/Cfbo5DH9cH/oLscq4AfqPC/HAGehU4CfpOmZ+IDno+92KDadNJkUrGGtLJR1ySB8vtZWrbhCpLbmwEEKw==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/core": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/core/-/core-1.10.8.tgz",
-      "integrity": "sha512-x0jUG6s4/la256Sg55DvERIEnZjSwUULL//YPMuEQRkTe+9pZztaZ/Cz5yuxwOmdMEH5HUVTwAL8y25VXPBy8w=="
+      "integrity": "sha512-x0jUG6s4/la256Sg55DvERIEnZjSwUULL//YPMuEQRkTe+9pZztaZ/Cz5yuxwOmdMEH5HUVTwAL8y25VXPBy8w==",
+      "peerDependencies": {
+        "@interactjs/utils": "1.10.8"
+      }
     },
     "node_modules/@interactjs/dev-tools": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/dev-tools/-/dev-tools-1.10.8.tgz",
       "integrity": "sha512-N6RP7RTjZgrp/RlvT7I2r+d0eY6k/+EdrJJJt7hzjyXbrWkToVGIZ21w2CivHlGyvgqtWZaMeXtMlo6aymuVGA==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/modifiers": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/inertia": {
@@ -3179,8 +3206,15 @@
       "resolved": "https://registry.npmjs.org/@interactjs/inertia/-/inertia-1.10.8.tgz",
       "integrity": "sha512-Fo+vBzOxVuf2qYIjMHNKn3VhRkGloiy4zHKrE38XGBDqhjEGLUGtJn4Ci17MjUfJUoxTLwBwrRhbyy4qVjN3iQ==",
       "dependencies": {
-        "@interactjs/interact": "1.10.8",
         "@interactjs/offset": "1.10.8"
+      },
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/modifiers": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/interact": {
@@ -3217,40 +3251,61 @@
       "resolved": "https://registry.npmjs.org/@interactjs/modifiers/-/modifiers-1.10.8.tgz",
       "integrity": "sha512-iXH5fSG5e+zxrqNof9QkyIxxEZofAngF7scMJHGNBu9gU0Qe1yjrLpxswgGmf2PHSHSq5E2nj6ZErFkWc9P7rg==",
       "dependencies": {
-        "@interactjs/interact": "1.10.8",
         "@interactjs/snappers": "1.10.8"
+      },
+      "optionalDependencies": {
+        "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/offset": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/offset/-/offset-1.10.8.tgz",
       "integrity": "sha512-OPC/d9sdyjhkFSD6S62x9Wt98/mIDsk0+ho5s0HG/EAlb76jSKDsRQlWkmI2OkD6Gr1m05ulDnWUzo7li6J66g==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/pointer-events": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/pointer-events/-/pointer-events-1.10.8.tgz",
       "integrity": "sha512-dHOyKorL+K685kNrrzbLH8+rrjqEC8URlyNbAk8UXJLb3lMuCYEJscsi3cHlLP0rt+3t0J3l4KK1/ZSo+tOrYA==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/reflow": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/reflow/-/reflow-1.10.8.tgz",
       "integrity": "sha512-qrwzRrmz+eTO8QcNnqCWoHCpFRSpdcqijcMoazgfj46jGcFdBle1FtOGCEXXZq50HUtQAtrKlpuJb/QbDMzZ7A==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/core": "1.10.8",
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/snappers": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/snappers/-/snappers-1.10.8.tgz",
       "integrity": "sha512-wQUDgDfeug6+8pzsLm+UiT6oVsgZFOT426XsRV+Eh2eyoU+CS9Q0YEm/sa6ow5QM5K00wPHqQTgM6AQXA8ytaQ==",
-      "dependencies": {
+      "optionalDependencies": {
         "@interactjs/interact": "1.10.8"
+      },
+      "peerDependencies": {
+        "@interactjs/utils": "1.10.8"
       }
     },
     "node_modules/@interactjs/types": {
@@ -3566,13 +3621,21 @@
       },
       "engines": {
         "node": ">= 10.0"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0-rc.1"
       }
     },
     "node_modules/@relative-ci/agent/node_modules/core-js": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
       "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
-      "dev": true
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/@relative-ci/agent/node_modules/cosmiconfig": {
       "version": "7.0.0",
@@ -3611,8 +3674,10 @@
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dev": true,
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/@relative-ci/agent/node_modules/parse-json": {
@@ -3628,6 +3693,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@relative-ci/agent/node_modules/path-type": {
@@ -3693,6 +3761,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
     "node_modules/@relative-ci/env-ci/node_modules/get-stream": {
@@ -3705,6 +3776,9 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@relative-ci/env-ci/node_modules/is-stream": {
@@ -3747,6 +3821,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@relative-ci/env-ci/node_modules/path-key": {
@@ -8246,9 +8323,6 @@
         "lru-cache": "^4.1.5",
         "semver": "^5.6.0",
         "sigmund": "^1.0.1"
-      },
-      "bin": {
-        "editorconfig": "bin/editorconfig"
       }
     },
     "node_modules/editorconfig/node_modules/commander": {
@@ -8476,6 +8550,11 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/escaper": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/escaper/-/escaper-2.5.3.tgz",
+      "integrity": "sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ=="
     },
     "node_modules/escodegen": {
       "version": "1.12.0",
@@ -9096,6 +9175,9 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0"
       }
     },
     "node_modules/eslint-plugin-node/node_modules/eslint-plugin-es": {
@@ -9109,6 +9191,12 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=4.19.1"
       }
     },
     "node_modules/eslint-plugin-node/node_modules/eslint-utils": {
@@ -9121,6 +9209,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint-plugin-node/node_modules/ignore": {
@@ -9139,6 +9230,9 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
       }
     },
     "node_modules/eslint-plugin-node/node_modules/semver": {
@@ -12169,7 +12263,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17393,6 +17486,9 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/querystring": {
@@ -18060,6 +18156,9 @@
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/resolve-cwd": {
@@ -18333,6 +18432,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/scope-css": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scope-css/-/scope-css-1.2.1.tgz",
+      "integrity": "sha512-UjLRmyEYaDNiOS673xlVkZFlVCtckJR/dKgr434VMm7Lb+AOOqXKdAcY7PpGlJYErjXXJzKN7HWo4uRPiZZG0Q==",
+      "dependencies": {
+        "escaper": "^2.5.3",
+        "slugify": "^1.3.1",
+        "strip-css-comments": "^3.0.0"
+      }
+    },
     "node_modules/select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -18417,7 +18526,10 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.3.1.tgz",
       "integrity": "sha512-oDMjBDqoutgbZIX+4xZxa+DD4gQ/q8C66ukPZbe27msutU21yML9UYsBz+jDKklQh6atdnGlTMHa6YBvjKZwhQ==",
-      "dev": true
+      "dev": true,
+      "peerDependencies": {
+        "query-string": "^5.1.1 || ^6"
+      }
     },
     "node_modules/serve-index": {
       "version": "1.9.1",
@@ -18621,6 +18733,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.0.tgz",
+      "integrity": "sha512-Q2UPZ2udzquy1ElHfOLILMBMqBEXkiD3wE75qtBvV+FsDdZZjUqPZ44vqLTejAVq+wLLHacOMcENnP8+ZbzmIA==",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/snapdragon": {
@@ -18987,11 +19107,6 @@
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -19754,6 +19869,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/strip-css-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
+      "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
+      "dependencies": {
+        "is-regexp": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-eof": {
@@ -26004,7 +26130,8 @@
     "@interactjs/core": {
       "version": "1.10.8",
       "resolved": "https://registry.npmjs.org/@interactjs/core/-/core-1.10.8.tgz",
-      "integrity": "sha512-x0jUG6s4/la256Sg55DvERIEnZjSwUULL//YPMuEQRkTe+9pZztaZ/Cz5yuxwOmdMEH5HUVTwAL8y25VXPBy8w=="
+      "integrity": "sha512-x0jUG6s4/la256Sg55DvERIEnZjSwUULL//YPMuEQRkTe+9pZztaZ/Cz5yuxwOmdMEH5HUVTwAL8y25VXPBy8w==",
+      "requires": {}
     },
     "@interactjs/dev-tools": {
       "version": "1.10.8",
@@ -30614,6 +30741,11 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "escaper": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/escaper/-/escaper-2.5.3.tgz",
+      "integrity": "sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ=="
+    },
     "escodegen": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
@@ -33636,8 +33768,7 @@
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk="
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -38723,6 +38854,16 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "scope-css": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/scope-css/-/scope-css-1.2.1.tgz",
+      "integrity": "sha512-UjLRmyEYaDNiOS673xlVkZFlVCtckJR/dKgr434VMm7Lb+AOOqXKdAcY7PpGlJYErjXXJzKN7HWo4uRPiZZG0Q==",
+      "requires": {
+        "escaper": "^2.5.3",
+        "slugify": "^1.3.1",
+        "strip-css-comments": "^3.0.0"
+      }
+    },
     "select-hose": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
@@ -38799,7 +38940,8 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/serialize-query-params/-/serialize-query-params-1.3.1.tgz",
       "integrity": "sha512-oDMjBDqoutgbZIX+4xZxa+DD4gQ/q8C66ukPZbe27msutU21yML9UYsBz+jDKklQh6atdnGlTMHa6YBvjKZwhQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "serve-index": {
       "version": "1.9.1",
@@ -38980,6 +39122,11 @@
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
+    },
+    "slugify": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.5.0.tgz",
+      "integrity": "sha512-Q2UPZ2udzquy1ElHfOLILMBMqBEXkiD3wE75qtBvV+FsDdZZjUqPZ44vqLTejAVq+wLLHacOMcENnP8+ZbzmIA=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -39941,6 +40088,14 @@
       "requires": {
         "babel-extract-comments": "^1.0.0",
         "babel-plugin-transform-object-rest-spread": "^6.26.0"
+      }
+    },
+    "strip-css-comments": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-css-comments/-/strip-css-comments-3.0.0.tgz",
+      "integrity": "sha1-elYl7/iisibPiUehElTaluE9rok=",
+      "requires": {
+        "is-regexp": "^1.0.0"
       }
     },
     "strip-eof": {

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -80,6 +80,7 @@
     "nearley": "^2.19.6",
     "pkce-challenge": "^2.1.0",
     "qrcode": "^1.0.0",
+    "scope-css": "^1.2.1",
     "sprintf-js": "^1.1.2",
     "template7": "^1.4.2",
     "tern": "^0.23.0",

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -9,6 +9,7 @@ import isoWeek from 'dayjs/plugin/isoWeek'
 import isToday from 'dayjs/plugin/isToday'
 import isYesterday from 'dayjs/plugin/isYesterday'
 import isTomorrow from 'dayjs/plugin/isTomorrow'
+import scope from 'scope-css'
 
 dayjs.extend(relativeTime)
 dayjs.extend(calendar)
@@ -46,7 +47,7 @@ export default {
       if (this.context.component.config) {
         if (typeof this.context.component.config !== 'object') return {}
         for (const key in this.context.component.config) {
-          if (key === 'visible' || key === 'visibleTo') continue
+          if (key === 'visible' || key === 'visibleTo' || key === 'stylesheet') continue
           this.$set(evalConfig, key, this.evaluateExpression(key, sourceConfig[key]))
         }
       }
@@ -66,6 +67,24 @@ export default {
         return false
       }
       return true
+    }
+  },
+  mounted () {
+    if (this.context.component.config && this.context.component.config.stylesheet) {
+      this.cssUid = 'scoped-' + this.$f7.utils.id()
+
+      this.$el.classList.add(this.cssUid)
+
+      let style = document.createElement('style')
+      style.id = this.cssUid
+      style.innerHTML = scope(this.context.component.config.stylesheet, '.' + this.cssUid)
+      document.head.appendChild(style)
+    }
+  },
+  beforeDestroy () {
+    if (this.cssUid) {
+      const scoped_stylesheet = document.getElementById(this.cssUid)
+      if (scoped_stylesheet) scoped_stylesheet.remove()
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -11,7 +11,7 @@
     * Disables use of inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
       * Enable inline JS: add 'unsafe-inline' to default-src
   -->
-  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content: blob:">
+  <meta http-equiv="Content-Security-Policy" content="default-src * 'self' 'unsafe-inline' 'unsafe-eval' data: gap: content: blob:; style-src 'self' 'unsafe-inline';">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
 
   <meta name="theme-color" content="#e64a19">

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -74,8 +74,6 @@
   z-index auto !important
   top 0
   height calc(100%)
-  .notready
-    visibility hidden
   .code-editor-fit
     height calc(100% - var(--f7-grid-gap))
   .row
@@ -120,7 +118,7 @@ export default {
     return {
       widgetDefinition: null,
       items: [],
-      ready: true,
+      ready: false,
       split: 'vertical',
       props: {},
       vars: {},
@@ -207,7 +205,6 @@ export default {
     load () {
       if (this.loading) return
       this.loading = true
-
       if (this.createMode) {
         this.widgetDefinition = YAML.stringify({
           uid: 'widget_' + this.$f7.utils.id(),

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -58,7 +58,6 @@ export default {
   data () {
     return {
       currentTab: 0,
-      loading: false,
       fullscreen: this.$fullscreen.getState()
     }
   },
@@ -115,7 +114,6 @@ export default {
   methods: {
     onPageAfterIn () {
       this.$store.dispatch('startTrackingStates')
-      this.load()
     },
     onPageBeforeOut () {
       this.$store.dispatch('stopTrackingStates')
@@ -126,8 +124,6 @@ export default {
     },
     onCommand (itemName, command) {
       this.$store.dispatch('sendCommand', { itemName, command })
-    },
-    load () {
     },
     tabContext (tab) {
       const page = this.$store.getters.page(tab.config.page.replace('page:', ''))


### PR DESCRIPTION
Hi @ghys,

I addressed something I think many powerusers have requested for: custom css stylesheets.

This first draft allows to define a stylesheet for a page, like this:

```yaml
config:
  layoutType: responsive
  label: stylesheet_test
  sidebar: true
  stylesheet: |
    .myoneclass {
      background-color: red;
    }
    .myotherclass {
      font-size: 40px;
    }
blocks:
...
```

The stylesheet gets added globally on pageIn and removed on pageOut (it's not scoped to the page, so it can generally also affect things like the panel, but I think powerusers can deal with that).

Please let me know if something like this is desired and if I should complete it (e.g. add to layouting). Please also share if a stylesheet per page is a good approach in your view.
Some users might also want to add a global stylesheet, so it affects all pages at once. I'm also planning on adding this (if ok by you), though the approach will definitely be different (requires a global config or a static include or similar).