### PR TITLE
Upgrade to Karaf 4.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
     <bnd.version>6.1.0</bnd.version>
     <eea.version>2.3.0</eea.version>
-    <karaf.version>4.3.4</karaf.version>
+    <karaf.version>4.3.6</karaf.version>
     <ohc.version>3.3.0-SNAPSHOT</ohc.version>
     <sat.version>0.12.0</sat.version>
     <spotless.version>2.0.3</spotless.version>


### PR DESCRIPTION
Syncs the karaf.version so the new Maven plugin is used.

---

Related to openhab/openhab-distro#1363