### PR TITLE
Add Crowdin badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Build Status](https://ci.openhab.org/job/openHAB-WebUI/badge/icon)](https://ci.openhab.org/job/openHAB-WebUI/)
 [![EPL-2.0](https://img.shields.io/badge/license-EPL%202-green.svg)](https://opensource.org/licenses/EPL-2.0)
+[![Crowdin](https://badges.crowdin.net/openhab-webui/localized.svg)](https://crowdin.com/project/openhab-webui)
 [![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=2164344)](https://www.bountysource.com/teams/openhab/issues?tracker_ids=2164344)
 
 This repository contains the official web user interfaces for openHAB.


### PR DESCRIPTION
If you enable "Display badges" in the [General settings](https://crowdin.com/project/openhab-webui/settings#general) we can add this badge so contributors can more easily find Crowdin and add translations.