### PR TITLE
Configure default timeout of 15 minutes for all testable and lifecycle methods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,11 @@ Import-Package: \\
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
+          <configuration>
+            <systemPropertyVariables>
+              <junit.jupiter.execution.timeout.default>15 m</junit.jupiter.execution.timeout.default>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
This helps to identify what tests cause builds to get stuck and it will more quickly end such builds.
When builds get stuck in tests, they would keep running for hours and then eventually when a timeout occurs, the job is killed without knowing why it got stuck.
Furhermore precious Jenkins executors will not keep being occupied by such jobs.

See: https://junit.org/junit5/docs/current/user-guide/#writing-tests-declarative-timeouts

It helps with identifying the root cause of issues like openhab/openhab-core#2551