### PR TITLE
Bump and fix habot dependencies

### DIFF
--- a/bundles/org.openhab.ui.habot/pom.xml
+++ b/bundles/org.openhab.ui.habot/pom.xml
@@ -15,17 +15,17 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.67</version>
+      <version>1.69</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>
       <artifactId>opennlp-tools</artifactId>
-      <version>1.8.3</version>
+      <version>1.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.bitbucket.b_c</groupId>
       <artifactId>jose4j</artifactId>
-      <version>0.6.3</version>
+      <version>0.7.9</version>
     </dependency>
     <dependency>
       <groupId>org.openhab.core.bundles</groupId>

--- a/features/src/main/feature/feature.xml
+++ b/features/src/main/feature/feature.xml
@@ -66,9 +66,9 @@
 		<bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.habot/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.semantics/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest/${project.version}</bundle>
-		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.54</bundle>
-		<bundle dependency="true">mvn:org.apache.opennlp/opennlp-tools/1.8.3</bundle>
-		<bundle dependency="true">mvn:org.bitbucket.b_c/jose4j/0.6.3</bundle>
+		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.69</bundle>
+		<bundle dependency="true">mvn:org.apache.opennlp/opennlp-tools/1.9.3</bundle>
+		<bundle dependency="true">mvn:org.bitbucket.b_c/jose4j/0.7.9</bundle>
 	</feature>
 
 	<feature name="openhab-ui-habpanel" description="HABPanel" version="${project.version}">


### PR DESCRIPTION
The HABot UI is currently broken because https://github.com/openhab/openhab-webui/pull/1142 did not update the features. Can you add these new/missing dependencies to the online repo @kaikreuzer? Otherwise it will still not be able to properly install HABot.

E.g:

`Suppressed: shaded.org.eclipse.aether.transfer.ArtifactNotFoundException: Could not find artifact org.bouncycastle:bcprov-jdk15on:jar:1.69 in openhab (https://openhab.jfrog.io/openhab/libs-snapshot/)`