### PR TITLE
Disable user-select on user facing pages (run mode) to prevent text selection issues

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-item.vue
@@ -45,7 +45,7 @@
         </f7-menu-dropdown>
       </f7-menu-item>
     </f7-menu>
-    <div @click.capture="eventControl" style="width: 100%; height: 100%; position:absolute;">
+    <div @click.capture="eventControl" style="width: 100%; height: 100%; position:absolute;" class="disable-user-select">
       <oh-placeholder-widget v-if="context.editmode && !context.component.slots.default.length" @click="context.editmode.addWidget(context.component, null, context.parent)" class="oh-canvas-item-content" />
       <generic-widget-component v-else-if="context.component.slots.default.length" :context="childContext(context.component.slots.default[0])" @command="onCommand" class="oh-canvas-item-content"
                                 :class="{

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="ohCanvasLayout" class="oh-canvas-layout" :class="context.editMode ? 'margin-top' : ''">
+  <div ref="ohCanvasLayout" class="oh-canvas-layout disable-user-select" :class="context.editMode ? 'margin-top' : ''">
     <f7-block v-if="context.editmode">
       <f7-menu class="configure-layout-menu">
         <f7-menu-item
@@ -72,7 +72,6 @@
         background: context.editmode
           ? 'var(--f7-page-master-border-color)'
           : false,
-        'user-select': context.editmode ? 'none' : 'auto',
         width: style.width + 'px',
         height: style.height + 'px',
         transform: `scale(${style.scale})`,
@@ -97,7 +96,7 @@
           left: 0;
         ">
         <img
-          class="oh-canvas-background"
+          class="oh-canvas-background disable-user-drag"
           :src="config.imageUrl"
           :srcset="config.imageSrcSet">
       </div>

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -274,12 +274,8 @@ html
 
 // Disable user select causing distracting text selection upon long press on phones/tablets
 .disable-user-select
-  -webkit-user-select none
-  -moz-user-select none
-  -ms-user-select none
   user-select none
 
 // Disable user dragging of background images in canvas layouts
 .disable-user-drag
   user-drag none
-  -webkit-user-drag none

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -270,3 +270,16 @@ html
 
 // .card-backdrop-out
 //   animation card-backdrop-fade-out 400ms forwards
+
+
+// Disable user select causing distracting text selection upon long press on phones/tablets
+.disable-user-select
+  -webkit-user-select none
+  -moz-user-select none
+  -ms-user-select none
+  user-select none
+
+// Disable user dragging of background images in canvas layouts
+.disable-user-drag
+  user-drag none
+  -webkit-user-drag none

--- a/bundles/org.openhab.ui/web/src/pages/group/group-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/group/group-popup.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-popup @popup:open="onOpen" @popup:close="onClose">
-    <f7-page class="analyzer-content">
+    <f7-page class="analyzer-content disable-user-select">
       <f7-navbar :title="(item) ? item.label || item.name : ''" :back-link="$t('dialogs.back')" />
 
       <div class="group-item-control no-padding no-margin">

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page stacked name="HomePage" class="page-home" :class="{ 'standard-background': $f7.data.themeOptions.homeBackground === 'standard' }" @page:init="onPageInit" @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
-    <f7-navbar :large="$f7.data.themeOptions.homeNavbar !== 'simple'" :large-transparent="$f7.data.themeOptions.homeNavbar !== 'simple'" class="home-nav">
+    <f7-navbar :large="$f7.data.themeOptions.homeNavbar !== 'simple'" :large-transparent="$f7.data.themeOptions.homeNavbar !== 'simple'" class="home-nav disable-user-select">
       <f7-nav-left>
         <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
       </f7-nav-left>

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="disable-user-select">
     <div v-for="(elements, idx) in groups" :key="idx">
       <f7-block-title medium v-if="elements.length > 0 && elements[0].separator">
         {{ elements[0].separator }}

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" hide-bars-on-scroll :style="pageStyle">
-    <f7-navbar v-if="!page || !page.config.hideNavbar" :back-link="(showBackButton) ? $t('page.navbar.back') : undefined">
+    <f7-navbar v-if="!page || !page.config.hideNavbar" :back-link="(showBackButton) ? $t('page.navbar.back') : undefined" class="disable-user-select">
       <f7-nav-left v-if="!showBackButton">
         <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
       </f7-nav-left>

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" hide-bars-on-scroll :style="pageStyle">
+  <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" hide-bars-on-scroll :style="pageStyle" class="disable-user-select">
     <f7-navbar v-if="!page || !page.config.hideNavbar" :back-link="(showBackButton) ? $t('page.navbar.back') : undefined" class="disable-user-select">
       <f7-nav-left v-if="!showBackButton">
         <f7-link icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />


### PR DESCRIPTION
Disable user-select on user facing pages (run mode) to prevent text selection issues

On iOS particularly, there are some issues when performing involuntary long presses while browsing and manipulation of main UI page, text in the displayed page or sometimes in background invisible pages can be highlighted which disrupts user manipulation. This patch prevents user selection on runtime pages to avoid these issues.

I had no access to Android device to test if the issue occurs but the patch has been made to also cover this platform.

Example of issue before PR applied:
![user-select-orig](https://user-images.githubusercontent.com/11686092/149985537-663ac827-31d2-4586-817d-3ad3eed40178.gif)

Result with PR applied:
![user-select-patched](https://user-images.githubusercontent.com/11686092/149985548-38ef5305-da86-4eca-8836-a18474630af5.gif)
