### PR TITLE
Minor changes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-item.vue
@@ -75,7 +75,7 @@
     width 30px
     height 30px
     background-image url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNnB4IiBoZWlnaHQ9IjZweCIgc3R5bGU9ImJhY2tncm91bmQtY29sb3I6I2ZmZmZmZjAwIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCA2IDYiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZD0ibTYgNmgtNnYtMS44aDQuMnYtNC4yaDEuOHoiIGZpbGw9IiM4ZThlOTMiLz48L3N2Zz4=')
-    z-index 10                // always on top
+    z-index 10000             // always on top
     touch-action none
   .configure-item-menu
     position absolute
@@ -83,7 +83,7 @@
     right 0px
     padding 2px
     color gray
-    z-index 10
+    z-index 10000
     i
       font-size 18px
       height 30px
@@ -99,7 +99,7 @@
     left 0px
     padding 2px
     color gray
-    z-index 10
+    z-index 10000
     touch-action none
   .configure-grid-menu        // show menu icon on upper right corner
     position absolute

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-page stacked name="HomePage" class="page-home" :class="{ 'standard-background': $f7.data.themeOptions.homeBackground === 'standard' }" @page:init="onPageInit" @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
+  <f7-page stacked name="HomePage" class="page-home" :class="{ 'standard-background': $f7.data.themeOptions.homeBackground === 'standard' }" @page:init="onPageInit" @page:beforein="onPageBeforeIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar :large="$f7.data.themeOptions.homeNavbar !== 'simple'" :large-transparent="$f7.data.themeOptions.homeNavbar !== 'simple'" class="home-nav">
       <f7-nav-left>
         <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -75,7 +75,7 @@
           <metadata-menu :item="item" />
         </f7-col>
       </f7-row>
-      <f7-row v-if="item.name && links.length && item.type !== 'Group'">
+      <f7-row v-if="item.name && item.type !== 'Group'">
         <f7-col>
           <f7-block-title>Channel Links</f7-block-title>
           <link-details :item="item" :links="links" />


### PR DESCRIPTION
Increase z-index for grid-item handles - see [community forums](https://community.openhab.org/t/oh3-ui-issue-with-fixed-layout-page/121696)
Allow link to be added when there is none - on item-details
Remove leftover from #1055 - removal of onPageAfterIn
