### PR TITLE
[MainUI] new HomeKit group mapping editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
@@ -1,209 +1,210 @@
-const accessories = {
+export const accessories = {
   'AirQualitySensor': [
-    'AirQuality',
-    'OzoneDensity',
-    'NitrogenDioxideDensity',
-    'SulphurDioxideDensity',
-    'PM25Density',
-    'PM10Density',
-    'VOCDensity',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'AirQuality', mandatory: true},
+    { label: 'OzoneDensity', mandatory: false},
+    { label: 'NitrogenDioxideDensity', mandatory: false},
+    { label: 'SulphurDioxideDensity', mandatory: false},
+    { label: 'PM25Density', mandatory: false},
+    { label: 'PM10Density', mandatory: false},
+    { label: 'VOCDensity', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'LeakSensor': [
-    'LeakDetectedState',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'LeakDetectedState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'MotionSensor': [
-    'MotionDetectedState',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'MotionDetectedState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'OccupancySensor': [
-    'OccupancyDetectedState',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'OccupancyDetectedState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'ContactSensor': [
-    'ContactSensorState',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'ContactSensorState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'SmokeSensor': [
-    'SmokeDetectedState',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'SmokeDetectedState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'LightSensor': [
-    'LightLevel',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'LightLevel', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'HumiditySensor': [
-    'RelativeHumidity',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'RelativeHumidity', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'TemperatureSensor': [
-    'CurrentTemperature',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'CurrentTemperature', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'CarbonDioxideSensor': [
-    'CarbonDioxideDetectedState',
-    'CarbonDioxideLevel',
-    'CarbonDioxidePeakLevel',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'CarbonDioxideDetectedState', mandatory: true},
+    { label: 'CarbonDioxideLevel', mandatory: false},
+    { label: 'CarbonDioxidePeakLevel', mandatory: false},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'CarbonMonoxideSensor': [
-    'CarbonMonoxideDetectedState',
-    'CarbonMonoxideLevel',
-    'CarbonMonoxidePeakLevel',
-    'Name',
-    'ActiveStatus',
-    'FaultStatus',
-    'TamperedStatus',
-    'BatteryLowStatus'
+    { label: 'CarbonMonoxideDetectedState', mandatory: true},
+    { label: 'CarbonMonoxideLevel', mandatory: false},
+    { label: 'CarbonMonoxidePeakLevel', mandatory: false},
+    { label: 'Name', mandatory: false},
+    { label: 'ActiveStatus', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false},
+    { label: 'BatteryLowStatus', mandatory: false}
   ],
   'Door': [
-    'CurrentPosition',
-    'TargetPosition',
-    'PositionState',
-    'Name',
-    'HoldPosition',
-    'ObstructionStatus'
+    { label: 'CurrentPosition', mandatory: true},
+    { label: 'TargetPosition', mandatory: true},
+    { label: 'PositionState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'HoldPosition', mandatory: false},
+    { label: 'ObstructionStatus', mandatory: false}
   ],
   'Window': [
-    'CurrentPosition',
-    'TargetPosition',
-    'PositionState',
-    'Name',
-    'HoldPosition',
-    'ObstructionStatus'
+    { label: 'CurrentPosition', mandatory: true},
+    { label: 'TargetPosition', mandatory: true},
+    { label: 'PositionState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'HoldPosition', mandatory: false},
+    { label: 'ObstructionStatus', mandatory: false}
   ],
   'WindowCovering': [
-    'CurrentPosition',
-    'TargetPosition',
-    'PositionState',
-    'Name',
-    'HoldPosition',
-    'ObstructionStatus',
-    'CurrentHorizontalTiltAngle',
-    'TargetHorizontalTiltAngle',
-    'CurrentVerticalTiltAngle',
-    'TargetVerticalTiltAngle'
+    { label: 'CurrentPosition', mandatory: true},
+    { label: 'TargetPosition', mandatory: true},
+    { label: 'PositionState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'HoldPosition', mandatory: false},
+    { label: 'ObstructionStatus', mandatory: false},
+    { label: 'CurrentHorizontalTiltAngle', mandatory: false},
+    { label: 'TargetHorizontalTiltAngle', mandatory: false},
+    { label: 'CurrentVerticalTiltAngle', mandatory: false},
+    { label: 'TargetVerticalTiltAngle', mandatory: false}
   ],
   'Switchable': [
-    'OnState',
-    'Name'
+    { label: 'OnState', mandatory: true},
+    { label: 'Name', mandatory: false}
   ],
   'Outlet': [
-    'OnState',
-    'InUseStatus',
-    'Name'
+    { label: 'OnState', mandatory: true},
+    { label: 'InUseStatus', mandatory: true},
+    { label: 'Name', mandatory: false}
   ],
   'Lighting': [
-    'OnState',
-    'Name',
-    'Hue',
-    'Saturation',
-    'Brightness',
-    'ColorTemperature'
+    { label: 'OnState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'Hue', mandatory: false},
+    { label: 'Saturation', mandatory: false},
+    { label: 'Brightness', mandatory: false},
+    { label: 'ColorTemperature', mandatory: false}
   ],
   'Fan': [
-    'ActiveStatus',
-    'CurrentFanState',
-    'TargetFanState',
-    'RotationDirection',
-    'RotationSpeed',
-    'SwingMode',
-    'LockControl'
+    { label: 'ActiveStatus', mandatory: true},
+    { label: 'CurrentFanState', mandatory: false},
+    { label: 'TargetFanState', mandatory: false},
+    { label: 'RotationDirection', mandatory: false},
+    { label: 'RotationSpeed', mandatory: false},
+    { label: 'SwingMode', mandatory: false},
+    { label: 'LockControl', mandatory: false}
   ],
   'Thermostat': [
-    'CurrentTemperature',
-    'TargetTemperature',
-    'CurrentHeatingCoolingMode',
-    'TargetHeatingCoolingMode',
-    'CoolingThresholdTemperature',
-    'HeatingThresholdTemperature'
+    { label: 'CurrentTemperature', mandatory: true},
+    { label: 'TargetTemperature', mandatory: true},
+    { label: 'CurrentHeatingCoolingMode', mandatory: true},
+    { label: 'TargetHeatingCoolingMode', mandatory: true},
+    { label: 'CoolingThresholdTemperature', mandatory: false},
+    { label: 'HeatingThresholdTemperature', mandatory: false}
   ],
   'HeaterCooler': [
-    'ActiveStatus',
-    'CurrentTemperature',
-    'CurrentHeaterCoolerState',
-    'TargetHeaterCoolerState',
-    'CoolingThresholdTemperature',
-    'HeatingThresholdTemperature',
-    'RotationSpeed',
-    'SwingMode',
-    'LockControl'
+    { label: 'ActiveStatus', mandatory: true},
+    { label: 'CurrentTemperature', mandatory: true},
+    { label: 'CurrentHeaterCoolerState', mandatory: true},
+    { label: 'TargetHeaterCoolerState', mandatory: true},
+    { label: 'CoolingThresholdTemperature', mandatory: false},
+    { label: 'HeatingThresholdTemperature', mandatory: false},
+    { label: 'RotationSpeed', mandatory: false},
+    { label: 'SwingMode', mandatory: false},
+    { label: 'LockControl', mandatory: false}
   ],
   'Lock': [
-    'LockCurrentState',
-    'LockTargetState',
-    'Name'
+    { label: 'LockCurrentState', mandatory: true},
+    { label: 'LockTargetState', mandatory: true},
+    { label: 'Name', mandatory: false}
   ],
   'Valve': [
-    'ActiveStatus',
-    'InUseStatus',
-    'Duration',
-    'RemainingDuration',
-    'Name',
-    'FaultStatus'
+    { label: 'ActiveStatus', mandatory: true},
+    { label: 'InUseStatus', mandatory: true},
+    { label: 'Duration', mandatory: false},
+    { label: 'RemainingDuration', mandatory: false},
+    { label: 'Name', mandatory: false},
+    { label: 'FaultStatus', mandatory: false}
   ],
   'SecuritySystem': [
-    'CurrentSecuritySystemState',
-    'TargetSecuritySystemState',
-    'Name',
-    'FaultStatus',
-    'TamperedStatus'
+    { label: 'CurrentSecuritySystemState', mandatory: true},
+    { label: 'TargetSecuritySystemState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'FaultStatus', mandatory: false},
+    { label: 'TamperedStatus', mandatory: false}
   ],
   'GarageDoorOpener': [
-    'ObstructionStatus',
-    'CurrentDoorState',
-    'TargetDoorState',
-    'Name',
-    'LockCurrentState',
-    'LockTargetState'
+    { label: 'ObstructionStatus', mandatory: true},
+    { label: 'CurrentDoorState', mandatory: true},
+    { label: 'TargetDoorState', mandatory: true},
+    { label: 'Name', mandatory: false},
+    { label: 'LockCurrentState', mandatory: false},
+    { label: 'LockTargetState', mandatory: false}
   ]
 }
 
 export const accessoriesAndCharacteristics = []
+
 for (const a in accessories) {
   accessoriesAndCharacteristics.push(a)
   for (const c of accessories[a]) {
-    accessoriesAndCharacteristics.push(a + '.' + c)
+    accessoriesAndCharacteristics.push(a + '.' + c.label)
   }
 }
 
@@ -263,6 +264,7 @@ const stepValue = {
   label: 'Step value for this characteristic',
   type: 'INTEGER'
 }
+
 const m = (name, type, label, description) => {
   return {
     name,
@@ -306,7 +308,6 @@ export const homekitParameters = {
   'Window': [invertedParameter],
   'Door': [invertedParameter],
   'WindowCovering': [invertedParameter],
-
   'Thermostat.CurrentTemperature': [minValue, maxValue, stepValue],
   'Thermostat.TargetTemperature': [minValue, maxValue, stepValue],
   'Thermostat.CoolingThresholdTemperature': [minValue, maxValue, stepValue],

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
@@ -1,201 +1,201 @@
 export const accessories = {
   'AirQualitySensor': [
-    { label: 'AirQuality', mandatory: true},
-    { label: 'OzoneDensity', mandatory: false},
-    { label: 'NitrogenDioxideDensity', mandatory: false},
-    { label: 'SulphurDioxideDensity', mandatory: false},
-    { label: 'PM25Density', mandatory: false},
-    { label: 'PM10Density', mandatory: false},
-    { label: 'VOCDensity', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'AirQuality', mandatory: true },
+    { label: 'OzoneDensity', mandatory: false },
+    { label: 'NitrogenDioxideDensity', mandatory: false },
+    { label: 'SulphurDioxideDensity', mandatory: false },
+    { label: 'PM25Density', mandatory: false },
+    { label: 'PM10Density', mandatory: false },
+    { label: 'VOCDensity', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'LeakSensor': [
-    { label: 'LeakDetectedState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'LeakDetectedState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'MotionSensor': [
-    { label: 'MotionDetectedState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'MotionDetectedState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'OccupancySensor': [
-    { label: 'OccupancyDetectedState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'OccupancyDetectedState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'ContactSensor': [
-    { label: 'ContactSensorState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'ContactSensorState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'SmokeSensor': [
-    { label: 'SmokeDetectedState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'SmokeDetectedState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'LightSensor': [
-    { label: 'LightLevel', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'LightLevel', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'HumiditySensor': [
-    { label: 'RelativeHumidity', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'RelativeHumidity', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'TemperatureSensor': [
-    { label: 'CurrentTemperature', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'CurrentTemperature', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'CarbonDioxideSensor': [
-    { label: 'CarbonDioxideDetectedState', mandatory: true},
-    { label: 'CarbonDioxideLevel', mandatory: false},
-    { label: 'CarbonDioxidePeakLevel', mandatory: false},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'CarbonDioxideDetectedState', mandatory: true },
+    { label: 'CarbonDioxideLevel', mandatory: false },
+    { label: 'CarbonDioxidePeakLevel', mandatory: false },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'CarbonMonoxideSensor': [
-    { label: 'CarbonMonoxideDetectedState', mandatory: true},
-    { label: 'CarbonMonoxideLevel', mandatory: false},
-    { label: 'CarbonMonoxidePeakLevel', mandatory: false},
-    { label: 'Name', mandatory: false},
-    { label: 'ActiveStatus', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false},
-    { label: 'BatteryLowStatus', mandatory: false}
+    { label: 'CarbonMonoxideDetectedState', mandatory: true },
+    { label: 'CarbonMonoxideLevel', mandatory: false },
+    { label: 'CarbonMonoxidePeakLevel', mandatory: false },
+    { label: 'Name', mandatory: false },
+    { label: 'ActiveStatus', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false },
+    { label: 'BatteryLowStatus', mandatory: false }
   ],
   'Door': [
-    { label: 'CurrentPosition', mandatory: true},
-    { label: 'TargetPosition', mandatory: true},
-    { label: 'PositionState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'HoldPosition', mandatory: false},
-    { label: 'ObstructionStatus', mandatory: false}
+    { label: 'CurrentPosition', mandatory: true },
+    { label: 'TargetPosition', mandatory: true },
+    { label: 'PositionState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'HoldPosition', mandatory: false },
+    { label: 'ObstructionStatus', mandatory: false }
   ],
   'Window': [
-    { label: 'CurrentPosition', mandatory: true},
-    { label: 'TargetPosition', mandatory: true},
-    { label: 'PositionState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'HoldPosition', mandatory: false},
-    { label: 'ObstructionStatus', mandatory: false}
+    { label: 'CurrentPosition', mandatory: true },
+    { label: 'TargetPosition', mandatory: true },
+    { label: 'PositionState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'HoldPosition', mandatory: false },
+    { label: 'ObstructionStatus', mandatory: false }
   ],
   'WindowCovering': [
-    { label: 'CurrentPosition', mandatory: true},
-    { label: 'TargetPosition', mandatory: true},
-    { label: 'PositionState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'HoldPosition', mandatory: false},
-    { label: 'ObstructionStatus', mandatory: false},
-    { label: 'CurrentHorizontalTiltAngle', mandatory: false},
-    { label: 'TargetHorizontalTiltAngle', mandatory: false},
-    { label: 'CurrentVerticalTiltAngle', mandatory: false},
-    { label: 'TargetVerticalTiltAngle', mandatory: false}
+    { label: 'CurrentPosition', mandatory: true },
+    { label: 'TargetPosition', mandatory: true },
+    { label: 'PositionState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'HoldPosition', mandatory: false },
+    { label: 'ObstructionStatus', mandatory: false },
+    { label: 'CurrentHorizontalTiltAngle', mandatory: false },
+    { label: 'TargetHorizontalTiltAngle', mandatory: false },
+    { label: 'CurrentVerticalTiltAngle', mandatory: false },
+    { label: 'TargetVerticalTiltAngle', mandatory: false }
   ],
   'Switchable': [
-    { label: 'OnState', mandatory: true},
-    { label: 'Name', mandatory: false}
+    { label: 'OnState', mandatory: true },
+    { label: 'Name', mandatory: false }
   ],
   'Outlet': [
-    { label: 'OnState', mandatory: true},
-    { label: 'InUseStatus', mandatory: true},
-    { label: 'Name', mandatory: false}
+    { label: 'OnState', mandatory: true },
+    { label: 'InUseStatus', mandatory: true },
+    { label: 'Name', mandatory: false }
   ],
   'Lighting': [
-    { label: 'OnState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'Hue', mandatory: false},
-    { label: 'Saturation', mandatory: false},
-    { label: 'Brightness', mandatory: false},
-    { label: 'ColorTemperature', mandatory: false}
+    { label: 'OnState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'Hue', mandatory: false },
+    { label: 'Saturation', mandatory: false },
+    { label: 'Brightness', mandatory: false },
+    { label: 'ColorTemperature', mandatory: false }
   ],
   'Fan': [
-    { label: 'ActiveStatus', mandatory: true},
-    { label: 'CurrentFanState', mandatory: false},
-    { label: 'TargetFanState', mandatory: false},
-    { label: 'RotationDirection', mandatory: false},
-    { label: 'RotationSpeed', mandatory: false},
-    { label: 'SwingMode', mandatory: false},
-    { label: 'LockControl', mandatory: false}
+    { label: 'ActiveStatus', mandatory: true },
+    { label: 'CurrentFanState', mandatory: false },
+    { label: 'TargetFanState', mandatory: false },
+    { label: 'RotationDirection', mandatory: false },
+    { label: 'RotationSpeed', mandatory: false },
+    { label: 'SwingMode', mandatory: false },
+    { label: 'LockControl', mandatory: false }
   ],
   'Thermostat': [
-    { label: 'CurrentTemperature', mandatory: true},
-    { label: 'TargetTemperature', mandatory: true},
-    { label: 'CurrentHeatingCoolingMode', mandatory: true},
-    { label: 'TargetHeatingCoolingMode', mandatory: true},
-    { label: 'CoolingThresholdTemperature', mandatory: false},
-    { label: 'HeatingThresholdTemperature', mandatory: false}
+    { label: 'CurrentTemperature', mandatory: true },
+    { label: 'TargetTemperature', mandatory: true },
+    { label: 'CurrentHeatingCoolingMode', mandatory: true },
+    { label: 'TargetHeatingCoolingMode', mandatory: true },
+    { label: 'CoolingThresholdTemperature', mandatory: false },
+    { label: 'HeatingThresholdTemperature', mandatory: false }
   ],
   'HeaterCooler': [
-    { label: 'ActiveStatus', mandatory: true},
-    { label: 'CurrentTemperature', mandatory: true},
-    { label: 'CurrentHeaterCoolerState', mandatory: true},
-    { label: 'TargetHeaterCoolerState', mandatory: true},
-    { label: 'CoolingThresholdTemperature', mandatory: false},
-    { label: 'HeatingThresholdTemperature', mandatory: false},
-    { label: 'RotationSpeed', mandatory: false},
-    { label: 'SwingMode', mandatory: false},
-    { label: 'LockControl', mandatory: false}
+    { label: 'ActiveStatus', mandatory: true },
+    { label: 'CurrentTemperature', mandatory: true },
+    { label: 'CurrentHeaterCoolerState', mandatory: true },
+    { label: 'TargetHeaterCoolerState', mandatory: true },
+    { label: 'CoolingThresholdTemperature', mandatory: false },
+    { label: 'HeatingThresholdTemperature', mandatory: false },
+    { label: 'RotationSpeed', mandatory: false },
+    { label: 'SwingMode', mandatory: false },
+    { label: 'LockControl', mandatory: false }
   ],
   'Lock': [
-    { label: 'LockCurrentState', mandatory: true},
-    { label: 'LockTargetState', mandatory: true},
-    { label: 'Name', mandatory: false}
+    { label: 'LockCurrentState', mandatory: true },
+    { label: 'LockTargetState', mandatory: true },
+    { label: 'Name', mandatory: false }
   ],
   'Valve': [
-    { label: 'ActiveStatus', mandatory: true},
-    { label: 'InUseStatus', mandatory: true},
-    { label: 'Duration', mandatory: false},
-    { label: 'RemainingDuration', mandatory: false},
-    { label: 'Name', mandatory: false},
-    { label: 'FaultStatus', mandatory: false}
+    { label: 'ActiveStatus', mandatory: true },
+    { label: 'InUseStatus', mandatory: true },
+    { label: 'Duration', mandatory: false },
+    { label: 'RemainingDuration', mandatory: false },
+    { label: 'Name', mandatory: false },
+    { label: 'FaultStatus', mandatory: false }
   ],
   'SecuritySystem': [
-    { label: 'CurrentSecuritySystemState', mandatory: true},
-    { label: 'TargetSecuritySystemState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'FaultStatus', mandatory: false},
-    { label: 'TamperedStatus', mandatory: false}
+    { label: 'CurrentSecuritySystemState', mandatory: true },
+    { label: 'TargetSecuritySystemState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'FaultStatus', mandatory: false },
+    { label: 'TamperedStatus', mandatory: false }
   ],
   'GarageDoorOpener': [
-    { label: 'ObstructionStatus', mandatory: true},
-    { label: 'CurrentDoorState', mandatory: true},
-    { label: 'TargetDoorState', mandatory: true},
-    { label: 'Name', mandatory: false},
-    { label: 'LockCurrentState', mandatory: false},
-    { label: 'LockTargetState', mandatory: false}
+    { label: 'ObstructionStatus', mandatory: true },
+    { label: 'CurrentDoorState', mandatory: true },
+    { label: 'TargetDoorState', mandatory: true },
+    { label: 'Name', mandatory: false },
+    { label: 'LockCurrentState', mandatory: false },
+    { label: 'LockTargetState', mandatory: false }
   ]
 }
 

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -5,8 +5,16 @@
     </div>
     <f7-list>
       <f7-list-item :key="classSelectKey"
-                    :title="(multiple) ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristics'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }" ref="classes">
-        <select name="parameters" @change="updateClasses" :multiple="multiple">
+                    :title="(multiple) ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }" ref="classes">
+        <select v-if="itemType == 'Group'" name="parameters" @change="updateClasses" :multiple="multiple">
+          <option v-if="!multiple" value="" />
+          <option v-for="cl in classesDefs.filter((c) => c.indexOf('.')===-1).filter((c) => c.indexOf('label:') !== 0)"
+                  :value="cl" :key="cl"
+                  :selected="isSelected(cl)">
+            {{ cl }}
+          </option>
+        </select>
+        <select v-else name="parameters" @change="updateClasses" :multiple="multiple">
           <option v-if="!multiple" value="" />
           <option v-for="cl in classesDefs.filter((c) => c.indexOf('label:') !== 0)"
                   :value="cl" :key="cl"
@@ -19,6 +27,31 @@
     <div>
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
     </div>
+    <f7-block class="padding-top no-padding no-margin" v-if="itemType === 'Group' && classes.length">
+      <f7-block-title class="padding-left">
+        Group HomeKit Characteristics Mapping
+      </f7-block-title>
+      <f7-block v-for="cl in classesAsArray" :key="cl">
+        <f7-block-title class="padding-left">
+          {{ cl }}
+        </f7-block-title>
+        <f7-list>
+          <f7-list-item v-for="accessory in accessories[cl]" :key="accessory.label" smart-select :title="accessory.mandatory?accessory.label+'*':accessory.label" :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
+            <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
+              <option value="" />
+              <option v-for="mbr in item.members" :value="mbr.name" :key="mbr.id" :selected="isLinked(cl, accessory.label, mbr)">
+                {{ mbr.label }}
+              </option>
+            </select>
+          </f7-list-item>
+        </f7-list>
+      </f7-block>
+      <f7-block-footer>
+        <f7-button color="blue" @click="updatedLinkedItem">
+          Update group members
+        </f7-button>
+      </f7-block-footer>
+    </f7-block>
     <p class="padding">
       <f7-link color="blue" external target="_blank" href="https://www.openhab.org/link/homekit">
         HomeKit integration documentation
@@ -28,22 +61,28 @@
 </template>
 
 <script>
-import { accessoriesAndCharacteristics, homekitParameters } from '@/assets/definitions/metadata/homekit'
+import { accessoriesAndCharacteristics, homekitParameters, accessories } from '@/assets/definitions/metadata/homekit'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['item', 'itemName', 'metadata', 'namespace'],
   components: {
     ConfigSheet
   },
   data () {
     return {
+      accessories: accessories,
       classesDefs: accessoriesAndCharacteristics,
       multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
-      classSelectKey: this.$f7.utils.id()
+      classSelectKey: this.$f7.utils.id(),
+      itemType: this.item.groupType || this.item.type,
+      dirtyItem: new Set()
     }
   },
   computed: {
+    classesAsArray () {
+      return (this.metadata.value) ? this.metadata.value.split(',') : []
+    },
     classes () {
       if (!this.multiple) return this.metadata.value
       return (this.metadata.value) ? this.metadata.value.split(',') : []
@@ -51,10 +90,22 @@ export default {
     parameters () {
       if (!this.classes) return []
       if (!this.multiple) return homekitParameters[this.classes]
+      if ((this.multiple) && (this.itemType === 'Group') && (this.classesAsArray.length > 1)) {
+        let primaryOptions = []
+        this.classesAsArray.forEach(aType => primaryOptions.push({ value: aType, label: aType }))
+        return [{ name: 'primary', label: 'Primary Accessory Type', type: 'TEXT', limitToOptions: true, options: primaryOptions }]
+      }
       return []
     }
   },
+
   methods: {
+    isLinked (accessoryClass, characteristic, item) {
+      if ((item.metadata) && (item.metadata.homekit)) {
+        return item.metadata.homekit.value.indexOf(characteristic) >= 0
+      }
+      return false
+    },
     isSelected (cl) {
       return (this.multiple) ? this.classes.indexOf(cl) >= 0 : this.classes === cl
     },
@@ -67,6 +118,40 @@ export default {
       const value = this.$refs.classes.f7SmartSelect.getValue()
       this.metadata.value = (Array.isArray(value)) ? value.join(',') : value
       this.$set(this.metadata, 'config', {})
+    },
+    updateLinkedItem (accessoryType, accessoryCharacteristic, itemName) {
+      const typeAndCharacteristic = accessoryType + '.' + accessoryCharacteristic
+      if (itemName) {
+        const groupMbr = this.item.members.find(mbr => mbr.name === itemName)
+        if (groupMbr) {
+          if (groupMbr.metadata.homekit.value) {
+            groupMbr.metadata.homekit.value = groupMbr.metadata.homekit.value + ',' + typeAndCharacteristic
+          } else {
+            groupMbr.metadata.homekit.value = typeAndCharacteristic
+          }
+          this.dirtyItem.add(groupMbr)
+        }
+      } else {
+        const groupMbr = this.item.members.find(mbr => mbr.metadata.homekit.value.indexOf(typeAndCharacteristic) > 0)
+        if (groupMbr) {
+          let itemClasses = groupMbr.metadata.homekit.value.split(',')
+          itemClasses = itemClasses.filter(tag => tag !== typeAndCharacteristic)
+          groupMbr.metadata.homekit.value = (Array.isArray(itemClasses)) ? itemClasses.join(',') : itemClasses
+          this.dirtyItem.add(groupMbr)
+        }
+      }
+    },
+    updatedLinkedItem () {
+      this.dirtyItem.forEach(it =>
+        this.$oh.api.put(`/rest/items/${it.name}/metadata/homekit`, it.metadata.homekit).then((data) => {
+          this.$f7.toast.create({
+            text: 'Metadata of group items updated. Please visit the items to review additional HomeKit configuration parameters.',
+            destroyOnClose: true,
+            closeTimeout: 3000
+          }).open()
+        })
+      )
+      this.dirtyItem.clear()
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -40,7 +40,7 @@
             <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
               <option value="" />
               <option v-for="mbr in item.members" :value="mbr.name" :key="mbr.id" :selected="isLinked(cl, accessory.label, mbr)">
-                {{ mbr.label }}
+                {{ mbr.label }} ({{ mbr.name }})
               </option>
             </select>
           </f7-list-item>


### PR DESCRIPTION
Complex HomeKit accessories like Thermostats or Fan with Lights are modelled as groups in openHAB and the users have to assign HomeKit characteristics to corresponding group members - openHAB items. 

this can be done already today at item level, i.e. adding HomeKit metadata to items, one after another. 
but an overview at group level was missing. 

this PR adds editor at group level for HomeKit metadata so that user can map HomeKit characteristics to openHAB item on one screen. 

it looks like this. The example shows Fan with Light. 
It lists all characteristics supported by HomeKit for these accessory types. Mandatory are marked with *. User can select the openHAB group item for each characteristics. And press "Update group members" button on the top to add required HomeKit metadata to the openHAB items. 

Group can be save also without this mapping and mapping can be done later at item level as well. 

Overview
<img width="859" alt="Screenshot 2022-02-18 at 11 14 29" src="https://user-images.githubusercontent.com/11726616/154663106-8947e05e-375d-4ba4-aa52-a22340c0b932.png">

Select OH item
<img width="856" alt="Screenshot 2022-02-18 at 11 14 41" src="https://user-images.githubusercontent.com/11726616/154663096-09a880af-2e28-4f3c-97ba-814545177606.png">



please review the code, UI design and wording especially thoroughly as im not a frontend or javascript developer. 


Signed-off-by: Eugen Freiter <freiter@gmx.de>