### PR TITLE
Item picker: load items when passed an empty array

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -48,7 +48,7 @@ export default {
   },
   created () {
     this.smartSelectParams.closeOnSelect = !(this.multiple)
-    if (!this.items) {
+    if (!this.items || !this.items.length) {
       // TODO use a Vuex store
       this.$oh.api.get('/rest/items').then((items) => {
         this.sortAndFilterItems(items)


### PR DESCRIPTION
Fix #1062.

Signed-off-by: Yannick Schaus <github@schaus.net>