### PR TITLE
Replace Add-on Management UI with Add-on Store

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -89,6 +89,7 @@
         "jest-serializer-vue": "^2.0.2",
         "jest-transform-stub": "^2.0.0",
         "jest-vue-preprocessor": "^1.7.1",
+        "marked": "^3.0.2",
         "mini-css-extract-plugin": "^0.5.0",
         "nearley-loader": "^2.0.0",
         "optimize-css-assets-webpack-plugin": "^5.0.4",
@@ -14205,6 +14206,18 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
+      "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/md5.js": {
@@ -35346,6 +35359,12 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "marked": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.2.tgz",
+      "integrity": "sha512-TMJQQ79Z0e3rJYazY0tIoMsFzteUGw9fB3FD+gzuIT3zLuG9L9ckIvUfF51apdJkcqc208jJN2KbtPbOvXtbjA==",
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.5",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -141,6 +141,7 @@
     "jest-serializer-vue": "^2.0.2",
     "jest-transform-stub": "^2.0.0",
     "jest-vue-preprocessor": "^1.7.1",
+    "marked": "^3.0.2",
     "mini-css-extract-plugin": "^0.5.0",
     "nearley-loader": "^2.0.0",
     "optimize-css-assets-webpack-plugin": "^5.0.4",

--- a/bundles/org.openhab.ui/web/src/assets/addon-store.js
+++ b/bundles/org.openhab.ui/web/src/assets/addon-store.js
@@ -1,0 +1,66 @@
+export const AddonIcons = {
+  automation: 'wand_stars',
+  binding: 'circle_grid_hex_fill',
+  persistence: 'download_circle',
+  transformation: 'function',
+  misc: 'rectangle_3_offgrid',
+  ui: 'play_rectangle',
+  voice: 'chat_bubble_2_fill'
+}
+
+export const ContentTypes = {
+  'application/java-archive': 'Java Archive',
+  'application/vnd.openhab.bundle': 'OSGi Bundle',
+  'application/vnd.openhab.feature;type=karaf': 'Karaf Feature',
+  'application/vnd.openhab.ruletemplate': 'Rule Template',
+  'application/vnd.openhab.uicomponent;type=widget': 'UI Component - Widget'
+}
+
+export const Formats = {
+  'yaml_content': 'Inline YAML Code',
+  'json_content': 'Inline JSON Code',
+  'yaml_download_url': 'Linked YAML File',
+  'json_download_url': 'Linked JSON File',
+  'jar_download_url': 'Linked JAR file',
+  'kar_download_url': 'Linked KAR file',
+  'karaf': 'Karaf'
+}
+
+export const AddonStoreTabShortcuts = [
+  {
+    id: 'bindings',
+    label: 'Bindings',
+    icon: 'circle_grid_hex',
+    subtitle: 'Connect and control hardware and online services'
+  },
+  {
+    id: 'automation',
+    label: 'Automation',
+    icon: 'sparkles',
+    subtitle: 'Scripting languages, templates and module types'
+  },
+  {
+    id: 'ui',
+    label: 'User Interfaces',
+    icon: 'play_rectangle',
+    subtitle: 'Community widgets & alternative frontends'
+  },
+  {
+    id: 'other',
+    label: 'Other Add-ons',
+    icon: 'ellipsis',
+    subtitle: 'System integrations, persistence, voice & more'
+  }
+]
+
+export function compareAddons (a1, a2) {
+  if (a1.installed && !a2.installed) return -1
+  if (a2.installed && !a1.installed) return 1
+  if (a1.verifiedAuthor && !a2.verifiedAuthor) return -1
+  if (a2.verifiedAuthor && !a1.verifiedAuthor) return 1
+  if (a1.properties && a2.properties && a1.properties.like_count >= 0 && a2.properties.like_count >= 0) return (a1.properties.like_count > a2.properties.like_count) ? 1 : -1
+  if (a1.properties && a2.properties && a1.properties.views >= 0 && a2.properties.views >= 0) return (a1.properties.views > a2.properties.views) ? 1 : -1
+  const nameOrId1 = a1.label || a1.id
+  const nameOrId2 = a2.label || a2.name
+  return nameOrId1.localeCompare(nameOrId2)
+}

--- a/bundles/org.openhab.ui/web/src/assets/addon-store.js
+++ b/bundles/org.openhab.ui/web/src/assets/addon-store.js
@@ -58,8 +58,18 @@ export function compareAddons (a1, a2) {
   if (a2.installed && !a1.installed) return 1
   if (a1.verifiedAuthor && !a2.verifiedAuthor) return -1
   if (a2.verifiedAuthor && !a1.verifiedAuthor) return 1
-  if (a1.properties && a2.properties && a1.properties.like_count >= 0 && a2.properties.like_count >= 0) return (a1.properties.like_count > a2.properties.like_count) ? 1 : -1
-  if (a1.properties && a2.properties && a1.properties.views >= 0 && a2.properties.views >= 0) return (a1.properties.views > a2.properties.views) ? 1 : -1
+  if (a2.properties && a2.properties) {
+    if (a1.properties.like_count >= 0 && a2.properties.like_count >= 0 &&
+      a1.properties.like_count !== a2.properties.like_count) {
+      return (a1.properties.like_count > a2.properties.like_count) ? -1 : 1
+    }
+
+    if (a1.properties.views >= 0 && a2.properties.views >= 0 &&
+      a1.properties.views !== a2.properties.views) {
+      return (a1.properties.views > a2.properties.views) ? -1 : 1
+    }
+  }
+
   const nameOrId1 = a1.label || a1.id
   const nameOrId2 = a2.label || a2.name
   return nameOrId1.localeCompare(nameOrId2)

--- a/bundles/org.openhab.ui/web/src/assets/addon-store.js
+++ b/bundles/org.openhab.ui/web/src/assets/addon-store.js
@@ -12,6 +12,7 @@ export const ContentTypes = {
   'application/java-archive': 'Java Archive',
   'application/vnd.openhab.bundle': 'OSGi Bundle',
   'application/vnd.openhab.feature;type=karaf': 'Karaf Feature',
+  'application/vnd.openhab.feature;type=karfile': 'Karaf KAR Archive',
   'application/vnd.openhab.ruletemplate': 'Rule Template',
   'application/vnd.openhab.uicomponent;type=widget': 'UI Component - Widget'
 }

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -14,9 +14,12 @@
       <div class="addon-card-label">
         {{ addon.label }}
       </div>
-      <div class="addon-card-author">
+      <div v-if="addon.verifiedAuthor" class="addon-card-subtitle">
         {{ addon.author }}
         <f7-icon v-if="addon.verifiedAuthor" size="15" :color="$f7.data.themeOptions.dark === 'dark' ? 'white' : 'blue'" f7="checkmark_seal_fill" style="margin-top: -3px;" />
+      </div>
+      <div v-else-if="addon.properties && addon.properties.views" class="addon-card-subtitle">
+        <addon-stats-line :addon="addon" :iconSize="15" />
       </div>
     </div>
     <div class="logo-square">
@@ -70,7 +73,7 @@
       justify-content center
       height var(--f7-button-small-height)
       --f7-preloader-size var(--f7-button-small-height)
-  .addon-card-author
+  .addon-card-subtitle
     color var(--f7-list-item-after-text-color)
     font-size var(--f7-list-item-subtitle-font-size) // 21px
     font-weight var(--f7-list-item-subtitle-font-weight)
@@ -107,9 +110,13 @@
 
 <script>
 import { AddonIcons } from '@/assets/addon-store'
+import AddonStatsLine from './addon-stats-line.vue'
 
 export default {
   props: ['addon', 'headline'],
+  components: {
+    AddonStatsLine
+  },
   data () {
     return {
       logoLoaded: false,

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -1,0 +1,148 @@
+<template>
+  <f7-link
+    v-if="addon"
+    class="addon-card padding-right-half" :href="addon.id">
+    <div class="addon-card-headline">
+      <div>{{ headline || autoHeadline }}</div>
+    </div>
+    <div class="addon-card-title">
+      <div class="addon-card-title-after">
+        <f7-preloader v-if="addon.pending" color="blue" />
+        <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />
+        <f7-button v-else class="install-button prevent-active-state-propagation" text="Install" color="blue" round small @click="buttonClicked" />
+      </div>
+      <div class="addon-card-label">
+        {{ addon.label }}
+      </div>
+      <div class="addon-card-author">
+        {{ addon.author }}
+        <f7-icon v-if="addon.verifiedAuthor" size="15" :color="$f7.data.themeOptions.dark === 'dark' ? 'white' : 'blue'" f7="checkmark_seal_fill" style="margin-top: -3px;" />
+      </div>
+    </div>
+    <div class="logo-square">
+      <f7-icon v-show="!logoLoaded" size="150" color="gray" :f7="addonIcon" class="card-default-icon" />
+      <img v-if="!logoError" class="lazy logo" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo" :data-src="imageUrl">
+    </div>
+  </f7-link>
+</template>
+
+<style lang="stylus">
+.addon-card
+  display flex
+  flex-direction column
+  align-items flex-start
+  align-content flex-end
+  color inherit
+  scroll-snap-align center center
+  padding 5px 0px 0px
+  position relative
+  margin-bottom 1rem
+  .install-button
+    // --f7-button-bg-color var(--f7-color-gray)
+    --f7-button-text-transform uppercase
+    --f7-button-bg-color var(--f7-list-item-border-color)
+  .addon-card-headline
+    text-transform uppercase
+    color var(--f7-theme-color)
+    font-size 11px
+    font-weight 500
+  .addon-card-title
+    height 3.4rem
+    width 100%
+    /* display flex
+    justify-content space-between
+    box-sizing border-box */
+    font-size var(--f7-timeline-item-title-font-size) // 21px
+    font-weight var(--f7-list-media-item-title-font-weight)
+    line-height 1.75
+    .addon-card-label
+      text-overflow ellipsis
+      overflow hidden
+      white-space nowrap
+      width calc(100% - 5rem)
+    .addon-card-title-after
+      .preloader-inner .preloader-inner-left, .preloader-inner .preloader-inner-right, .preloader-inner .preloader-inner-line
+        margin-left inherit !important
+      display flex
+      float right
+      align-self top
+      min-width 70px
+      justify-content center
+      height var(--f7-button-small-height)
+      --f7-preloader-size var(--f7-button-small-height)
+  .addon-card-author
+    color var(--f7-list-item-after-text-color)
+    font-size var(--f7-list-item-subtitle-font-size) // 21px
+    font-weight var(--f7-list-item-subtitle-font-weight)
+    line-height 1.75
+    &:after
+      content ' '
+      display inline-block
+  .logo-square
+    position relative
+    background #fff
+    width 100%
+    margin-top 5px
+    // height 220px
+    border 1px solid var(--f7-list-item-border-color)
+    border-radius 5px
+    display flex
+    justify-content center
+    align-items center
+    &:after
+      content ' '
+      display block
+      padding-bottom 100%
+  .card-default-icon
+    opacity 0.2
+    position absolute
+  .logo
+    position absolute
+    top 3px
+    left 3px
+    width calc(100% - 6px)
+    height calc(100% - 6px)
+    object-fit contain
+</style>
+
+<script>
+import { AddonIcons } from '@/assets/addon-store'
+
+export default {
+  props: ['addon', 'headline'],
+  data () {
+    return {
+      logoLoaded: false,
+      logoError: false,
+      addonIcon: null
+    }
+  },
+  computed: {
+    autoHeadline () {
+      if (this.addon.properties && this.addon.properties.like_count && this.addon.properties.like_count >= 20) return 'Top'
+      if (this.addon.properties && this.addon.properties.views && this.addon.properties.views >= 1000) return 'Popular'
+      if (this.addon.properties && this.addon.properties.posts_count && this.addon.properties.posts_count >= 15) return 'Hot'
+      return ''
+    },
+    imageUrl () {
+      if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
+      return 'https://www.openhab.org/logos/' + this.addon.id.substring(this.addon.id.indexOf('-') + 1) + '.png'
+    }
+  },
+  mounted () {
+    this.addonIcon = AddonIcons[this.addon.type]
+    this.$$(this.$refs.logo).once('lazy:loaded', (e) => {
+      console.log(this.addon.id + ' logo lazy loaded')
+      this.logoLoaded = true
+    })
+    this.$$(this.$refs.logo).once('lazy:error', (e) => {
+      this.logoError = true
+    })
+  },
+  methods: {
+    buttonClicked () {
+      this.$emit('addonButtonClick', this.addon)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -9,7 +9,7 @@
       <div class="addon-card-title-after">
         <f7-preloader v-if="addon.pending" color="blue" />
         <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />
-        <f7-button v-else class="install-button prevent-active-state-propagation" text="Install" color="blue" round small @click="buttonClicked" />
+        <f7-button v-else class="install-button prevent-active-state-propagation" :text="installActionText || 'Install'" color="blue" round small @click="buttonClicked" />
       </div>
       <div class="addon-card-label">
         {{ addon.label }}
@@ -113,7 +113,7 @@ import { AddonIcons } from '@/assets/addon-store'
 import AddonStatsLine from './addon-stats-line.vue'
 
 export default {
-  props: ['addon', 'headline'],
+  props: ['addon', 'headline', 'installActionText'],
   components: {
     AddonStatsLine
   },
@@ -139,7 +139,6 @@ export default {
   mounted () {
     this.addonIcon = AddonIcons[this.addon.type]
     this.$$(this.$refs.logo).once('lazy:loaded', (e) => {
-      console.log(this.addon.id + ' logo lazy loaded')
       this.logoLoaded = true
     })
     this.$$(this.$refs.logo).once('lazy:error', (e) => {

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -30,6 +30,10 @@
 </style>
 
 <script>
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+dayjs.extend(utc)
+
 import { ContentTypes, Formats } from '@/assets/addon-store'
 
 export default {
@@ -90,7 +94,7 @@ export default {
         info.push({
           id: 'createdAt',
           title: 'Created At',
-          value: this.addon.properties.created_at
+          value: dayjs(this.addon.properties.created_at).utc('z').local().format('LLL')
         })
       }
 
@@ -98,7 +102,7 @@ export default {
         info.push({
           id: 'updated',
           title: 'Updated At',
-          value: this.addon.properties.updated_at
+          value: dayjs(this.addon.properties.updated_at).utc('z').local().format('LLL')
         })
       }
 

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -1,0 +1,132 @@
+<template>
+  <f7-list v-if="addon && information && information.length > 0" class="information-table">
+    <f7-list-item v-for="line in information" :key="line.id"
+                  :title="line.title" :after="line.value"
+                  :link="line.linkUrl" external no-chevron target="_blank">
+      <f7-icon slot="after" v-if="line.linkIcon" :f7="line.linkIcon" />
+    </f7-list-item>
+  </f7-list>
+</template>
+
+<style lang="stylus">
+.information-table
+  --f7-list-bg-color transparent
+  --f7-theme-color var(--f7-color-blue)
+  .item-after
+    align-items center
+    i
+      margin-left 3px
+      font-size var(--f7-list-item-subtitle-font-size)
+      &:first-child
+        font-size x-large
+  .item-link
+    --f7-list-item-title-text-color var(--f7-theme-color)
+    --f7-list-item-after-text-color: var(--f7-theme-color)
+</style>
+
+<script>
+import { ContentTypes, Formats } from '@/assets/addon-store'
+
+export default {
+  props: ['addon'],
+  computed: {
+    information () {
+      let info = []
+      if (!this.addon || !this.addon.id) return info
+      const marketplace = this.addon.id.indexOf('marketplace:') === 0
+
+      info.push({
+        id: 'provider',
+        title: 'Provided By',
+        value: (marketplace) ? 'Community Marketplace' : 'openHAB Distribution'
+      })
+
+      info.push({
+        id: 'author',
+        title: 'Author',
+        value: this.addon.author,
+        linkIcon: (this.addon.verifiedAuthor) ? 'checkmark_seal_fill' : ''
+      })
+
+      if (this.addon.version) {
+        info.push({
+          id: 'version',
+          title: 'Version',
+          value: this.addon.version
+        })
+      }
+
+      info.push({
+        id: 'type',
+        title: 'Type',
+        value: this.addon.type
+      })
+
+      info.push({
+        id: 'contentType',
+        title: 'Content Type',
+        value: ContentTypes[this.addon.contentType] || this.addon.contentType
+      })
+
+      let format = Formats.karaf
+      if (marketplace && Object.keys(this.addon.properties).length > 0) {
+        for (const property in this.addon.properties) {
+          if (Formats[property]) format = Formats[property]
+        }
+      }
+
+      info.push({
+        id: 'format',
+        title: 'Provisioned With',
+        value: format
+      })
+
+      if (this.addon.properties && this.addon.properties.created_at) {
+        info.push({
+          id: 'createdAt',
+          title: 'Created At',
+          value: this.addon.properties.created_at
+        })
+      }
+
+      if (this.addon.properties && this.addon.properties.updated_at) {
+        info.push({
+          id: 'updated',
+          title: 'Updated At',
+          value: this.addon.properties.updated_at
+        })
+      }
+
+      if (marketplace) {
+        info.push({
+          id: 'communityTopicLink',
+          title: 'Community Topic',
+          linkIcon: 'chat_bubble_2_fill',
+          linkUrl: this.addon.link
+        })
+      } else {
+        info.push({
+          id: 'documentationLink',
+          title: 'Documentation',
+          linkIcon: 'question_circle_fill',
+          linkUrl: `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}` // this.addon.link
+        })
+        info.push({
+          id: 'issuesLink',
+          title: 'Issues',
+          linkIcon: 'exclamationmark_bubble_fill',
+          linkUrl: 'https://github.com/openhab/openhab-addons/issues?q=is%3Aopen+' + this.addon.id.substring(this.addon.id.indexOf('-') + 1)
+        })
+        info.push({
+          id: 'discussionsLink',
+          title: 'Community Discussions',
+          linkIcon: 'chat_bubble_2_fill',
+          linkUrl: 'https://community.openhab.org/search?q=' + this.addon.id.substring(this.addon.id.indexOf('-') + 1)
+        })
+      }
+
+      return info
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -3,7 +3,7 @@
     <f7-list-item v-for="line in information" :key="line.id"
                   :title="line.title" :after="line.value"
                   :link="line.linkUrl" external no-chevron target="_blank">
-      <f7-icon slot="after" v-if="line.linkIcon" :f7="line.linkIcon" />
+      <f7-icon slot="after" v-if="line.afterIcon" :f7="line.afterIcon" />
     </f7-list-item>
   </f7-list>
 </template>
@@ -12,7 +12,10 @@
 .information-table
   --f7-list-bg-color transparent
   --f7-theme-color var(--f7-color-blue)
+  .item-title
+    --f7-list-item-title-text-color var(--f7-list-item-footer-text-color)
   .item-after
+    --f7-list-item-after-text-color var(--f7-list-item-title-text-color)
     align-items center
     i
       margin-left 3px
@@ -20,8 +23,10 @@
       &:first-child
         font-size x-large
   .item-link
-    --f7-list-item-title-text-color var(--f7-theme-color)
-    --f7-list-item-after-text-color: var(--f7-theme-color)
+    .item-title
+      --f7-list-item-title-text-color var(--f7-theme-color) !important
+    .item-after
+      --f7-list-item-after-text-color: var(--f7-theme-color) !important
 </style>
 
 <script>
@@ -36,16 +41,16 @@ export default {
       const marketplace = this.addon.id.indexOf('marketplace:') === 0
 
       info.push({
-        id: 'provider',
-        title: 'Provided By',
+        id: 'service',
+        title: 'Source',
         value: (marketplace) ? 'Community Marketplace' : 'openHAB Distribution'
       })
 
       info.push({
         id: 'author',
-        title: 'Author',
+        title: 'Provided By',
         value: this.addon.author,
-        linkIcon: (this.addon.verifiedAuthor) ? 'checkmark_seal_fill' : ''
+        afterIcon: (this.addon.verifiedAuthor) ? 'checkmark_seal_fill' : ''
       })
 
       if (this.addon.version) {
@@ -101,26 +106,26 @@ export default {
         info.push({
           id: 'communityTopicLink',
           title: 'Community Topic',
-          linkIcon: 'chat_bubble_2_fill',
+          afterIcon: 'chat_bubble_2_fill',
           linkUrl: this.addon.link
         })
       } else {
         info.push({
           id: 'documentationLink',
           title: 'Documentation',
-          linkIcon: 'question_circle_fill',
+          afterIcon: 'question_circle_fill',
           linkUrl: `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}` // this.addon.link
         })
         info.push({
           id: 'issuesLink',
           title: 'Issues',
-          linkIcon: 'exclamationmark_bubble_fill',
+          afterIcon: 'exclamationmark_bubble_fill',
           linkUrl: 'https://github.com/openhab/openhab-addons/issues?q=is%3Aopen+' + this.addon.id.substring(this.addon.id.indexOf('-') + 1)
         })
         info.push({
           id: 'discussionsLink',
           title: 'Community Discussions',
-          linkIcon: 'chat_bubble_2_fill',
+          afterIcon: 'chat_bubble_2_fill',
           linkUrl: 'https://community.openhab.org/search?q=' + this.addon.id.substring(this.addon.id.indexOf('-') + 1)
         })
       }

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -18,7 +18,7 @@
     <div slot="after">
       <f7-preloader v-if="addon.pending" color="blue" />
       <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />
-      <f7-button v-else class="install-button prevent-active-state-propagation" text="Install" color="blue" round small @click="buttonClicked" />
+      <f7-button v-else class="install-button prevent-active-state-propagation" :text="installActionText || 'Install'" color="blue" round small @click="buttonClicked" />
     </div>
   </f7-list-item>
 </template>
@@ -60,7 +60,7 @@ import { AddonIcons } from '@/assets/addon-store'
 import AddonStatsLine from './addon-stats-line.vue'
 
 export default {
-  props: ['addon'],
+  props: ['addon', 'installActionText'],
   components: {
     AddonStatsLine
   },
@@ -80,7 +80,6 @@ export default {
   mounted () {
     this.addonIcon = AddonIcons[this.addon.type]
     this.$$(this.$refs.logo).once('lazy:loaded', (e) => {
-      console.log(this.addon.id + ' logo lazy loaded')
       this.logoLoaded = true
     })
     this.$$(this.$refs.logo).once('lazy:error', (e) => {

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -1,0 +1,87 @@
+<template>
+  <f7-list-item
+    v-if="addon"
+    class="addon-list-item padding-right-half"
+    :title="addon.label"
+    :link="addon.id"
+    :subtitle="addon.author">
+    <f7-icon v-if="addon.verifiedAuthor" slot="subtitle" size="15" :color="$f7.data.themeOptions.dark === 'dark' ? 'white' : 'blue'" f7="checkmark_seal_fill" style="margin-top: -3px; margin-left: 3px" />
+    <f7-icon v-show="!logoLoaded" slot="media" size="64" color="gray" :f7="addonIcon" class="item-default-icon" />
+    <div class="item-logo" slot="media">
+      <img v-if="!logoError" class="lazy" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo" width="54" :data-src="imageUrl">
+    </div>
+    <div slot="after">
+      <f7-preloader v-if="addon.pending" color="blue" />
+      <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />
+      <f7-button v-else class="install-button prevent-active-state-propagation" text="Install" color="blue" round small @click="buttonClicked" />
+    </div>
+  </f7-list-item>
+</template>
+
+<style lang="stylus">
+.addon-list-item
+  --f7-list-item-subtitle-text-color var(--f7-list-item-after-text-color)
+  .item-inner
+    padding-right 3px !important
+  .item-logo
+    display flex
+    justify-content center
+    align-items center
+    margin-left 3px
+    width 64px
+    height 64px
+    background white
+    border-radius 5px
+    img
+      max-height 54px
+  .item-default-icon
+    opacity 0.2
+    position absolute
+  .item-media i
+    padding-left 3px
+  .item-after
+    min-width 70px
+    justify-content center
+    height var(--f7-button-small-height)
+    --f7-preloader-size var(--f7-button-small-height)
+  .install-button
+    // --f7-button-bg-color var(--f7-color-gray)
+    --f7-button-text-transform uppercase
+    --f7-button-bg-color var(--f7-list-item-border-color)
+</style>
+
+<script>
+import { AddonIcons } from '@/assets/addon-store'
+
+export default {
+  props: ['addon'],
+  data () {
+    return {
+      logoLoaded: false,
+      logoError: false,
+      addonIcon: null
+    }
+  },
+  computed: {
+    imageUrl () {
+      if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
+      return 'https://www.openhab.org/logos/' + this.addon.id.substring(this.addon.id.indexOf('-') + 1) + '.png'
+    }
+  },
+  mounted () {
+    this.addonIcon = AddonIcons[this.addon.type]
+    this.$$(this.$refs.logo).once('lazy:loaded', (e) => {
+      console.log(this.addon.id + ' logo lazy loaded')
+      this.logoLoaded = true
+    })
+    this.$$(this.$refs.logo).once('lazy:error', (e) => {
+      this.logoError = true
+    })
+  },
+  methods: {
+    buttonClicked () {
+      this.$emit('addonButtonClick', this.addon)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -3,9 +3,14 @@
     v-if="addon"
     class="addon-list-item padding-right-half"
     :title="addon.label"
-    :link="addon.id"
-    :subtitle="addon.author">
-    <f7-icon v-if="addon.verifiedAuthor" slot="subtitle" size="15" :color="$f7.data.themeOptions.dark === 'dark' ? 'white' : 'blue'" f7="checkmark_seal_fill" style="margin-top: -3px; margin-left: 3px" />
+    :link="addon.id">
+    <div v-if="addon.verifiedAuthor" slot="subtitle">
+      {{ addon.author }}
+      <f7-icon v-if="addon.verifiedAuthor" size="15" :color="$f7.data.themeOptions.dark === 'dark' ? 'white' : 'blue'" f7="checkmark_seal_fill" style="margin-top: -3px" />
+    </div>
+    <div v-else-if="addon.properties && addon.properties.views" slot="subtitle">
+      <addon-stats-line :addon="addon" :iconSize="15" />
+    </div>
     <f7-icon v-show="!logoLoaded" slot="media" size="64" color="gray" :f7="addonIcon" class="item-default-icon" />
     <div class="item-logo" slot="media">
       <img v-if="!logoError" class="lazy" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo" width="54" :data-src="imageUrl">
@@ -52,9 +57,13 @@
 
 <script>
 import { AddonIcons } from '@/assets/addon-store'
+import AddonStatsLine from './addon-stats-line.vue'
 
 export default {
   props: ['addon'],
+  components: {
+    AddonStatsLine
+  },
   data () {
     return {
       logoLoaded: false,

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-stats-line.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-stats-line.vue
@@ -1,0 +1,28 @@
+<template>
+  <span v-if="addon.properties" class="addon-stats-line">
+    <span v-if="addon.properties.like_count >= 0">
+      <f7-icon f7="heart_fill" :size="iconSize" />
+      {{ addon.properties.like_count }}
+    </span>
+    <span v-if="addon.properties.views >= 0">
+      <f7-icon f7="eye_fill" :size="iconSize" />
+      {{ addon.properties.views }}
+    </span>
+    <span v-if="addon.properties.posts_count >= 0">
+      <f7-icon f7="chat_bubble_fill" :size="iconSize" />
+      {{ addon.properties.posts_count }}
+    </span>
+  </span>
+</template>
+
+<style lang="stylus">
+.addon-stats-line
+  & > span
+    margin-right 4px
+</style>
+
+<script>
+export default {
+  props: ['addon', 'iconSize']
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
@@ -1,0 +1,147 @@
+<template>
+  <f7-block class="addons-section" ref="addongroup">
+    <f7-block-title medium>
+      {{ title }}
+      <f7-link v-if="canExpand" color="blue" class="see-all-button margin-right" @click="expand">
+        See All
+      </f7-link>
+    </f7-block-title>
+    <f7-block-footer v-if="subtitle">
+      {{ subtitle }}
+    </f7-block-footer>
+    <div class="addons-cards">
+      <addon-card v-for="addon in featuredAddons" :key="addon.id" :addon="addon" :headline="'Featured'" @addonButtonClick="addonButtonClick" />
+    </div>
+    <div v-if="showAsCards" class="addons-cards">
+      <addon-card v-for="addon in addonsList" :key="addon.id" :addon="addon" @addonButtonClick="addonButtonClick" />
+    </div>
+    <f7-list v-else media-list ref="addonlist" class="addons-table-list" no-chevron no-hairlines>
+      <addon-list-item v-for="addon in addonsList" :key="addon.id" :addon="addon" @addonButtonClick="addonButtonClick" />
+    </f7-list>
+  </f7-block>
+</template>
+
+<style lang="stylus">
+.addons-section
+  margin-top 2rem
+  .see-all-button
+    float right
+    font-size 16px
+    font-weight normal
+    padding-top 8px
+    vertical-align baseline
+.addons-table-list
+  --f7-list-bg-color transparent
+  --f7-list-item-title-white-space normal
+  --f7-list-item-text-max-lines 1
+  --f7-list-item-text-font-size 13px
+  --f7-list-link-pressed-bg-color transparent
+  --f7-list-item-title-line-height 1.2
+  .item-link .item-inner
+    padding-right 0
+  .item-content
+    padding-left 0px
+  ul
+    display flex
+    flex-shrink 0
+    flex-direction row
+    align-content flex-start
+    flex-wrap wrap
+    overflow auto
+    padding-left calc(var(--f7-safe-area-left) + var(--f7-list-item-padding-horizontal))
+    scroll-snap-type x mandatory
+    scrollbar-width none
+    &::-webkit-scrollbar
+      display none
+      opacity 0
+    @media (min-width 768px)
+      scroll-padding-left calc(20px + var(--f7-safe-area-left))
+    li
+      width 100%
+      @media (min-width 768px)
+        width 50%
+      @media (min-width 1281px)
+        width 33.333%
+      @media (min-width 1601px)
+        width 25%
+.addons-cards
+    margin-top 1rem
+    display flex
+    flex-shrink 0
+    flex-direction row
+    align-content flex-start
+    align-items flex-end
+    flex-wrap wrap
+    padding-left calc(var(--f7-safe-area-left) + var(--f7-list-item-padding-horizontal))
+    .addon-card
+      width 100%
+      @media (min-width: 481px)
+        width 50%
+      @media (min-width: 768px)
+        width 33.333%
+      @media (min-width: 1281px)
+        width 25%
+      @media (min-width: 1601px)
+        width 20%
+</style>
+
+<script>
+import AddonListItem from './addon-list-item.vue'
+import AddonCard from './addon-card.vue'
+import { compareAddons } from '@/assets/addon-store'
+
+export default {
+  props: ['addons', 'title', 'subtitle', 'showAll', 'featured', 'showAsCards'],
+  components: {
+    AddonListItem,
+    AddonCard
+  },
+  data () {
+    return {
+      collapsed: true
+    }
+  },
+  computed: {
+    featuredAddons () {
+      if (this.featured) {
+        return this.addons.filter(a => this.featured.indexOf(a.id) >= 0).sort(compareAddons)
+      }
+      return null
+    },
+    notFeaturedAddons () {
+      return (this.featuredAddons && this.featuredAddons.length)
+        ? this.addons.filter(a => this.featuredAddons.indexOf(a) < 0).sort(compareAddons)
+        : [...this.addons].sort(compareAddons)
+    },
+    addonCollapsedLimit () {
+      const installedCount = this.notFeaturedAddons.filter(a => a.installed).length
+      if (installedCount >= 22) return 36
+      if (installedCount >= 10) return 24
+      return 12
+    },
+    addonsList () {
+      if (this.collapsed) return this.notFeaturedAddons.slice(0, this.addonCollapsedLimit)
+      return this.notFeaturedAddons
+    },
+    canExpand () {
+      if (!this.collapsed) return false
+      if (this.addons.length < this.addonCollapsedLimit) return false
+      return true
+    }
+  },
+  methods: {
+    expand () {
+      this.collapsed = false
+      setTimeout(() => {
+        this.$f7.lazy.create('.page-addon-store')
+      }, 100)
+    },
+    addonButtonClick (addon) {
+      this.$emit('addonButtonClick', addon)
+    }
+  },
+  mounted () {
+    if (this.showAll) this.expand()
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-block class="addons-section" ref="addongroup">
+  <f7-block class="addons-section" ref="addongroup" v-if="addons && addons.length > 0">
     <f7-block-title medium>
       {{ title }}
       <f7-link v-if="canExpand" color="blue" class="see-all-button margin-right" @click="expand">
@@ -10,13 +10,13 @@
       {{ subtitle }}
     </f7-block-footer>
     <div class="addons-cards">
-      <addon-card v-for="addon in featuredAddons" :key="addon.id" :addon="addon" :headline="'Featured'" @addonButtonClick="addonButtonClick" />
+      <addon-card v-for="addon in featuredAddons" :key="addon.id" :addon="addon" :install-action-text="installActionText" :headline="'Featured'" @addonButtonClick="addonButtonClick" />
     </div>
     <div v-if="showAsCards" class="addons-cards">
-      <addon-card v-for="addon in addonsList" :key="addon.id" :addon="addon" @addonButtonClick="addonButtonClick" />
+      <addon-card v-for="addon in addonsList" :key="addon.id" :addon="addon" :install-action-text="installActionText" @addonButtonClick="addonButtonClick" />
     </div>
     <f7-list v-else media-list ref="addonlist" class="addons-table-list" no-chevron no-hairlines>
-      <addon-list-item v-for="addon in addonsList" :key="addon.id" :addon="addon" @addonButtonClick="addonButtonClick" />
+      <addon-list-item v-for="addon in addonsList" :key="addon.id" :addon="addon" :install-action-text="installActionText" @addonButtonClick="addonButtonClick" />
     </f7-list>
   </f7-block>
 </template>
@@ -91,7 +91,7 @@ import AddonCard from './addon-card.vue'
 import { compareAddons } from '@/assets/addon-store'
 
 export default {
-  props: ['addons', 'title', 'subtitle', 'showAll', 'featured', 'showAsCards'],
+  props: ['addons', 'title', 'subtitle', 'showAll', 'featured', 'showAsCards', 'installActionText'],
   components: {
     AddonListItem,
     AddonCard

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -13,7 +13,6 @@
             <img src="@/images/openhab-logo.svg" type="image/svg+xml" width="196px">
           </div>
         </f7-link>
-        </f7-link>
         <f7-list v-if="ready">
           <f7-list-item v-if="$store.getters.apiEndpoint('ui') && (!pages || !pages.length)">
             <span><em>{{ $t('sidebar.noPages') }}</em></span>

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -255,6 +255,8 @@ html
 
 #framework7-root:not(.theme-dark) .page-home:not(.standard-background),
 #framework7-root:not(.theme-dark) .page-about:not(.standard-background),
+#framework7-root:not(.theme-dark) .page-addon-store:not(.standard-background),
+#framework7-root:not(.theme-dark) .page-addon-details:not(.standard-background),
 //#framework7-root:not(.theme-dark) .page-settings
   --f7-page-bg-color #fff
 

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -161,10 +161,10 @@ export default [
             path: 'add',
             async: loadAsync(AddThingChooseBindingPage),
             routes: [
-              {
-                path: 'install-binding',
-                async: loadAsync(AddonsAddPage, { addonType: 'binding' })
-              },
+              // {
+              //   path: 'install-binding',
+              //   async: loadAsync(AddonsAddPage, { addonType: 'binding' })
+              // },
               {
                 path: ':bindingId',
                 async: loadAsync(AddThingChooseThingTypePage),

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -11,6 +11,8 @@ const ServiceSettingsPage = () => import(/* webpackChunkName: "admin-base" */ '.
 const AddonsListPage = () => import(/* webpackChunkName: "admin-base" */ '../pages/settings/addons/addons-list.vue')
 const AddonsAddPage = () => import(/* webpackChunkName: "admin-base" */ '../pages/settings/addons/addons-add.vue')
 const AddonsConfigureBindingPage = () => import(/* webpackChunkName: "admin-base" */ '../pages/settings/addons/binding-config.vue')
+const AddonsStorePage = () => import(/* webpackChunkName: "admin-base" */ '../pages/settings/addons/addons-store.vue')
+const AddonDetailsPage = () => import(/* webpackChunkName: "admin-base" */ '../pages/settings/addons/addon-details.vue')
 
 const ItemsListPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/items/items-list-vlist.vue')
 const ItemDetailsPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/items/item-details.vue')
@@ -231,12 +233,12 @@ export default [
         ]
       },
       {
-        path: 'addons/:addonType',
-        async: loadAsync(AddonsListPage),
+        path: 'addons',
+        async: loadAsync(AddonsStorePage),
         routes: [
           {
-            path: 'add',
-            async: loadAsync(AddonsAddPage)
+            path: ':addonId',
+            async: loadAsync(AddonDetailsPage)
           },
           {
             path: ':bindingId/config',

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details-sheet.vue
@@ -1,16 +1,37 @@
 <template>
   <f7-sheet ref="sheet" class="demo-sheet-swipe-to-step" @sheet:closed="$emit('closed')" swipe-to-close swipe-to-step backdrop>
     <div class="sheet-modal-swipe-step">
-      <div class="swipe-handler" @click="toggleSwipeStep" />
+      <div v-if="!noDetails" class="swipe-handler" @click="toggleSwipeStep" />
       <f7-block-title><strong><big>{{ addon.label }}</big></strong></f7-block-title>
+      <f7-block v-if="state === 'UNINSTALLED'">
+        <div v-if="addon.verifiedAuthor" class="text-color-green display-flex align-items-center">
+          <f7-icon f7="checkmark_shield" class="margin-right" />
+          Verified Author
+        </div>
+        <h3 v-else-if="showUnpublishedWarning" class="text-color-red display-flex align-items-center">
+          <f7-icon f7="xmark_shield" class="margin-right" />
+          WARNING! UNPUBLISHED ADD-ON
+        </h3>
+        <div v-else-if="showUnverifiedAuthorWarning" class="text-color-orange display-flex align-items-center">
+          <f7-icon f7="exclamationmark_shield" class="margin-right" />
+          Unverified Author
+        </div>
+        <f7-block-footer v-if="showUnpublishedWarning" class="display-flex align-items-center text-color-red">
+          This add-on has not been published to the Marketplace. DO NOT install this add-on, unless for debugging purposes if you are the author or a marketplace curator!<br><br>
+          Please make sure "Show Unpublished Entries" is not inadvertently turned on in Settings > Community Marketplace.
+        </f7-block-footer>
+        <f7-block-footer v-if="showUnverifiedAuthorWarning" class="display-flex align-items-center">
+          <small>Adding this type of add-on from unknown providers can harm your system because its code might not have been properly reviewed. Make sure you trust the source and understand the risks before installing this add-on.</small>
+        </f7-block-footer>
+      </f7-block>
       <f7-block>
         <f7-row>
           <f7-col class="col-100 margin-top padding-horizontal">
             <f7-button large fill color="blue" v-if="state === 'UNINSTALLED'" @click="install()">
-              Install
+              {{ installableAddon ? 'Install' : 'Add' }}
             </f7-button>
             <f7-button large fill color="red" v-if="state !== 'UNINSTALLED'" @click="uninstall()">
-              Uninstall
+              {{ installableAddon ? 'Uninstall' : 'Remove' }}
             </f7-button>
           </f7-col>
         </f7-row>
@@ -21,7 +42,7 @@
         </div>
       </f7-block>
     </div>
-    <f7-page-content v-if="!noDetails" class="no-margin-top">
+    <f7-page-content v-if="!noDetails" style="margin-top: var(--f7-safe-area-top)">
       <addon-info-table :addon="addon" class="no-margin-top" />
     </f7-page-content>
   </f7-sheet>
@@ -127,6 +148,15 @@ export default {
       // TODO: figure out somehow whether the addon is BEING installed/uninstalled.
       if (!this.addon) return 'UNKNOWN'
       return this.addon.installed ? 'INSTALLED' : 'UNINSTALLED'
+    },
+    installableAddon () {
+      return (this.addon && this.addon.contentType && (this.addon.contentType === 'application/vnd.openhab.bundle' || this.addon.contentType.indexOf('application/vnd.openhab.feature') === 0))
+    },
+    showUnverifiedAuthorWarning () {
+      return (this.addon && !this.addon.verifiedAuthor && this.installableAddon)
+    },
+    showUnpublishedWarning () {
+      return (this.serviceId === 'marketplace' && this.addon.properties && this.addon.properties.tags && this.addon.properties.tags.indexOf('published') < 0)
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details-sheet.vue
@@ -15,32 +15,14 @@
           </f7-col>
         </f7-row>
       </f7-block>
-      <f7-block class="padding-bottom" @click.native="toggleSwipeStep" style="cursor:pointer">
-        <div class="margin-top margin-bottom text-align-center">
+      <f7-block class="padding-bottom no-margin-vertical" @click.native="toggleSwipeStep">
+        <div v-if="!noDetails" class="margin-top margin-bottom text-align-center" style="cursor:pointer">
           <f7-icon f7="chevron_down_circle" />&nbsp;Expand for details
         </div>
       </f7-block>
     </div>
-    <f7-page-content>
-      <f7-block v-if="bindingInfo.description">
-        <div class="padding-left padding-right" v-html="bindingInfo.description" />
-        <!-- <p class="padding-left padding-right">
-          <em>Author: {{bindingInfo.author}}</em>
-        </p> -->
-      </f7-block>
-      <f7-block>
-        <f7-list>
-          <f7-list-item v-if="addon.author" title="Author" :after="addon.author" />
-          <f7-list-item v-if="addon.version" title="Version" :after="addon.version" />
-        </f7-list>
-        <f7-list>
-          <f7-list-button v-if="bindingInfo.configDescriptionURI" color="blue" :href="bindingInfo.id + '/config'" title="Configure" />
-          <f7-list-button v-if="addon.link" color="blue" external target="_blank" :href="addon.link" title="Documentation" />
-        </f7-list>
-      </f7-block>
-      <!-- <f7-block v-else>
-        <p>No description available.</p>
-      </f7-block> -->
+    <f7-page-content v-if="!noDetails" class="no-margin-top">
+      <addon-info-table :addon="addon" class="no-margin-top" />
     </f7-page-content>
   </f7-sheet>
 </template>
@@ -92,8 +74,13 @@
 </style>
 
 <script>
+import AddonInfoTable from '@/components/addons/addon-info-table.vue'
+
 export default {
-  props: ['addonId', 'serviceId', 'opened'],
+  props: ['addonId', 'serviceId', 'opened', 'noDetails'],
+  components: {
+    AddonInfoTable
+  },
   data () {
     return {
       addon: {},
@@ -118,14 +105,14 @@ export default {
               this.bindingInfo = data2.find(b => b.id === this.addonId.replace('binding-', '')) || {}
               self.$f7.preloader.hide()
               setTimeout(() => {
-                self.$refs.sheet.f7Sheet.setSwipeStep()
+                if (!this.noDetails) self.$refs.sheet.f7Sheet.setSwipeStep()
                 self.$refs.sheet.f7Sheet.open()
               })
             })
           } else {
             self.$f7.preloader.hide()
             setTimeout(() => {
-              self.$refs.sheet.f7Sheet.setSwipeStep()
+              if (!this.noDetails) self.$refs.sheet.f7Sheet.setSwipeStep()
               self.$refs.sheet.f7Sheet.open()
             })
           }

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details-sheet.vue
@@ -30,8 +30,8 @@
       </f7-block>
       <f7-block>
         <f7-list>
-          <f7-list-item v-if="bindingInfo.author" title="Author" :after="bindingInfo.author" />
-          <f7-list-item title="Version" :after="addon.version" />
+          <f7-list-item v-if="addon.author" title="Author" :after="addon.author" />
+          <f7-list-item v-if="addon.version" title="Version" :after="addon.version" />
         </f7-list>
         <f7-list>
           <f7-list-button v-if="bindingInfo.configDescriptionURI" color="blue" :href="bindingInfo.id + '/config'" title="Configure" />
@@ -93,7 +93,7 @@
 
 <script>
 export default {
-  props: ['addonId', 'opened'],
+  props: ['addonId', 'serviceId', 'opened'],
   data () {
     return {
       addon: {},
@@ -110,7 +110,7 @@ export default {
           return
         }
         self.$f7.preloader.show()
-        this.$oh.api.get('/rest/addons/' + this.addonId).then(data => {
+        this.$oh.api.get('/rest/addons/' + this.addonId + (this.serviceId ? '?serviceId=' + this.serviceId : '')).then(data => {
           this.addon = data
 
           if (this.addon.type === 'binding' && this.addon.installed) {
@@ -148,12 +148,12 @@ export default {
       self.$refs.sheet.f7Sheet.stepToggle('.demo-sheet-swipe-to-step')
     },
     install () {
-      this.$oh.api.post('/rest/addons/' + this.addonId + '/install', {}, 'text').then((data) => {
+      this.$oh.api.post('/rest/addons/' + this.addonId + '/install' + (this.serviceId ? '?serviceId=' + this.serviceId : ''), {}, 'text').then((data) => {
         this.$emit('install', this.addon)
       })
     },
     uninstall () {
-      this.$oh.api.post('/rest/addons/' + this.addonId + '/uninstall', {}, 'text').then((data) => {
+      this.$oh.api.post('/rest/addons/' + this.addonId + '/uninstall' + (this.serviceId ? '?serviceId=' + this.serviceId : ''), {}, 'text').then((data) => {
         this.$emit('uninstall', this.addon)
       })
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -366,6 +366,7 @@ export default {
         body = body.replace(/<table>/gm, '<div class="data-table"><table>')
         body = body.replace(/<\/table>/gm, '</table></div>')
         body = body.replace(/<a class="lightbox" href="/gm, '<a class="external" target="_blank" href="')
+        body = body.replace(/<a href="http/gm, '<a class="external" target="_blank" href="http')
         body = body.replace(/<img src="\/\/community-openhab-org/gm, '<img class="lazy lazy-fade-in" data-src="//community-openhab-org')
         this.parsedDescription = body
         this.descriptionReady = true

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -16,7 +16,6 @@
             <div class="addon-header-content">
               <div class="addon-header-title">
                 {{ addon.label }}
-                <f7-link v-if="!isPending(addon) && bindingInfo && bindingInfo.configDescriptionURI" icon-f7="gears" tooltip="Configure Binding" color="gray" :href="'/settings/addons/' + bindingInfo.id + '/config'" round small />
               </div>
               <div v-if="addon.verifiedAuthor" class="addon-header-subtitle">
                 {{ addon.author }}
@@ -29,6 +28,7 @@
                 <f7-preloader v-if="isPending(addon)" color="blue" />
                 <f7-button v-else-if="addon.installed" class="install-button" text="Remove" color="red" round small fill @click="openAddonPopup" />
                 <f7-button v-else class="install-button" :text="installableAddon(addon) ? 'Install' : 'Add'" color="blue" round small fill @click="openAddonPopup" />
+                <f7-link v-if="!isPending(addon) && bindingInfo && bindingInfo.configDescriptionURI" icon-f7="gears" tooltip="Configure Binding" color="blue" :href="'/settings/addons/' + bindingInfo.id + '/config'" round small />
               </div>
             </div>
           </div>
@@ -143,9 +143,11 @@
             font-size 20px
     .addon-header-actions
       display flex
-      justify-content flex-start
+      justify-content space-between
+      align-items center
       margin-top auto
       margin-bottom auto
+      margin-right 15px
       .install-button
         --f7-button-text-transform uppercase
         padding-left 15px

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -9,10 +9,10 @@
       <f7-row>
         <f7-col class="margin-left">
           <div class="addon-header">
-            <div class="logo-container">
+            <f7-link class="logo-container" :href="docLinkUrl" external target="_blank">
               <f7-icon v-show="!logoLoaded" size="100" color="gray" :f7="addonIcon" style="opacity: 0.2; position: absolute;" />
               <img v-if="!logoError" class="logo lazy" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo" :data-src="imageUrl">
-            </div>
+            </f7-link>
             <div class="addon-header-content">
               <div class="addon-header-title">
                 {{ addon.label }}
@@ -30,29 +30,6 @@
                 <f7-button v-else class="install-button prevent-active-state-propagation" text="Install" color="blue" round small fill @click="openAddonPopup" />
               </div>
             </div>
-          </div>
-          <div v-if="addon.properties" class="addon-header-stats padding margin-top">
-            <f7-link v-if="addon.properties.like_count >= 0" :href="addon.link" target="_blank" external class="addon-header-stat">
-              <f7-icon f7="heart_fill" size="24" />
-              {{ addon.properties.like_count }}
-              <div class="addon-header-stat-sub">
-                Likes
-              </div>
-            </f7-link>
-            <f7-link v-if="addon.properties.views >= 0" :href="addon.link" target="_blank" external class="addon-header-stat">
-              <f7-icon f7="eye_fill" size="24" />
-              {{ addon.properties.views }}
-              <div class="addon-header-stat-sub">
-                Views
-              </div>
-            </f7-link>
-            <f7-link v-if="addon.properties.posts_count >= 0" :href="addon.link" target="_blank" external class="addon-header-stat">
-              <f7-icon f7="chat_bubble_fill" size="24" />
-              {{ addon.properties.posts_count }}
-              <div class="addon-header-stat-sub">
-                Posts
-              </div>
-            </f7-link>
           </div>
         </f7-col>
       </f7-row>
@@ -171,25 +148,6 @@
         --f7-button-text-transform uppercase
         min-width 100px
         font-size 16px
-  .addon-header-stats
-    width calc(100% - 2*var(--f7-block-padding-horizontal))
-    justify-content center
-    display flex
-    opacity 0.55
-    align-items center
-    position relative
-    --f7-theme-color var(--f7-color-gray)
-    .addon-header-stat
-      display flex
-      flex-direction column
-      align-items center
-      font-size 18px
-      font-weight bold
-      margin-right 4px
-      min-width 90px
-      .addon-header-stat-sub
-        font-size 10px
-        text-transform uppercase
   .addon-description
     --f7-block-strong-bg-color transparent
     width calc(100%)
@@ -208,19 +166,6 @@
     img
       max-width calc(100%)
       height auto
-  .information-table
-    --f7-list-bg-color transparent
-    --f7-theme-color var(--f7-color-blue)
-    .item-after
-      align-items center
-      i
-        margin-left 3px
-        font-size var(--f7-list-item-subtitle-font-size)
-        &:first-child
-          font-size x-large
-    .item-link
-      --f7-list-item-title-text-color var(--f7-theme-color)
-      --f7-list-item-after-text-color: var(--f7-theme-color)
 </style>
 
 <script>
@@ -272,6 +217,10 @@ export default {
         return this.parsedDescription
       }
       return 'No description found'
+    },
+    docLinkUrl () {
+      if (!this.addon) return ''
+      return (this.serviceId === 'marketplace') ? this.addon.link : `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}`
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-store-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-store-mixin.js
@@ -34,6 +34,9 @@ export default {
       this.currentlyUninstalling.push(addon.id)
       if (this.currentAddon) this.$set(this.currentAddon, 'pending', 'UNINSTALL')
     },
+    installableAddon (addon) {
+      return (addon && (addon.contentType === 'application/vnd.openhab.bundle' || addon.contentType.indexOf('application/vnd.openhab.feature') === 0))
+    },
     isInstalling (addon) {
       return this.currentlyInstalling.indexOf(addon.id) >= 0
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-store-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-store-mixin.js
@@ -1,0 +1,84 @@
+import AddonDetailsSheet from './addon-details-sheet.vue'
+
+export default {
+  components: {
+    AddonDetailsSheet
+  },
+  data () {
+    return {
+      addons: {},
+      currentAddon: null,
+      currentAddonId: null,
+      currentServiceId: null,
+      ready: false,
+      initSearchbar: false,
+      addonPopupOpened: false,
+      currentlyInstalling: [],
+      currentlyUninstalling: []
+    }
+  },
+  methods: {
+    openAddonPopup (addonId, serviceId, addon) {
+      this.currentAddonId = addonId
+      this.currentServiceId = serviceId
+      if (addon) this.currentAddon = addon
+      this.addonPopupOpened = true
+    },
+    installAddon (addon) {
+      this.addonPopupOpened = false
+      this.currentlyInstalling.push(addon.id)
+      if (this.currentAddon) this.$set(this.currentAddon, 'pending', 'INSTALL')
+    },
+    uninstallAddon (addon) {
+      this.addonPopupOpened = false
+      this.currentlyUninstalling.push(addon.id)
+      if (this.currentAddon) this.$set(this.currentAddon, 'pending', 'UNINSTALL')
+    },
+    isInstalling (addon) {
+      return this.currentlyInstalling.indexOf(addon.id) >= 0
+    },
+    isUninstalling (addon) {
+      return this.currentlyUninstalling.indexOf(addon.id) >= 0
+    },
+    isPending (addon) {
+      return this.isInstalling(addon) || this.isUninstalling(addon)
+    },
+    resetPending () {
+      this.$set(this, 'currentlyInstalling', [])
+      this.$set(this, 'currentlyUninstalling', [])
+      this.$set(this, 'currentAddon', null)
+      this.currentAddonId = null
+      this.currentServiceId = null
+    },
+    startEventSource () {
+      this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/addons/*/*', null, (event) => {
+        const topicParts = event.topic.split('/')
+        switch (topicParts[3]) {
+          case 'installed':
+          case 'uninstalled':
+            this.stopEventSource()
+            this.load()
+            this.$f7.emit('addonChange', null)
+            break
+          case 'failed':
+            this.$f7.toast.create({
+              text: `Installation of add-on ${topicParts[2]} failed`,
+              closeButton: true,
+              destroyOnClose: true
+            }).open()
+            this.stopEventSource()
+            this.load()
+            break
+        }
+      }, () => {
+        // in case of error, maybe the SSE connection was closed by the add-ons change itself - try reloading to refresh
+        this.stopEventSource()
+        this.load()
+      })
+    },
+    stopEventSource () {
+      this.$oh.sse.close(this.eventSource)
+      this.eventSource = null
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
@@ -1,0 +1,230 @@
+<template>
+  <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" ref="addonstore" class="page-addon-store">
+    <f7-navbar large :large-transparent="true" back-link="Back" back-link-url="/settings/" back-link-force class="store-nav">
+      <f7-nav-title-large class="store-title-large">
+        <span v-if="currentTab === 'bindings'">Bindings</span>
+        <span v-if="currentTab === 'automation'">Automation</span>
+        <span v-if="currentTab === 'ui'">User Interfaces</span>
+        <span v-if="currentTab === 'other'">Other Add-ons</span>
+        <span v-if="currentTab === 'search'">Search</span>
+      </f7-nav-title-large>
+      <f7-nav-title>
+        <span v-if="currentTab === 'bindings'">Bindings</span>
+        <span v-if="currentTab === 'automation'">Automation</span>
+        <span v-if="currentTab === 'ui'">User Interfaces</span>
+        <span v-if="currentTab === 'other'">Other Add-ons</span>
+        <span v-if="currentTab === 'search'">Search</span>
+      </f7-nav-title>
+      <f7-nav-right>
+        <f7-link
+          v-show="currentTab === 'search'"
+          class="searchbar-enable"
+          data-searchbar=".searchbar-store"
+          icon-ios="f7:search_strong"
+          icon-aurora="f7:search_strong"
+          icon-md="material:search" />
+      </f7-nav-right>
+      <f7-searchbar
+        ref="storeSearchbar"
+        class="searchbar-store"
+        placeholder="Search add-ons"
+        expandable
+        custom-search
+        search-in=".item-title"
+        :disable-button="!$theme.aurora"
+        @searchbar:search="search" @searchbar:clear="clearSearch" />
+    </f7-navbar>
+    <f7-toolbar tabbar labels bottom>
+      <f7-link tab-link @click="switchTab('bindings')" :tab-link-active="currentTab === 'bindings'" icon-ios="f7:circle_grid_hex_fill" icon-aurora="f7:circle_grid_hex_fill" icon-md="f7:circle_grid_hex_fill" text="Bindings" />
+      <f7-link tab-link @click="switchTab('automation')" :tab-link-active="currentTab === 'automation'" icon-ios="f7:sparkles" icon-aurora="f7:sparkles" icon-md="f7:sparkles" text="Automation" />
+      <f7-link tab-link @click="switchTab('ui')" :tab-link-active="currentTab === 'ui'" icon-ios="f7:play_rectangle_fill" icon-aurora="f7:play_rectangle_fill" icon-md="f7:play_rectangle_fill" text="UI" />
+      <f7-link tab-link @click="switchTab('other')" :tab-link-active="currentTab === 'other'" icon-ios="f7:ellipsis" icon-aurora="f7:ellipsis" icon-md="f7:ellipsis" text="Other" />
+      <f7-link tab-link @click="switchTab('search')" :tab-link-active="currentTab === 'search'" icon-ios="f7:search" icon-aurora="f7:search" icon-md="f7:search" text="Search" />
+    </f7-toolbar>
+    <f7-block v-if="!ready" class="text-align-center">
+      <f7-block-title>
+        <f7-preloader />
+        <div>Loading...</div>
+      </f7-block-title>
+    </f7-block>
+    <div v-show="currentTab === 'bindings'">
+      <addons-section
+        v-if="addons && addons.karaf"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.karaf.filter((a) => a.type === 'binding')"
+        :title="'openHAB Distribution'"
+        :subtitle="'Official bindings maintained by the openHAB project'" />
+      <addons-section
+        v-if="addons && addons.marketplace"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.marketplace.filter((a) => a.type === 'binding')"
+        :title="'Community Marketplace'"
+        :subtitle="'Bindings independently released by the community'" />
+    </div>
+    <div v-show="currentTab === 'automation'">
+      <addons-section
+        v-if="addons && addons.marketplace"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.marketplace.filter((a) => a.type === 'automation')"
+        :title="'Rule Templates'"
+        :subtitle="'Shared by the community to bootstrap your automation'" />
+      <addons-section
+        v-if="addons && addons.karaf"
+        :addons="addons.karaf.filter((a) => a.type === 'automation')"
+        :title="'Automation Add-ons'"
+        :subtitle="'Add functionality with add-ons from the distribution'" />
+    </div>
+    <div v-show="currentTab === 'ui'">
+      <addons-section
+        v-if="addons && addons.marketplace" v-show="currentTab === 'ui'"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.marketplace.filter((a) => a.type === 'ui' && a.contentType === 'application/vnd.openhab.uicomponent;type=widget')"
+        :show-as-cards="true"
+        :title="'Widgets for the Main UI'"
+        :subtitle="'Extend your pages with these community-designed widgets'" />
+      <addons-section
+        v-if="addons && addons.karaf" v-show="currentTab === 'ui'" :show-all="true"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.karaf.filter((a) => a.type === 'ui')"
+        :title="'Other User Interfaces'"
+        :subtitle="'Official add-ons from the distribution'" />
+    </div>
+    <div v-show="currentTab === 'other'">
+      <addons-section
+        v-if="addons && addons.karaf" :show-all="true"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.karaf.filter((a) => a.type === 'misc')"
+        :title="'System Integrations'"
+        :featured="['misc-openhabcloud', 'misc-homekit', 'misc-metrics']"
+        :subtitle="'Integrate openHAB with external systems'" />
+      <addons-section
+        v-if="addons && addons.karaf"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.karaf.filter((a) => a.type === 'persistence')" :show-all="true"
+        :title="'Persistence Services'"
+        :subtitle="'Backend connectors to store historical data'" />
+      <addons-section
+        v-if="addons && addons.karaf"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.karaf.filter((a) => a.type === 'transformation')" :show-all="true"
+        :title="'Transformation Add-ons'"
+        :subtitle="'Backend connectors to store historical data'" />
+      <addons-section
+        v-if="addons && addons.karaf" :show-all="true"
+        @addonButtonClick="addonButtonClick"
+        :addons="addons.karaf.filter((a) => a.type === 'voice')"
+        :title="'Voice &amp; Speech'"
+        :subtitle="'Convert between text and speech, interpret human language queries'" />
+    </div>
+    <div v-show="currentTab === 'search'" style="padding-top: 2rem">
+      <addons-section
+        v-if="addons && searchResults.length"
+        :show-as-cards="searchResults.length <= 3"
+        @addonButtonClick="addonButtonClick"
+        :title="searchResults.length + ' result' + ((searchResults.length === 1) ? '' : 's')"
+        :addons="searchResults" />
+    </div>
+    <addon-details-sheet
+      v-if="ready"
+      :addon-id="currentAddonId"
+      :service-id="currentServiceId"
+      :opened="addonPopupOpened"
+      @closed="addonPopupOpened = false"
+      @install="installAddon"
+      @uninstall="uninstallAddon" />
+  </f7-page>
+</template>
+
+<style lang="stylus">
+.theme-filled .store-nav .store-title-large .title-large-text
+  color var(--f7-text-color)
+.theme-filled .store-nav.navbar-large:not(.navbar-large-collapsed) .link
+  color var(--f7-theme-color)
+  transition color 0.3s
+.theme-filled .store-nav.navbar-large.navbar-large-collapsed .link
+  color var(--f7-navbar-link-color)
+  transition color 0.3s
+</style>
+
+<script>
+import AddonStoreMixin from './addon-store-mixin'
+import AddonsSection from '@/components/addons/addons-section.vue'
+
+export default {
+  mixins: [AddonStoreMixin],
+  props: ['initialTab'],
+  components: {
+    AddonsSection
+  },
+  data () {
+    return {
+      currentTab: this.initialTab || 'bindings',
+      services: null,
+      ready: false,
+      searchResults: []
+    }
+  },
+  methods: {
+    onPageAfterIn () {
+      this.load()
+    },
+    onPageBeforeOut () {
+      this.stopEventSource()
+    },
+    load () {
+      this.stopEventSource()
+      this.$oh.api.get('/rest/addons/services').then((data) => {
+        this.services = data
+        Promise.all(this.services.map((s) => this.$oh.api.get('/rest/addons?serviceId=' + s.id))).then((data2) => {
+          data2.forEach((addons, idx) => {
+            this.$set(this.addons, data[idx].id, data2[idx])
+          })
+          console.log(this.addons)
+          this.ready = true
+          this.startEventSource()
+          setTimeout(() => {
+            this.$f7.lazy.create('.page-addon-store')
+          }, 100)
+          if (this.currentTab === 'search') {
+            const searchbar = this.$refs.storeSearchbar.f7Searchbar
+            const filterQuery = searchbar.query
+            this.search(this.$refs.storeSearchbar.$el, filterQuery)
+          }
+        })
+      })
+    },
+    switchTab (tab) {
+      this.currentTab = tab
+      this.$f7.lazy.create('.page-addon-store')
+      if (this.currentTab === 'search') {
+        this.$refs.storeSearchbar.enable()
+        setTimeout(() => {
+          this.$refs.storeSearchbar.f7Searchbar.$inputEl.focus()
+        }, 500)
+      } else {
+        this.$refs.storeSearchbar.disable()
+      }
+    },
+    addonButtonClick (addon) {
+      const realAddonId = (addon.id.indexOf(':') > 0) ? addon.id.substring(addon.id.indexOf(':') + 1) : addon.id
+      const serviceId = (addon.id.indexOf(':') > 0) ? addon.id.substring(0, addon.id.indexOf(':')) : undefined
+      this.openAddonPopup(realAddonId, serviceId, addon)
+    },
+    search (searchbar, query, previousQuery) {
+      let results = []
+      if (query) {
+        for (const service in this.addons) {
+          results = results.concat(this.addons[service].filter((a) => a.label.toLowerCase().indexOf(query.toLowerCase()) >= 0))
+        }
+      }
+      this.$set(this, 'searchResults', results)
+      setTimeout(() => {
+        this.$f7.lazy.create('.page-addon-store')
+      }, 100)
+    },
+    clearSearch () {
+
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
@@ -70,6 +70,7 @@
         :subtitle="'Shared by the community to bootstrap your automation'" />
       <addons-section
         v-if="addons && addons.karaf"
+        @addonButtonClick="addonButtonClick"
         :addons="addons.karaf.filter((a) => a.type === 'automation')"
         :title="'Automation Add-ons'"
         :subtitle="'Add functionality with add-ons from the distribution'" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" ref="addonstore" class="page-addon-store">
-    <f7-navbar large :large-transparent="true" back-link="Back" back-link-url="/settings/" back-link-force class="store-nav">
+    <f7-navbar large :large-transparent="true" :back-link="initialTab ? 'Settings' : 'Back'" class="store-nav">
       <f7-nav-title-large class="store-title-large">
         <span v-if="currentTab === 'bindings'">Bindings</span>
         <span v-if="currentTab === 'automation'">Automation</span>
@@ -41,90 +41,109 @@
       <f7-link tab-link @click="switchTab('other')" :tab-link-active="currentTab === 'other'" icon-ios="f7:ellipsis" icon-aurora="f7:ellipsis" icon-md="f7:ellipsis" text="Other" />
       <f7-link tab-link @click="switchTab('search')" :tab-link-active="currentTab === 'search'" icon-ios="f7:search" icon-aurora="f7:search" icon-md="f7:search" text="Search" />
     </f7-toolbar>
-    <f7-block v-if="!ready" class="text-align-center">
+    <f7-block v-if="!ready" class="text-align-center padding-top margin-top">
       <f7-block-title>
-        <f7-preloader />
+        <f7-preloader :size="30" />
         <div>Loading...</div>
       </f7-block-title>
     </f7-block>
-    <div v-show="currentTab === 'bindings'">
-      <addons-section
-        v-if="addons && addons.karaf"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'binding')"
-        :title="'openHAB Distribution'"
-        :subtitle="'Official bindings maintained by the openHAB project'" />
-      <addons-section
-        v-if="addons && addons.marketplace"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.marketplace.filter((a) => a.type === 'binding')"
-        :title="'Community Marketplace'"
-        :subtitle="'Bindings independently released by the community'" />
-    </div>
-    <div v-show="currentTab === 'automation'">
-      <addons-section
-        v-if="addons && addons.marketplace"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.marketplace.filter((a) => a.type === 'automation')"
-        :title="'Rule Templates'"
-        :subtitle="'Shared by the community to bootstrap your automation'" />
-      <addons-section
-        v-if="addons && addons.karaf"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'automation')"
-        :title="'Automation Add-ons'"
-        :subtitle="'Add functionality with add-ons from the distribution'" />
-    </div>
-    <div v-show="currentTab === 'ui'">
-      <addons-section
-        v-if="addons && addons.marketplace" v-show="currentTab === 'ui'"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.marketplace.filter((a) => a.type === 'ui' && a.contentType === 'application/vnd.openhab.uicomponent;type=widget')"
-        :show-as-cards="true"
-        :title="'Widgets for the Main UI'"
-        :subtitle="'Extend your pages with these community-designed widgets'" />
-      <addons-section
-        v-if="addons && addons.karaf" v-show="currentTab === 'ui'" :show-all="true"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'ui')"
-        :title="'Other User Interfaces'"
-        :subtitle="'Official add-ons from the distribution'" />
-    </div>
-    <div v-show="currentTab === 'other'">
-      <addons-section
-        v-if="addons && addons.karaf" :show-all="true"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'misc')"
-        :title="'System Integrations'"
-        :featured="['misc-openhabcloud', 'misc-homekit', 'misc-metrics']"
-        :subtitle="'Integrate openHAB with external systems'" />
-      <addons-section
-        v-if="addons && addons.karaf"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'persistence')" :show-all="true"
-        :title="'Persistence Services'"
-        :subtitle="'Backend connectors to store historical data'" />
-      <addons-section
-        v-if="addons && addons.karaf"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'transformation')" :show-all="true"
-        :title="'Transformation Add-ons'"
-        :subtitle="'Backend connectors to store historical data'" />
-      <addons-section
-        v-if="addons && addons.karaf" :show-all="true"
-        @addonButtonClick="addonButtonClick"
-        :addons="addons.karaf.filter((a) => a.type === 'voice')"
-        :title="'Voice &amp; Speech'"
-        :subtitle="'Convert between text and speech, interpret human language queries'" />
-    </div>
-    <div v-show="currentTab === 'search'" style="padding-top: 2rem">
-      <addons-section
-        v-if="addons && searchResults.length"
-        :show-as-cards="searchResults.length <= 3"
-        @addonButtonClick="addonButtonClick"
-        :title="searchResults.length + ' result' + ((searchResults.length === 1) ? '' : 's')"
-        :addons="searchResults" />
-    </div>
+    <f7-tabs>
+      <f7-tab :tab-active="currentTab === 'bindings'">
+        <addons-section
+          v-if="addons && addons.karaf"
+          @addonButtonClick="addonButtonClick"
+          :addons="addons.karaf.filter((a) => a.type === 'binding')"
+          :title="'openHAB Distribution'"
+          :subtitle="'Official bindings maintained by the openHAB project'" />
+        <addons-section
+          v-if="addons && addons.marketplace"
+          @addonButtonClick="addonButtonClick"
+          :addons="addons.marketplace.filter((a) => a.type === 'binding')"
+          :title="'Community Marketplace'"
+          :subtitle="'Bindings independently released by the community'" />
+        <addons-section
+          v-if="otherAddons && otherAddons.length"
+          @addonButtonClick="addonButtonClick"
+          :addons="otherAddons.filter((a) => a.type === 'binding')"
+          :title="'Other Add-ons'" />
+      </f7-tab>
+      <f7-tab :tab-active="currentTab === 'automation'">
+        <addons-section
+          v-if="addons && addons.marketplace"
+          @addonButtonClick="addonButtonClick"
+          :addons="addons.marketplace.filter((a) => a.type === 'automation')"
+          :install-action-text="'Add'"
+          :title="'Rule Templates'"
+          :subtitle="'Shared by the community to bootstrap your automation'" />
+        <addons-section
+          v-if="addons && addons.karaf"
+          @addonButtonClick="addonButtonClick"
+          :addons="addons.karaf.filter((a) => a.type === 'automation')"
+          :title="'Automation Add-ons'"
+          :subtitle="'Add functionality with add-ons from the distribution'" />
+        <addons-section
+          v-if="otherAddons && otherAddons.length"
+          @addonButtonClick="addonButtonClick"
+          :addons="otherAddons.filter((a) => a.type === 'automation')"
+          :title="'Other Add-ons'" />
+      </f7-tab>
+      <f7-tab :tab-active="currentTab === 'ui'">
+        <addons-section
+          v-if="addons && addons.marketplace"
+          @addonButtonClick="addonButtonClick"
+          :addons="addons.marketplace.filter((a) => a.type === 'ui' && a.contentType === 'application/vnd.openhab.uicomponent;type=widget')"
+          :install-action-text="'Add'"
+          :show-as-cards="true"
+          :title="'Widgets for the Main UI'"
+          :subtitle="'Extend your pages with these community-designed widgets'" />
+        <addons-section
+          v-if="addons && addons.karaf" :show-all="true"
+          @addonButtonClick="addonButtonClick"
+          :addons="addons.karaf.filter((a) => a.type === 'ui')"
+          :title="'Other User Interfaces'"
+          :subtitle="'Official add-ons from the distribution'" />
+        <addons-section
+          v-if="otherAddons && otherAddons.length"
+          @addonButtonClick="addonButtonClick"
+          :addons="otherAddons.filter((a) => a.type === 'ui')"
+          :title="'Other Add-ons'" />
+      </f7-tab>
+      <f7-tab :tab-active="currentTab === 'other'">
+        <addons-section
+          v-if="addons && addons.karaf" :show-all="true"
+          @addonButtonClick="addonButtonClick"
+          :addons="allAddons.filter((a) => a.type === 'misc')"
+          :title="'System Integrations'"
+          :featured="['misc-openhabcloud', 'misc-homekit', 'misc-metrics']"
+          :subtitle="'Integrate openHAB with external systems'" />
+        <addons-section
+          v-if="addons && addons.karaf"
+          @addonButtonClick="addonButtonClick"
+          :addons="allAddons.filter((a) => a.type === 'persistence')" :show-all="true"
+          :title="'Persistence Services'"
+          :subtitle="'Backend connectors to store historical data'" />
+        <addons-section
+          v-if="addons && addons.karaf"
+          @addonButtonClick="addonButtonClick"
+          :addons="allAddons.filter((a) => a.type === 'transformation')" :show-all="true"
+          :title="'Transformation Add-ons'"
+          :subtitle="'Backend connectors to store historical data'" />
+        <addons-section
+          v-if="addons && addons.karaf" :show-all="true"
+          @addonButtonClick="addonButtonClick"
+          :addons="allAddons.filter((a) => a.type === 'voice')"
+          :title="'Voice &amp; Speech'"
+          :subtitle="'Convert between text and speech, interpret human language queries'" />
+      </f7-tab>
+      <f7-tab :tab-active="currentTab === 'search'" style="padding-top: 2rem">
+        <addons-section
+          v-if="addons && searchResults.length"
+          :show-as-cards="searchResults.length <= 3"
+          @addonButtonClick="addonButtonClick"
+          :title="searchResults.length + ' result' + ((searchResults.length === 1) ? '' : 's')"
+          :addons="searchResults" />
+      </f7-tab>
+    </f7-tabs>
     <addon-details-sheet
       v-if="ready"
       :addon-id="currentAddonId"
@@ -165,6 +184,14 @@ export default {
       searchResults: []
     }
   },
+  computed: {
+    allAddons () {
+      return Object.keys(this.addons).flatMap((k) => this.addons[k])
+    },
+    otherAddons () {
+      return Object.keys(this.addons).filter((k) => k !== 'karaf' && k !== 'marketplace').flatMap((k) => this.addons[k])
+    }
+  },
   methods: {
     onPageAfterIn () {
       this.load()
@@ -180,7 +207,6 @@ export default {
           data2.forEach((addons, idx) => {
             this.$set(this.addons, data[idx].id, data2[idx])
           })
-          console.log(this.addons)
           this.ready = true
           this.startEventSource()
           setTimeout(() => {
@@ -195,16 +221,19 @@ export default {
       })
     },
     switchTab (tab) {
-      this.currentTab = tab
-      this.$f7.lazy.create('.page-addon-store')
-      if (this.currentTab === 'search') {
-        this.$refs.storeSearchbar.enable()
-        setTimeout(() => {
-          this.$refs.storeSearchbar.f7Searchbar.$inputEl.focus()
-        }, 500)
-      } else {
-        this.$refs.storeSearchbar.disable()
-      }
+      this.currentTab = ''
+      this.$nextTick(() => {
+        this.$f7.lazy.create('.page-addon-store')
+        this.currentTab = tab
+        if (this.currentTab === 'search') {
+          this.$refs.storeSearchbar.enable()
+          setTimeout(() => {
+            this.$refs.storeSearchbar.f7Searchbar.$inputEl.focus()
+          }, 500)
+        } else {
+          this.$refs.storeSearchbar.disable()
+        }
+      })
     },
     addonButtonClick (addon) {
       const realAddonId = (addon.id.indexOf(':') > 0) ? addon.id.substring(addon.id.indexOf(':') + 1) : addon.id

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/binding-config.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/binding-config.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page>
-    <f7-navbar :title="'Configure ' + binding.name" back-link="Bindings">
+    <f7-navbar :title="'Configure ' + binding.name" back-link="Back">
       <f7-nav-right>
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only />
         <f7-link @click="save()" v-if="!$theme.md">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -49,11 +49,11 @@
     <f7-block class="block-narrow" v-if="$store.getters.apiEndpoint('addons')">
       <f7-col v-if="bindings.length">
         <f7-list>
-          <f7-list-button color="blue" title="Install More Bindings" href="install-binding" />
+          <f7-list-button color="blue" title="Install More Bindings" href="/settings/addons" />
         </f7-list>
       </f7-col>
       <f7-row v-else-if="ready" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" href="install-binding">
+        <f7-button large fill color="blue" href="/settings/addons">
           Install Bindings
         </f7-button>
       </f7-row>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -41,7 +41,7 @@
             badge-color="red"
             :footer="(binding.description && binding.description.indexOf('<br>') >= 0) ?
               binding.description.split('<br>')[0] : binding.description">
-            <f7-link slot="after" v-if="binding.configDescriptionURI" :href="`/settings/addons/bindings/${binding.id}/config`" class="margin-left" icon-size="20" icon-f7="gear_alt" color="gray" tooltip="Configure Binding" />
+            <f7-link slot="after" v-if="binding.configDescriptionURI" :href="`/settings/addons/${binding.id}/config`" class="margin-left" icon-size="20" icon-f7="gear_alt" color="gray" tooltip="Configure Binding" />
           </f7-list-item>
         </f7-list>
       </f7-col>


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/2405.

This replaces the current section of the UI for managing
add-ons with a completely new "store-like" interface.
External data, like logos and detailed descriptions for
distribution add-ons are fetched from well-known locations
on the website or GitHub to provide a "store" look & feel.

The add-on store is orgnanized around 4 categories: bindings,
automation, UI, and others, with a separate search tab.
Each category is splitted into subsections. The availability
of these sections depend on the add-on services that are
registered. The sections currently supports add-ons provided
by the "karaf" & "marketplace" services, as provided by
https://github.com/openhab/openhab-core/pull/2405.

Signed-off-by: Yannick Schaus <github@schaus.net>