### PR TITLE
escape quotes in generate.js script

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -59,7 +59,7 @@ A regular or expandable cell
     Color to use when highlighted
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="on" label=""On" expression">
+<PropBlock type="TEXT" name="on" label="&quot;On&quot; expression">
   <PropDescription>
     Expression to determine when the card should be highlighted. If blank, determine automatically from the primary bound item if applicable.
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -59,7 +59,7 @@ A cell expanding to a color picker
     Color to use when highlighted
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="on" label=""On" expression">
+<PropBlock type="TEXT" name="on" label="&quot;On&quot; expression">
   <PropDescription>
     Expression to determine when the card should be highlighted. If blank, determine automatically from the primary bound item if applicable.
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -59,7 +59,7 @@ A cell expanding to a knob control
     Color to use when highlighted
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="on" label=""On" expression">
+<PropBlock type="TEXT" name="on" label="&quot;On&quot; expression">
   <PropDescription>
     Expression to determine when the card should be highlighted. If blank, determine automatically from the primary bound item if applicable.
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -59,7 +59,7 @@ A cell with a big label to show a short item state value
     Color to use when highlighted
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="on" label=""On" expression">
+<PropBlock type="TEXT" name="on" label="&quot;On&quot; expression">
   <PropDescription>
     Expression to determine when the card should be highlighted. If blank, determine automatically from the primary bound item if applicable.
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-location-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-location-card.md
@@ -86,6 +86,7 @@ A card showing model items in a certain location
     Select the badges you wish to show in the header of the card. Display all if none are selected.
   </PropDescription>
   <PropOptions multiple="true">
+    <PropOption value="battery" label="Low Battery Warning" />
     <PropOption value="lights" label="Lights On" />
     <PropOption value="windows" label="Open Windows" />
     <PropOption value="doors" label="Open Doors" />

--- a/bundles/org.openhab.ui/doc/components/oh-repeater.md
+++ b/bundles/org.openhab.ui/doc/components/oh-repeater.md
@@ -38,12 +38,12 @@ Iterate over an array and repeat the children components in the default slot
     What to iterate on
   </PropDescription>
   <PropOptions>
-    <PropOption value="array" label="Array (default) in the "in" parameter" />
-    <PropOption value="range" label="Range of integers defined by "rangeStart", "rangeStop", "rangeStep"" />
-    <PropOption value="itemsInGroup" label="Member of the group defined in the "groupItem" parameter" />
-    <PropOption value="itemsWithTags" label="Items with tags in the "itemTags" parameter" />
-    <PropOption value="itemStateOptions" label="State options of the item specified in "itemOptions"" />
-    <PropOption value="itemCommandOptions" label="Command options of the item specified in "itemOptions"" />
+    <PropOption value="array" label="Array (default) in the &quot;in&quot; parameter" />
+    <PropOption value="range" label="Range of integers defined by &quot;rangeStart&quot;, &quot;rangeStop&quot;, &quot;rangeStep&quot;" />
+    <PropOption value="itemsInGroup" label="Member of the group defined in the &quot;groupItem&quot; parameter" />
+    <PropOption value="itemsWithTags" label="Items with tags in the &quot;itemTags&quot; parameter" />
+    <PropOption value="itemStateOptions" label="State options of the item specified in &quot;itemOptions&quot;" />
+    <PropOption value="itemCommandOptions" label="Command options of the item specified in &quot;itemOptions&quot;" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="in" label="Source array">

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
@@ -59,7 +59,7 @@ A cell expanding to rollershutter controls
     Color to use when highlighted
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="on" label=""On" expression">
+<PropBlock type="TEXT" name="on" label="&quot;On&quot; expression">
   <PropDescription>
     Expression to determine when the card should be highlighted. If blank, determine automatically from the primary bound item if applicable.
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -59,7 +59,7 @@ A cell expanding to a big vertical slider
     Color to use when highlighted
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="on" label=""On" expression">
+<PropBlock type="TEXT" name="on" label="&quot;On&quot; expression">
   <PropDescription>
     Expression to determine when the card should be highlighted. If blank, determine automatically from the primary bound item if applicable.
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/src/generate.js
+++ b/bundles/org.openhab.ui/doc/components/src/generate.js
@@ -41,6 +41,13 @@ const replaceBetweenComments = (commentTag, text, value) => {
   return text.replace(regexp, '$1' + value + '$2')
 }
 
+const escapeQuotes = (text) => {
+  if (text !== undefined) {
+    return text.replace(/"/g, "&quot;");
+  }
+  return text
+}
+
 const buildProp = (prop) => {
   let ret = ''
   ret += '<PropBlock type="' + prop.type + '" '
@@ -61,7 +68,7 @@ const buildProp = (prop) => {
     if (prop.multiple) ret += ' multiple="true"'
     ret += '>\n'
     prop.options.forEach((o) => {
-      ret += '    <PropOption value="' + (o.value || '(empty)') + '" label="' + o.label + '" />\n'
+      ret += '    <PropOption value="' + (escapeQuotes(o.value) || '(empty)') + '" label="' + escapeQuotes(o.label) + '" />\n'
     })
     ret +='  </PropOptions>\n'
   }
@@ -127,3 +134,5 @@ Object.keys(widgetLibraries).forEach((l) => {
 })
 
 fs.writeFileSync('../index.md', index)
+
+

--- a/bundles/org.openhab.ui/doc/components/src/generate.js
+++ b/bundles/org.openhab.ui/doc/components/src/generate.js
@@ -134,5 +134,3 @@ Object.keys(widgetLibraries).forEach((l) => {
 })
 
 fs.writeFileSync('../index.md', index)
-
-

--- a/bundles/org.openhab.ui/doc/components/src/generate.js
+++ b/bundles/org.openhab.ui/doc/components/src/generate.js
@@ -50,11 +50,11 @@ const escapeQuotes = (text) => {
 
 const buildProp = (prop) => {
   let ret = ''
-  ret += '<PropBlock type="' + prop.type + '" '
-  if (prop.name) ret += 'name="' + prop.name + '" '
-  if (prop.label) ret += 'label="' + prop.label + '" '
+  ret += '<PropBlock type="' + escapeQuotes(prop.type) + '" '
+  if (prop.name) ret += 'name="' + escapeQuotes(prop.name) + '" '
+  if (prop.label) ret += 'label="' + escapeQuotes(prop.label) + '" '
   if (prop.required) ret += 'required="true" '
-  if (prop.context) ret += 'context="' + prop.context + '" '
+  if (prop.context) ret += 'context="' + escapeQuotes(prop.context) + '" '
   ret = ret.trim() + '>\n'
 
   if (prop.description) {
@@ -89,7 +89,7 @@ const buildProps = (component) => {
   if (component.props.parameterGroups) {
     component.props.parameterGroups.forEach((g) => {
       ret += '### ' + g.label + '\n'
-      ret += '<div class="props">\n<PropGroup name="' + g.name + '" label="' + g.label + '">\n'
+      ret += '<div class="props">\n<PropGroup name="' + escapeQuotes(g.name) + '" label="' + escapeQuotes(g.label) + '">\n'
       if (g.description) ret += '  ' + g.description + '\n'
       const propsInGroup = component.props.parameters.filter((p) => p.groupName === g.name)
       propsInGroup.forEach((p) => ret += buildProp(p))


### PR DESCRIPTION
Added functionality in generate.js script to escape the double quotes inside attribute values
See also #1084

Signed-off-by: Georgios Moutsos <georgios.moutsos@gmail.com>