### PR TITLE
Allow width/height for floorplan marker as advanced params

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -64,6 +64,16 @@ A marker on a floor plan
     Size of the icon in pixels (40 by default)
   </PropDescription>
 </PropBlock>
+<PropBlock type="INTEGER" name="iconWidth" label="Icon Width">
+  <PropDescription>
+    Width of the icon in pixels (for openHAB icons only, 40 by default)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="iconHeight" label="Icon Height">
+  <PropDescription>
+    Height of the icon in pixels (for openHAB icons only, 40 by default)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">
   <PropDescription>
     Color of the icon (for Framework7/Material icons); use expression for dynamic colors

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -30,6 +30,8 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)'),
     pb('iconUseState', 'Icon depends on state', 'Use the state of the item to get a dynamic icon (for openHAB icons only)'),
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
+    pn('iconWidth', 'Icon Width', 'Height of the icon in pixels (for openHAB icons only, 40 by default)').a(),
+    pn('iconHeight', 'Icon Heigth', 'Width of the icon in pixels (for openHAB icons only, 40 by default)').a(),
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material icons); use expression for dynamic colors')
   ])
   .paramGroup(pg('tooltip', 'Tooltip', 'You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)'), [

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -30,8 +30,8 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)'),
     pb('iconUseState', 'Icon depends on state', 'Use the state of the item to get a dynamic icon (for openHAB icons only)'),
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
-    pn('iconWidth', 'Icon Width', 'Height of the icon in pixels (for openHAB icons only, 40 by default)').a(),
-    pn('iconHeight', 'Icon Heigth', 'Width of the icon in pixels (for openHAB icons only, 40 by default)').a(),
+    pn('iconWidth', 'Icon Width', 'Width of the icon in pixels (for openHAB icons only, 40 by default)').a(),
+    pn('iconHeight', 'Icon Height', 'Height of the icon in pixels (for openHAB icons only, 40 by default)').a(),
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material icons); use expression for dynamic colors')
   ])
   .paramGroup(pg('tooltip', 'Tooltip', 'You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)'), [

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -11,7 +11,7 @@
       <div v-if="config.useTooltipAsLabel" style="white-space: nowrap" :style="tooltipStyle">
         {{ tooltip }}
       </div>
-      <oh-icon v-else-if="config.icon && config.icon.indexOf('oh:') === 0" :icon="config.icon.split(':')[1]" :width="config.iconSize || 40" :height="config.iconSize || 40" :state="config.iconUseState ? state : undefined" />
+      <oh-icon v-else-if="config.icon && config.icon.indexOf('oh:') === 0" :icon="config.icon.split(':')[1]" :width="config.iconWidth || config.iconSize || 40" :height="config.iconHeight || config.iconSize || 40" :state="config.iconUseState ? state : undefined" />
       <f7-icon v-else-if="config.icon" :color="config.iconColor" :size="config.iconSize || 40" :ios="config.icon" :md="config.icon" :aurora="config.icon" />
     </l-icon>
     <l-popup v-if="context.editmode != null && !dragging">


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

This change allows floorplan-markers to be of unequal size which provides the possibility to "overlay" specific visualization images on the floorplan not being squared. See https://community.openhab.org/t/allow-oh-marker-to-provide-width-and-height-individually/120246/6 for an example and discussion of the feature.