### PR TITLE
Rework metadata UI for new GA binding - Part 2

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
@@ -14,12 +14,12 @@ const p = (type, name, label, description, options, advanced) => {
 }
 
 // Common
-const tfaAckParameter = p('BOOLEAN', 'tfaAck', 'Two-Factor-Authentication Ack Needed')
-const tfaPinParameter = p('TEXT', 'tfaPin', 'Two-Factor-Authentication Pin')
-const nameParameter = p('TEXT', 'name', 'Name', 'Custom name (use of the synonyms is preferred)', null, true)
+const tfaAckParameter = p('BOOLEAN', 'tfaAck', 'Secondary User Verification - Acknowledgement needed', 'When this is set, Google will ask for acknowledgement (yes or no) before executing the action', null, true)
+const tfaPinParameter = p('TEXT', 'tfaPin', 'Secondary User Verification - PIN', 'When this is set, Google will require this PIN before executing the action', null, true)
+const nameParameter = p('TEXT', 'name', 'Custom name', 'The name of the device used in Google (use synonyms instead if possible)', null, true)
 const roomHintParameter = p('TEXT', 'roomHint', 'Room hint', 'Suggested name for the room where this device is installed', null, true)
 const structureHintParameter = p('TEXT', 'structureHint', 'Structure hint', 'Suggested name for the structure where this device is installed', null, true)
-const invertedParameter = p('BOOLEAN', 'inverted', 'Inverted')
+const invertedParameter = p('BOOLEAN', 'inverted', 'Inverted', 'Inverts the values, e.g. ON becomes OFF for a switch or 0% becomes 100% for a curtain')
 const langParameter = p('TEXT', 'lang', 'Language', 'Language used for parsing text in the other parameters, e.g. "en"')
 // Camera
 const protocolsParameter = p('TEXT', 'protocols', 'Protocols', 'List of supported protocols (comma separated), e.g. "hls,dash,smooth_stream,progressive_mp4"')
@@ -29,22 +29,22 @@ const speedParameter = p('TEXT', 'speeds', 'Speeds', 'Mappings between items sta
 const orderedParameter = p('BOOLEAN', 'ordered', 'Ordered')
 // Lights
 const colorTemperatureRangeParameter = p('TEXT', 'colorTemperatureRange', 'Color temperature range', '(Color lights only) Supported color temperature range in Kelvin (comma separated), e.g. "2000,9000"')
-const useKelvinParameter = p('BOOLEAN', 'useKelvin', '(Color lights only) Use Kelvin instead of percentage for a the "lightColorTemperature" child in a grouped light')
+const useKelvinParameter = p('BOOLEAN', 'useKelvin', 'Use Kelvin', '(Color lights only) Use Kelvin instead of percentage for a the "lightColorTemperature" child in a grouped light')
 // OpenCloseDevices
-const discreteOnlyParameter = p('BOOLEAN', 'discreteOnlyOpenClose', 'Device must either be fully open or fully closed (no states in between)')
-const queryOnlyParameter = p('BOOLEAN', 'queryOnlyOpenClose', 'Device is read-only (can not be controlled)')
+const discreteOnlyParameter = p('BOOLEAN', 'discreteOnly', 'Discrete values only', 'Device must either be fully open or fully closed (no states in between)')
+const queryOnlyParameter = p('BOOLEAN', 'queryOnly', 'Read-only', 'Device is read-only (can not be controlled)')
 // Scenes
-const sceneReversibleParameter = p('BOOLEAN', 'sceneReversible', 'Scene can be reversed ("turned off")')
+const sceneReversibleParameter = p('BOOLEAN', 'sceneReversible', 'Reversible', 'Scene can be reversed ("turned off")')
 // Sensors
-const sensorNameParameter = p('TEXT', 'sensorName', 'Sensor name', 'Supported sensor type, see https://developers.google.com/assistant/smarthome/traits/sensorstate?hl=en#supported-sensors for supported values')
-const valueUnitParameter = p('TEXT', 'valueUnit', 'Value unit', 'Supported value unit, see https://developers.google.com/assistant/smarthome/traits/sensorstate?hl=en#supported-sensors for supported values')
-const statesParameter = p('TEXT', 'states', 'States', 'Supported states with mapping from Google values to openHAB values (comma seperated), e.g. "no smoke detected=0,smoke detected=1". See https://developers.google.com/assistant/smarthome/traits/sensorstate?hl=en#supported-sensors for supported values')
+const sensorNameParameter = p('TEXT', 'sensorName', 'Sensor name', 'Sensor name (type), see <a class="link external" target="_blank" external href="https://developers.google.com/assistant/smarthome/traits/sensorstate?hl=en#supported-sensors">the docs</a> for supported values')
+const valueUnitParameter = p('TEXT', 'valueUnit', 'Value unit', 'Sensor value unit, see <a class="link external" target="_blank" external href="https://developers.google.com/assistant/smarthome/traits/sensorstate?hl=en#supported-sensors">the docs</a> for supported values')
+const statesParameter = p('TEXT', 'states', 'states', 'Sensor states with mappings from Google values to openHAB item values (comma seperated), e.g. "no smoke detected=0,smoke detected=1". See <a class="link external" target="_blank" external href="https://developers.google.com/assistant/smarthome/traits/sensorstate?hl=en#supported-sensors">the docs</a> for supported values')
 // Speakers
-const volumeMaxLevelParameter = p('INTEGER', 'volumeMaxLevel', 'Maximum volume level')
-const volumeDefaultPercentageParameter = p('INTEGER', 'volumeDefaultPercentage', 'Default volume in percent of the maximum volume')
-const levelStepSizeParameter = p('INTEGER', 'levelStepSize', 'Step size for relative volume queries like "volume up"')
+const volumeMaxLevelParameter = p('INTEGER', 'volumeMaxLevel', 'Maximum volume level', 'Depends on the device, e.g. "10"')
+const volumeDefaultPercentageParameter = p('INTEGER', 'volumeDefaultPercentage', 'Default volume', 'Default volume in percent of the maximum volume (default is 40%)')
+const levelStepSizeParameter = p('INTEGER', 'levelStepSize', 'Step size', 'Step size for relative volume queries like "volume up" (default is 1)')
 // Thermostat
-const thermostatModesParameter = p('TEXT', 'modes', 'Thermostat modes', 'Mappings between items states and Google modes (comma separated), e.g. "off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto"')
+const thermostatModesParameter = p('TEXT', 'modes', 'Thermostat modes', 'Mappings from Google values to openHAB item values (comma separated), e.g. "off=OFF:WINDOW_OPEN,heat=COMFORT:BOOST,eco=ECO,on=ON,auto"')
 const thermostatTemperatureRangeParameter = p('TEXT', 'thermostatTemperatureRange', 'Temperature range', 'The temperature range your thermostat supports (comma separated), e.g. "10,30"')
 const useFahrenheitParameter = p('BOOLEAN', 'useFahrenheit', 'Use Fahrenheit')
 // TV
@@ -52,7 +52,7 @@ const transportControlSupportedCommandsParameter = p('TEXT', 'transportControlSu
 const availableInputsParameter = p('TEXT', 'availableInputs', 'Available inputs', 'List of available inputs with mapping (comma separated), e.g. "inputKey=inputName:inputSynonym1:inputSynonym2:..."')
 const availableChannelsParameter = p('TEXT', 'availableChannels', 'Available channels', 'List of available channels with mapping (comma separated), e.g. "channelNumber=channelId=channelName:channelSynonym1:channelSynonym2:..."')
 
-let classes = {
+const deviceTypes = {
   // Switches
   'Switch': [invertedParameter],
   'Coffee_Maker': [invertedParameter],
@@ -90,12 +90,11 @@ let classes = {
   'Valve': [invertedParameter]
 }
 
-for (let c in classes) {
-  classes[c] = [...classes[c], tfaAckParameter, tfaPinParameter, nameParameter, roomHintParameter, structureHintParameter]
+for (let c in deviceTypes) {
+  deviceTypes[c] = [...deviceTypes[c], nameParameter, roomHintParameter, structureHintParameter, tfaAckParameter, tfaPinParameter]
 }
 
-classes = {
-  ...classes,
+const deviceAttributes = {
   'thermostatTemperatureAmbient': [],
   'thermostatHumidityAmbient': [],
   'thermostatTemperatureSetpoint': [],
@@ -110,6 +109,16 @@ classes = {
   'tvChannel': [],
   'tvInput': [],
   'tvTransport': []
+}
+
+let classes = {}
+
+for (let l in deviceTypes) {
+  classes['type:' + l] = deviceTypes[l]
+}
+
+for (let l in deviceAttributes) {
+  classes['attribute:' + l] = deviceAttributes[l]
 }
 
 export default classes

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -5,9 +5,22 @@
                     :title="'Google Assistant Class'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="classes">
         <select name="classes" @change="updateClass">
           <option value="" />
-          <option v-for="cl in orderedClasses" :value="cl" :key="cl" :selected="isSelected(cl)">
-            {{ cl }}
-          </option>
+          <optgroup label="Types">
+            <option v-for="cl in orderedClasses.filter((c) => c.indexOf('type:') === 0)"
+                    :value="cl.replace('type:', '')"
+                    :key="cl"
+                    :selected="isSelected(cl.replace('type:', ''))">
+              {{ cl.replace('type:', '') }}
+            </option>
+          </optgroup>
+          <optgroup label="Attributes">
+            <option v-for="cl in orderedClasses.filter((c) => c.indexOf('attribute:') === 0)"
+                    :value="cl.replace('attribute:', '')"
+                    :key="cl"
+                    :selected="isSelected(cl.replace('attribute:', ''))">
+              {{ cl.replace('attribute:', '') }}
+            </option>
+          </optgroup>
         </select>
       </f7-list-item>
     </f7-list>
@@ -48,7 +61,7 @@ export default {
     },
     parameters () {
       if (!this.metadata.value) return []
-      return [...GoogleDefinitions[this.metadata.value]]
+      return GoogleDefinitions['type:' + this.metadata.value] || GoogleDefinitions['attribute:' + this.metadata.value]
     }
   },
   methods: {


### PR DESCRIPTION
Sorry, I missed some things in the first PR you merged today.
- Added some more description text
- Moved some text from title to description where everything was crammed in the title
- Made URLs work as links
- Split the list in two option groups (like the Alexa metadata UI does, code is mainly from there):

![image](https://user-images.githubusercontent.com/1475672/116000768-da1d8080-a5f1-11eb-9da1-54cd37f269e2.png)
