### PR TITLE
Add slot for slides to oh-swiper, fixes #840

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
@@ -1,6 +1,11 @@
 <template>
   <f7-swiper v-bind="config" :params="{ observer: true, observeParents: true }">
     <oh-swiper-slide :context="childContext(slide)" v-for="(slide, idx) in slides" :key="idx" v-on="$listeners" />
+
+    <template v-if="context.component.slots && context.component.slots.slides && Array.isArray(context.component.slots.slides)">
+      <generic-widget-component :context="childContext(slide)" v-for="(slide, idx) in context.component.slots.slides" :key="idx" v-on="$listeners" />
+    </template>
+
     <f7-swiper-slide v-if="context.editmode">
       <oh-placeholder-widget @click="context.editmode.addWidget(context.component, null, context.parent)" />
     </f7-swiper-slide>


### PR DESCRIPTION
Looking into issue #840, the anlaysis given (init of swiper before population) seemed plausible and similar similar to #967.

Since the app cannot have any influence in widgets created with f7 components only, I checked why it wasn't possible use oh-swiper.
I found that oh-swiper does not accept slides as child components but wraps children in slides. That way it's not possible I think to use oh-repeater.
So, to make that possible and to possibly run a `swiper.update` after mount (similar to #967) I adjusted oh-swiper and added a new slot `slides`, which expects child components of type `oh-swiper-slide` or `f7-swiper-slide`.

Luckily, with this no `swiper.update` is even required - it simply works. The sample given in #840 now works without any resize required (e.g. "1|2|3" as "reparray"):

```yaml
uid: repeater_bug
tags: []
props:
  parameters:
    - description: Repeater Array
      label: Repeater Array
      name: reparray
      required: true
      type: TEXT
  parameterGroups: []
timestamp: Apr 16, 2021, 1:31:34 PM
component: f7-card
slots:
  content:
    - component: oh-swiper
      config:
        scrollbar: true
        params:
          slidesPerView: 1
          direction: vertical
        style:
          width: 200px
          height: 200px
      slots:
        slides:
          - component: oh-repeater
            config:
              for: repeat
              in: =props.reparray.split("|")
              fragment: true
            slots:
              default:
                - component: f7-swiper-slide
                  slots:
                    default:
                      - component: f7-col
                        config:
                          class:
                            - display-flex
                            - flex-direction-column
                            - align-items-center
                        slots:
                          default:
                            - component: f7-block-title
                              slots:
                                default:
                                  - component: Label
                                    config:
                                      text: =loop.repeat
```

So, in the end this fixes the display issue and allows for `oh-repeater` to be used in `oh-swiper`.