### PR TITLE
Implement link editable flag

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -7,8 +7,9 @@
                         :title="l.thing.label" :subtitle="l.channel.label || '?'" :footer="l.link.channelUID"
                         :badge="thingStatusBadgeText(l.thing.statusInfo)"
                         :badge-color="thingStatusBadgeColor(l.thing.statusInfo)"
-                        link="#" @click="editLink(l)">
+                        :link="!l.link.editable && l._invalid ? undefined : '#'" @click="!l.link.editable && l._invalid ? undefined : editLink(l)">
             <span slot="media" class="item-initial">{{ !l._invalid && l.channel.label ? l.channel.label[0] : '?' }}</span>
+            <f7-icon v-if="!l.link.editable" slot="title" f7="lock_fill" size="1rem" color="gray" />
           </f7-list-item>
         </ul>
       </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -1,12 +1,13 @@
 <template>
   <f7-page @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar :title="item.label || item.name" :subtitle="thing.label" back-link="Cancel">
-      <f7-nav-right>
+      <f7-nav-right v-if="link.editable">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only />
         <f7-link @click="save()" v-if="!$theme.md">
           Save
         </f7-link>
       </f7-nav-right>
+      <f7-link v-else slot="right" icon-f7="lock_fill" icon-only tooltip="links defined in a .items file are not editable from this screen" />
     </f7-navbar>
     <f7-block class="block-narrow">
       <f7-col>
@@ -33,12 +34,12 @@
               </ul>
             </f7-list>
           </f7-card-content>
-          <f7-card-footer v-if="item">
+          <f7-card-footer v-if="item && (item.editable || link.editable)">
             <f7-button color="red" fill @click="unlinkAndDelete()" v-if="source === 'thing' && item.editable">
               Unlink &amp; Remove Item
             </f7-button>
-            <f7-button color="red" @click="unlink()">
-              {{ source === 'thing' && item.editable ? 'Unlink Only' : 'Unlink' }}
+            <f7-button color="red" @click="unlink()" v-if="link.editable">
+              {{ source === 'thing' && link.editable ? 'Unlink Only' : 'Unlink' }}
             </f7-button>
           </f7-card-footer>
         </f7-card>
@@ -55,9 +56,10 @@
             <div>Loading...</div>
           </f7-block>
           <f7-list v-else>
-            <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="(No Profile)" name="profile-type" />
+            <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="(No Profile)" name="profile-type" :disabled="!link.editable" />
             <f7-list-item radio v-for="profileType in profileTypes"
                           :checked="currentProfileType && profileType.uid === currentProfileType.uid"
+                          :disabled="!link.editable"
                           @change="onProfileTypeChange(profileType.uid)"
                           :key="profileType.uid" :title="profileType.label" name="profile-type" />
           </f7-list>
@@ -68,7 +70,8 @@
         <config-sheet ref="profileConfiguration"
                       :parameter-groups="profileTypeConfiguration.parameterGroups"
                       :parameters="profileTypeConfiguration.parameters"
-                      :configuration="link.configuration" />
+                      :configuration="link.configuration"
+                      :read-only="!link.editable" />
       </f7-col>
     </f7-block>
   </f7-page>


### PR DESCRIPTION
Related to #903, #693 and #413

Make use of the new `editable` flag for links:
- If a link is not editable, instead of "Save" a red lock icon is shown, the link's card footer is hidden (no "Unlink" buttons shown) and the Profile is read only.
- At "link-details" a lock is shown next to non-editable links, and the click action is disabled for non-editable, invalid links.