### PR TITLE
This adds back oh-icon color support for plan markers

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -11,7 +11,7 @@
       <div v-if="config.useTooltipAsLabel" style="white-space: nowrap" :style="tooltipStyle">
         {{ tooltip }}
       </div>
-      <oh-icon v-else-if="config.icon" :icon="config.icon" :width="config.iconWidth || config.iconSize || 40" :height="config.iconHeight || config.iconSize || 40" :state="config.iconUseState ? state : undefined" />
+      <oh-icon v-else-if="config.icon" :icon="config.icon" :color="config.iconColor" :width="config.iconWidth || config.iconSize || 40" :height="config.iconHeight || config.iconSize || 40" :state="config.iconUseState ? state : undefined" />
     </l-icon>
     <l-popup v-if="context.editmode != null && !dragging">
       <div class="display-flex">


### PR DESCRIPTION
PR #1149 looks to have accidentally removed the iconColor parameter for plan markers. 
Signed-off-by: Dan Cunningham <dan@digitaldan.com>