### PR TITLE
Revert analyzer z-index changes

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer-popup.vue
@@ -4,10 +4,6 @@
   </f7-popup>
 </template>
 
-<style lang="stylus" scoped>
-.analyzer-popup
-  z-index 10490
-</style>
 <script>
 export default {
   components: {

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -225,7 +225,7 @@
   --f7-theme-color var(--f7-color-blue)
   --f7-theme-color-rgb var(--f7-color-blue-rgb)
   --f7-theme-color-tint var(--f7-color-blue-tint)
-  z-index 10499
+  z-index 11000
 .analyzer-content
   .analyzer-chart.sheet-opened
     .oh-chart-page-chart


### PR DESCRIPTION
Reverts the CSS z-index changes made in #1095, without reinstating #1067
& #1068 because now the analyzer route is correctly modal. There doesn't seem to be an
easy way to insert the popup-backdrop between the item picker smart select popup
(or model picker) and the analyzer popup/analyzer controls sheet, especially if there's
another popup _behind_ the analyzer popup with the `popup-behind` class.

Fixes #1105.

Signed-off-by: Yannick Schaus <github@schaus.net>