### PR TITLE
Fixes "Other Apps" menu not opening when the developer sidebar is active

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -115,15 +115,16 @@
     </f7-panel>
 
     <!-- Right Panel -->
-    <f7-panel right reveal theme-dark v-if="ready">
+    <f7-panel v-if="ready" right theme-dark>
       <panel-right />
-    <!-- <f7-view url="/panel-right/"></f7-view> -->
     </f7-panel>
 
-    <f7-panel v-if="showDeveloperSidebar" right :visible-breakpoint="1280" resizable>
+    <!-- Developer Sidebar -->
+    <f7-panel v-if="showDeveloperSidebar" right resizable :visible-breakpoint="1280">
       <developer-sidebar />
     </f7-panel>
 
+    <!-- Main Content -->
     <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
 
   <!-- <f7-login-screen id="my-login-screen" :opened="loginScreenOpened">


### PR DESCRIPTION
Since there can't be two sidebars active at a time, it opens above the developer sidebar, but I think that's okay.

Before:
![image](https://user-images.githubusercontent.com/1475672/116007142-938a4f00-a60e-11eb-94c5-eccf83dbedd9.png)

After:
![image](https://user-images.githubusercontent.com/1475672/116007126-7eadbb80-a60e-11eb-88cc-7e31094de39d.png)


Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>