### PR TITLE
Change unit from "lux" to "lx" on badges

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
@@ -34,7 +34,7 @@ export default {
       badgeConfigs: {
         temperature: { icon: 'f7:thermometer', unit: '°' },
         humidity: { icon: 'f7:drop', unit: '%' },
-        luminance: { icon: 'f7:sun_min', unit: 'lux' }
+        luminance: { icon: 'f7:sun_min', unit: 'lx' }
       }
     }
   },


### PR DESCRIPTION
- Change unit from "lux" to "lx" on badges

We are using unit signs for temperature and humidity. The correct unit for illumination is lx.

See also https://en.m.wikipedia.org/wiki/Lux

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>