### PR TITLE
Fix detection of protected user API operations

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/openhab/auth.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/auth.js
@@ -84,17 +84,22 @@ export function storeBasicCredentials () {
 }
 
 export function setAccessToken (token, api) {
-  accessToken = token
-  if (!token || !api || requireToken !== undefined) return Promise.resolve()
-
-  // determine whether the token is required for user operations
-  return api.get('/rest/sitemaps').then((resp) => {
-    requireToken = false
+  if (!token || !api) return Promise.resolve()
+  if (requireToken === undefined) {
+    // determine whether the token is required for user operations
+    return api.get('/rest/sitemaps').then((resp) => {
+      accessToken = token
+      requireToken = false
+      return Promise.resolve()
+    }).catch((err) => {
+      if (err === 'Unauthorized' || err === 401) requireToken = true
+      accessToken = token
+      return Promise.resolve()
+    })
+  } else {
+    accessToken = token
     return Promise.resolve()
-  }).catch((err) => {
-    if (err === 'Unauthorized' || err === 401) requireToken = true
-    return Promise.resolve()
-  })
+  }
 }
 
 export function clearAccessToken () {


### PR DESCRIPTION
The current implementation would set the access token before trying out calling `/rest/sitemaps` which would obviously always succeed, since the call would be made with the token. Therefore the "requireToken" flag would not be set properly and prevent the alternative SSE implementation (which allows headers) to be used.

Fixes #1146.

Signed-off-by: Yannick Schaus <github@schaus.net>