### PR TITLE
Link and Profile related fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -65,7 +65,11 @@ export default {
         return labelA.localeCompare(labelB)
       })
       if (this.filterType) {
-        this.preparedItems = this.preparedItems.filter((i) => i.type === this.filterType)
+        if (Array.isArray(this.filterType)) {
+          this.preparedItems = this.preparedItems.filter((i) => this.filterType.includes(i.type.split(':', 1)[0]))
+        } else {
+          this.preparedItems = this.preparedItems.filter((i) => i.type === this.filterType)
+        }
       }
       if (this.editableOnly) {
         this.preparedItems = this.preparedItems.filter((i) => i.editable)

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -84,9 +84,11 @@
             Learn more about profiles.
           </f7-link>
         </f7-block-footer>
-        <f7-list>
-          <f7-list-item radio v-for="profileType in compatibleProfileTypes"
+        <f7-list class="profile-list profile-disabled">
+          <f7-list-item radio v-for="profileType in profileTypes" class="profile-item"
                         :checked="!currentProfileType && profileType.uid === 'system:default' || currentProfileType && profileType.uid === currentProfileType.uid"
+                        :disabled="!compatibleProfileTypes.includes(profileType)"
+                        :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
                         @change="onProfileTypeChange(profileType.uid)"
                         :key="profileType.uid" :title="profileType.label" name="profile-type" />
         </f7-list>
@@ -94,6 +96,7 @@
       <f7-col v-if="profileTypeConfiguration != null">
         <f7-block-title>Profile Configuration</f7-block-title>
         <config-sheet ref="profileConfiguration"
+                      :key="'profileTypeConfiguration-' + currentProfileType.uid"
                       :parameter-groups="profileTypeConfiguration.parameterGroups"
                       :parameters="profileTypeConfiguration.parameters"
                       :configuration="configuration" />
@@ -109,6 +112,16 @@
     </div>
   </f7-page>
 </template>
+
+<style lang="stylus">
+.profile-list
+  .profile-item.profile-disabled
+    pointer-events none
+    .icon-radio
+      opacity 0.3
+    .item-title
+      opacity 0.55
+</style>
 
 <script>
 import diacritic from 'diacritic'

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -15,7 +15,7 @@
           <f7-list-item media-item class="channel-item"
                         :title="channel.label || channelType.label"
                         :footer="channel.description || channelType.description"
-                        :subtitle="channel.uid" />
+                        :subtitle="channel.uid + ' (' + getItemType(channel) + ')'" />
         </f7-list>
       </f7-col>
 
@@ -37,7 +37,8 @@
         <f7-col v-if="!createItem">
           <f7-list>
             <!-- TODO: filter with compatible item types -->
-            <item-picker key="itemLink" title="Item to Link" name="item" :value="selectedItemName" :multiple="false" :items="items" @input="(value) => selectedItemName = value" />
+            <item-picker key="itemLink" title="Item to Link" name="item" :value="selectedItemName" :multiple="false" :items="items" :filterType="getCompatibleItemTypes()"
+                         @input="(value) => selectedItemName = value" />
           </f7-list>
         </f7-col>
 
@@ -213,6 +214,17 @@ export default {
         console.warn(`No configuration for profile type ${profileTypeUid}: ` + err)
         this.profileTypeConfiguration = null
       })
+    },
+    getItemType (channel) {
+      if (channel && channel.kind === 'TRIGGER') return 'Trigger'
+      if (!channel || !channel.itemType) return '?'
+      return channel.itemType
+    },
+    getCompatibleItemTypes () {
+      let compatibleItemTypes = this.channel.itemType.split(':', 1)
+      if (this.channel.itemType === 'Color') { compatibleItemTypes.push('Switch', 'Dimmer') }
+      if (this.channel.itemType === 'Dimmer') { compatibleItemTypes.push('Switch') }
+      return compatibleItemTypes
     },
     itemTypeCompatible () {
       // debugger

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -89,9 +89,8 @@
           </f7-link>
         </f7-block-footer>
         <f7-list>
-          <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="(No Profile)" name="profile-type" />
           <f7-list-item radio v-for="profileType in profileTypes"
-                        :value="profileType.uid"
+                        :checked="!currentProfileType && profileType.uid === 'system:default' || currentProfileType && profileType.uid === currentProfileType.uid"
                         @change="onProfileTypeChange(profileType.uid)"
                         :key="profileType.uid" :title="profileType.label" name="profile-type" />
         </f7-list>
@@ -195,6 +194,7 @@ export default {
       const getProfileTypes = this.$oh.api.get('/rest/profile-types?channelTypeUID=' + channel.channelTypeUID)
       getProfileTypes.then((data) => {
         this.profileTypes = data
+        this.profileTypes.unshift(data.splice(data.findIndex(p => p.uid === 'system:default'), 1)[0]) // move default to be first
         this.ready = true
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -67,6 +67,7 @@
       <f7-col v-if="profileTypeConfiguration != null">
         <f7-block-title>Profile Configuration</f7-block-title>
         <config-sheet ref="profileConfiguration"
+                      :key="'profileTypeConfiguration-' + currentProfileType.uid"
                       :parameter-groups="profileTypeConfiguration.parameterGroups"
                       :parameters="profileTypeConfiguration.parameters"
                       :configuration="link.configuration"
@@ -125,7 +126,7 @@ export default {
       this.$oh.api.get('/rest/profile-types?channelTypeUID=' + this.channel.channelTypeUID + '&itemType=' + itemType).then((data) => {
         this.profileTypes = data
         this.profileTypes.unshift(data.splice(data.findIndex(p => p.uid === 'system:default'), 1)[0]) // move default to be first
-          .filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(this.item.type)) // only show compatible profile types
+        this.profileTypes = this.profileTypes.filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(this.item.type)) // only show compatible profile types
 
         this.$oh.api.get('/rest/links/' + itemName + '/' + channelUID).then((data2) => {
           this.link = data2

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -56,9 +56,8 @@
             <div>Loading...</div>
           </f7-block>
           <f7-list v-else>
-            <f7-list-item radio :checked="!currentProfileType" value="" @change="onProfileTypeChange()" title="(No Profile)" name="profile-type" :disabled="!link.editable" />
             <f7-list-item radio v-for="profileType in profileTypes"
-                          :checked="currentProfileType && profileType.uid === currentProfileType.uid"
+                          :checked="!currentProfileType && profileType.uid === 'system:default' || currentProfileType && profileType.uid === currentProfileType.uid"
                           :disabled="!link.editable"
                           @change="onProfileTypeChange(profileType.uid)"
                           :key="profileType.uid" :title="profileType.label" name="profile-type" />
@@ -123,9 +122,9 @@ export default {
       const itemName = this.item.name
       const itemType = this.item.type
       const channelUID = this.channel.uid.replace('#', '%23')
-      const getProfileTypes = this.$oh.api.get('/rest/profile-types?channelTypeUID=' + this.channel.channelTypeUID + '&itemType=' + itemType)
-      getProfileTypes.then((data) => {
+      this.$oh.api.get('/rest/profile-types?channelTypeUID=' + this.channel.channelTypeUID + '&itemType=' + itemType).then((data) => {
         this.profileTypes = data
+        this.profileTypes.unshift(data.splice(data.findIndex(p => p.uid === 'system:default'), 1)[0]) // move default to be first
 
         this.$oh.api.get('/rest/links/' + itemName + '/' + channelUID).then((data2) => {
           this.link = data2

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -125,6 +125,7 @@ export default {
       this.$oh.api.get('/rest/profile-types?channelTypeUID=' + this.channel.channelTypeUID + '&itemType=' + itemType).then((data) => {
         this.profileTypes = data
         this.profileTypes.unshift(data.splice(data.findIndex(p => p.uid === 'system:default'), 1)[0]) // move default to be first
+          .filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(this.item.type)) // only show compatible profile types
 
         this.$oh.api.get('/rest/links/' + itemName + '/' + channelUID).then((data2) => {
           this.link = data2

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -23,7 +23,7 @@
                 <f7-list-item divider title="Channel" />
                 <f7-list-item media-item class="channel-item"
                               :title="channel.label || channelType.label"
-                              :footer="channel.uid"
+                              :footer="channel.uid + ' (' + getItemType(channel) + ')'"
                               :subtitle="thing.label"
                               :badge="thingStatusBadgeText(thing.statusInfo)"
                               :badge-color="thingStatusBadgeColor(thing.statusInfo)">
@@ -153,6 +153,11 @@ export default {
         console.log(`No configuration for profile type ${profileTypeUid}: ` + err)
         this.profileTypeConfiguration = null
       })
+    },
+    getItemType (channel) {
+      if (channel && channel.kind === 'TRIGGER') return 'Trigger'
+      if (!channel || !channel.itemType) return '?'
+      return channel.itemType
     },
     unlink () {
       this.$f7.dialog.confirm(


### PR DESCRIPTION
This PR addresses #884 and #885. Changes:

- drop "no profile" and use the "Default" profile instead (link-add and link-edit)
- filter the item list for items compatible to the channel's type (link-add)
- only show profiles compatible to the current item (link-add, link-edit)

Note: This PR is based on the branch used for PR #1000, to avoid blocking after that has been merged.