### PR TITLE
item-picker adjustments

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -10,7 +10,7 @@
       <f7-button slot="media" icon-f7="list_bullet_indent" @click.native="pickFromModel" />
     </f7-list-item>
     <!-- for placeholder purposes before items are loaded -->
-    <f7-list-item link v-show="!ready" :title="title">
+    <f7-list-item link v-show="!ready" :title="title" disabled no-chevron>
       <f7-button slot="media" icon-f7="list_bullet_indent" @click.native="pickFromModel" />
     </f7-list-item>
   </ul>
@@ -50,7 +50,8 @@ export default {
     this.smartSelectParams.closeOnSelect = !(this.multiple)
     if (!this.items || !this.items.length) {
       // TODO use a Vuex store
-      this.$oh.api.get('/rest/items').then((items) => {
+      const filter = Array.isArray(this.filterType) ? this.filterType.join(',') : this.filterType
+      this.$oh.api.get('/rest/items' + (filter ? '?type=' + filter : '')).then((items) => {
         this.sortAndFilterItems(items)
       })
     } else {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -79,7 +79,7 @@ export default {
       let oldError = this.nameErrorMessage
       if (!/^[A-Za-z0-9_]+$/.test(name)) {
         this.nameErrorMessage = 'Required. Alphanumeric & underscores only'
-      } else if (this.items.some(item => item.name === name)) {
+      } else if (Array.isArray(this.items) && this.items.some(item => item.name === name)) {
         this.nameErrorMessage = 'An item with this name already exists'
       } else {
         this.nameErrorMessage = ''
@@ -91,7 +91,6 @@ export default {
     if (!this.item) return
     if (!this.item.category) this.$set(this.item, 'category', '')
     if (this.enableName) {
-      if (!this.items) this.items = []
       this.validateName(this.item.name)
     }
     const categoryControl = this.$refs.category


### PR DESCRIPTION
_Edit:_ ~This fixes #1062.~ (fixed in #1073)

Additionally, I adjusted the following: with slow item loading I found that
- the item-picker element for groups looks exactly the same, but does not react to clicks unless the items are actually loaded. It now shows "Loading..." instead of "Parent Groups" and a spinner until items are ready. Let me know if the design is ok. (at first I wanted the popup to show a single loading item and then update to the items, but updates within a smart select seem to not be rendered. I the end I like the current solution even better.)
- the item picker always loads all items, even when only groups are required. In my test setup that makes a difference of about ~600 items or ~300KB. I adjusted the rest call to use the type filter prop if provided to the item-picker (and sincerely hope that despite my double checks to not have introduced new regressions again 😄.)
