### PR TITLE
Fix group slider triggering change, fixes #789

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -43,13 +43,12 @@ export default {
     },
     toStepFixed (value) {
       // uses the number of decimals in the step config to round the provided number
-      if (!this.config.step) return value
-      const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]
+      const nbDecimals = this.config.step ? Number(this.config.step).toString().replace(',', '.').split('.')[1] : 0
       return parseFloat(Number(value).toFixed(nbDecimals))
     },
     onChange (value) {
       const newValue = this.toStepFixed(value)
-      if (newValue === this.value) return
+      if (newValue === this.toStepFixed(this.value)) return
       if (this.config.variable) {
         this.$set(this.context.vars, this.config.variable, value)
       } else if (this.config.item) {


### PR DESCRIPTION
Explanation:
Even with integer steps only for each member, a group can become a floating number (e.g. avg. 3 and 4 resulting in 3.5). The computed `value` then is the floating number, which is different from the rounded slider value.

Adjusting `toStepFixed` to always compute and `value` to be rounded for the comparison in `onChange` seemed to be enough to fix this.

I wasn't able to find any relation to "rollershutters" like mentioned in #894, which has been closed as duplicate.