### PR TITLE
Taphold action on oh-label-card and oh-button

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
@@ -18,6 +18,7 @@ import TrendParameters from '../system/trend.js'
 export const OhLabelCardDefinition = () => new WidgetDefinition('oh-label-card', 'Label Card', 'Display the state of an item in a card')
   .paramGroup(CardParameterGroup(), CardParameters())
   .paramGroup(actionGroup(), actionParams())
+  .paramGroup(actionGroup('Tap Hold', 'Action performed when tapping and holding card (or calling contextual menu on desktop)', 'taphold'), actionParams(null, 'taphold')).a()
   .paramGroup(pg('label', 'Label', 'Parameters of the label'), [
     pi('item', 'Item', 'Item to display'),
     pt('label', 'Label', 'Display this text (or expression result) instead of the item\'s state'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/index.js
@@ -7,6 +7,7 @@ const ClearVariableParameter = pb('clearVariable', 'Clear Variable After Action'
 import ButtonParameters from './button.js'
 export const OhButtonDefinition = () => new WidgetDefinition('oh-button', 'Button', 'Button performing an action')
   .paramGroup(actionGroup(), actionParams())
+  .paramGroup(actionGroup('Tap Hold', 'Action performed when tapping and holding card (or calling contextual menu on desktop)', 'taphold'), actionParams(null, 'taphold')).a()
   .params([...ButtonParameters(), VariableParameter, ClearVariableParameter])
 
 import ChartParameters from './chart.js'

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-label-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-label-card.vue
@@ -3,7 +3,7 @@
     <f7-card-header v-if="config.title">
       <div>{{ config.title }}</div>
     </f7-card-header>
-    <f7-card-content ref="cardContent" @click.native="performAction" class="label-card-content" :style="{ background: config.background }" :class="{ 'vertical-arrangement': config.vertical }">
+    <f7-card-content ref="cardContent" @click.native="performAction" @taphold.native="onTaphold($event)" @contextmenu.native="onContextMenu($event)" class="label-card-content" :style="{ background: config.background }" :class="{ 'vertical-arrangement': config.vertical }">
       <oh-trend v-if="config.trendItem" :key="'trend' + config.item" class="trend" :width="($refs.cardContent) ? $refs.cardContent.$el.clientWidth : 0" :context="context" />
       <f7-list>
         <f7-list-item :link="config.action ? true : false" no-chevron>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-button v-bind="config" @click="clicked">
+  <f7-button v-bind="config" @click="clicked" @taphold.native="onTaphold($event)" @contextmenu.native="onContextMenu($event)">
     <template v-if="context.component.slots && context.component.slots.default">
       <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
     </template>

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -30,7 +30,7 @@ export const actionsMixin = {
     },
     performAction (evt, prefix) {
       if (!this.context || !this.config) return
-      const actionPropsParameterGroup = this.config[((prefix) ? prefix += '_' : '') + 'actionPropsParameterGroup']
+      const actionPropsParameterGroup = this.config[((prefix) ? prefix + '_' : '') + 'actionPropsParameterGroup']
       const actionConfig = (actionPropsParameterGroup) ? this.evaluateExpression('$props', this.context.props) : this.config
       prefix = (actionPropsParameterGroup) ? actionPropsParameterGroup.replace(/action/gi, '') : prefix
       prefix = (prefix) ? prefix += '_' : ''
@@ -231,6 +231,17 @@ export const actionsMixin = {
           console.log('Invalid action: ' + action)
           break
       }
+      return true
+    },
+    onTaphold (event) {
+      this.performAction(event, 'taphold')
+    },
+    onContextMenu (event) {
+      if (this.performAction(event, 'taphold')) {
+        event.preventDefault()
+        event.stopPropagation()
+      }
+      // System contextual menu will be displayed
     }
   }
 }


### PR DESCRIPTION
This PR provides another configurable action upon taphold (or calling contextual menu on desktop) in oh-label-cards and oh-buttons.

This is quite interesting for wall mounted interfaces when using canvas layout and a floor plan. A button controlling a light might do the basic action upon touch (toggle the light), and display a popup with additional actions upon hold (like dimming, color...).