### PR TITLE
[habot] Removing old ephemeral cards to debug

### DIFF
--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/card/internal/CardRegistry.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/card/internal/CardRegistry.java
@@ -100,7 +100,7 @@ public class CardRegistry extends AbstractRegistry<Card, String, CardProvider> {
                 .collect(Collectors.toList());
 
         for (Card card : oldCards) {
-            logger.info("Removing old ephemeral card {}", card.getUID());
+            logger.debug("Removing old ephemeral card {}", card.getUID());
             remove(card.getUID());
         }
 


### PR DESCRIPTION
Believe this should not be info level as it is not useful to most users and my logs are getting it way too often.

To reproduce:

Type in "show temperature for 1 month".
The graph appears and the log now has an entry like:
Removing old ephemeral card d7xxx2-f1b4-4x5a-xxx9-x7f56xxxxxd

Signed-off-by: Matthew Skinner <matt@pcmus.com>