### PR TITLE
[blockly] fix item.getAttributes

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-things.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-things.js
@@ -29,7 +29,7 @@ export default function defineOHBlocks (f7) {
   Blockly.Blocks['oh_getthing_state'] = {
     init: function () {
       this.appendValueInput('thingUid')
-        .appendField('get thing state')
+        .appendField('get thing status')
         .setCheck('String')
       this.setInputsInline(false)
       this.setOutput(true, 'String')

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -344,7 +344,7 @@
           <sep gap="48" />
           <block type="oh_thing" />
           <block type="oh_getthing_state">
-            <value name="itemName">
+            <value name="thingUid">
               <shadow type="oh_thing" />
             </value>
           </block>


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

Fix for what has been mentioned in https://community.openhab.org/t/blockly-reference/128785 (Documentation has already been updated related to this fix)

- [Get Item attribute](https://community.openhab.org/t/blockly-reference/128785#get-particular-attributes-of-an-item-14) has the wrong block type. As a result it cannot be connected to any other block and cannot be used. Fix: Return "String" instead of "any"
- [Get Item attribute returning categories](https://community.openhab.org/t/blockly-reference/128785#get-particular-attributes-of-an-item-14) returns an Array of Strings that cannot be used with further blocks. Fix: Return a Collection instead of String in case it is Set of attributes

**Work in Progress: Fix is coming**
- Get context attribute has the wrong block type. As a result it cannot be connected to any other block and cannot be used. Fix: Return "String" instead of "any"
