### PR TITLE
Add-on store adjustments

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -133,7 +133,9 @@ export default {
     },
     imageUrl () {
       if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
-      return 'https://www.openhab.org/logos/' + this.addon.id.substring(this.addon.id.indexOf('-') + 1) + '.png'
+      let docsBranch = 'final'
+      if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
+      return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -74,7 +74,9 @@ export default {
   computed: {
     imageUrl () {
       if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
-      return 'https://www.openhab.org/logos/' + this.addon.id.substring(this.addon.id.indexOf('-') + 1) + '.png'
+      let docsBranch = 'final'
+      if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
+      return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
@@ -2,9 +2,9 @@
   <f7-block class="addons-section" ref="addongroup" v-if="addons && addons.length > 0">
     <f7-block-title medium>
       {{ title }}
-      <f7-link v-if="canExpand" color="blue" class="see-all-button margin-right" @click="expand">
-        See All
-      </f7-link>
+      <!-- <f7-link v-if="canExpand" color="blue" class="see-all-button margin-right" @click="expand">
+        Show All
+      </f7-link> -->
     </f7-block-title>
     <f7-block-footer v-if="subtitle">
       {{ subtitle }}
@@ -18,6 +18,9 @@
     <f7-list v-else media-list ref="addonlist" class="addons-table-list" no-chevron no-hairlines>
       <addon-list-item v-for="addon in addonsList" :key="addon.id" :addon="addon" :install-action-text="installActionText" @addonButtonClick="addonButtonClick" />
     </f7-list>
+    <f7-block v-if="canExpand" class="display-flex justify-content-center">
+      <f7-button class="" outline color="blue" @click="expand" :text="`Show ${addons.length - addonCollapsedLimit} More`" />
+    </f7-block>
   </f7-block>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -215,7 +215,9 @@ export default {
     imageUrl () {
       if (!this.addon) return null
       if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
-      return 'https://www.openhab.org/logos/' + this.addon.id.substring(this.addon.id.indexOf('-') + 1) + '.png'
+      let docsBranch = 'final'
+      if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
+      return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
     },
     addonDescription () {
       if (!this.descriptionReady) return null

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -171,6 +171,8 @@
     img
       max-width calc(100%)
       height auto
+      &[alt="logo"]
+        display none
       &.lazy:not(.lazy-loaded)
         opacity 0
 </style>
@@ -228,8 +230,8 @@ export default {
     },
     docLinkUrl () {
       if (!this.addon) return ''
-      if (this.serviceId !== 'karaf' && this.addon.link) return this.addon.link
-      if (this.serviceId === 'karaf') {
+      if (this.serviceId && this.serviceId !== 'karaf' && this.addon.link) return this.addon.link
+      if (this.addon.id.indexOf('-') > 0) {
         let url = `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org` +
           `/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}` +
           `/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}`

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
@@ -69,23 +69,18 @@
       </f7-tab>
       <f7-tab :tab-active="currentTab === 'automation'">
         <addons-section
-          v-if="addons && addons.marketplace"
+          v-if="addons"
           @addonButtonClick="addonButtonClick"
-          :addons="addons.marketplace.filter((a) => a.type === 'automation')"
+          :addons="allAddons.filter((a) => a.type === 'automation' && a.contentType === 'application/vnd.openhab.ruletemplate')"
           :install-action-text="'Add'"
           :title="'Rule Templates'"
           :subtitle="'Shared by the community to bootstrap your automation'" />
         <addons-section
-          v-if="addons && addons.karaf"
+          v-if="addons"
           @addonButtonClick="addonButtonClick"
-          :addons="addons.karaf.filter((a) => a.type === 'automation')"
-          :title="'Automation Add-ons'"
-          :subtitle="'Add functionality with add-ons from the distribution'" />
-        <addons-section
-          v-if="otherAddons && otherAddons.length"
-          @addonButtonClick="addonButtonClick"
-          :addons="otherAddons.filter((a) => a.type === 'automation')"
-          :title="'Other Add-ons'" />
+          :addons="allAddons.filter((a) => a.type === 'automation' && a.contentType !== 'application/vnd.openhab.ruletemplate')"
+          :title="'Other Automation Add-ons'"
+          :subtitle="'Add new scripting languages and various functionality'" />
       </f7-tab>
       <f7-tab :tab-active="currentTab === 'ui'">
         <addons-section
@@ -99,14 +94,9 @@
         <addons-section
           v-if="addons && addons.karaf" :show-all="true"
           @addonButtonClick="addonButtonClick"
-          :addons="addons.karaf.filter((a) => a.type === 'ui')"
-          :title="'Other User Interfaces'"
-          :subtitle="'Official add-ons from the distribution'" />
-        <addons-section
-          v-if="otherAddons && otherAddons.length"
-          @addonButtonClick="addonButtonClick"
-          :addons="otherAddons.filter((a) => a.type === 'ui')"
-          :title="'Other Add-ons'" />
+          :addons="allAddons.filter((a) => a.type === 'ui' && a.contentType !== 'application/vnd.openhab.uicomponent;type=widget')"
+          :title="'Other UI Add-ons'"
+          :subtitle="'Alternative user interfaces and icon sets'" />
       </f7-tab>
       <f7-tab :tab-active="currentTab === 'other'">
         <addons-section


### PR DESCRIPTION
- Move non-rule templates automation add-ons in the second section
- Merge all non-widget UI add-ons in the second section
- Use GitHub well-known URLs in the openhab-docs repo (final or final-stable
  branch) for the logo URL - avoids having to cherry-pick new binding logos
  to stable, and CloudFlare caching issues
- Use correct version on next.openhab.org or www.openhab.org when clicking
  the logo in the details page
- Hide images with alt text set to "logo" in description. For marketplace
  entries this can be set with this syntax:
  `![logo](url)` or `![logo|...](url)`

Closes #1189.

Signed-off-by: Yannick Schaus <github@schaus.net>