### PR TITLE
Show error message when link cannot be removed, fixes #903

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -102,6 +102,12 @@ export default {
                 closeTimeout: 2000
               }).open()
               this.$f7router.back()
+            }).catch((err) => {
+              this.$f7.toast.create({
+                text: 'Link not deleted (links defined in a .items file are not editable from this screen): ' + err,
+                destroyOnClose: true,
+                closeTimeout: 2000
+              }).open()
             })
           })
         return


### PR DESCRIPTION
See #903. Copied the code from `link-edit.vue`.