### PR TITLE
Check if item exists when creating new, fixes #573

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -3,7 +3,7 @@
     <f7-list-item :title="title" smart-select :smart-select-params="smartSelectParams" v-if="ready" ref="smartSelect" class="item-picker">
       <select :name="name" :multiple="multiple" @change="select" :required="required">
         <option value="" v-if="!multiple" />
-        <option v-for="item in items" :value="item.name" :key="item.name" :selected="(multiple) ? Array.isArray(value) && value.indexOf(item.name) >= 0 : value === item.name">
+        <option v-for="item in preparedItems" :value="item.name" :key="item.name" :selected="(multiple) ? Array.isArray(value) && value.indexOf(item.name) >= 0 : value === item.name">
           {{ item.label ? item.label + ' (' + item.name + ')' : item.name }}
         </option>
       </select>
@@ -30,11 +30,11 @@
 import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 
 export default {
-  props: ['title', 'name', 'value', 'multiple', 'filterType', 'required', 'editableOnly'],
+  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly'],
   data () {
     return {
       ready: false,
-      items: [],
+      preparedItems: [],
       icons: {},
       smartSelectParams: {
         view: this.$f7.view.main,
@@ -48,23 +48,30 @@ export default {
   },
   created () {
     this.smartSelectParams.closeOnSelect = !(this.multiple)
-    // TODO use a Vuex store
-    this.$oh.api.get('/rest/items').then((data) => {
-      this.items = data.sort((a, b) => {
+    if (!this.items) {
+      // TODO use a Vuex store
+      this.$oh.api.get('/rest/items').then((items) => {
+        this.sortAndFilterItems(items)
+      })
+    } else {
+      this.sortAndFilterItems(this.items)
+    }
+  },
+  methods: {
+    sortAndFilterItems (items) {
+      this.preparedItems = items.sort((a, b) => {
         const labelA = a.label || a.name
         const labelB = b.label || b.name
         return labelA.localeCompare(labelB)
       })
       if (this.filterType) {
-        this.items = this.items.filter((i) => i.type === this.filterType)
+        this.preparedItems = this.preparedItems.filter((i) => i.type === this.filterType)
       }
       if (this.editableOnly) {
-        this.items = this.items.filter((i) => i.editable)
+        this.preparedItems = this.preparedItems.filter((i) => i.editable)
       }
       this.ready = true
-    })
-  },
-  methods: {
+    },
     select (e) {
       this.$f7.input.validateInputs(this.$refs.smartSelect.$el)
       const value = this.$refs.smartSelect.f7SmartSelect.getValue()

--- a/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
@@ -3,7 +3,7 @@
     <item-state-preview v-if="model.item.created !== false" :item="model.item" :context="context" :key="$utils.id()" />
 
     <f7-block-title>Item</f7-block-title>
-    <item-details :model="model" :links="links" @item-updated="$emit('item-updated')" @item-created="$emit('item-created')" @item-removed="$emit('item-removed')" @cancel-create="$emit('cancel-create')" />
+    <item-details :model="model" :links="links" :items="items" @item-updated="$emit('item-updated')" @item-created="$emit('item-created')" @item-removed="$emit('item-removed')" @cancel-create="$emit('cancel-create')" />
     <f7-block-title v-if="model.item.created !== false">
       Metadata
     </f7-block-title>
@@ -22,7 +22,7 @@ import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 import LinkDetails from '@/components/model/link-details.vue'
 
 export default {
-  props: ['model', 'links', 'context'],
+  props: ['model', 'links', 'items', 'context'],
   components: {
     ItemStatePreview,
     ItemDetails,

--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -12,7 +12,7 @@
         <item-form :item="editedItem" :hide-type="true" :force-semantics="forceSemantics" />
       </div>
       <div class="padding-top" v-else-if="createMode">
-        <item-form :item="editedItem" :enable-name="true" :force-semantics="forceSemantics" />
+        <item-form :item="editedItem" :items="items" :enable-name="true" :force-semantics="forceSemantics" />
       </div>
     </f7-card-content>
     <f7-card-footer v-if="createMode || editMode" key="item-card-buttons">
@@ -42,7 +42,7 @@ import Item from '@/components/item/item.vue'
 import ItemForm from '@/components/item/item-form.vue'
 
 export default {
-  props: ['model', 'links'],
+  props: ['model', 'links', 'items'],
   components: {
     Item,
     ItemForm

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -48,7 +48,7 @@
                               @channel-updated="(e) => $emit('channels-updated', e)" />
               </template>
               <template #default="{ channel }" v-else-if="multipleLinksMode">
-                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :enable-name="true" :channel="channel" :checked="isChecked(channel)" />
+                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :items="items" :enable-name="true" :channel="channel" :checked="isChecked(channel)" />
               </template>
               <!-- <channel-link #default="{ channelId }" /> -->
             </channel-group>
@@ -98,7 +98,7 @@ import ItemForm from '@/components/item/item-form.vue'
 import { Points } from '@/assets/semantics'
 
 export default {
-  props: ['thingType', 'thing', 'channelTypes', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems', 'context'],
+  props: ['thingType', 'thing', 'channelTypes', 'items', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems', 'context'],
   components: {
     ChannelGroup,
     ChannelLink,

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -15,12 +15,12 @@
         </div>
       </f7-col>
       <f7-col>
-        <item-form :item="item" :enable-name="createMode" />
+        <item-form :item="item" :items="items" :enable-name="createMode" />
       </f7-col>
       <f7-col>
         <f7-block-title>Group Membership</f7-block-title>
         <f7-list v-if="ready">
-          <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" @input="(value) => item.groupNames = value" :multiple="true" filterType="Group" />
+          <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" @input="(value) => item.groupNames = value" :items="items" :multiple="true" filterType="Group" />
         </f7-list>
       </f7-col>
       <f7-col v-if="item && item.type === 'Group'">
@@ -74,6 +74,7 @@ export default {
     return {
       ready: false,
       item: {},
+      items: [],
       types: Types,
       semanticClasses: SemanticClasses,
       semanticClass: '',
@@ -106,7 +107,10 @@ export default {
           created: false
         }
         this.$set(this, 'item', newItem)
-        this.ready = true
+        this.$oh.api.get('/rest/items').then((items) => {
+          this.items = items
+          this.ready = true
+        })
       } else {
         const loadItem = this.$oh.api.get('/rest/items/' + this.itemName + '?metadata=semantics')
         loadItem.then((data) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -60,7 +60,7 @@
           <div>Loading...</div>
         </f7-block>
         <div v-else-if="selectedThing.UID && selectedThingType.UID">
-          <item-form v-if="createEquipment" :item="newEquipmentItem" :enable-name="true" :hide-type="true" :force-semantics="true" />
+          <item-form v-if="createEquipment" :item="newEquipmentItem" :items="items" :enable-name="true" :hide-type="true" :force-semantics="true" />
           <f7-block-title>Channels</f7-block-title>
           <f7-block-footer class="padding-left padding-right">
             Check the channels you wish to create as new Point items.
@@ -71,7 +71,7 @@
               Expert Mode
             </f7-link>
           </f7-block-footer>
-          <channel-list :thing="selectedThing" :thingType="selectedThingType" :channelTypes="selectedThingChannelTypes"
+          <channel-list :thing="selectedThing" :thingType="selectedThingType" :channelTypes="selectedThingChannelTypes" :items="items"
                         :multiple-links-mode="true" :new-items-prefix="(createEquipment) ? newEquipmentItem.name : (parentGroup) ? parentGroup.name : ''"
                         :new-items="newPointItems" />
         </div>
@@ -120,7 +120,8 @@ export default {
       selectedThingType: {},
       selectedThingChannelTypes: {},
       newEquipmentItem: {},
-      newPointItems: []
+      newPointItems: [],
+      items: null
     }
   },
   methods: {
@@ -281,7 +282,15 @@ export default {
               groupNames: (this.parent) ? [this.parent.item.name] : []
             }
           }
-          this.ready = true
+
+          if (this.items) {
+            this.ready = true
+          } else {
+            this.$oh.api.get('/rest/items').then((items) => {
+              this.items = items
+              this.ready = true
+            })
+          }
         })
       })
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -40,7 +40,7 @@
         </f7-col>
         <f7-col width="100" medium="50" class="details-pane">
           <f7-block v-if="selectedItem" no-gap>
-            <model-details-pane :key="itemDetailsKey" :model="selectedItem" :links="links" :context="context" @item-updated="update" @item-created="update" @item-removed="selectItem(null)" @cancel-create="selectItem(null)" />
+            <model-details-pane :key="itemDetailsKey" :model="selectedItem" :links="links" :items="items" :context="context" @item-updated="update" @item-created="update" @item-removed="selectItem(null)" @cancel-create="selectItem(null)" />
           </f7-block>
           <f7-block v-else>
             <div class="padding text-align-center">
@@ -114,7 +114,7 @@
         </f7-toolbar>
         <f7-block style="margin-bottom: 6rem" v-if="selectedItem">
           <item-state-preview v-if="detailsTab === 'state' && !newItem" :item="selectedItem.item" :context="context" />
-          <item-details v-if="detailsTab === 'item'" :model="selectedItem" :links="links" @item-updated="update" @item-created="update" @item-removed="selectItem(null)" @cancel-create="selectItem(null)" />
+          <item-details v-if="detailsTab === 'item'" :model="selectedItem" :links="links" :items="items" @item-updated="update" @item-created="update" @item-removed="selectItem(null)" @cancel-create="selectItem(null)" />
           <metadata-menu v-if="detailsTab === 'meta'" :item="selectedItem.item" />
           <link-details v-if="detailsTab === 'links'" :item="selectedItem.item" :links="links" />
         </f7-block>


### PR DESCRIPTION
This addresses #573. It adds an existence check to item-form.

Since the UI would load the items from the server multiple times and also each time the radio button is toggled between "new" and "existing", I modified `item-form` and `item-picker` to accept already loaded items as property. Items are now loaded in `link-add` (if required) and passed on to those components.

Originally I wanted to start migrating this to Vuex. But during planning I realized that this would become too big a change, since I think when doing this the whole REST API should be wrapped in a cache (e.g. [vuex-rest-api-cache](https://github.com/netsells/vuex-rest-api-cache)), so unchanged stuff doesn't always get loaded from the server. Since this would have had major impact in API communications and required a lot of time for testing, I dropped it.
