### PR TITLE
[habpanel] Initialize configuration-provided widgets

### DIFF
--- a/bundles/org.openhab.ui.habpanel/web/app/services/persistence.service.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/services/persistence.service.js
@@ -34,6 +34,7 @@
 
         function loadDashboards(rejectIfEditingLocked) {
             var deferred = $q.defer();
+            $rootScope.configWidgets = {}; // for OH2 compatibility
             OH3StorageService.getPanelRegistry().then(function (data) {
                 $rootScope.useRegistry = true;
 


### PR DESCRIPTION
This feature is deprecated in OH3 but code remains which would break if `$rootScope.configWidgets` is left undefined.
So define it as an empty object early.
Fixes #733.

Signed-off-by: Yannick Schaus <github@schaus.net>