### PR TITLE
add hsb block, dict get, triggeredEvent, check value, inline script

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
@@ -16,7 +16,7 @@ export default function (f7) {
         .setCheck('Colour')
       this.setInputsInline(false)
       this.setOutput(true, 'String')
-      this.setColour(0)
+      this.setColour('%{BKY_COLOUR_HUE}')
       this.setTooltip('converts a colour\'s hex rgb representation to openHAB\'s hue-saturation-brightness string')
       this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html#state')
     }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
@@ -41,12 +41,12 @@ export default function (f7) {
       'colorHexToHSB',
       [
         'function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' (hexColor) {',
-        'var rgb = /^#?([a-f\\d]{2})([a-f\\d]{2})([a-f\\d]{2})$/i.exec(hexColor);',
-        'if (!rgb) return \'\';',
-        'var r = parseInt(rgb[1], 16) / 255, g = parseInt(rgb[2], 16) / 255, b = parseInt(rgb[3], 16) / 255;',
-        'var v = Math.max(r, g, b), n = v - Math.min(r, g, b);',
-        'var h = n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n;',
-        'return [60 * (h < 0 ? h + 6 : h), v && (n / v) * 100, v * 100].join(\',\');',
+        '  var rgb = /^#?([a-f\\d]{2})([a-f\\d]{2})([a-f\\d]{2})$/i.exec(hexColor);',
+        '  if (!rgb) return \'\';',
+        '  var r = parseInt(rgb[1], 16) / 255, g = parseInt(rgb[2], 16) / 255, b = parseInt(rgb[3], 16) / 255;',
+        '  var v = Math.max(r, g, b), n = v - Math.min(r, g, b);',
+        '  var h = n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n;',
+        '  return [60 * (h < 0 ? h + 6 : h), v && (n / v) * 100, v * 100].join(\',\');',
         '}'
       ])
     return hsbConversion

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
@@ -1,0 +1,54 @@
+/*
+* Adds new blocks to the colour sections
+*/
+
+import Blockly from 'blockly'
+
+export default function (f7) {
+  /*
+  * converts a hex color string in to an openHAB hue-saturation-brightness string
+  * Block
+  */
+  Blockly.Blocks['oh_color_to_hsb'] = {
+    init: function () {
+      this.appendValueInput('hexColor')
+        .appendField('hsb of')
+        .setCheck('Colour')
+      this.setInputsInline(false)
+      this.setOutput(true, 'String')
+      this.setColour(0)
+      this.setTooltip('converts a colour\'s hex rgb representation to openHAB\'s hue-saturation-brightness string')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html#state')
+    }
+  }
+
+  /*
+  * converts a hex color string in to an openHAB hue-saturation-brightness string
+  * Code generation
+  */
+  Blockly.JavaScript['oh_color_to_hsb'] = function (block) {
+    let conversionFunction = addConvertColourHexToHSB()
+    const hexColor = Blockly.JavaScript.valueToCode(block, 'hexColor', Blockly.JavaScript.ORDER_ATOMIC)
+    let code = `${conversionFunction}(${hexColor})`
+    return [code, 0]
+  }
+
+  /*
+  * converts rgb to hsb (thanks to https://www.30secondsofcode.org/js/s/rgb-to-hsb)
+  */
+  function addConvertColourHexToHSB () {
+    const hsbConversion = Blockly.JavaScript.provideFunction_(
+      'colorHexToHSB',
+      [
+        'function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' (hexColor) {',
+        'var rgb = /^#?([a-f\\d]{2})([a-f\\d]{2})([a-f\\d]{2})$/i.exec(hexColor);',
+        'if (!rgb) return \'\';',
+        'var r = parseInt(rgb[1], 16) / 255, g = parseInt(rgb[2], 16) / 255, b = parseInt(rgb[3], 16) / 255;',
+        'var v = Math.max(r, g, b), n = v - Math.min(r, g, b);',
+        'var h = n === 0 ? 0 : n && v === r ? (g - b) / n : v === g ? 2 + (b - r) / n : 4 + (r - g) / n;',
+        'return [60 * (h < 0 ? h + 6 : h), v && (n / v) * 100, v * 100].join(\',\');',
+        '}'
+      ])
+    return hsbConversion
+  }
+}

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
@@ -171,4 +171,34 @@ export default function (f7) {
     let code = '{' + elements.join(', ') + '}'
     return [code, Blockly.JavaScript.ORDER_ATOMIC]
   }
+
+  /*
+  * Allows retrieving parameters provided by a rule
+  * Blockly part
+  */
+  Blockly.Blocks['dicts_get'] = {
+    init: function () {
+      this.setStyle('list_blocks')
+      this.appendValueInput('key')
+        .appendField('get')
+        .setCheck('String')
+      this.appendValueInput('varName')
+        .appendField('from dictionary')
+        .setCheck('String')
+      this.setInputsInline(true)
+      this.setOutput(true, 'String')
+      this.setTooltip('Retrieve a specified attribute from the context that could be set from a calling rule or script')
+    }
+  }
+
+  /*
+  * Allows retrieving parameters provided by a rule
+  * Code part
+  */
+  Blockly.JavaScript['dicts_get'] = function (block) {
+    const key = Blockly.JavaScript.valueToCode(block, 'key', Blockly.JavaScript.ORDER_ATOMIC)
+    const varName = Blockly.JavaScript.valueToCode(block, 'varName', Blockly.JavaScript.ORDER_ATOMIC).replace(/'/g, '')
+    let code = `${varName}[${key}]`
+    return [code, 0]
+  }
 }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -22,7 +22,7 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Calls a script file which must be located in the $OPENHAB_CONF/scripts folder')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#openhab-subsystem-actions')
     }
   }
 
@@ -117,13 +117,13 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
         const type = thisBlock.getFieldValue('type')
         switch (type) {
           case 'MAP':
-            return 'transforms an input via a map file. Specify the file as the function'
+            return 'transforms an input via a map file. Specify the file as the function.\nREGEX und JSONPATH are also valid.'
           case 'REGEX':
-            return 'transforms / filters an input by applying the provided regular expression'
+            return 'transforms / filters an input by applying the provided regular expression.\nMAP und JSONPATH are also valid.'
           case 'JSONPATH':
-            return 'transforms / filters an JSON input by executing the provided JSONPath query'
+            return 'transforms / filters an JSON input by executing the provided JSONPath query.\nMAP und REGEX are also valid.'
           default:
-            return 'transforms the input with the ' + type + ' transformation'
+            return 'transforms the input with the ' + type + ' transformation.'
         }
       })
       this.setHelpUrl(function () {
@@ -160,7 +160,9 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
           ['previous state of item', 'oldItemState'],
           ['triggering item name', 'itemName'],
           ['received command', 'itemCommand'],
-          ['triggered channel', 'channel']]),
+          ['triggered channel', 'channel'],
+          ['triggered event', 'event']
+        ]),
         'contextInfo')
       this.setInputsInline(true)
       this.setOutput(true, null)
@@ -175,7 +177,8 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
           'oldItemState': 'the old item state (only applicable for rules with triggers related to changed and updated items)',
           'itemName': 'the item name that caused the event (if relevant)',
           'itemCommand': 'the command name that triggered the event',
-          'channel': 'the channel UID that triggered the event (only applicable for rules including a "trigger channel fired" event)'
+          'channel': 'the channel UID that triggered the event (only applicable for rules including a "trigger channel fired" event)',
+          'event': 'the channel event type that triggered the event (only applicable for rules including a "trigger channel fired" event)'
         }
         return TIP[contextData]
       })
@@ -213,5 +216,31 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
     const key = Blockly.JavaScript.valueToCode(block, 'key', Blockly.JavaScript.ORDER_ATOMIC)
     let code = `ctx[${key}]`
     return [code, 0]
+  }
+
+  /*
+  * Allows inlining arbitrary code
+  * Blockly part
+  */
+  Blockly.Blocks['oh_script_inline'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('inline script')
+        .appendField(new Blockly.FieldMultilineInput('insert javascript code here (multiple lines are supported)'), 'inlineScript')
+      this.setInputsInline(true)
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setColour(0)
+      this.setTooltip('Allows inlining arbitrary script code which has to be syntactically correct')
+    }
+  }
+
+  /*
+  * Allows inlining arbitrary code
+  * Code part
+  */
+  Blockly.JavaScript['oh_script_inline'] = function (block) {
+    const code = block.getFieldValue('inlineScript') + '\n'
+    return code
   }
 }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -225,9 +225,10 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
   Blockly.Blocks['oh_script_inline'] = {
     init: function () {
       this.appendDummyInput()
-        .appendField('inline script')
-        .appendField(new Blockly.FieldMultilineInput('insert javascript code here (multiple lines are supported)'), 'inlineScript')
-      this.setInputsInline(true)
+        .appendField('inline script (advanced)')
+      this.appendDummyInput()
+        .appendField(new Blockly.FieldMultilineInput('for (var i = 0; i < 10; i++) {\n  print(i.toString());\n}'), 'inlineScript')
+      this.setInputsInline(false)
       this.setPreviousStatement(true, null)
       this.setNextStatement(true, null)
       this.setColour(0)

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
@@ -60,7 +60,7 @@ export default function defineOHBlocks_Variables (f7) {
       this.setInputsInline(true)
       this.setOutput(true, null)
       this.setColour(0)
-      this.setTooltip('retrieves the value that was previously stored for that particular script/rule')
+      this.setTooltip('returns whether the given value is undefined')
       this.setHelpUrl('')
     }
   }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
@@ -52,6 +52,25 @@ export default function defineOHBlocks_Variables (f7) {
     return [code, Blockly.JavaScript.ORDER_NONE]
   }
 
+  Blockly.Blocks['oh_check_undefined_value'] = {
+    init: function () {
+      this.appendValueInput('key')
+      this.appendDummyInput()
+        .appendField('is undefined')
+      this.setInputsInline(true)
+      this.setOutput(true, null)
+      this.setColour(0)
+      this.setTooltip('retrieves the value that was previously stored for that particular script/rule')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_check_undefined_value'] = function (block) {
+    let key = Blockly.JavaScript.valueToCode(block, 'key', Blockly.JavaScript.ORDER_ATOMIC)
+    let code = `typeof this.storedValues[${key}] === 'undefined'`
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  }
+
   function addStoredValues () {
     let storedValues = 'if (typeof this.storedValues === \'undefined\') {\n  this.storedValues = [];\n}'
     Blockly.JavaScript.provideFunction_('storedValues', [storedValues])

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
@@ -10,7 +10,8 @@ import defineTimerBlocks from './blocks-timers'
 import defineValueStorageBlocks from './blocks-valuestorage'
 import defineEphemerisBlocks from './blocks-ephemeris'
 import defineScriptsBlocks from './blocks-scripts'
-import definePeristenceBlocks from './blocks-persistence'
+import definePersistenceBlocks from './blocks-persistence'
+import defineColorBlocks from './blocks-color'
 import { defineLibraries } from './libraries'
 
 import Blockly from 'blockly'
@@ -28,6 +29,7 @@ export default function (f7, libraryDefinitions, data) {
   defineValueStorageBlocks(f7)
   defineEphemerisBlocks(f7)
   defineScriptsBlocks(f7)
-  definePeristenceBlocks(f7)
+  definePersistenceBlocks(f7)
+  defineColorBlocks(f7)
   defineLibraries(libraryDefinitions)
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -263,12 +263,12 @@
         <block type="lists_sort" />
         <sep gap="48" />
         <block type="dicts_create_with" />
-        <block type="dicts_get" >
-            <value name="key">
-              <shadow type="text">
-                <field name="TEXT">key</field>
-              </shadow>
-            </value>
+        <block type="dicts_get">
+          <value name="key">
+            <shadow type="text">
+              <field name="TEXT">key</field>
+            </shadow>
+          </value>
         </block>
       </category>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -708,6 +708,7 @@
               </shadow>
             </value>
           </block>
+          <sep gap="48" />
           <block type="oh_script_inline" />
         </category>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -263,6 +263,13 @@
         <block type="lists_sort" />
         <sep gap="48" />
         <block type="dicts_create_with" />
+        <block type="dicts_get" >
+            <value name="key">
+              <shadow type="text">
+                <field name="TEXT">key</field>
+              </shadow>
+            </value>
+        </block>
       </category>
 
       <category name="Color" colour="%{BKY_COLOUR_HUE}">
@@ -302,6 +309,7 @@
             </shadow>
           </value>
         </block>
+        <block type="oh_color_to_hsb" />
       </category>
 
       <category name="openHAB" colour="0">
@@ -649,6 +657,13 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_check_undefined_value">
+            <value name="key">
+              <shadow type="text">
+                <field name="TEXT">key</field>
+              </shadow>
+            </value>
+          </block>
         </category>
 
         <category name="Run &amp; Process">
@@ -693,6 +708,7 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_script_inline" />
         </category>
 
         <category name="Logging &amp; Output">


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

Add a block that converts blockly’s rgb block with hexadecimal color representation to openhab HSB
Add a block that allows retrieving dictionary key / values
Add triggeredEvent to “contextual info” block
Add block to check if a stored value exists
Add block that allows to inline script