### PR TITLE
Use status instead of message for error responses to detect Unauthorized requests

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -376,8 +376,8 @@ export default {
       const useCredentialsPromise = (useCredentials) ? this.setBasicCredentials() : Promise.resolve()
       return useCredentialsPromise
         .then(() => { return this.$oh.api.get('/rest/') })
-        .catch((err, status) => {
-          if (status === 401) {
+        .catch((err) => {
+          if (err === 'Unauthorized' || err === 401) {
             if (!useCredentials) {
               // try again with credentials
               this.loadData(true)
@@ -393,8 +393,8 @@ export default {
                   this.$oh.api.get('/rest/').then((rootResponse) => {
                     this.storeBasicCredentials()
                     this.loadData()
-                  }).catch((err, status) => {
-                    if (status === 401) {
+                  }).catch((err) => {
+                    if (err === 'Unauthorized' || err === 401) {
                       this.clearBasicCredentials()
                       this.loadData()
                       return Promise.reject()

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -376,8 +376,8 @@ export default {
       const useCredentialsPromise = (useCredentials) ? this.setBasicCredentials() : Promise.resolve()
       return useCredentialsPromise
         .then(() => { return this.$oh.api.get('/rest/') })
-        .catch((err) => {
-          if (err === 'Unauthorized') {
+        .catch((err, status) => {
+          if (status === 401) {
             if (!useCredentials) {
               // try again with credentials
               this.loadData(true)
@@ -393,8 +393,8 @@ export default {
                   this.$oh.api.get('/rest/').then((rootResponse) => {
                     this.storeBasicCredentials()
                     this.loadData()
-                  }).catch((err) => {
-                    if (err === 'Unauthorized') {
+                  }).catch((err, status) => {
+                    if (status === 401) {
                       this.clearBasicCredentials()
                       this.loadData()
                       return Promise.reject()

--- a/bundles/org.openhab.ui/web/src/js/openhab/api.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/api.js
@@ -4,8 +4,8 @@ import { getAccessToken, getTokenInCustomHeader, getBasicCredentials } from './a
 function wrapPromise (f7promise) {
   return new Promise((resolve, reject) => {
     f7promise
-      .then((data) => resolve(data.data, data.status, data.xhr))
-      .catch((err) => reject(err.message, err.status, err.xhr))
+      .then((data) => resolve(data.data))
+      .catch((err) => reject(err.message || err.status))
   })
 }
 

--- a/bundles/org.openhab.ui/web/src/js/openhab/auth.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/auth.js
@@ -92,7 +92,7 @@ export function setAccessToken (token, api) {
     requireToken = false
     return Promise.resolve()
   }).catch((err) => {
-    if (err === 'Unauthorized') requireToken = true
+    if (err === 'Unauthorized' || err === 401) requireToken = true
     return Promise.resolve()
   })
 }

--- a/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
@@ -124,7 +124,7 @@ export default {
         })
         .catch((err) => {
           console.log('Error while loading model: ' + err)
-          if (err === 'Unauthorized') {
+          if (err === 'Unauthorized' || err === 401) {
             authorize()
           }
         })


### PR DESCRIPTION
With HTTP2 there is no status code  reason-phrase and even in HTTP1 it is optional. Therefore the response status codes must be used to detect unauthorized request errors.

fix #1018

@ghys based on your comment I assume the second argument is the integer status code, I did not test this code, but I think it should work.