### PR TITLE
Location sensitive model tab pages sorting

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
@@ -1,11 +1,46 @@
-
 export function compareItems (i1, i2) {
+  const isLocationContext = i1.metadata && i1.metadata.semantics && i1.metadata.semantics.value.indexOf('Location') === 0 &&
+    i2.metadata && i2.metadata.semantics && i2.metadata.semantics.value.indexOf('Location') === 0
+
+  // Compare widgetOrder
   const order1 = (i1.metadata && i1.metadata.widgetOrder) ? i1.metadata.widgetOrder.value : Infinity
   const order2 = (i2.metadata && i2.metadata.widgetOrder) ? i2.metadata.widgetOrder.value : Infinity
-  if (order1 === order2) {
-    const nameOrLabel1 = i1.label || i1.name
-    const nameOrLabel2 = i2.label || i2.name
-    return nameOrLabel1.localeCompare(nameOrLabel2)
+  const widgetOrder = (order1 !== order2) ? ((order1 < order2) ? -1 : 1) : 0
+
+  // When comparing Location Items compare on ancestors first
+  if (!isLocationContext && widgetOrder !== 0) return widgetOrder
+
+  // Compare ancestors in Model (starting at the top level)
+  let modelOrder = 0
+  if (i1.modelPath && i2.modelPath) {
+    const minDepth = Math.min(i1.modelPath.length, i2.modelPath.length) // Compare shortest path
+    for (let d = 0; d < minDepth; d++) {
+      if (i1.modelPath[d] === i2.modelPath[d]) continue
+
+      // widgetOrder comparison...
+      const order1 = (i1.modelPath[d].metadata && i1.modelPath[d].metadata.widgetOrder) ? i1.modelPath[d].metadata.widgetOrder.value : Infinity
+      const order2 = (i2.modelPath[d].metadata && i2.modelPath[d].metadata.widgetOrder) ? i2.modelPath[d].metadata.widgetOrder.value : Infinity
+      if (order1 !== order2) {
+        modelOrder = (order1 < order2) ? -1 : 1
+        break
+      }
+
+      // ... or lexicographical comparison
+      const nameOrLabel1 = i1.modelPath[d].label || i1.modelPath[d].name
+      const nameOrLabel2 = i2.modelPath[d].label || i2.modelPath[d].name
+      modelOrder = nameOrLabel1.localeCompare(nameOrLabel2)
+      if (modelOrder !== 0) break
+    }
+
+    // A parent compares greater than its children
+    if (modelOrder === 0 && (i1.modelPath.length !== i2.modelPath.length)) modelOrder = (i1.modelPath.length < i2.modelPath.length) ? -1 : 1
+
+    if (modelOrder !== 0) return modelOrder
   }
-  return (order1 < order2) ? -1 : 1
+  if (widgetOrder !== 0) return widgetOrder // For Locations Items, own-item widgetOrder only used to compare Items sharing the same parent location
+
+  // Compare label/name
+  const nameOrLabel1 = i1.label || i1.name
+  const nameOrLabel2 = i2.label || i2.name
+  return nameOrLabel1.localeCompare(nameOrLabel2)
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
@@ -7,10 +7,23 @@ export function compareItems (i1, i2) {
   const order2 = (i2.metadata && i2.metadata.widgetOrder) ? i2.metadata.widgetOrder.value : Infinity
   const widgetOrder = (order1 !== order2) ? ((order1 < order2) ? -1 : 1) : 0
 
-  // When comparing Location Items compare on ancestors first
+  // Unless comparing Location Items simply return the order based on widgetOrder metadata if determined
   if (!isLocationContext && widgetOrder !== 0) return widgetOrder
 
   // Compare ancestors in Model (starting at the top level)
+  const modelOrder = compareParents(i1, i2)
+  if (modelOrder !== 0) return modelOrder
+  if (widgetOrder !== 0) return widgetOrder // For Locations Items, own-item widgetOrder only used to compare Items sharing the same parent location
+
+  // Compare label/name
+  const nameOrLabel1 = i1.label || i1.name
+  const nameOrLabel2 = i2.label || i2.name
+  return nameOrLabel1.localeCompare(nameOrLabel2)
+}
+
+// Compares items based on widgetOrder or lexicographical order of their ancestors in Model (starting at the top level)
+// Returns 0 if both items are siblings.
+export function compareParents (i1, i2) {
   let modelOrder = 0
   if (i1.modelPath && i2.modelPath) {
     const minDepth = Math.min(i1.modelPath.length, i2.modelPath.length) // Compare shortest path
@@ -34,13 +47,6 @@ export function compareItems (i1, i2) {
 
     // A parent compares greater than its children
     if (modelOrder === 0 && (i1.modelPath.length !== i2.modelPath.length)) modelOrder = (i1.modelPath.length < i2.modelPath.length) ? -1 : 1
-
-    if (modelOrder !== 0) return modelOrder
   }
-  if (widgetOrder !== 0) return widgetOrder // For Locations Items, own-item widgetOrder only used to compare Items sharing the same parent location
-
-  // Compare label/name
-  const nameOrLabel1 = i1.label || i1.name
-  const nameOrLabel2 = i2.label || i2.name
-  return nameOrLabel1.localeCompare(nameOrLabel2)
+  return modelOrder
 }


### PR DESCRIPTION
This PR performs the following changes when sorting items displayed in the model tab pages:
- When sorting 2 locations (Locations tab), sorting is first performed according to the ancestors widgetOrder, so that locations within the same parent appear grouped according to the choice of the administrator, then use the widgetOrder among all locations of the same parent, before finally using lexicographical comparison.

- When sorting 2 equipment (Equipment tab) or 2 properties (Properties tab), sorting is performed according to the widgetOrder. If undefined (or equal), sorting is performed according to the location (taking into account all ancestors). then only if undefined/equal does lexicographical comparison takes place. 

> In this situation, location-sensitive sorting is performed before label, this is a change of design but makes more sense IMHO: Let's say you have 12 OpenState properties, 10 "Doors" in various rooms and 1 "Main Door" and 1 "Back Door" in the same room, the status of the 2 doors of the same room will still appear next to each other in the properties page rather than completely spread apart with current design.

Performance measurement on sample installation with 600 items in model yields no measurable difference (using `performance.now()`,  2.3GHz intel Core i9: average model data processing ~150ms).