### PR TITLE
Labelling of items in Model tab pages (Equipment & Properties)

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
@@ -65,6 +65,12 @@ export default {
     }
   },
   methods: {
+    itemPathLabel (item) {
+      if (!item.modelPath) return '(?) > ' + item.name
+      return item.modelPath.map((parent) => {
+        return parent.label || parent.name
+      }).join(' > ')
+    },
     cardOpening () {
       this.cardId = this.title + '-' + this.$f7.utils.id()
       history.pushState({ cardId: this.cardId }, null, window.location.href.split('#card=')[0] + '#' + this.$f7.utils.serializeObject({ card: this.element.key }))

--- a/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
@@ -35,13 +35,13 @@ export default {
   },
   computed: {
     listContext () {
-      const standaloneEquipment = this.element.equipment.filter((i) => i.points.length === 0).map((i) => itemDefaultListComponent(i.item, true))
+      const standaloneEquipment = this.element.equipment.filter((i) => i.points.length === 0).map((i) => itemDefaultListComponent(i.item, this.itemPathLabel(i.item)))
       const equipmentWithPoints = this.element.equipment.filter((i) => i.points.length !== 0).map((i) => {
         return [
           {
             component: 'oh-list-item',
             config: {
-              title: i.item.label || i.item.name,
+              title: [this.itemPathLabel(i.item), i.item.label || i.item.name].filter((label) => label && label.length > 0).join(' > '),
               divider: true
             }
           },

--- a/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
@@ -54,7 +54,7 @@ export default {
               divider: true
             }
           },
-          ...this.itemsByPointType[pointType].map((p) => itemDefaultListComponent(p, true))
+          ...this.itemsByPointType[pointType].map((p) => itemDefaultListComponent(p, this.itemPathLabel(p)))
         ])
       }
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -3,7 +3,7 @@
    in the "listWidget" metadata namespace of the item
  */
 
-export default function itemDefaultListComponent (item, itemNameAsFooter) {
+export default function itemDefaultListComponent (item, itemNameAsFooterOrLocation) {
   const stateDescription = item.stateDescription || {}
   const metadata = (item.metadata && item.metadata.listWidget) ? item.metadata.listWidget : {}
   let component = null
@@ -98,7 +98,8 @@ export default function itemDefaultListComponent (item, itemNameAsFooter) {
   if (!component.config.title) component.config.title = item.label || item.name
   if (item.category && !component.config.icon) component.config.icon = 'oh:' + item.category
   if (item.category && ['Switch', 'Rollershutter', 'Contact', 'Dimmer', 'Group'].indexOf(item.type) >= 0) component.config.iconUseState = true
-  if (item.label && itemNameAsFooter) component.config.footer = item.name
+  if (item.label && itemNameAsFooterOrLocation === true) component.config.footer = item.name
+  else if (item.label && itemNameAsFooterOrLocation) component.config.footer = itemNameAsFooterOrLocation
   if (!item.category) component.config.fallbackIconToInitial = true
 
   return component

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -26,8 +26,8 @@
 
 <style lang="stylus">
 .item-divider > span
-  flex-shrink:1
-  overflow: hidden;
+  flex-shrink 1
+  overflow hidden
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-list-button v-if="config.listButton && !context.editmode" :title="config.title || 'Action'" :color="config.color || 'blue'" @click="performAction" />
-  <f7-list-item divider :title="config.title" v-else-if="config.divider && !context.editmode" />
+  <f7-list-item divider ref="divider" :title="config.title" v-else-if="config.divider && !context.editmode" />
   <f7-list-item v-else v-bind="config" :divider="config.divider && !context.editmode"
                 :media-item="context.parent.component.config.mediaList && !config.divider"
                 :badge="(config.divider) ? 'Divider' : (config.listButton) ? 'List button' : config.badge"
@@ -24,6 +24,12 @@
   </f7-list-item>
 </template>
 
+<style lang="stylus">
+.item-divider > span
+  flex-shrink:1
+  overflow: hidden;
+</style>
+
 <script>
 import mixin from '../../widget-mixin'
 import { actionsMixin } from '../../widget-actions'
@@ -32,6 +38,49 @@ import { OhListItemDefinition } from '@/assets/definitions/widgets/standard/list
 export default {
   name: 'oh-list-item',
   mixins: [mixin, actionsMixin],
-  widget: OhListItemDefinition
+  widget: OhListItemDefinition,
+  mounted () {
+    mixin.mounted.call(this)
+    if (this.config.divider && !this.context.editmode) {
+      this.$nextTick(function () {
+        this.trimTitle()
+      })
+    }
+  },
+  created () {
+    if (this.config.divider && !this.context.editmode) {
+      window.addEventListener('resize', this.duringResize)
+    }
+  },
+  destroyed () {
+    window.removeEventListener('resize', this.duringResize)
+    if (this.timer) clearTimeout(this.timer)
+  },
+  methods: {
+    duringResize () {
+      if (this.timer) clearTimeout(this.timer)
+      this.timer = setTimeout(this.resized, 200)
+    },
+    resized () {
+      if (this.$refs.divider && this.$refs.divider.$el && this.$refs.divider.$el.firstChild) {
+        this.$refs.divider.$el.firstChild.textContent = this.config.title
+      }
+      this.trimTitle()
+    },
+    trimTitle () {
+      if (this.$refs.divider && this.$refs.divider.$el && this.$refs.divider.$el.firstChild) {
+        let element = this.$refs.divider.$el.firstChild
+        let trimCount = 0
+        if (element.scrollWidth > element.offsetWidth) {
+          let value = '…' + element.textContent
+          do {
+            value = '…' + value.substr(2)
+            trimCount++
+            element.textContent = value
+          } while (element.scrollWidth > element.offsetWidth && trimCount < 100)
+        }
+      }
+    }
+  }
 }
 </script>


### PR DESCRIPTION
In order to have something understandable in Equipment/Properties model tab pages when having many Equipment and/or Properties of the same type (potentially having the same user-facing label), it is necessary to label them with something that allows to distinguish them from one another, which is usually the location of the equipment/point item.

This labelling is redundant with the labelling of the Location items to which these Equipment/Properties items may belong and leads to additional configuration work. In addition, it will clutter the pages in the Locations tab because all the items displayed there would have one common part which is the location, providing no user value in this context but more visual load (particularly problematic on small mobile screen where the end of the label, which may contain the most meaningful part will be trimmed).

This pull request provides some changes providing model context for the Equipment and Properties model tab pages. This  should allow having simple labels definition for items belonging to the model:

- In Equipment tab page cards: display the Location / Upper-level-equipment path in the divider title before items belonging to some equipment, trimming to preserve the end of this label if needed
- In Properties tab page cards: display the Location / Upper-level-equipment path in the subtitle of the item, instead of the item name (which I believe is not meant to be displayed in first-level user-facing non admin-level task pages)

Here is an illustration of the issue with the current version (3.2.0) with either short or complete labels used, and the resulting effect of the patch using the short labels.

Current status with model-redundant labels
![current-long labels](https://user-images.githubusercontent.com/11686092/148392831-c34ddb83-b04b-44b9-8aa1-e8c2df486308.gif)

Current status with short labels
![current-short labels](https://user-images.githubusercontent.com/11686092/148393628-fdc37823-f427-4c16-80b7-6b1f6bc9cc51.gif)

Pull request version with short labels
![patched-short labels](https://user-images.githubusercontent.com/11686092/148393686-d3bd90d9-5329-454e-9912-27713afcb98d.gif)


