### PR TITLE
[Main UI] Use full list of item types for groups

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/item-types.js
+++ b/bundles/org.openhab.ui/web/src/assets/item-types.js
@@ -1,5 +1,7 @@
-export const ItemTypes = ['Switch', 'Contact', 'String', 'Number', 'Dimmer', 'DateTime', 'Color', 'Image', 'Player', 'Location', 'Rollershutter', 'Call', 'Group']
-export const GroupTypes = ['None', 'Switch', 'Contact', 'Number', 'Dimmer', 'Rollershutter', 'DateTime']
+const SharedTypes = ['Call', 'Color', 'Contact', 'DateTime', 'Dimmer', 'Image', 'Location', 'Number', 'Player', 'Rollershutter', 'String', 'Switch']
+
+export const ItemTypes = SharedTypes.concat(['Group'])
+export const GroupTypes = ['None'].concat(SharedTypes)
 export const Dimensions = ['Area', 'Length', 'Mass', 'Pressure', 'Speed', 'Temperature', 'Volume', 'Dimensionless', 'Acceleration', 'AmountOfSubstance', 'Angle', 'ArealDensity', 'CatalyticActivity', 'DataAmount', 'DataTransferRate', 'Density', 'ElectricCapacitance', 'ElectricCharge', 'ElectricConductance', 'ElectricCurrent', 'ElectricInductance', 'ElectricPotential', 'ElectricResistance', 'Energy', 'Force', 'Frequency', 'Illuminance', 'Intensity', 'LuminousFlux', 'LuminousIntensity', 'MagneticFlux', 'MagneticFluxDensity', 'Power', 'RadiationDoseAbsorbed', 'RadiationDoseEffective', 'Radioactivity', 'SolidAngle', 'Time', 'VolumetricFlowRate']
 
 export const ArithmeticFunctions = [{


### PR DESCRIPTION
Closes #957 

- Also sorted list in Alphabetical order (with None at the start of group types), was there a reason for the old order?

It does not implement any new aggregation functions, although some arithmetic functions such as `AVG` make sense for `Color`, these are not yet implemented within Core.

Signed-off-by: Ben Clark <ben@benjyc.uk>