### PR TITLE
Add as Thing (with custom ID) - suggest last segment only

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -267,7 +267,7 @@ export default {
                       entry.label)
                   },
                   null,
-                  entry.thingUID.substring(entry.thingUID.indexOf(':', entry.thingUID.indexOf(':') + 1) + 1))
+                  entry.thingUID.substring(entry.thingUID.lastIndexOf(':') + 1))
               }
             },
             {


### PR DESCRIPTION
Fixes #1034.

Signed-off-by: Yannick Schaus <github@schaus.net>