### PR TITLE
fix homekit config - make boolean to text

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
@@ -222,14 +222,24 @@ const valveTypeParameter = {
 const invertedParameter = {
   name: 'inverted',
   label: 'inverted',
-  type: 'BOOLEAN',
-  description: 'invert the value for HomeKit'
+  type: 'TEXT',
+  description: 'invert the value for HomeKit (default is true)',
+  limitToOptions: true,
+  options: [
+    { value: 'false', label: 'false' },
+    { value: 'true', label: 'true' }
+  ]
 }
 
 const valveTimerParameter = {
   name: 'homekitTimer',
   label: 'Timer',
-  type: 'BOOLEAN'
+  type: 'TEXT',
+  limitToOptions: true,
+  options: [
+    { value: 'false', label: 'false' },
+    { value: 'true', label: 'true' }
+  ]
 }
 
 const valveDefaultDuration = {


### PR DESCRIPTION
currently, the homekit true/false values are defined in main UI as BOOLEAN values but 
according to HomeKit binding documentation and confirmed in this thread, 
https://community.openhab.org/t/homekit-rollershutter-are-reversed/110862/22

the true/false values must be TEXT and not BOOLEAN values.

this PR fix this



Signed-off-by: Eugen Freiter <freiter@gmx.de>