### PR TITLE
Prevent modified files with Maven builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 src-gen/
 bin/
 .metadata/
+.openapi-generator/
 **/.settings/org.eclipse.*
 features/*/src/main/history
 npm-debug.log

--- a/bundles/org.openhab.ui.habot/pom.xml
+++ b/bundles/org.openhab.ui.habot/pom.xml
@@ -87,10 +87,13 @@
           </execution>
 
           <execution>
-            <id>npm install</id>
+            <id>npm ci</id>
             <goals>
               <goal>npm</goal>
             </goals>
+            <configuration>
+              <arguments>ci</arguments>
+            </configuration>
           </execution>
 
           <execution>

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -53,12 +53,12 @@
           </execution>
 
           <execution>
-            <id>npm install</id>
+            <id>npm ci</id>
             <goals>
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>ci</arguments>
             </configuration>
           </execution>
 


### PR DESCRIPTION
#1113 only partially solved #241.

It might be better to run `npm ci` by default for more reproducible builds and to prevent changes to `package-lock.json`.