### PR TITLE
Make UI configurations translatable

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/i18n/basic.properties
+++ b/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/i18n/basic.properties
@@ -1,7 +1,33 @@
+ui.config.basic.capitalizeValues.label = Capitalize Values
+ui.config.basic.capitalizeValues.description = Displays all widget states in uppercase.
+ui.config.basic.capitalizeValues.option.true = Enable
+ui.config.basic.capitalizeValues.option.false = Disable
+ui.config.basic.condensedLayout.label = Condensed Layout
+ui.config.basic.condensedLayout.description = When enabled, changes the layout so that more widgets can fit on the screen.
+ui.config.basic.condensedLayout.option.true = Enable
+ui.config.basic.condensedLayout.option.false = Disable
+ui.config.basic.defaultSitemap.label = Default Sitemap
+ui.config.basic.defaultSitemap.description = The sitemap to show if no parameter is passed.
+ui.config.basic.enableIcons.label = Enable Icons
+ui.config.basic.enableIcons.description = Defines whether UI renders icons for the widgets or not.
+ui.config.basic.enableIcons.option.true = Enable
+ui.config.basic.enableIcons.option.false = Disable
+ui.config.basic.theme.label = Theme
+ui.config.basic.theme.description = Defines the UI theme.
+ui.config.basic.theme.option.default = Default
+ui.config.basic.theme.option.dark = Dark
+
+# service
+
+service.ui.basic.label = Basic UI
+
+# messages
+
 main.offline-msg = Offline: waiting for connection to become available
 main.long-polling-mode-msg = SSE subscription failed ({error}): running in fallback mode
 
-sitemaps-list.welcome = Welcome!
-sitemaps-list.available-sitemaps = Available sitemaps
+# sitemaps
 
 sitemaps-list-empty.info = It seems like you have not defined any sitemaps yet. To build one, please check the documentation for guidance.
+sitemaps-list.welcome = Welcome!
+sitemaps-list.available-sitemaps = Available sitemaps

--- a/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/i18n/basic_de.properties
+++ b/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/i18n/basic_de.properties
@@ -1,6 +1,10 @@
-main.offline-msg = Offline: Warte auf Verbindung
-main.long-polling-mode-msg = SSE-Abonnement fehlgeschlagen ({error}): Im Fallback-Modus ausgeführt
+# messages
 
-sitemaps-list.welcome = Willkommen!
-sitemaps-list.available-sitemaps = Verfügbare Sitemaps
+main.offline-msg = Offline: Warte auf Verbindung
+main.long-polling-mode-msg = SSE-Abonnement fehlgeschlagen ({error}): Im Fallback-Modus ausgefÃ¼hrt
+
+# sitemaps
+
 sitemaps-list-empty.info = Sie haben noch keine Sitemaps definiert. Hilfe zur Erstellung von Sitemaps finden Sie in der Dokumentation.
+sitemaps-list.welcome = Willkommen!
+sitemaps-list.available-sitemaps = VerfÃ¼gbare Sitemaps

--- a/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/i18n/basic_fr.properties
+++ b/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/i18n/basic_fr.properties
@@ -1,7 +1,10 @@
-main.offline-msg = Non connecté: en attente d'une connexion disponible
-main.long-polling-mode-msg = Échec de l'abonnement SSE ({error}): exécution en mode secours
+# messages
 
+main.offline-msg = Non connectÃ©: en attente d'une connexion disponible
+main.long-polling-mode-msg = Ã‰chec de l'abonnement SSE ({error}): exÃ©cution en mode secours
+
+# sitemaps
+
+sitemaps-list-empty.info = Il semble que vous n'ayez encore dÃ©fini aucune sitemap. Pour en construire une, merci de vous aider de la documentation.
 sitemaps-list.welcome = Bienvenue!
 sitemaps-list.available-sitemaps = Sitemaps disponibles
-
-sitemaps-list-empty.info = Il semble que vous n'ayez encore défini aucune sitemap. Pour en construire une, merci de vous aider de la documentation.

--- a/bundles/org.openhab.ui.cometvisu/src/main/resources/OH-INF/i18n/cometvisu.properties
+++ b/bundles/org.openhab.ui.cometvisu/src/main/resources/OH-INF/i18n/cometvisu.properties
@@ -1,0 +1,10 @@
+ui.config.cometvisu.autoDownload.label = Auto-Download
+ui.config.cometvisu.autoDownload.description = If you enable this feature, the current release of CometVisu client (GNU General Public License v3.0) will be automatically downloaded to your openHAB server and extracted into the folder you defined in the Filesystem path, if it is not found there.
+ui.config.cometvisu.webAlias.label = Browser path
+ui.config.cometvisu.webAlias.description = The relative browser path where you can access the client e.g http://<openhab-server>:8080/<webAlias>/
+ui.config.cometvisu.webFolder.label = Filesystem path
+ui.config.cometvisu.webFolder.description = Defines the path to the CometVisu client directory.
+
+# service
+
+service.ui.cometvisu.label = CometVisu

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/nlp/internal/OpenNLPInterpreter.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/nlp/internal/OpenNLPInterpreter.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.openhab.core.common.registry.RegistryChangeListener;
+import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemRegistry;
@@ -52,10 +53,11 @@ import org.osgi.service.component.annotations.ReferencePolicy;
  *
  * @author Yannick Schaus - Initial contribution
  */
-@Component(service = HumanLanguageInterpreter.class, immediate = true, name = "org.openhab.opennlphli", property = {
-        "service.config.description.uri=voice:opennlphli", "service.config.label=OpenNLP Interpreter for HABot",
-        "service.config.category=voice" })
+@Component(service = HumanLanguageInterpreter.class, immediate = true, name = "org.openhab.opennlphli")
+@ConfigurableService(category = "voice", label = "OpenNLP Interpreter for HABot", description_uri = OpenNLPInterpreter.CONFIG_URI)
 public class OpenNLPInterpreter implements HumanLanguageInterpreter {
+
+    protected static final String CONFIG_URI = "voice:opennlphli";
 
     public static final Set<Locale> SUPPORTED_LOCALES = Set.of(Locale.ENGLISH, Locale.FRENCH, Locale.GERMAN);
 

--- a/bundles/org.openhab.ui.habot/src/main/resources/OH-INF/i18n/opennlphli.properties
+++ b/bundles/org.openhab.ui.habot/src/main/resources/OH-INF/i18n/opennlphli.properties
@@ -1,0 +1,8 @@
+voice.config.opennlphli.theme.label = Tokenizer
+voice.config.opennlphli.theme.description = The alphanumeric tokenizer removes punctuation and might help with languages where entities might not always be enclosed between whitespaces (French, Spanish, Italian... Example: "l'humidité", "l'alarme")
+voice.config.opennlphli.theme.option.whitespace = Whitespace
+voice.config.opennlphli.theme.option.alphanumeric = Alphanumeric
+
+# service
+
+service.voice.opennlphli.label = OpenNLP Interpreter for HABot

--- a/bundles/org.openhab.ui.iconset.classic/src/main/resources/OH-INF/i18n/iconset.properties
+++ b/bundles/org.openhab.ui.iconset.classic/src/main/resources/OH-INF/i18n/iconset.properties
@@ -1,0 +1,2 @@
+iconset.label = Classic Icons
+iconset.description = This is a modernized version of the original icon set of openHAB 1.

--- a/bundles/org.openhab.ui.iconset.classic/src/main/resources/OH-INF/i18n/iconset_de.properties
+++ b/bundles/org.openhab.ui.iconset.classic/src/main/resources/OH-INF/i18n/iconset_de.properties
@@ -1,0 +1,2 @@
+iconset.label = Classic Icons
+iconset.description = Dies ist eine modernisierte Variante der ursprünglichen openHAB 1 Icons.

--- a/bundles/org.openhab.ui.iconset.classic/src/main/resources/OH-INF/i18n/iconset_de_DE.properties
+++ b/bundles/org.openhab.ui.iconset.classic/src/main/resources/OH-INF/i18n/iconset_de_DE.properties
@@ -1,2 +1,0 @@
-iconset.label = Classic Icons
-iconset.description = Dies ist eine modernisierte Variante der ursprünglichen openHAB 1 Icons.

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,7 @@
 files:
   - source: /bundles/org.openhab.ui/web/src/assets/i18n/**/en.json
     translation: /%original_path%/%two_letters_code%.json
+  - source: /bundles/**/i18n/**/*.properties
+    ignore:
+      - /bundles/**/i18n/**/*_*.properties
+    translation: /%original_path%/%file_name%_%two_letters_code%.properties

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
     <bnd.version>6.1.0</bnd.version>
     <eea.version>2.3.0</eea.version>
     <karaf.version>4.3.4</karaf.version>
+    <ohc.version>3.3.0-SNAPSHOT</ohc.version>
     <sat.version>0.12.0</sat.version>
     <spotless.version>2.0.3</spotless.version>
   </properties>
@@ -420,6 +421,12 @@ Import-Package: \\
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.openhab.core.tools</groupId>
+          <artifactId>i18n-maven-plugin</artifactId>
+          <version>${ohc.version}</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Adds the default translation strings so the UI configuration can be translated with Crowdin.

Other fixes/improvements:

* Adds config for this to crowdin.yml
* Adds the i18n Maven plugin dependency so it can be more easily used
* Fixes a few encoding issues
* Uses the ConfigurableService annotation