### PR TITLE
Add Log Viewer (Frontail) to the Developer Tools

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -71,7 +71,12 @@
           </li>
 
           <f7-list-item link="/developer/" :title="$t('sidebar.developerTools')" panel-close
-                        :class="{ currentsection: currentUrl.indexOf('/developer/') >= 0 && currentUrl.indexOf('/developer/widgets') < 0 && currentUrl.indexOf('/developer/api-explorer') < 0 }">
+                        :class="{
+                          currentsection: currentUrl.indexOf('/developer/') >= 0 &&
+                            currentUrl.indexOf('/developer/widgets') < 0 &&
+                            currentUrl.indexOf('/developer/api-explorer') < 0 &&
+                            currentUrl.indexOf('/developer/frontail') < 0
+                        }">
             <f7-icon slot="media" ios="f7:exclamationmark_shield_fill" aurora="f7:exclamationmark_shield_fill" md="material:extension" color="gray" />
           </f7-list-item>
           <li v-if="showDeveloperSubmenu">
@@ -83,6 +88,10 @@
               <f7-list-item link="/developer/api-explorer" title="API Explorer" view=".view-main" panel-close :animate="false" no-chevron
                             :class="{ currentsection: currentUrl.indexOf('/developer/api-explorer') >= 0 }">
                 <f7-icon slot="media" f7="burn" color="gray" />
+              </f7-list-item>
+              <f7-list-item link="/developer/frontail" title="Log Viewer" view=".view-main" panel-close :animate="false" no-chevron
+                            :class="{ currentsection: currentUrl.indexOf('/developer/frontail') >= 0 }">
+                <f7-icon slot="media" f7="list_bullet" color="gray" />
               </f7-list-item>
             </ul>
           </li>

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -48,6 +48,7 @@ const DeveloperToolsPage = () => import(/* webpackChunkName: "admin-devtools" */
 const WidgetsListPage = () => import(/* webpackChunkName: "admin-devtools" */ '../pages/developer/widgets/widget-list.vue')
 const WidgetEditPage = () => import(/* webpackChunkName: "admin-devtools" */ '../pages/developer/widgets/widget-edit.vue')
 const ApiExplorerPage = () => import(/* webpackChunkName: "admin-devtools" */ '../pages/developer/api-explorer.vue')
+const FrontailPage = () => import(/* webpackChunkName: "admin-devtools" */ '../pages/developer/frontail.vue')
 
 const SetupWizardPage = () => import(/* webpackChunkName: "setup-wizard" */ '../pages/wizards/setup-wizard.vue')
 
@@ -273,6 +274,10 @@ export default [
       {
         path: 'api-explorer',
         async: loadAsync(ApiExplorerPage)
+      },
+      {
+        path: 'frontail',
+        async: loadAsync(FrontailPage)
       }
     ]
   },

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -38,6 +38,9 @@
                 <f7-list-item media-item title="API Explorer" footer="Discover and access the REST API directly" link="api-explorer">
                   <f7-icon slot="media" f7="burn" color="gray" />
                 </f7-list-item>
+                <f7-list-item media-item title="Log Viewer" footer="Frontail - Real-time preview of openhab logs and events" link="frontail">
+                  <f7-icon slot="media" f7="list_bullet" color="gray" />
+                </f7-list-item>
               </f7-list>
             </f7-col>
           </f7-row>

--- a/bundles/org.openhab.ui/web/src/pages/developer/frontail.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/frontail.vue
@@ -1,0 +1,63 @@
+<template>
+  <f7-page name="frontail" ref="page">
+    <f7-navbar title="Log Viewer" ref="navbar" back-link="Developer Tools" back-link-url="/developer/" back-link-force />
+    <f7-block class="frontail-block">
+      <f7-col class="frontail-block--col">
+        <iframe
+          id="frontailUi"
+          ref="frontailIframe"
+          :src="`${frontailUrl}/${this.filter ? '?filter=' + this.filter : ''}`"
+          scrolling="yes"
+          frameborder="0"
+          allowtransparency="true"
+          :height="iframeHeight" />
+      </f7-col>
+    </f7-block>
+  </f7-page>
+</template>
+
+<style lang="stylus">
+.frontail-block
+  padding-left: 0
+  padding-right: 0
+  margin: 0 !important
+.frontail-block--col
+  flex-direction: column
+  height: calc(99vh - var(--f7-block-margin-vertical) - var(--f7-block-margin-vertical) - calc(var(--f7-navbar-height) + var(--f7-safe-area-top)))
+  display: flex
+  flex-flow: column
+#frontailUi
+  width: 0
+  min-width: 100% !important
+  border: 0
+  min-height: 350px
+  flex: 1 1 auto
+  display: flex
+</style>
+
+<script>
+import auth from '@/components/auth-mixin.js'
+
+export default {
+  mixins: [auth],
+  data () {
+    return {
+      filter: this.$f7route.query.filter
+    }
+  },
+  computed: {
+    iframeHeight () {
+      return Number(
+        this.$refs['page']?.offsetHeight - this.$refs['navbar']?.offsetHeight
+      )
+    },
+    frontailUrl () {
+      const FRONTAIL_PORT = 9001
+      const url = new URL(window.location.origin)
+      const { protocol, hostname } = url
+
+      return `${protocol}//${hostname}:${FRONTAIL_PORT}`
+    }
+  }
+}
+</script>


### PR DESCRIPTION
Welcome back! 👋🏻 

This PR draft introduces Log Viewer (Frontail) embedded directly in the UI. 
![image](https://user-images.githubusercontent.com/2270505/122685249-8652a080-d20a-11eb-8a0b-fa4050434e37.png)

It also reacts to `filter` query string and passes it to Frontail, so we're able to quickly diagnose a problem:
![image](https://user-images.githubusercontent.com/2270505/122685251-8a7ebe00-d20a-11eb-8356-a148e4997957.png)

Drawbacks:
* Frontail port is currently hardcoded to `9001` as I couldn't find a proper place to add it as a  configuration param. Basic UI offers some sort of settings (dark theme, png/svg icons etc), which main UI is currently missing.
* This will only work locally (as it tries to access `window.location.origin` with replaced port

Side note: it would be nice to introduce some sort of feature flag system in the main UI, so we're able to gradually turn on that kind of features to the broader audience (experiments?), make it's presence toggleable on the UI and ultimately - merge bigger changes (even not necessarily completed) more frequently, without them affecting the UX.

@ghys chapeau bas, awesome job on the UI!

Cheers,
Kuba

Signed-off-by: Kuba Wolanin <hi@kubawolanin.com>