### PR TITLE
[blockly] fix audio block code generation

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-audio.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-audio.js
@@ -58,7 +58,7 @@ export default function (f7, sinks, voices) {
     let fileName = Blockly.JavaScript.valueToCode(block, 'fileName', Blockly.JavaScript.ORDER_ATOMIC)
     let sinkName = Blockly.JavaScript.valueToCode(block, 'sinkName', Blockly.JavaScript.ORDER_ATOMIC).replace('(', '').replace(/[()]/g, '')
 
-    let code = `audio.playSound('${sinkName}', ${fileName});\n`
+    let code = `audio.playSound(${sinkName}, ${fileName});\n`
     return code
   }
 


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

Fix: There was a bug that produced two single quotes instead of one for one of the audio blocks