### PR TITLE
Fix exception on parameter-script editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-script.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-script.vue
@@ -14,7 +14,7 @@
 import ScriptEditorPopup from './script-editor-popup.vue'
 
 export default {
-  props: ['configDescription', 'value'],
+  props: ['configDescription', 'configuration', 'value'],
   data () {
     return {
     }
@@ -39,6 +39,8 @@ export default {
       }, {
         props: {
           title: this.configDescription.label,
+          // use the "type" parameter as the mode if found (for rule modules)
+          mode: (this.configuration && this.configuration.type) ? this.configuration.type : '',
           fullscreen: fullscreen,
           value: this.value
         }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor-popup.vue
@@ -8,7 +8,7 @@
           </f7-link>
         </f7-nav-right>
       </f7-navbar>
-      <editor v-if="showEditor" v-model="code" />
+      <editor v-if="showEditor" v-model="code" :mode="mode || ''" />
     </f7-page>
   </f7-popup>
 </template>
@@ -23,7 +23,7 @@ export default {
   components: {
     'editor': () => import(/* webpackChunkName: "script-editor" */ './script-editor.vue')
   },
-  props: ['title', 'value', 'opened', 'fullscreen', 'popupId'],
+  props: ['title', 'value', 'mode', 'opened', 'fullscreen', 'popupId'],
   data () {
     return {
       code: this.value,


### PR DESCRIPTION
Also uses the parameter named "type" as
the mode (for the script automation modules)
so the editor has the same features as the
full-fledged script editor, like syntax highlighting
and hints.

Closes #1244.

Signed-off-by: Yannick Schaus <github@schaus.net>