### PR TITLE
Fix add link "compatible item" logic

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -239,7 +239,8 @@ export default {
     getCompatibleItemTypes () {
       let compatibleItemTypes = []
       if (this.channel.itemType) {
-        this.channel.itemType.split(':', 1)
+        compatibleItemTypes.push(this.channel.itemType)
+        if (this.channel.itemType.indexOf('Number:') === 0) { compatibleItemTypes.push('Number') }
         if (this.channel.itemType === 'Color') { compatibleItemTypes.push('Switch', 'Dimmer') }
         if (this.channel.itemType === 'Dimmer') { compatibleItemTypes.push('Switch') }
       }


### PR DESCRIPTION
The checks on which item types are allowed to be linked introduced with
#1106 & #1043 have a serious issue that prevents the items of the actual
type of the channel to be linked individually.

Fixes #1204.
Fixes https://github.com/openhab/openhab-core/issues/2568.

Signed-off-by: Yannick Schaus <github@schaus.net>