### PR TITLE
Fix analyzer back button if another popup was opened

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -1,6 +1,7 @@
 import HomePage from '../pages/home.vue'
 import NotFoundPage from '../pages/not-found.vue'
 import PageViewPage from '../pages/page/page-view.vue'
+import AnalyzerPopup from '../pages/analyzer/analyzer-popup.vue'
 
 const AboutPage = () => import(/* webpackChunkName: "about-page" */ '../pages/about.vue')
 const UserProfilePage = () => import(/* webpackChunkName: "profile-page" */ '../pages/profile.vue')
@@ -42,8 +43,6 @@ const RulesListPage = () => import(/* webpackChunkName: "admin-rules" */ '../pag
 const RuleEditPage = () => import(/* webpackChunkName: "admin-rules" */ '../pages/settings/rules/rule-edit.vue')
 const ScriptEditPage = () => import(/* webpackChunkName: "admin-rules" */ '../pages/settings/rules/script/script-edit.vue')
 const SchedulePage = () => import(/* webpackChunkName: "admin-schedule" */ '../pages/settings/schedule/schedule.vue')
-
-const AnalyzerPage = () => import(/* webpackChunkName: "analyzer" */ '../pages/analyzer/analyzer.vue')
 
 const DeveloperToolsPage = () => import(/* webpackChunkName: "admin-devtools" */ '../pages/developer/developer-tools.vue')
 const WidgetsListPage = () => import(/* webpackChunkName: "admin-devtools" */ '../pages/developer/widgets/widget-list.vue')
@@ -279,8 +278,8 @@ export default [
   },
   {
     path: '/analyzer/',
-    async (routeTo, routeFrom, resolve, reject) {
-      AnalyzerPage().then((c) => { resolve({ popup: { component: c.default } }) })
+    popup: {
+      component: AnalyzerPopup
     }
   },
   /* For Cordova */

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer-popup.vue
@@ -1,0 +1,17 @@
+<template>
+  <f7-popup tablet-fullscreen :backdrop="false" class="analyzer-popup" @popup:close="$refs.analyzer.onClose()">
+    <analyzer ref="analyzer" />
+  </f7-popup>
+</template>
+
+<style lang="stylus" scoped>
+.analyzer-popup
+  z-index 10490
+</style>
+<script>
+export default {
+  components: {
+    'analyzer': () => import(/* webpackChunkName: "analyzer" */ './analyzer.vue')
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -1,23 +1,21 @@
 <template>
-  <f7-popup tablet-fullscreen @popup:open="onOpen" @popup:close="onClose" @popup:opened="initChart">
-    <f7-page class="analyzer-content">
-      <f7-navbar :title="titleDisplayText" :back-link="$t('analyzer.back')">
-        <f7-nav-right>
-          <f7-link v-if="$store.getters.isAdmin" icon-md="material:save" @click="savePage">
-            {{ $theme.md ? '' : $t('analyzer.save') }}
-          </f7-link>
-        </f7-nav-right>
-      </f7-navbar>
-      <f7-toolbar bottom>
-        <span />
-        <f7-link class="right controls-link padding-right" ref="detailsLink" @click="openControls">
-          {{ $t('analyzer.controls') }}&nbsp;<f7-icon f7="chevron_up" />
+  <f7-page class="analyzer-content">
+    <f7-navbar :title="titleDisplayText" :back-link="$t('analyzer.back')">
+      <f7-nav-right>
+        <f7-link v-if="$store.getters.isAdmin" icon-md="material:save" @click="savePage">
+          {{ $theme.md ? '' : $t('analyzer.save') }}
         </f7-link>
-        <f7-link v-if="coordSystem !== 'time'" color="blue" icon-f7="crop_rotate" @click="orientation = (orientation === 'horizontal') ? 'vertical' : 'horizontal'" />
-        <span v-else />
-      </f7-toolbar>
-      <oh-chart-page v-if="showChart" class="analyzer-chart" :class="{ 'sheet-opened': controlsOpened }" :key="chartKey" :context="context" />
-    </f7-page>
+      </f7-nav-right>
+    </f7-navbar>
+    <f7-toolbar bottom>
+      <span />
+      <f7-link class="right controls-link padding-right" ref="detailsLink" @click="openControls">
+        {{ $t('analyzer.controls') }}&nbsp;<f7-icon f7="chevron_up" />
+      </f7-link>
+      <f7-link v-if="coordSystem !== 'time'" color="blue" icon-f7="crop_rotate" @click="orientation = (orientation === 'horizontal') ? 'vertical' : 'horizontal'" />
+      <span v-else />
+    </f7-toolbar>
+    <oh-chart-page v-if="showChart" class="analyzer-chart" :class="{ 'sheet-opened': controlsOpened }" :key="chartKey" :context="context" />
     <f7-sheet class="analyzer-controls" :backdrop="false" :close-on-escape="true" :opened="controlsOpened" @sheet:closed="controlsOpened = false">
       <f7-page>
         <f7-toolbar tabbar :bottom="true">
@@ -219,7 +217,7 @@
         </f7-block>
       </f7-page>
     </f7-sheet>
-  </f7-popup>
+  </f7-page>
 </template>
 
 <style lang="stylus">
@@ -227,7 +225,7 @@
   --f7-theme-color var(--f7-color-blue)
   --f7-theme-color-rgb var(--f7-color-blue-rgb)
   --f7-theme-color-tint var(--f7-color-blue-tint)
-  z-index 11000
+  z-index 10499
 .analyzer-content
   .analyzer-chart.sheet-opened
     .oh-chart-page-chart
@@ -284,6 +282,9 @@ export default {
   },
   i18n: {
     messages: loadLocaleMessages(require.context('@/assets/i18n/analyzer'))
+  },
+  mounted () {
+    this.initChart()
   },
   methods: {
     onOpen () {


### PR DESCRIPTION
Framework7 would not consider an async route to be a modal route,
leading to critical code not being executed and thus causing #1068.
This regression was introduced when the routes were changed to async in #948.

So introduce a new component and lazy load the analyzer inside it, so
there's a minimal impact on the app entry point.

Changed some z-indexes to make sure the popup backdrop is displayed between
the analyzer popup and the item picker popup.

Fixes #1068.
Fixes #1067.

Signed-off-by: Yannick Schaus <github@schaus.net>