### PR TITLE
[BasicUI] create dynamic manifest, fixes #8

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
@@ -114,20 +114,21 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
     }
 
     /**
-     * This method provides the html snippet for a given elementType of the sitemap model.
+     * This method provides the snippet for a given elementType and snippetExt of the sitemap model.
      *
      * @param elementType the name of the model type (e.g. "Group" or "Switch")
-     * @return the html snippet to be used in the UI (including placeholders for variables)
+     * @param snippetExt the extension of the snippet file (e.g. ".html" or ".json")
+     * @return the snippet to be used in the UI (including placeholders for variables)
      * @throws RenderException if snippet could not be read
      */
-    protected synchronized String getSnippet(String elementType) throws RenderException {
+    protected synchronized String getSnippet(String elementType, String snippetExt) throws RenderException {
         String lowerTypeElementType = elementType.toLowerCase();
         String snippet = SNIPPET_CACHE.get(lowerTypeElementType);
         if (snippet != null) {
             return snippet;
         }
 
-        String snippetLocation = SNIPPET_LOCATION + lowerTypeElementType + SNIPPET_EXT;
+        String snippetLocation = SNIPPET_LOCATION + lowerTypeElementType + snippetExt;
         URL entry = bundleContext.getBundle().getEntry(snippetLocation);
         if (entry == null) {
             throw new RenderException("Cannot find a snippet for element type '" + lowerTypeElementType + "'");
@@ -140,6 +141,17 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
         } catch (IOException e) {
             throw new RenderException("Cannot load snippet for element type '" + lowerTypeElementType + "'");
         }
+    }
+
+    /**
+     * This method provides the html snippet for a given elementType of the sitemap model.
+     *
+     * @param elementType the name of the model type (e.g. "Group" or "Switch")
+     * @return the html snippet to be used in the UI (including placeholders for variables)
+     * @throws RenderException if snippet could not be read
+     */
+    protected synchronized String getSnippet(String elementType) throws RenderException {
+        return getSnippet(elementType, SNIPPET_EXT);
     }
 
     /**

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
@@ -114,6 +114,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
         snippet = snippet.replace("%htmlclass%", config.getCssClassList());
         snippet = snippet.replace("%icon_type%", ICON_TYPE);
         snippet = snippet.replace("%theme%", config.getTheme());
+        snippet = snippet.replace("%sitemapquery%", String.format("?sitemap=%s", sitemap));
 
         String[] parts = snippet.split("%children%");
 
@@ -256,7 +257,15 @@ public class PageRenderer extends AbstractWidgetRenderer {
         pageSnippet = pageSnippet.replace("%htmlclass%", config.getCssClassList() + " page-welcome-sitemaps");
         pageSnippet = pageSnippet.replace("%theme%", config.getTheme());
         pageSnippet = pageSnippet.replace("%content%", listSnippet);
+        pageSnippet = pageSnippet.replace("%sitemapquery", "");
 
         return pageSnippet;
+    }
+
+    public CharSequence renderManifest(String sitemapName) throws RenderException {
+        String manifestSnippet = getSnippet("manifest", ".json");
+        manifestSnippet = manifestSnippet.replace("%sitemapquery%",
+                sitemapName == null ? "" : String.format("?sitemap=%s", sitemapName));
+        return manifestSnippet;
     }
 }

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
@@ -257,7 +257,6 @@ public class PageRenderer extends AbstractWidgetRenderer {
         pageSnippet = pageSnippet.replace("%htmlclass%", config.getCssClassList() + " page-welcome-sitemaps");
         pageSnippet = pageSnippet.replace("%theme%", config.getTheme());
         pageSnippet = pageSnippet.replace("%content%", listSnippet);
-        pageSnippet = pageSnippet.replace("%sitemapquery", "");
 
         return pageSnippet;
     }

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/ManifestServlet.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/ManifestServlet.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2010-2021 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.ui.basic.internal.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.io.http.HttpContextFactoryService;
+import org.openhab.core.items.ItemRegistry;
+import org.openhab.ui.basic.internal.render.PageRenderer;
+import org.openhab.ui.basic.render.RenderException;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.http.HttpContext;
+import org.osgi.service.http.HttpService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This is the manifest servlet for the Basic UI. It dynamically genrates a
+ * manifest on the sitemap model.
+ *
+ * @author Kevin Haunschmied - Dynamic Manifest generation
+ *
+ */
+@Component(immediate = true, service = {})
+@NonNullByDefault
+public class ManifestServlet extends BaseServlet {
+
+    private static final long serialVersionUID = 4591967180619528326L;
+
+    private final Logger logger = LoggerFactory.getLogger(ManifestServlet.class);
+
+    public static final String MANIFEST_NAME = "manifest.json";
+
+    private static final String MANIFEST_CONTENT_TYPE = "application/json;charset=UTF-8";
+
+    private final PageRenderer renderer;
+
+    @Activate
+    public ManifestServlet(final @Reference HttpService httpService,
+            final @Reference HttpContextFactoryService httpContextFactoryService,
+            final @Reference ItemRegistry itemRegistry, final @Reference PageRenderer renderer) {
+        super(httpService, httpContextFactoryService, itemRegistry);
+        this.renderer = renderer;
+    }
+
+    @Activate
+    protected void activate(Map<String, Object> configProps, BundleContext bundleContext) {
+        HttpContext httpContext = createHttpContext(bundleContext.getBundle());
+        super.activate(WEBAPP_ALIAS + "/" + MANIFEST_NAME, httpContext);
+    }
+
+    @Deactivate
+    protected void deactivate() {
+        super.deactivate(WEBAPP_ALIAS + "/" + MANIFEST_NAME);
+    }
+
+    private void generateManifest(ServletResponse res, String sitemapName) throws IOException, RenderException {
+        PrintWriter resWriter;
+        resWriter = res.getWriter();
+        resWriter.append(renderer.renderManifest(sitemapName));
+
+        res.setContentType(MANIFEST_CONTENT_TYPE);
+    }
+
+    @Override
+    protected void service(@NonNullByDefault({}) HttpServletRequest req, @NonNullByDefault({}) HttpServletResponse res)
+            throws ServletException, IOException {
+        logger.debug("Manifest request received!");
+
+        // read request parameters
+        String sitemapName = req.getParameter("sitemap");
+        String requestUri = req.getRequestURI();
+
+        try {
+            if (requestUri.endsWith(MANIFEST_NAME)) {
+                generateManifest(res, sitemapName);
+                return;
+            }
+        } catch (RenderException e) {
+            throw new ServletException(e.getMessage(), e);
+        }
+    }
+}

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/main.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/main.html
@@ -21,7 +21,7 @@
 		<link href="images/touch-icon-167.png" sizes="167x167" rel="apple-touch-icon-precomposed">
 		<link href="images/touch-icon-180.png" sizes="180x180" rel="apple-touch-icon-precomposed">
 
-		<link rel="manifest" href="manifest.json">
+		<link rel="manifest" href="manifest.json%sitemapquery%">
 
 		<link rel="stylesheet" type="text/css" href="mdl/material.min.css" />
 		<link rel="stylesheet" type="text/css" href="material-icons.css" />

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/main_static.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/main_static.html
@@ -10,11 +10,13 @@
 		<meta name="apple-mobile-web-app-status-bar-style" content="black" />
 		<meta name="theme-color" content="#354497">
 
-		<link rel="shortcut icon" href="favicon.ico" />		
+		<link rel="shortcut icon" href="favicon.ico" />
 		<link rel="apple-touch-icon" href="images/app-icon.png" />
 		<link rel="apple-touch-startup-image" href="images/splash-ipad-h.png" media="screen and (min-device-width: 481px) and (max-device-width: 1024px) and (orientation:landscape)" />
 		<link rel="apple-touch-startup-image" href="images/splash-ipad-v.png" media="screen and (min-device-width: 481px) and (max-device-width: 1024px) and (orientation:portrait)" />
-		<link rel="apple-touch-startup-image" href="images/splash-iphone.png" media="screen and (max-device-width: 320px)" />	   
+		<link rel="apple-touch-startup-image" href="images/splash-iphone.png" media="screen and (max-device-width: 320px)" />
+
+		<link rel="manifest" href="manifest.json">
 
 		<link rel="stylesheet" type="text/css" href="mdl/material.min.css" />
 		<link rel="stylesheet" type="text/css" href="material-icons.css" />

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/manifest.json
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/manifest.json
@@ -38,6 +38,6 @@
 			"density": 4.0
 		}
 	],
-	"start_url": "app",
+	"start_url": "app%sitemapquery%",
 	"display": "standalone"
 }


### PR DESCRIPTION
Fixes #8 

This PR proposes a solution to set the sitemap query parameter to the `start_url` in `manifest.json` dynamically. 

It uses a new `ManifestServlet` that injects the query string to the `start_url` when the manifest is requested. It also considers the manifest as a snippet now and therefor overloads the `getSnippet` method with an optional `snippetExt` parameter to allow different extensions than `.html` as snippets.

Finally the `manifest.json` was added to the `main_static` snippet. (That's funny because the `/basicui/app` path uses this snippet that didn't use the manifest, but the snippet used for sitemaps pahts like `/basicui/app?sitemap=xxx` uses a manifest with `/basicui/app` as the `start_url`.)