### PR TITLE
[Blockly] don't use a shadow block for oh_runrule parameters

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -666,9 +666,9 @@
               </shadow>
             </value>
             <value name="parameters">
-              <shadow type="dicts_create_with">
+              <block type="dicts_create_with">
                 <mutation items="0" />
-              </shadow>
+              </block>
             </value>
           </block>
           <sep gap="48" />


### PR DESCRIPTION
Reported in https://community.openhab.org/t/blockly-doesnt-like-the-value-in-key-value-pairs/131049 and other places.
This seems to be an issue with Blockly - shadow blocks with mutations don't work.

Signed-off-by: Yannick Schaus <github@schaus.net>