### PR TITLE
[blockly] add script param block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-eventbus.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-eventbus.js
@@ -28,44 +28,4 @@ export default function (f7) {
     const value = Blockly.JavaScript.valueToCode(block, 'value', Blockly.JavaScript.ORDER_ATOMIC)
     return 'events.' + eventType + '(' + itemName + ', ' + value + ');\n'
   }
-
-  Blockly.Blocks['oh_context_info'] = {
-    init: function () {
-      this.appendDummyInput()
-        .appendField('contextual info')
-        .appendField(new Blockly.FieldDropdown([
-          ['rule UID', 'ruleUID'],
-          ['event type', 'type'],
-          ['new state of item', 'itemState'],
-          ['previous state of item', 'oldItemState'],
-          ['triggering item name', 'itemName'],
-          ['received command', 'itemCommand'],
-          ['triggered channel', 'channel']]),
-        'contextInfo')
-      this.setInputsInline(true)
-      this.setOutput(true, null)
-      this.setColour(0)
-      let thisBlock = this
-      this.setTooltip(function () {
-        const contextData = thisBlock.getFieldValue('contextInfo')
-        const TIP = {
-          'ruleUID': 'The current rule\'s UID',
-          'type': 'the event type name',
-          'itemState': 'the new item state (only applicable for rules with triggers related to changed and updated items)',
-          'oldItemState': 'the old item state (only applicable for rules with triggers related to changed and updated items)',
-          'itemName': 'the item name that caused the event (if relevant)',
-          'itemCommand': 'the command name that triggered the event',
-          'channel': 'the channel UID that triggered the event (only applicable for rules including a "trigger channel fired" event)'
-        }
-        return TIP[contextData]
-      })
-      this.setHelpUrl('https://www.openhab.org/docs/developer/utils/events.html')
-    }
-  }
-
-  Blockly.JavaScript['oh_context_info'] = function (block) {
-    const contextInfo = block.getFieldValue('contextInfo')
-    if (contextInfo === 'ruleUID') return ['ctx.ruleUID', Blockly.JavaScript.ORDER_ATOMIC]
-    return [`event.${contextInfo}`, Blockly.JavaScript.ORDER_ATOMIC]
-  }
 }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -158,4 +158,33 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
       'transformation',
       ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type(\'org.openhab.core.transform.actions.Transformation\');'])
   }
+
+  /*
+  * Allows retrieving parameters provided by a rule
+  * Blockly part
+  */
+  Blockly.Blocks['oh_getscript_attribute'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('get parameter')
+      this.appendValueInput('scriptParam')
+        .setCheck('String')
+      this.appendDummyInput()
+        .appendField('of rule')
+      this.setInputsInline(true)
+      this.setOutput(true, 'any')
+      this.setColour(0)
+      this.setTooltip('Retrieve a specified parameter that was passed from a calling rule')
+    }
+  }
+
+  /*
+  * Allows retrieving parameters provided by a rule
+  * Code part
+  */
+  Blockly.JavaScript['oh_getscript_attribute'] = function (block) {
+    const scriptParam = Blockly.JavaScript.valueToCode(block, 'scriptParam', Blockly.JavaScript.ORDER_ATOMIC)
+    let code = `context.getAttribute(${scriptParam})`
+    return [code, 0]
+  }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -672,6 +672,13 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_getscript_attribute">
+            <value name="scriptParam">
+              <shadow type="text">
+                <field name="TEXT">ruleParameterName</field>
+              </shadow>
+            </value>
+          </block>
           <sep gap="48" />
           <block type="oh_transformation">
             <value name="function">

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -348,7 +348,6 @@
               <shadow type="oh_thing" />
             </value>
           </block>
-          <block type="oh_context_info" />
         </category>
 
         <category name="Timers &amp; Delays">
@@ -672,10 +671,12 @@
               </shadow>
             </value>
           </block>
-          <block type="oh_getscript_attribute">
-            <value name="scriptParam">
+          <sep gap="48" />
+          <block type="oh_context_info" />
+          <block type="oh_context_attribute">
+            <value name="key">
               <shadow type="text">
-                <field name="TEXT">ruleParameterName</field>
+                <field name="TEXT">key</field>
               </shadow>
             </value>
           </block>


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

This finalizes the blockly "Run & Process" section by allowing provided parameters by a rule to be retrieved via a blockly written _script_  as this PR provides a simple block to retrieve the value via blockly

Use of the new parameter retrieval block

![image](https://user-images.githubusercontent.com/5937600/146631902-aa99ea6f-57ce-46e8-9707-b631365ec5c7.png)


The rule that calls the script (for reference)
![image](https://user-images.githubusercontent.com/5937600/146631921-2470e807-6f75-4dc9-ad03-d86084eb3bc4.png)

