### PR TITLE
fix small bug in widget mixin

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -70,7 +70,7 @@ export default {
     }
   },
   mounted () {
-    if (this.context.component.config && this.context.component.config.stylesheet) {
+    if (this.context && this.context.component.config && this.context.component.config.stylesheet) {
       this.cssUid = 'scoped-' + this.$f7.utils.id()
 
       this.$el.classList.add(this.cssUid)


### PR DESCRIPTION
fix a small bug in widget-mixin, introduced by #979, ocurring when there's no `context` available (which happened regularly for me with `oh-icon`)