### PR TITLE
Evaluate expressions in action analyzer items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -211,7 +211,9 @@ export const actionsMixin = {
           break
         case 'analyze':
         case 'analyzer':
-          const actionAnalyzerItems = actionConfig[prefix + 'actionAnalyzerItems']
+          const actionAnalyzerItems = actionConfig[prefix + 'actionAnalyzerItems'].map((item) => {
+            return this.evaluateExpression(item, item, this.config)
+          })
           const actionAnalyzerChartType = actionConfig[prefix + 'actionAnalyzerChartType']
           const actionAnalyzerCoordSystem = actionConfig[prefix + 'actionAnalyzerCoordSystem']
           this.$f7.views.main.router.navigate(`/analyzer/?items=${actionAnalyzerItems.join(',')}&chartType=${actionAnalyzerChartType || ''}&coordSystem=${actionAnalyzerCoordSystem || ''}`)


### PR DESCRIPTION
Allows custom widgets to define the analyze action without hard coding the item, like 

```yaml
    config:
      action: analyzer
      actionAnalyzerItems:
        - '=props.item'
```

Ideally something like this should be added to all the other actions, let me know if there's an interest in doing that.