### PR TITLE
Make Blockly OH blocks compatible with the JSScripting add-on

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -440,6 +440,17 @@ import defineOHBlocks from '@/assets/definitions/blockly/ohblocks'
 
 Vue.config.ignoredElements = ['field', 'block', 'category', 'xml', 'mutation', 'value', 'sep']
 
+// Code to prepend to have a common API to openHAB objects when running GraalVM JS or Nashorn.
+const prependCode = `
+if (typeof(require) === "function") {
+  ctx = this;
+  var runtime = require("@runtime");
+  itemRegistry = runtime.itemRegistry;
+  events = runtime.events;
+}
+
+`
+
 export default {
   props: ['blocks'],
   data () {
@@ -470,7 +481,7 @@ export default {
       return Blockly.Xml.domToText(xml)
     },
     getCode () {
-      return Blockly.JavaScript.workspaceToCode(this.workspace)
+      return prependCode + Blockly.JavaScript.workspaceToCode(this.workspace)
     },
     onChange (event) {
       if (event.type === Blockly.Events.FINISHED_LOADING) {


### PR DESCRIPTION
This prepends code that makes the `ctx`, `itemRegistry` & `events`
objects accessible when the scripts are run with GraalVM, as they
are when run with Nashorn.

Closes #1169.

Signed-off-by: Yannick Schaus <github@schaus.net>