### PR TITLE
Add releaseOnly parameter to sliders

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-knob-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-card.md
@@ -118,7 +118,7 @@ Display a knob in a card to visualize and control a quantifiable item
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-card.md
@@ -116,9 +116,14 @@ Display a knob in a card to visualize and control a quantifiable item
     Size the control using percentages instead of pixels
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -127,7 +127,7 @@ A cell expanding to a knob control
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -125,9 +125,14 @@ A cell expanding to a knob control
     Size the control using percentages instead of pixels
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-knob.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob.md
@@ -83,9 +83,14 @@ Knob control, allow to change a number value on a circular track
     Size the control using percentages instead of pixels
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-knob.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob.md
@@ -85,7 +85,7 @@ Knob control, allow to change a number value on a circular track
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/doc/components/oh-location-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-location-card.md
@@ -86,6 +86,7 @@ A card showing model items in a certain location
     Select the badges you wish to show in the header of the card. Display all if none are selected.
   </PropDescription>
   <PropOptions multiple="true">
+    <PropOption value="battery" label="Low Battery Warning" />
     <PropOption value="lights" label="Lights On" />
     <PropOption value="windows" label="Open Windows" />
     <PropOption value="doors" label="Open Doors" />

--- a/bundles/org.openhab.ui/doc/components/oh-slider-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-card.md
@@ -110,9 +110,14 @@ Display a slider in a card to control an item
     Text to append to the label while dragging the cursor
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-card.md
@@ -112,7 +112,7 @@ Display a slider in a card to control an item
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -120,9 +120,14 @@ A cell expanding to a big vertical slider
     Text to append to the label while dragging the cursor
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -122,7 +122,7 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-item.md
@@ -117,7 +117,7 @@ Display a slider control in a list
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-item.md
@@ -115,9 +115,14 @@ Display a slider control in a list
     Text to append to the label while dragging the cursor
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-slider.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider.md
@@ -78,9 +78,14 @@ Slider control, allows to pick a number value on a scale
     Text to append to the label while dragging the cursor
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="updateInterval" label="Update Interval">
+<PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    Time to wait between subsequent commands in ms (default 500)
+    If true, no commands are sent during sliding
+  </PropDescription>
+</PropBlock>
+<PropBlock type="INTEGER" name="commandInterval" label="Command Interval">
+  <PropDescription>
+    Time to wait between subsequent commands in ms (default 200)
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="delayStateDisplay" label="Delay State Display">

--- a/bundles/org.openhab.ui/doc/components/oh-slider.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider.md
@@ -80,7 +80,7 @@ Slider control, allows to pick a number value on a scale
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
-    If true, no commands are sent during sliding
+    If enabled, no commands are sent during sliding
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="commandInterval" label="Command Interval">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
@@ -12,6 +12,7 @@ export default () => [
   pt('textColor', 'Text Color', 'Color of the value text (HTML value, default #000000)'),
   pt('strokeWidth', 'Stroke Width', 'Thickness of the arcs, default 17'),
   pb('responsive', 'Responsive', 'Size the control using percentages instead of pixels'),
-  pn('updateInterval', 'Update Interval', 'Time to wait between subsequent commands in ms (default 500)').a(),
+  pb('releaseOnly', 'Send command only on release', 'If true, no commands are sent during sliding'),
+  pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),
   pn('delayStateDisplay', 'Delay State Display', 'Time to wait before switching from displaying user input to displaying item state in ms (default 2000)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
@@ -12,7 +12,7 @@ export default () => [
   pt('textColor', 'Text Color', 'Color of the value text (HTML value, default #000000)'),
   pt('strokeWidth', 'Stroke Width', 'Thickness of the arcs, default 17'),
   pb('responsive', 'Responsive', 'Size the control using percentages instead of pixels'),
-  pb('releaseOnly', 'Send command only on release', 'If true, no commands are sent during sliding'),
+  pb('releaseOnly', 'Send command only on release', 'If enabled, no commands are sent during sliding'),
   pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),
   pn('delayStateDisplay', 'Delay State Display', 'Time to wait before switching from displaying user input to displaying item state in ms (default 2000)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
@@ -11,6 +11,7 @@ export default () => [
   pn('scaleSteps', 'Scale steps', 'Number of (major) scale markers'),
   pn('scaleSubSteps', 'Scale sub-steps', 'Number of scale minor markers between each major marker'),
   pt('unit', 'Unit', 'Text to append to the label while dragging the cursor'),
-  pn('updateInterval', 'Update Interval', 'Time to wait between subsequent commands in ms (default 500)').a(),
+  pb('releaseOnly', 'Send command only on release', 'If true, no commands are sent during sliding'),
+  pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),
   pn('delayStateDisplay', 'Delay State Display', 'Time to wait before switching from displaying user input to displaying item state in ms (default 2000)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
@@ -11,7 +11,7 @@ export default () => [
   pn('scaleSteps', 'Scale steps', 'Number of (major) scale markers'),
   pn('scaleSubSteps', 'Scale sub-steps', 'Number of scale minor markers between each major marker'),
   pt('unit', 'Unit', 'Text to append to the label while dragging the cursor'),
-  pb('releaseOnly', 'Send command only on release', 'If true, no commands are sent during sliding'),
+  pb('releaseOnly', 'Send command only on release', 'If enabled, no commands are sent during sliding'),
   pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),
   pn('delayStateDisplay', 'Delay State Display', 'Time to wait before switching from displaying user input to displaying item state in ms (default 2000)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -80,7 +80,7 @@ export default {
       this.$f7.input.validateInputs(this.$refs.smartSelect.$el)
       const value = this.$refs.smartSelect.f7SmartSelect.getValue()
       this.$emit('input', value)
-      if (!this.multiple) this.$emit('itemSelected', this.items.find((i) => i.name === value))
+      if (!this.multiple) this.$emit('itemSelected', this.preparedItems.find((i) => i.name === value))
     },
     updateFromModelPicker (value) {
       if (this.multiple) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/slide-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/slide-mixin.js
@@ -7,13 +7,13 @@ export default {
   mounted () {
     delete this.config.value
 
-    this.updateInterval = this.config.updateInterval ? this.config.updateInterval : 200
+    this.commandInterval = this.config.commandInterval ? this.config.commandInterval : 200
     this.delayStateDisplay = this.config.delayStateDisplay ? this.config.delayStateDisplay : 2000
   },
   computed: {
     value () {
       if (this.config.variable) return this.context.vars[this.config.variable]
-      if (this.pendingCommand) return this.pendingCommand // to keep the control reactive when operating
+      if (this.pendingCommand !== null) return this.pendingCommand // to keep the control reactive when operating
       const value = this.context.store[this.config.item].state
       // use as a brightness control for HSB values
       if (value.split && value.split(',').length === 3) return parseFloat(value.split(',')[2])
@@ -32,8 +32,11 @@ export default {
       if (!this.config.item) return
 
       this.pendingCommand = value
-      let diff = this.lastDateSent ? Date.now() - this.lastDateSent : this.updateInterval
-      let delay = diff < this.updateInterval ? this.updateInterval - diff : stop ? 0 : this.updateInterval
+
+      if (this.config.releaseOnly && !stop) return
+
+      let diff = this.lastDateSent ? Date.now() - this.lastDateSent : this.commandInterval
+      let delay = diff < this.commandInterval ? this.commandInterval - diff : stop ? 0 : this.commandInterval
 
       if (this.sendCommandTimer && stop) {
         clearTimeout(this.sendCommandTimer)


### PR DESCRIPTION
This adds a parameter to sliders to not send commands while sliding but only on release. Fixes #1114.

I also renamed the parameter `updateInterval` to `commandInterval` since I had the feeling "update" is ambiguous, i.e. it can be confused with a displaying update as in `delayStateDisplay`.

Also, the `commandInterval` is not an advanced parameter anymore. I think it's too hidden then and users wouldn't find it.
