### PR TITLE
Apply cronLastSpecificDomDay to DOW-field instead of DOM-field

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -468,7 +468,6 @@ export default {
           days = 'LW'
           break
         case '8':
-          days = this.day.cronLastSpecificDomDay + 'L'
           break
         case '9':
           days = 'L-' + this.day.cronDaysBeforeEomMinus
@@ -499,10 +498,12 @@ export default {
           break
         case '6':
         case '7':
-        case '8':
         case '9':
         case '10':
           weeks = '?'
+          break
+        case '8':
+          weeks = this.day.cronLastSpecificDomDay + 'L'
           break
         case '11':
           weeks = this.week.cronNthDayDay + '#' + this.week.cronNthDayNth


### PR DESCRIPTION
The cron builder erroneously set the "On the last ???day of the month" option on the day-of-month-field in the cron expression. This PR changes to set it on the day-of-week-field. See openhab/openhab-core#2379

Closes openhab/openhab-core#2379