### PR TITLE
Upgrade to Karaf 4.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
     <bnd.version>5.3.0</bnd.version>
     <eea.version>2.3.0</eea.version>
-    <karaf.version>4.3.1</karaf.version>
+    <karaf.version>4.3.2</karaf.version>
     <sat.version>0.10.0</sat.version>
     <spotless.version>2.0.3</spotless.version>
   </properties>


### PR DESCRIPTION
Syncs the karaf.version so the new Maven plugin is used.

---

Related to openhab/openhab-distro#1287