### PR TITLE
Configuration option to hide item state in main UI list widgets

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/listitems.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/listitems.js
@@ -9,6 +9,7 @@ export const ListItemParameters = () => [
   pt('title', 'Title', 'Title of the item'),
   pt('subtitle', 'Subtitle', 'Subtitle of the item'),
   pt('after', 'After', 'Text to display on the opposite side of the item (set either this or a badge)').a(),
+  pb('hideState', 'Hide State', 'Do not display the state of the item at all').a(),
   pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),
   pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons').a(),
   pb('iconUseState', 'Icon depends on state', 'Use the state of the item to get a dynamic icon (for openHAB icons only)').a()

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/listitems.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/listitems.js
@@ -9,7 +9,6 @@ export const ListItemParameters = () => [
   pt('title', 'Title', 'Title of the item'),
   pt('subtitle', 'Subtitle', 'Subtitle of the item'),
   pt('after', 'After', 'Text to display on the opposite side of the item (set either this or a badge)').a(),
-  pb('hideState', 'Hide State', 'Do not display the state of the item at all').a(),
   pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),
   pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons').a(),
   pb('iconUseState', 'Icon depends on state', 'Use the state of the item to get a dynamic icon (for openHAB icons only)').a()

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
@@ -1,7 +1,7 @@
 <template>
   <oh-list-item :context="context">
     <div slot="after">
-      {{ context.store[config.item].displayState || context.store[config.item].state }}
+      {{ config.hideState ? '' : context.store[config.item].displayState || context.store[config.item].state }}
     </div>
   </oh-list-item>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
@@ -1,7 +1,7 @@
 <template>
   <oh-list-item :context="context">
-    <div slot="after">
-      {{ config.hideState ? '' : context.store[config.item].displayState || context.store[config.item].state }}
+    <div slot="after" v-if="config.after === undefined">
+      {{ context.store[config.item].displayState || context.store[config.item].state }}
     </div>
   </oh-list-item>
 </template>


### PR DESCRIPTION
With a standard label card it is possible to replace the item label using the label parameter. On list items, there is the possibility to add labels before or after the item state, but never to modify the item state itself. There is now way to override this even using a transformation for pure command items because the items always remain NULL. For these items, I found no way to hide the "NULL" label in the UI while preserving the built-in commands capability.

With this patch, it is possible to take full benefit of the oh-label-item automatic creation (giving access to the list of possible commands to be sent for example for a Number item with commandDescription metadata set), but not display the ugly "NULL" label.

Some related issues:
[https://community.openhab.org/t/hide-item-state-for-group-items-in-widget/117121](https://community.openhab.org/t/hide-item-state-for-group-items-in-widget/117121)
[https://community.openhab.org/t/how-to-get-rid-of-item-states-undef-or-null-in-main-ui/126013](https://community.openhab.org/t/how-to-get-rid-of-item-states-undef-or-null-in-main-ui/126013)

I use this for example to command KNX scenes (via the popup list), which are items without a valid state. With the single parameter set, the default rendering is perfect.