### PR TITLE
New option to display equipment as accordion in Locations cards

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
@@ -24,20 +24,20 @@ export const OhHomePageDefinition = () => new WidgetDefinition('oh-home-page', '
 const EquipmentListParameterGroup = () => pg('equipmentList', 'Equipment List', 'General settings for equipment lists in this tab')
 
 const EquipmentListParameters = () => [
-  pt('eqptNesting', 'Display sub-equipment levels')
+  pt('equipmentNesting', 'Display sub-equipment levels')
     .o([
       { value: 'nested', label: 'Nested pages for sub-equipment (default)' },
       { value: 'accordion', label: 'Equipment items grouped as accordion cards' }
     ]),
-  pb('eqptPromoteSingle', 'Promote single item equipments', 'Display groups with a single Point as a single item'),
-  pb('eqptPromoteMain', 'Promote the main item of an equipment', 'Promote the main item of an equipment (widgetOrder equal to 0) as the equipment representation'),
-  pt('eqptPromotedLabel', 'Label promoted elements', 'Choose what elements to display in label of promoted items')
+  pb('equipmentPromoteSingle', 'Promote single item equipments', 'Display groups with a single Point as a single item'),
+  pb('equipmentPromoteMain', 'Promote the main item of an equipment', 'Promote the main item of an equipment (widgetOrder equal to 0) as the equipment representation'),
+  pt('equipmentPromotedLabel', 'Label promoted elements', 'Choose what elements to display in label of promoted items')
     .o([
       { value: 'equipment', label: 'Label of the equipment' },
       { value: 'separator', label: 'Separator character (>)' },
       { value: 'item', label: 'Label of the item within the equipment' }
     ]).m().v((value, configuration, configDescription, parameters) => {
-      return configuration.eqptPromoteSingle === true || configuration.eqptPromoteMain === true
+      return configuration.equipmentPromoteSingle === true || configuration.equipmentPromoteMain === true
     })
 ]
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
@@ -29,15 +29,17 @@ const EquipmentListParameters = () => [
       { value: 'nested', label: 'Nested pages for sub-equipment (default)' },
       { value: 'accordion', label: 'Equipment items grouped as accordion cards' }
     ]),
-  pb('equipmentPromoteSingle', 'Promote single item equipments', 'Display groups with a single Point as a single item'),
-  pb('equipmentPromoteMain', 'Promote the main item of an equipment', 'Promote the main item of an equipment (widgetOrder equal to 0) as the equipment representation'),
-  pt('equipmentPromotedLabel', 'Label promoted elements', 'Choose what elements to display in label of promoted items')
+  pb('equipmentPromoteSingle', 'Promote single Points', 'Flatten equipment which only have a single Point (only display the Point as the Equipment\'s representation')
+    .v((value, configuration, configDescription, parameters) => { return configuration.equipmentNesting === 'accordion' }),
+  pb('equipmentPromoteMain', 'Promote the main Point of an Equipment', 'Promote the main Point item of an Equipment (widgetOrder equal to 0) as the Equipment\'s representation')
+    .v((value, configuration, configDescription, parameters) => { return configuration.equipmentNesting === 'accordion' }),
+  pt('equipmentPromotedLabel', 'Label for promoted elements', 'Choose what to include in the labels of promoted items')
     .o([
       { value: 'equipment', label: 'Label of the equipment' },
       { value: 'separator', label: 'Separator character (>)' },
       { value: 'item', label: 'Label of the item within the equipment' }
     ]).m().v((value, configuration, configDescription, parameters) => {
-      return configuration.equipmentPromoteSingle === true || configuration.equipmentPromoteMain === true
+      return (configuration.equipmentPromoteSingle === true || configuration.equipmentPromoteMain === true) && configuration.equipmentNesting === 'accordion'
     })
 ]
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
@@ -21,6 +21,32 @@ export const OhHomePageDefinition = () => new WidgetDefinition('oh-home-page', '
       ]).m()
   ])
 
+const EquipmentListParameterGroup = () => pg('equipmentList', 'Equipment List', 'General settings for equipment lists in this tab')
+
+const EquipmentListParameters = () => [
+  pt('eqptNesting', 'Display sub-equipment levels')
+    .o([
+      { value: 'nested', label: 'Nested pages for sub-equipment (default)' },
+      { value: 'accordion', label: 'Equipment items grouped as accordion cards' }
+    ]),
+  pb('eqptPromoteSingle', 'Promote single item equipments', 'Display groups with a single Point as a single item'),
+  pb('eqptPromoteMain', 'Promote the main item of an equipment', 'Promote the main item of an equipment (widgetOrder equal to 0) as the equipment representation'),
+  pt('eqptPromotedLabel', 'Label promoted elements', 'Choose what elements to display in label of promoted items')
+    .o([
+      { value: 'equipment', label: 'Label of the equipment' },
+      { value: 'separator', label: 'Separator character (>)' },
+      { value: 'item', label: 'Label of the item within the equipment' }
+    ]).m().v((value, configuration, configDescription, parameters) => {
+      return configuration.eqptPromoteSingle === true || configuration.eqptPromoteMain === true
+    })
+]
+
+export const OhLocationsTabParameters = () => new WidgetDefinition('oh-locations-tab', 'Locations Tab', 'The tab showing all locations of the installation')
+  .paramGroup(EquipmentListParameterGroup(), EquipmentListParameters())
+
+export const OhEquipmentTabParameters = () => new WidgetDefinition('oh-equipment-tab', 'Equipment Tab', 'The tab showing all equipment of the installation, by category')
+  .paramGroup(EquipmentListParameterGroup(), EquipmentListParameters())
+
 const ModelCardParameterGroup = () => pg('card', 'Model Card', 'General settings for this card')
 
 const ModelCardParameters = () => [

--- a/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
@@ -65,12 +65,6 @@ export default {
     }
   },
   methods: {
-    itemPathLabel (item) {
-      if (!item.modelPath) return '(?) > ' + item.name
-      return item.modelPath.map((parent) => {
-        return parent.label || parent.name
-      }).join(' > ')
-    },
     cardOpening () {
       this.cardId = this.title + '-' + this.$f7.utils.id()
       history.pushState({ cardId: this.cardId }, null, window.location.href.split('#card=')[0] + '#' + this.$f7.utils.serializeObject({ card: this.element.key }))

--- a/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
@@ -30,6 +30,7 @@ import ModelCard from './model-card.vue'
 
 export default {
   mixins: [mixin, CardMixin],
+  props: ['tabContext'],
   components: {
     ModelCard
   },

--- a/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
@@ -24,7 +24,7 @@
 
 <script>
 import mixin from '@/components/widgets/widget-mixin'
-import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
+import itemDefaultListComponent, { equipmentListComponent } from '@/components/widgets/standard/list/default-list-item'
 import CardMixin from './card-mixin'
 import ModelCard from './model-card.vue'
 
@@ -36,31 +36,9 @@ export default {
   },
   computed: {
     listContext () {
-      const standaloneEquipment = this.element.equipment.filter((i) => i.points.length === 0).map((i) => itemDefaultListComponent(i.item, this.itemPathLabel(i.item)))
-      const equipmentWithPoints = this.element.equipment.filter((i) => i.points.length !== 0).map((i) => {
-        return [
-          {
-            component: 'oh-list-item',
-            config: {
-              title: [this.itemPathLabel(i.item), i.item.label || i.item.name].filter((label) => label && label.length > 0).join(' > '),
-              divider: true
-            }
-          },
-          ...i.points.map((p) => itemDefaultListComponent(p))
-        ]
-      })
-
       return {
         store: this.$store.getters.trackedItems,
-        component: {
-          component: 'oh-list',
-          config: {
-            mediaList: true
-          },
-          slots: {
-            default: [...standaloneEquipment, ...equipmentWithPoints].flat()
-          }
-        }
+        component: equipmentListComponent(this.element.equipment, this.tabContext, false)
       }
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
@@ -24,7 +24,7 @@
 
 <script>
 import mixin from '@/components/widgets/widget-mixin'
-import itemDefaultListComponent, { equipmentListComponent } from '@/components/widgets/standard/list/default-list-item'
+import { equipmentListComponent } from '@/components/widgets/standard/list/default-list-item'
 import CardMixin from './card-mixin'
 import ModelCard from './model-card.vue'
 

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -47,7 +47,7 @@
 
 <script>
 import mixin from '@/components/widgets/widget-mixin'
-import itemDefaultListComponent, { itemAccordionEquipmentComponent } from '@/components/widgets/standard/list/default-list-item'
+import itemDefaultListComponent, { equipmentListComponent } from '@/components/widgets/standard/list/default-list-item'
 import CardMixin from './card-mixin'
 import ModelCard from './model-card.vue'
 import StatusBadge from './glance/location/status-badge.vue'
@@ -85,39 +85,9 @@ export default {
       }
     },
     equipmentListContext () {
-      let components = []
-      const isAccordion = this.tabContext && this.tabContext.eqptNesting && this.tabContext.eqptNesting === 'accordion'
-      if (!isAccordion) {
-        const standaloneEquipment = this.element.equipment.filter((eqpt) => eqpt.item.equipmentOrPoints.length === 0).map((eqpt) => itemDefaultListComponent(eqpt.item))
-        const equipmentWithPoints = this.element.equipment.filter((eqpt) => eqpt.item.equipmentOrPoints.length !== 0).map((eqpt) => {
-          return [
-            {
-              component: 'oh-list-item',
-              config: {
-                title: eqpt.item.label || eqpt.item.name,
-                divider: true
-              }
-            },
-            ...eqpt.item.equipmentOrPoints.map((p) => itemDefaultListComponent(p))
-          ]
-        })
-        components = [...standaloneEquipment, ...equipmentWithPoints].flat()
-      } else {
-        components = this.element.item.equipmentOrPoints.map((item) => itemAccordionEquipmentComponent(item, this.tabContext || {}))
-      }
-
       return {
         store: this.$store.getters.trackedItems,
-        component: {
-          component: 'oh-list',
-          config: {
-            accordionEquipment: isAccordion,
-            mediaList: true
-          },
-          slots: {
-            default: [...components].flat()
-          }
-        }
+        component: equipmentListComponent(this.element.item.equipment, this.tabContext, true)
       }
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
@@ -29,7 +29,7 @@
 
 <script>
 import mixin from '@/components/widgets/widget-mixin'
-import itemDefaultListComponent from '@/components/widgets/standard/list/default-list-item'
+import itemDefaultListComponent, { itemPathLabel } from '@/components/widgets/standard/list/default-list-item'
 import CardMixin from './card-mixin'
 import ModelCard from './model-card.vue'
 import { loadLocaleMessages } from '@/js/i18n'
@@ -54,7 +54,7 @@ export default {
               divider: true
             }
           },
-          ...this.itemsByPointType[pointType].map((p) => itemDefaultListComponent(p, this.itemPathLabel(p)))
+          ...this.itemsByPointType[pointType].map((p) => itemDefaultListComponent(p, itemPathLabel(p)))
         ])
       }
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -105,6 +105,8 @@ export default function itemDefaultListComponent (item, itemNameAsFooterOrLocati
   return component
 }
 
+/* The functions below deal with specifically with equipment representation in the home page cards */
+
 export function itemPathLabel (item) {
   if (!item.modelPath) return '(?) > ' + item.name
   return item.modelPath.map((parent) => {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -104,3 +104,54 @@ export default function itemDefaultListComponent (item, itemNameAsFooterOrLocati
 
   return component
 }
+
+function promotedEquipmentContext (item, config) {
+  let c = itemDefaultListComponent(item)
+  const parts = (config.eqptPromotedLabel && config.eqptPromotedLabel.length > 0) ? config.eqptPromotedLabel : false
+  c.config.title = [
+    !parts || parts.includes('equipment') ? (item.parent.label || item.parent.name) : null, // Default setting: display parent name
+    parts && parts.includes('separator') ? '>' : null,
+    parts && parts.includes('item') ? (item.label || item.name) : null
+  ].flat().join(' ')
+  return c
+}
+
+export function itemAccordionEquipmentComponent (item, config) {
+  console.log('Accordion equipment context for ' + item.name)
+  if (item.equipmentOrPoints.length === 0) {
+    // Item is a point or equipment without points or sub-equipment
+    return itemDefaultListComponent(item)
+  }
+
+  if (item.equipmentOrPoints.length === 1 && config.eqptPromoteSingle) {
+    // TODO: take into account visibility for promoting single elements (do not count siblings not visible)
+    return promotedEquipmentContext(item.equipmentOrPoints[0], config)
+  }
+
+  // Try to promote main item based on widgetOrder metadata
+  let promoted = config.eqptPromoteMain ? item.points.find((p) => {
+    return p.metadata && p.metadata.widgetOrder && p.metadata.widgetOrder && p.metadata.widgetOrder.value && (+p.metadata.widgetOrder.value) === 0
+  }) : null
+
+  if (promoted) console.log(`Will promote ${promoted.name} for ${item.name}`)
+
+  let c = promoted ? promotedEquipmentContext(promoted, config) : itemDefaultListComponent(item)
+  c.config.action = undefined
+  c.config.after = ''
+  c.slots = {
+    accordion: [
+      {
+        component: 'oh-list',
+        config: {
+          mediaList: true,
+          accordionEquipment: true
+        },
+        slots: {
+          default: item.equipmentOrPoints.filter((i) => { return i !== promoted }).map((i) => itemAccordionEquipmentComponent(i, config))
+        }
+      }
+    ]
+  }
+
+  return c
+}

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -1,12 +1,14 @@
 <template>
-  <f7-list-button v-if="config.listButton && !context.editmode" :title="config.title || 'Action'" :color="config.color || 'blue'" @click="performAction" />
+  <f7-list-button v-if="config.listButton && !context.editmode" :title="config.title || 'Action'" :color="config.color || 'blue'" @click.stop="performAction" />
   <f7-list-item divider ref="divider" :title="config.title" v-else-if="config.divider && !context.editmode" />
   <f7-list-item v-else v-bind="config" :divider="config.divider && !context.editmode"
                 :media-item="context.parent.component.config.mediaList && !config.divider"
                 :badge="(config.divider) ? 'Divider' : (config.listButton) ? 'List button' : config.badge"
-                :accordion-item="context.component.slots && context.component.slots.accordion && !config.divider && !context.editmode"
+                :accordion-item="isRegularAccordion && !config.divider && !context.editmode"
                 :link="(config.action !== undefined && config.action !== '' && !context.editmode) ? true : undefined"
-                @click="performAction">
+                @click.stop="openAccordionOrPerformAction"
+                :class="{ 'oh-accordion-item' : isEquipmentAccordion}"
+                ref="f7AccordionContent">
     <slot name="inner" #inner />
     <slot name="after" #after />
     <slot name="content" #content />
@@ -15,9 +17,10 @@
     <generic-widget-component slot="after" v-if="context.component.slots && context.component.slots.after && context.component.slots.after.length"
                               :context="childContext(context.component.slots.after[0])" v-on="$listeners" />
     <f7-accordion-content v-if="context.parent.component.config.accordionList && !context.editmode">
-      <generic-widget-component v-if="context.component.slots && context.component.slots.accordion && context.component.slots.accordion.length"
-                                :context="childContext(context.component.slots.accordion[0])" v-on="$listeners" />
-      <!-- <oh-placeholder-widget v-else-if="context.editmode" class="oh-column-item placeholder" @click="context.editmode.addWidget(context.component, null, context.parent, 'accordion')" /> -->
+      <generic-widget-component v-if="isRegularAccordion" :context="childContext(context.component.slots.accordion[0])" v-on="$listeners" />
+    </f7-accordion-content>
+    <f7-accordion-content slot="root" v-if="isEquipmentAccordion && !context.editmode">
+      <generic-widget-component :context="childContext(context.component.slots.accordion[0])" v-on="$listeners" />
     </f7-accordion-content>
     <oh-icon slot="media" v-if="config.icon" :icon="config.icon" height="32" width="32" :color="config.iconColor" :state="(config.item && config.iconUseState) ? context.store[config.item].state : null" />
     <span slot="media" v-else-if="config.fallbackIconToInitial && config.title && context.parent.component.config && context.parent.component.config.mediaList" class="item-initial">{{ config.title[0].toUpperCase() }}</span>
@@ -25,6 +28,82 @@
 </template>
 
 <style lang="stylus">
+.oh-accordion-item
+  .item-link .item-inner:after
+    transition-duration: 300ms
+
+  .list,
+  .block
+    margin-top: 0
+    margin-bottom: 0
+
+  .block
+    > h1,
+    > h2,
+    > h3,
+    > h4,
+    > p
+      &:first-child
+        margin-top: 10px
+
+      &:last-child
+        margin-bottom: 10px
+
+.list li.oh-accordion-item ul
+  ltr(
+    padding-left: 0
+
+)
+  rtl(
+    padding-right: 0
+
+)
+
+.list ul ul
+  padding-left: var(--f7-list-item-padding-horizontal)!important
+
+.media-list .oh-accordion-item .item-inner {
+    padding-right: calc(16px + 0px)
+    padding-right: calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-right))
+}
+
+.media-list .oh-accordion-item .item-title-row {
+    padding-right: @css{max(20px, calc(var(--f7-list-chevron-icon-area)))}
+}
+
+.media-list .oh-accordion-item > .item-content > .item-inner > .item-title-row:before
+    font-family: 'framework7-core-icons'
+    font-weight: normal
+    font-style: normal
+    font-size: var(--f7-list-chevron-icon-font-size)
+    line-height: 1
+    letter-spacing: normal
+    text-transform: none
+    white-space: nowrap
+    word-wrap: normal
+    direction: ltr
+    -webkit-font-smoothing: antialiased
+    text-rendering: optimizeLegibility
+    -moz-osx-font-smoothing: grayscale
+    -moz-font-feature-settings: "liga"
+    font-feature-settings: "liga"
+    content: var(--f7-accordion-chevron-icon-down)
+    width: 14px
+    height: 8px
+    margin-top: -4px
+    line-height: 8px
+    right: 0
+    text-align: right
+    display: block
+    width: 100%
+    height: 100%
+    position: absolute
+    top: 50%
+    color: var(--f7-list-chevron-icon-color)
+
+.media-list .accordion-item-opened  > .item-content > .item-inner > .item-title-row:before
+    content: var(--f7-accordion-chevron-icon-up)
+
 .item-divider > span
   flex-shrink 1
   overflow hidden
@@ -39,6 +118,14 @@ export default {
   name: 'oh-list-item',
   mixins: [mixin, actionsMixin],
   widget: OhListItemDefinition,
+  computed: {
+    isEquipmentAccordion () {
+      return this.context.parent.component.config.accordionEquipment && this.context.component.slots && this.context.component.slots.accordion && this.context.component.slots.accordion.length
+    },
+    isRegularAccordion () {
+      return this.context.parent.component.config.accordionList && this.context.component.slots && this.context.component.slots.accordion && this.context.component.slots.accordion.length
+    }
+  },
   mounted () {
     mixin.mounted.call(this)
     if (this.config.divider && !this.context.editmode) {
@@ -57,6 +144,13 @@ export default {
     if (this.timer) clearTimeout(this.timer)
   },
   methods: {
+    openAccordionOrPerformAction () {
+      if (this.isEquipmentAccordion) {
+        this.$f7.accordion.toggle(this.$refs.f7AccordionContent.$el)
+      } else {
+        this.performAction()
+      }
+    },
     duringResize () {
       if (this.timer) clearTimeout(this.timer)
       this.timer = setTimeout(this.resized, 200)

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -7,7 +7,7 @@
                 :accordion-item="isRegularAccordion && !config.divider && !context.editmode"
                 :link="(config.action !== undefined && config.action !== '' && !context.editmode) ? true : undefined"
                 @click.stop="openAccordionOrPerformAction"
-                :class="{ 'oh-accordion-item' : isEquipmentAccordion}"
+                :class="{ 'oh-equipment-accordion-item' : isEquipmentAccordion}"
                 ref="f7AccordionContent">
     <slot name="inner" #inner />
     <slot name="after" #after />
@@ -28,14 +28,14 @@
 </template>
 
 <style lang="stylus">
-.oh-accordion-item
+.oh-equipment-accordion-item
   .item-link .item-inner:after
-    transition-duration: 300ms
+    transition-duration 300ms
 
   .list,
   .block
-    margin-top: 0
-    margin-bottom: 0
+    margin-top 0
+    margin-bottom 0
 
   .block
     > h1,
@@ -44,65 +44,59 @@
     > h4,
     > p
       &:first-child
-        margin-top: 10px
+        margin-top 10px
 
       &:last-child
-        margin-bottom: 10px
+        margin-bottom 10px
 
-.list li.oh-accordion-item ul
-  ltr(
-    padding-left: 0
+.list li.oh-equipment-accordion-item ul
+  ltr(padding-left 0)
+  rtl(padding-right 0)
 
-)
-  rtl(
-    padding-right: 0
+ul > .oh-equipment-accordion-item > .accordion-item-content > div > ul
+    padding-left var(--f7-list-item-padding-horizontal)!important
 
-)
-
-.list ul ul
-  padding-left: var(--f7-list-item-padding-horizontal)!important
-
-.media-list .oh-accordion-item .item-inner {
-    padding-right: calc(16px + 0px)
-    padding-right: calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-right))
+.media-list .oh-equipment-accordion-item .item-inner {
+    padding-right calc(16px + 0px)
+    padding-right calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-right))
 }
 
-.media-list .oh-accordion-item .item-title-row {
-    padding-right: @css{max(20px, calc(var(--f7-list-chevron-icon-area)))}
+.media-list .oh-equipment-accordion-item .item-title-row {
+    padding-right @css{max(20px, calc(var(--f7-list-chevron-icon-area)))}
 }
 
-.media-list .oh-accordion-item > .item-content > .item-inner > .item-title-row:before
-    font-family: 'framework7-core-icons'
-    font-weight: normal
-    font-style: normal
-    font-size: var(--f7-list-chevron-icon-font-size)
-    line-height: 1
-    letter-spacing: normal
-    text-transform: none
-    white-space: nowrap
-    word-wrap: normal
-    direction: ltr
-    -webkit-font-smoothing: antialiased
-    text-rendering: optimizeLegibility
-    -moz-osx-font-smoothing: grayscale
-    -moz-font-feature-settings: "liga"
-    font-feature-settings: "liga"
-    content: var(--f7-accordion-chevron-icon-down)
-    width: 14px
-    height: 8px
-    margin-top: -4px
-    line-height: 8px
-    right: 0
-    text-align: right
-    display: block
-    width: 100%
-    height: 100%
-    position: absolute
-    top: 50%
-    color: var(--f7-list-chevron-icon-color)
+.media-list .oh-equipment-accordion-item > .item-content > .item-inner > .item-title-row:before
+    font-family 'framework7-core-icons'
+    font-weight normal
+    font-style normal
+    font-size var(--f7-list-chevron-icon-font-size)
+    line-height 1
+    letter-spacing normal
+    text-transform none
+    white-space nowrap
+    word-wrap normal
+    direction ltr
+    -webkit-font-smoothing antialiased
+    text-rendering optimizeLegibility
+    -moz-osx-font-smoothing grayscale
+    -moz-font-feature-settings "liga"
+    font-feature-settings "liga"
+    content var(--f7-accordion-chevron-icon-down)
+    width 14px
+    height 8px
+    margin-top -4px
+    line-height 8px
+    right 0
+    text-align right
+    display block
+    width 100%
+    height 100%
+    position absolute
+    top 50%
+    color var(--f7-list-chevron-icon-color)
 
-.media-list .accordion-item-opened  > .item-content > .item-inner > .item-title-row:before
-    content: var(--f7-accordion-chevron-icon-up)
+.media-list .oh-equipment-accordion-item.accordion-item-opened  > .item-content > .item-inner > .item-title-row:before
+    content var(--f7-accordion-chevron-icon-up)
 
 .item-divider > span
   flex-shrink 1

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -49,23 +49,21 @@
       &:last-child
         margin-bottom 10px
 
-.list li.oh-equipment-accordion-item ul
-  ltr(padding-left 0)
-  rtl(padding-right 0)
+  & > ul
+    ltr(padding-left 0)
+    rtl(padding-right 0)
 
-ul > .oh-equipment-accordion-item > .accordion-item-content > div > ul
-    padding-left var(--f7-list-item-padding-horizontal)!important
+  & > .accordion-item-content > div > ul
+    padding-left var(--f7-list-item-padding-horizontal) !important
 
-.media-list .oh-equipment-accordion-item .item-inner {
+  .item-inner
     padding-right calc(16px + 0px)
     padding-right calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-right))
-}
 
-.media-list .oh-equipment-accordion-item .item-title-row {
-    padding-right @css{max(20px, calc(var(--f7-list-chevron-icon-area)))}
-}
+  .item-title-row
+    padding-right @css{ max(20px, calc(var(--f7-list-chevron-icon-area))) }
 
-.media-list .oh-equipment-accordion-item > .item-content > .item-inner > .item-title-row:before
+  & > .item-content > .item-inner > .item-title-row:before
     font-family 'framework7-core-icons'
     font-weight normal
     font-style normal
@@ -95,7 +93,7 @@ ul > .oh-equipment-accordion-item > .accordion-item-content > div > ul
     top 50%
     color var(--f7-list-chevron-icon-color)
 
-.media-list .oh-equipment-accordion-item.accordion-item-opened  > .item-content > .item-inner > .item-title-row:before
+  &.accordion-item-opened > .item-content > .item-inner > .item-title-row:before
     content var(--f7-accordion-chevron-icon-up)
 
 .item-divider > span

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -2,7 +2,7 @@
   <f7-input v-if="!config.item || !config.sendButton" class="input-field" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value" @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
   <f7-row no-gap v-else class="oh-input-with-send-button">
     <f7-input class="input-field col-90" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value" @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
-    <f7-button class="send-button col-10" v-if="this.config.sendButton" @click="sendButtonClicked" v-bind="config.sendButtonConfig || { iconMaterial: 'done', iconColor: 'gray' }" />
+    <f7-button class="send-button col-10" v-if="this.config.sendButton" @click.stop="sendButtonClicked" v-bind="config.sendButtonConfig || { iconMaterial: 'done', iconColor: 'gray' }" />
   </f7-row>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
@@ -1,10 +1,10 @@
 <template>
   <f7-segmented v-bind="config" round outline strong class="player-controls">
-    <f7-button color="blue" @click="skipPrevious()" large icon-material="skip_previous" icon-size="24" icon-color="gray" />
-    <f7-button v-if="this.config.showRewindFFward" color="blue" @click="rewind()" large icon-material="fast_rewind" icon-size="24" icon-color="gray" />
-    <f7-button color="blue" @click="playPause()" large round fill :icon-f7="(isPlaying) ? 'pause_fill' : 'play_fill'" icon-size="24" />
-    <f7-button v-if="this.config.showRewindFFward" color="blue" @click="fastForward()" large icon-material="fast_forward" icon-size="24" icon-color="gray" />
-    <f7-button color="blue" @click="skipNext()" large icon-material="skip_next" icon-size="24" icon-color="gray" />
+    <f7-button color="blue" @click.stop="skipPrevious()" large icon-material="skip_previous" icon-size="24" icon-color="gray" />
+    <f7-button v-if="this.config.showRewindFFward" color="blue" @click.stop="rewind()" large icon-material="fast_rewind" icon-size="24" icon-color="gray" />
+    <f7-button color="blue" @click.stop="playPause()" large round fill :icon-f7="(isPlaying) ? 'pause_fill' : 'play_fill'" icon-size="24" />
+    <f7-button v-if="this.config.showRewindFFward" color="blue" @click.stop="fastForward()" large icon-material="fast_forward" icon-size="24" icon-color="gray" />
+    <f7-button color="blue" @click.stop="skipNext()" large icon-material="skip_next" icon-size="24" icon-color="gray" />
   </f7-segmented>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
@@ -1,11 +1,11 @@
 <template>
   <f7-segmented round outline strong class="rollershutter-controls">
-    <f7-button @click="up()" large :icon-ios="upIcon" :icon-md="upIcon" :icon-aurora="upIcon" icon-size="24" icon-color="gray" />
-    <f7-button v-if="config.stateInCenter" @click="stop()" large class="state">
+    <f7-button @click.stop="up()" large :icon-ios="upIcon" :icon-md="upIcon" :icon-aurora="upIcon" icon-size="24" icon-color="gray" />
+    <f7-button v-if="config.stateInCenter" @click.stop="stop()" large class="state">
       <small>{{ context.store[config.item].state }}</small>
     </f7-button>
-    <f7-button v-else @click="stop()" large :icon-ios="stopIcon" :icon-md="stopIcon" :icon-aurora="stopIcon" icon-size="24" icon-color="red" />
-    <f7-button @click="down()" large :icon-ios="downIcon" :icon-md="downIcon" :icon-aurora="downIcon" icon-size="24" icon-color="gray" />
+    <f7-button v-else @click.stop="stop()" large :icon-ios="stopIcon" :icon-md="stopIcon" :icon-aurora="stopIcon" icon-size="24" icon-color="red" />
+    <f7-button @click.stop="down()" large :icon-ios="downIcon" :icon-md="downIcon" :icon-aurora="downIcon" icon-size="24" icon-color="gray" />
   </f7-segmented>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-range ref="rangeslider" class="oh-slider" v-bind="config" :value="value" :format-label="formatLabel" :format-scale-label="formatScaleLabel"
-            @range:change="sendCommandDebounced($event)" @click.native="sendCommandDebounced(value, true)" @touchend.native="sendCommandDebounced(value, true)" />
+            @range:change="sendCommandDebounced($event)" @click.native.stop="sendCommandDebounced(value, true)" @touchend.native="sendCommandDebounced(value, true)" />
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-stepper ref="stepper" v-bind="config" :value="value" @stepper:change="onChange"
+  <f7-stepper ref="stepper" v-bind="config" :value="value" @stepper:change="onChange" @click.native.stop
               :manual-input-mode="false" :format-value="formatValue" />
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-toggle.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-toggle.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-toggle v-bind="config" :checked="value" @toggle:change="onChange" />
+  <f7-toggle v-bind="config" :checked="value" @toggle:change="onChange" @click.native.stop />
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -154,7 +154,7 @@ export default {
     },
     childWidgetContext () {
       if (!this.componentType.startsWith('widget:')) return null
-      const widget = this.$store.getters.widget(this.componentType.substring(7))
+      let widget = this.$store.getters.widget(this.componentType.substring(7))
       if (!widget) {
         console.warn('widget not found, cannot render: ' + this.componentType)
       }
@@ -163,6 +163,7 @@ export default {
           this.$set(this.widgetVars, varKey, this.context.vars[varKey])
         }
       }
+      Object.assign(widget.slots, this.context.component.slots)
       const widgetContext = {
         component: widget,
         root: widget,

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -163,7 +163,7 @@ export default {
           this.$set(this.widgetVars, varKey, this.context.vars[varKey])
         }
       }
-      Object.assign(widget.slots, this.context.component.slots)
+      if (this.context.component.slots) Object.assign(widget.slots, this.context.component.slots)
       const widgetContext = {
         component: widget,
         root: widget,

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -30,6 +30,10 @@
         <f7-preloader :size="30" />
         <div>Loading...</div>
       </f7-block-title>
+      <f7-block-title v-if="loopError">
+        <div>Error!</div>
+      </f7-block-title>
+      {{ loopError }}. Please correct and refresh.
     </f7-block>
     <f7-tabs v-else>
       <f7-tab id="tab-overview" :tab-active="currentTab === 'overview'" @tab:show="() => this.currentTab = 'overview'">

--- a/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
@@ -52,7 +52,8 @@ export default {
       }
     },
     // Recursively builds path in model (sorted array of relations to ancestors, either Equipment or Location) for an item
-    // that has semantics configuration and returns it
+    // that has semantics configuration and returns it.
+    // At the same time, adds all items not already processed to the filteredItems property depending on their semantic type.
     buildPathInModel (item, filteredItems) {
       if (!item.metadata || !item.metadata.semantics) return
       if (item.modelPath) return item.modelPath
@@ -79,29 +80,31 @@ export default {
       item.equipment = []
       item.equipmentOrPoints = []
 
-      if (parent) {
-        parent.children.push(item)
+      if (parent) parent.children.push(item)
 
-        if (item.metadata.semantics.value.startsWith('Location')) {
-          parent.locations.push(item)
-          filteredItems.locations.push(item)
-        }
+      if (item.metadata.semantics.value.startsWith('Location')) {
+        if (parent) parent.locations.push(item)
+        filteredItems.locations.push(item)
+      }
 
-        if (item.metadata.semantics.value.startsWith('Point')) {
+      if (item.metadata.semantics.value.startsWith('Point')) {
+        if (parent) {
           parent.points.push(item)
           parent.equipmentOrPoints.push(item)
         }
+      }
 
-        if (item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) {
-          parent.properties.push(item)
-          filteredItems.properties.push(item)
-        }
+      if (item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) {
+        if (parent) parent.properties.push(item)
+        filteredItems.properties.push(item)
+      }
 
-        if (item.metadata.semantics.value.startsWith('Equipment')) {
+      if (item.metadata.semantics.value.startsWith('Equipment')) {
+        if (parent) {
           parent.equipment.push(item)
           parent.equipmentOrPoints.push(item)
-          filteredItems.equipment.push(item)
         }
+        filteredItems.equipment.push(item)
       }
 
       return item.modelPath

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -7,9 +7,9 @@
       <div class="model-cards-section" v-if="elements.length > 0">
         <div v-for="(element, idx) in elements.filter((e) => !isCardExcluded(e))" :key="idx">
           <location-card v-if="type === 'locations' && !element.separator && (element.equipment.length > 0 || element.properties.length > 0)" :key="element.key"
-                         type="location" :element="element" :context="cardContext(element)" :parent-location="parentLocationName(element.item)" />
+                         type="location" :element="element" :context="cardContext(element)" :parent-location="parentLocationName(element.item)" :tab-context="tabContext(type)" />
           <equipment-card v-if="type === 'equipment' && !element.separator" :key="element.key"
-                          type="equipment" :element="element" :context="cardContext(element)" />
+                          type="equipment" :element="element" :context="cardContext(element)" :tab-context="tabContext(type)" />
           <property-card v-if="type === 'properties' && !element.separator" :key="element.key"
                          type="property" :element="element" :context="cardContext(element)" />
         </div>
@@ -122,6 +122,14 @@ export default {
         return parent.item.label || parent.item.name
       }
       return ''
+    },
+    tabContext (type) {
+      const page = this.page
+      if (page && page.slots && page.slots[type] && page.slots[type][0] && page.slots[type][0].config) {
+        return page.slots[type][0].config
+      } else {
+        return {}
+      }
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -117,11 +117,7 @@ export default {
       return context
     },
     parentLocationName (item) {
-      if (item.metadata.semantics.config && item.metadata.semantics.config.isPartOf) {
-        const parent = (this.model.locations.find((i) => i.item.name === item.metadata.semantics.config.isPartOf))
-        return parent.item.label || parent.item.name
-      }
-      return ''
+      return item.parent ? item.parent.label || item.parent.name : ''
     },
     tabContext (type) {
       const page = this.page

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -51,22 +51,6 @@
               <f7-button v-for="tab in modelTabs" :key="tab.value" @click="showCardControls = false; currentModelTab = tab.value" :active="currentModelTab === tab.value" :text="tab.label" />
             </f7-segmented>
 
-            <div v-if="currentModelTab === 'locations'">
-              <config-sheet
-                :parameterGroups="locationsTabParameters.props.parameterGroups || []"
-                :parameters="locationsTabParameters.props.parameters || []"
-                :configuration="page.slots.locations[0].config"
-                @updated="dirty = true" />
-            </div>
-
-            <div v-if="currentModelTab === 'equipment'">
-              <config-sheet
-                :parameterGroups="equipmentTabParameters.props.parameterGroups || []"
-                :parameters="equipmentTabParameters.props.parameters || []"
-                :configuration="page.slots.equipment[0].config"
-                @updated="dirty = true" />
-            </div>
-
             <f7-block-title>Cards</f7-block-title>
             <div v-if="modelReady && !previewMode">
               <div class="display-block padding">
@@ -98,6 +82,22 @@
                   <f7-checkbox :checked="!isCardExcluded(card)" :disabled="card.separator !== undefined" slot="content-start" class="margin-right" />
                 </f7-list-item>
               </f7-list>
+            </div>
+
+            <div v-if="currentModelTab === 'locations'">
+              <config-sheet
+                :parameterGroups="locationsTabParameters.props.parameterGroups || []"
+                :parameters="locationsTabParameters.props.parameters || []"
+                :configuration="page.slots.locations[0].config"
+                @updated="dirty = true" />
+            </div>
+
+            <div v-if="currentModelTab === 'equipment'">
+              <config-sheet
+                :parameterGroups="equipmentTabParameters.props.parameterGroups || []"
+                :parameters="equipmentTabParameters.props.parameters || []"
+                :configuration="page.slots.equipment[0].config"
+                @updated="dirty = true" />
             </div>
           </f7-col>
         </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -28,7 +28,7 @@
     </f7-toolbar>
     <f7-tabs class="tabs-editor-tabs">
       <f7-tab id="design" class="tabs-editor-design-tab" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
-        <f7-block v-if="!ready" class="text-align-center">
+        <f7-block v-if="!ready || !modelReady" class="text-align-center">
           <f7-preloader />
           <div>Loading...</div>
         </f7-block>
@@ -36,7 +36,7 @@
           <page-settings :page="page" :createMode="createMode" />
         </f7-block> -->
 
-        <f7-block class="block-narrow" style="padding-bottom: 8rem" v-if="ready && !previewMode">
+        <f7-block class="block-narrow" style="padding-bottom: 8rem" v-else-if="ready && modelReady && !previewMode">
           <f7-col>
             <f7-block-title>Page Configuration</f7-block-title>
             <config-sheet
@@ -52,7 +52,7 @@
             </f7-segmented>
 
             <f7-block-title>Cards</f7-block-title>
-            <div v-if="modelReady && !previewMode">
+            <div>
               <div class="display-block padding">
                 <div class="no-padding float-right">
                   <f7-button @click="showCardControls = !showCardControls" small outline :fill="showCardControls" sortable-toggle=".sortable" style="margin-top: -3px; margin-right: 5px"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -46,41 +46,59 @@
               @updated="dirty = true" />
           </f7-col>
 
-          <f7-col v-if="modelReady && !previewMode">
-            <f7-block-title>Cards</f7-block-title>
+          <f7-col>
             <f7-segmented strong tag="p">
               <f7-button v-for="tab in modelTabs" :key="tab.value" @click="showCardControls = false; currentModelTab = tab.value" :active="currentModelTab === tab.value" :text="tab.label" />
             </f7-segmented>
 
-            <div class="display-block padding">
-              <div class="no-padding float-right">
-                <f7-button @click="showCardControls = !showCardControls" small outline :fill="showCardControls" sortable-toggle=".sortable" style="margin-top: -3px; margin-right: 5px"
-                           color="gray" icon-size="12" icon-ios="material:wrap_text" icon-md="material:wrap_text" icon-aurora="material:wrap_text">
-                  &nbsp;Reorder
-                </f7-button>
-              </div>
+            <div v-if="currentModelTab === 'locations'">
+              <config-sheet
+                :parameterGroups="locationsTabParameters.props.parameterGroups || []"
+                :parameters="locationsTabParameters.props.parameters || []"
+                :configuration="page.slots.locations[0].config"
+                @updated="dirty = true" />
             </div>
 
-            <f7-list media-list class="homecards-list" sortable :key="'cards-' + currentModelTab + cardListId" @sortable:sort="reorderCard">
-              <f7-list-item media-item :link="(showCardControls) ? undefined : ''"
-                            @click.native="(ev) => cardClicked(ev, card, idx)"
-                            v-for="(card, idx) in cardGroups(currentModelTab, page).flat()" :key="idx"
-                            :title="card.separator || card.defaultTitle" :footer="(card.separator) ? '(separator)' : card.key">
-                <f7-menu slot="content-start" class="configure-layout-menu">
-                  <f7-menu-item icon-f7="list_bullet" dropdown>
-                    <f7-menu-dropdown>
-                      <f7-menu-dropdown-item v-if="!card.separator" @click="configureCard(card)" href="#" text="Configure Card" />
-                      <f7-menu-dropdown-item v-if="!card.separator" @click="editCardCode(card)" href="#" text="Edit YAML" />
-                      <f7-menu-dropdown-item v-if="card.separator" @click="renameCardSeparator(idx)" href="#" text="Rename" />
-                      <f7-menu-dropdown-item divider />
-                      <f7-menu-dropdown-item v-if="!card.separator" @click="addCardSeparator(idx)" href="#" text="Add Separator Before" />
-                      <f7-menu-dropdown-item v-if="card.separator" @click="removeCardSeparator(idx)" href="#" text="Remove Separator" />
-                    </f7-menu-dropdown>
-                  </f7-menu-item>
-                </f7-menu>
-                <f7-checkbox :checked="!isCardExcluded(card)" :disabled="card.separator !== undefined" slot="content-start" class="margin-right" />
-              </f7-list-item>
-            </f7-list>
+            <div v-if="currentModelTab === 'equipment'">
+              <config-sheet
+                :parameterGroups="equipmentTabParameters.props.parameterGroups || []"
+                :parameters="equipmentTabParameters.props.parameters || []"
+                :configuration="page.slots.equipment[0].config"
+                @updated="dirty = true" />
+            </div>
+
+            <f7-block-title>Cards</f7-block-title>
+            <div v-if="modelReady && !previewMode">
+              <div class="display-block padding">
+                <div class="no-padding float-right">
+                  <f7-button @click="showCardControls = !showCardControls" small outline :fill="showCardControls" sortable-toggle=".sortable" style="margin-top: -3px; margin-right: 5px"
+                             color="gray" icon-size="12" icon-ios="material:wrap_text" icon-md="material:wrap_text" icon-aurora="material:wrap_text">
+                    &nbsp;Reorder
+                  </f7-button>
+                </div>
+              </div>
+
+              <f7-list media-list class="homecards-list" sortable :key="'cards-' + currentModelTab + cardListId" @sortable:sort="reorderCard">
+                <f7-list-item media-item :link="(showCardControls) ? undefined : ''"
+                              @click.native="(ev) => cardClicked(ev, card, idx)"
+                              v-for="(card, idx) in cardGroups(currentModelTab, page).flat()" :key="idx"
+                              :title="card.separator || card.defaultTitle" :footer="(card.separator) ? '(separator)' : card.key">
+                  <f7-menu slot="content-start" class="configure-layout-menu">
+                    <f7-menu-item icon-f7="list_bullet" dropdown>
+                      <f7-menu-dropdown>
+                        <f7-menu-dropdown-item v-if="!card.separator" @click="configureCard(card)" href="#" text="Configure Card" />
+                        <f7-menu-dropdown-item v-if="!card.separator" @click="editCardCode(card)" href="#" text="Edit YAML" />
+                        <f7-menu-dropdown-item v-if="card.separator" @click="renameCardSeparator(idx)" href="#" text="Rename" />
+                        <f7-menu-dropdown-item divider />
+                        <f7-menu-dropdown-item v-if="!card.separator" @click="addCardSeparator(idx)" href="#" text="Add Separator Before" />
+                        <f7-menu-dropdown-item v-if="card.separator" @click="removeCardSeparator(idx)" href="#" text="Remove Separator" />
+                      </f7-menu-dropdown>
+                    </f7-menu-item>
+                  </f7-menu>
+                  <f7-checkbox :checked="!isCardExcluded(card)" :disabled="card.separator !== undefined" slot="content-start" class="margin-right" />
+                </f7-list-item>
+              </f7-list>
+            </div>
           </f7-col>
         </f7-block>
         <div v-else-if="ready && previewMode && currentTab === 'design'" :context="context" :key="pageKey">
@@ -122,7 +140,7 @@ import HomeCards from '../../../home/homecards-mixin'
 
 import YAML from 'yaml'
 
-import { OhHomePageDefinition, OhLocationCardParameters, OhEquipmentCardParameters, OhPropertyCardParameters } from '@/assets/definitions/widgets/home'
+import { OhHomePageDefinition, OhLocationsTabParameters, OhEquipmentTabParameters, OhLocationCardParameters, OhEquipmentCardParameters, OhPropertyCardParameters } from '@/assets/definitions/widgets/home'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import ModelTab from '@/pages/home/model-tab.vue'
@@ -144,6 +162,8 @@ export default {
   data () {
     return {
       pageWidgetDefinition: OhHomePageDefinition(),
+      locationsTabParameters: OhLocationsTabParameters(),
+      equipmentTabParameters: OhEquipmentTabParameters(),
       currentModelTab: 'locations',
       modelTabs: [],
       showCardControls: false,


### PR DESCRIPTION
This PR provides a new option to display equipment as accordion in Locations cards, also giving the possibility to promote the main item of the equipment (widgetOrder == 0) as the accordion opening item (or equipment with a single point), while keeping the functionality of the control in the list item:

![Screen Recording 2022-02-09 at 14 11 21](https://user-images.githubusercontent.com/11686092/153208931-148c82b8-c53b-433c-b23c-fb163316e5fe.gif)
 

This is an improvement when having very long list of equipment in one location, as it give a fast access to each point, while not having to scroll a lot and be overwhelmed by the quantity of items. A good selection of the main item for each equipment and selection of the 'promote' option further increases speed of use.