### PR TITLE
Check config before allowing oh-icon style customization

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -8,13 +8,15 @@
        onload="this.classList.remove('no-icon')" onerror="this.classList.add('no-icon')">
   <f7-icon v-else-if="iconType === 'f7'"
            :ios="icon || ((config) ? config.icon : null)" :md="icon || ((config) ? config.icon : null)" :aurora="icon || ((config) ? config.icon : null)"
-           :color="color || ((config) ? config.color : null)" :size="width || height || ((config) ? (config.width || config.height) : null)" />
+           :color="color || ((config) ? config.color : null)" :size="width || height || ((config) ? (config.width || config.height) : null)"
+           :style="(config) ? config.style : null" />
   <iconify-icon v-else-if="iconType === 'iconify'"
                 :icon="iconName"
                 :width="width || ((config) ? config.width : null)" :height="height || ((config) ? config.height : null)"
                 :color="color || ((config) ? config.color : null)" :rotate="rotate || ((config) ? config.rotate : null)"
                 :horizontal-flip="horizontalFlip || ((config) ? config.horizontalFlip : null)"
-                :vertical-flip="verticalFlip || ((config) ? config.verticalFlip : null)" />
+                :vertical-flip="verticalFlip || ((config) ? config.verticalFlip : null)"
+                :style="(config) ? config.style : null" />                
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -16,7 +16,7 @@
                 :color="color || ((config) ? config.color : null)" :rotate="rotate || ((config) ? config.rotate : null)"
                 :horizontal-flip="horizontalFlip || ((config) ? config.horizontalFlip : null)"
                 :vertical-flip="verticalFlip || ((config) ? config.verticalFlip : null)"
-                :style="(config) ? config.style : null" />                
+                :style="(config) ? config.style : null" />
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -8,15 +8,13 @@
        onload="this.classList.remove('no-icon')" onerror="this.classList.add('no-icon')">
   <f7-icon v-else-if="iconType === 'f7'"
            :ios="icon || ((config) ? config.icon : null)" :md="icon || ((config) ? config.icon : null)" :aurora="icon || ((config) ? config.icon : null)"
-           :color="color || ((config) ? config.color : null)" :size="width || height || ((config) ? (config.width || config.height) : null)"
-           :style="config.style" />
+           :color="color || ((config) ? config.color : null)" :size="width || height || ((config) ? (config.width || config.height) : null)" />
   <iconify-icon v-else-if="iconType === 'iconify'"
                 :icon="iconName"
                 :width="width || ((config) ? config.width : null)" :height="height || ((config) ? config.height : null)"
                 :color="color || ((config) ? config.color : null)" :rotate="rotate || ((config) ? config.rotate : null)"
                 :horizontal-flip="horizontalFlip || ((config) ? config.horizontalFlip : null)"
-                :vertical-flip="verticalFlip || ((config) ? config.verticalFlip : null)"
-                :style="config.style" />
+                :vertical-flip="verticalFlip || ((config) ? config.verticalFlip : null)" />
 </template>
 
 <style lang="stylus">


### PR DESCRIPTION
#1233 offers style customization properties for f7 and iconify icons but they end
up conflicting with those set by the `f7-icon` & `iconify-icon` components themselves.

Fixes #1242.

Signed-off-by: Yannick Schaus <github@schaus.net>