### PR TITLE
Renamed Secondary User Verification parameters

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/ga.js
@@ -14,8 +14,8 @@ const p = (type, name, label, description, options, advanced) => {
 }
 
 // Common
-const tfaAckParameter = p('BOOLEAN', 'tfaAck', 'Secondary User Verification - Acknowledgement needed', 'When this is set, Google will ask for acknowledgement (yes or no) before executing the action', null, true)
-const tfaPinParameter = p('TEXT', 'tfaPin', 'Secondary User Verification - PIN', 'When this is set, Google will require this PIN before executing the action', null, true)
+const tfaAckParameter = p('BOOLEAN', 'ackNeeded', 'Secondary User Verification - Acknowledgement needed', 'When this is set, Google will ask for acknowledgement (yes or no) before executing the action', null, true)
+const tfaPinParameter = p('TEXT', 'pinNeeded', 'Secondary User Verification - PIN', 'When this is set, Google will require this PIN before executing the action', null, true)
 const nameParameter = p('TEXT', 'name', 'Custom name', 'The name of the device used in Google (use synonyms instead if possible)', null, true)
 const roomHintParameter = p('TEXT', 'roomHint', 'Room hint', 'Suggested name for the room where this device is installed', null, true)
 const structureHintParameter = p('TEXT', 'structureHint', 'Structure hint', 'Suggested name for the structure where this device is installed', null, true)


### PR DESCRIPTION
Sorry to put this into yet another PR, but I just received word from @michikrug that these parameters should be renamed for better consistency, the old ones are deprecated.

https://github.com/openhab/openhab-google-assistant/pull/196#issuecomment-826386283

About the timing of this: Apparently it needs to go live at the same time the new GA binding goes live, so maybe synchronizing with @michikrug is a good idea before merging this.

Signed-off-by: Eiko Wagenknecht <eiko.wagenknecht@web.de>