### PR TITLE
Fix Z-Wave network map not rendering when a node has no zwave_neighbours property

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/zwave/zwave-network.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/zwave/zwave-network.vue
@@ -100,6 +100,7 @@ export default {
           let nodeid = t.properties.zwave_nodeid
           let bridgeUID = t.bridgeUID
           let listening = t.properties.zwave_listening === 'true'
+          let neighbours = t.properties.zwave_neighbours ? t.properties.zwave_neighbours : ''
           serie.data.push({
             name: nodeid,
             value: t.label,
@@ -110,7 +111,7 @@ export default {
               borderWidth: 3
             }
           })
-          t.properties.zwave_neighbours.split(',').forEach((n) => {
+          neighbours.split(',').forEach((n) => {
             let returnlink = serie.links.find((l) => l.target === nodeid && l.source === n)
             if (!returnlink) {
               serie.links.push({


### PR DESCRIPTION
This pull requests fixes the error "Cannot read property 'split' of undefined" in the ZWave Network Map if some ZWave things do not have the "neighbours" property.

Signed-off-by: David Masshardt <david@masshardt.ch>