### PR TITLE
[blockly] change help urls to official OH blockly rules docs

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blockly_futureblocks/ohblocks_exec.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blockly_futureblocks/ohblocks_exec.js
@@ -1,0 +1,93 @@
+import Blockly from 'blockly'
+import { FieldItemModelPicker } from './ohitemfield'
+
+export default function defineOHBlocks_Exec (f7) {
+  Blockly.Blocks['oh_exec'] = {
+    init: function () {
+      this.appendValueInput('sendTo')
+        .setCheck(null)
+        .appendField('Execute command')
+        .appendField(new Blockly.FieldTextInput('/usr/bin/command'), 'execCommand')
+        .appendField('output to')
+      this.appendDummyInput()
+        .appendField('Timeout')
+        .appendField(new Blockly.FieldNumber(60), 'timeout')
+        .appendField('Seconds')
+      this.setInputsInline(false)
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setColour(230)
+      this.setTooltip('')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_exec'] = function (block) {
+    let runCommand = block.getFieldValue('execCommand')
+    const itemName = Blockly.JavaScript.valueToCode(block, 'sendTo', Blockly.JavaScript.ORDER_ATOMIC)
+    let code = 'var exec = Java.type("org.openhab.core.model.script.actions.Exec");\n'
+    code += 'var duration = Java.type("java.time.Duration");\n'
+    code += 'var results = exec.executeCommandLine(duration.ofSeconds(1), "' + runCommand + '", "")\n'
+    code += 'events.sendCommand(' + itemName + ', results );\n'
+    return code
+  }
+
+  Blockly.Blocks['oh_exec2'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('Execute command')
+        .appendField(new Blockly.FieldTextInput('/usr/bin/command'), 'cmdExecute')
+      this.appendDummyInput()
+        .appendField('Timeout')
+        .appendField(new Blockly.FieldNumber(60), 'timeout')
+        .appendField('Seconds')
+      this.setOutput(true, null)
+      this.setColour(230)
+      this.setTooltip('')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_exec2'] = function (block) {
+    const exec = Blockly.JavaScript.provideFunction_(
+      'exec',
+      ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("org.openhab.core.model.script.actions.Exec");'])
+    const duration = Blockly.JavaScript.provideFunction_(
+      'duration',
+      ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("java.time.Duration");'])
+    let runCommand = block.getFieldValue('cmdExecute').replace(/ /g, '","')
+    let timeout = block.getFieldValue('timeout')
+    let code = exec + '.executeCommandLine(' + duration + '.ofSeconds(' + timeout + '),"' + runCommand + '")\n'
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  }
+
+  Blockly.Blocks['oh_exec3'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('Execute command')
+        .appendField(new Blockly.FieldTextInput('/usr/bin/command'), 'cmdExecute')
+      this.appendDummyInput()
+        .appendField('Timeout')
+        .appendField(new Blockly.FieldNumber(60), 'timeout')
+        .appendField('Seconds')
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setColour(230)
+      this.setTooltip('')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_exec3'] = function (block) {
+    const exec = Blockly.JavaScript.provideFunction_(
+      'exec',
+      ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("org.openhab.core.model.script.actions.Exec");'])
+    const duration = Blockly.JavaScript.provideFunction_(
+      'duration',
+      ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("java.time.Duration");'])
+    let runCommand = block.getFieldValue('cmdExecute').replace(/ /g, '","')
+    let timeout = block.getFieldValue('timeout')
+    let code = exec + '.executeCommandLine(' + duration + '.ofSeconds(' + timeout + '),"' + runCommand + '")\n'
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  }
+}

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blockly_futureblocks/ohblocks_http.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blockly_futureblocks/ohblocks_http.js
@@ -1,0 +1,87 @@
+import Blockly from 'blockly'
+import { FieldItemModelPicker } from './ohitemfield'
+
+export default function defineOHBlocks_HTTP (f7, scripts) {
+  Blockly.Blocks['oh_httprequest'] = {
+    init: function () {
+      this.appendValueInput('url')
+        .setCheck('String')
+        .appendField('Method')
+        .appendField(new Blockly.FieldDropdown([['sendHttpGetRequest', 'sendHttpGetRequest'], ['sendHttpPutRequest', 'sendHttpPutRequest'], ['sendHttpPostRequest', 'sendHttpPostRequest'], ['sendHttpDeleteRequest', 'sendHttpDeleteRequest']]), 'requestType')
+        .appendField('Content Type')
+        .appendField(new Blockly.FieldDropdown([['none', 'none'], ['application/javascript', 'application/javascript'], ['application/xhtml+xml ', 'application/xhtml+xml '], ['application/json', 'application/json'], ['application/xml ', 'application/xml '], ['application/x-www-form-urlencoded ', 'application/x-www-form-urlencoded '], ['text/html', 'text/html'], ['text/javascript', 'text/javascript'], ['text/plain', 'text/plain'], ['text/xml', 'text/xml']]), 'contentType')
+        .appendField('URL')
+      this.appendValueInput('payload')
+        .setCheck(null)
+        .appendField('Payload')
+      this.setInputsInline(true)
+      this.setOutput(true, null)
+      this.setColour(230)
+      this.setTooltip('')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_httprequest'] = function (block) {
+    const http = Blockly.JavaScript.provideFunction_(
+      'http',
+      ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("org.openhab.core.model.script.actions.HTTP");'])
+    let requesttype = block.getFieldValue('requestType')
+    let contenttype = block.getFieldValue('contentType')
+    let url = Blockly.JavaScript.valueToCode(block, 'url', Blockly.JavaScript.ORDER_ATOMIC)
+    let payload = Blockly.JavaScript.valueToCode(block, 'payload', Blockly.JavaScript.ORDER_ATOMIC)
+    let code = ''
+    if (contenttype === 'none') {
+      code = http + '.' + requesttype + '("' + url + '",60)'
+    } else {
+      code = http + '.' + requesttype + '(' + url + ',"' + contenttype + '","' + payload + '")'
+    }
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  }
+
+  Blockly.Blocks['oh_script_dropdown'] = {
+    init: function () {
+      let input = this.appendDummyInput()
+        .appendField('script')
+        .appendField(new Blockly.FieldDropdown(this.generateOptions), 'script')
+      this.setOutput(true, null)
+    },
+    generateOptions: function () {
+      let options = []
+      if (scripts != null) {
+        for (let key in scripts) {
+          let tmp1 = scripts[key]
+          options.push([tmp1.name, tmp1.uid])
+        }
+      }
+      return options
+    }
+  }
+
+  Blockly.JavaScript['oh_script_dropdown'] = function (block) {
+    let scriptName = block.getFieldValue('script')
+    let code = scriptName
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  }
+
+  Blockly.Blocks['oh_ping'] = {
+    init: function () {
+      this.appendValueInput('hostName')
+        .setCheck('String')
+        .appendField('Ping')
+      this.setOutput(true, null)
+      this.setColour(230)
+      this.setTooltip('')
+      this.setHelpUrl('')
+    }
+  }
+
+  Blockly.JavaScript['oh_ping'] = function (block) {
+    const actions = Blockly.JavaScript.provideFunction_(
+      'actions',
+      ['var ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("org.openhab.core.model.script.actions.Ping");'])
+    let hostname = Blockly.JavaScript.valueToCode(block, 'hostName', Blockly.JavaScript.ORDER_ATOMIC)
+    let code = actions + '.checkVitality(' + hostname + ',0,10)'
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  }
+}

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-audio.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-audio.js
@@ -45,7 +45,7 @@ export default function (f7, sinks, voices) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Plays a sound file from the sounds folder to the given sink.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/multimedia.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html#play-audio')
     }
   }
 
@@ -82,7 +82,7 @@ export default function (f7, sinks, voices) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Plays a sound file from the sounds folder to the given sink at a given volume. \n Note: rather set volume first via thing volume channel, then play sound without volume parameter as it may be more reliable.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/multimedia.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html#play-audio-with-volume')
     }
   }
 
@@ -118,7 +118,7 @@ export default function (f7, sinks, voices) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('plays an audio stream from an url to the given sink(s)')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/multimedia.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html#play-stream')
     }
   }
 
@@ -148,7 +148,7 @@ export default function (f7, sinks, voices) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('stops the audio stream at the given sink')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/multimedia.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html#stop-stream')
     }
   }
 
@@ -183,7 +183,7 @@ export default function (f7, sinks, voices) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Speak text at the given device via text-to-speech')
-      this.setHelpUrl('https://www.openhab.org/addons/voice/googletts/')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html#say')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
@@ -18,7 +18,7 @@ export default function (f7) {
       this.setOutput(true, 'String')
       this.setColour('%{BKY_COLOUR_HUE}')
       this.setTooltip('converts a colour\'s hex rgb representation to openHAB\'s hue-saturation-brightness string')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html#state')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#create-hsb-color-from-rgb-color-openhab')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
@@ -15,7 +15,7 @@ export default function (f7) {
       this.setOutput(true, 'DayOffset')
       this.setColour(70)
       this.setTooltip('today\'s date for ephemeris check block')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#today')
     }
   }
 
@@ -42,7 +42,7 @@ export default function (f7) {
       this.setOutput(true, 'DayOffset')
       this.setColour(70)
       this.setTooltip('today with a positive or negative day offset for ephemeris check block')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#today-x-days')
     }
   }
 
@@ -76,7 +76,7 @@ export default function (f7) {
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(70)
       this.setTooltip('today with a positive or negative day offset for ephemeris check block')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-date-now-with-offset')
     }
   }
 
@@ -106,7 +106,7 @@ export default function (f7) {
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(70)
       this.setTooltip('Calender entry for ephemeris check block or other openHAB Blocks that require a day or date input in the format yyyy-MM-dd')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#date-picker')
     }
   }
 
@@ -134,7 +134,7 @@ export default function (f7) {
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(70)
       this.setTooltip('Calender entry as format yyyy-MM-dd or yyyy-MM-dd HH:mm:ss or yyyy-MM-dd HH:mm:ss +HH:mm (ZonedDateTime)')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-date')
     }
   }
 
@@ -164,7 +164,7 @@ export default function (f7) {
       this.setOutput(true, 'String')
       this.setColour(160)
       this.setTooltip('converts an ZonedDateTime into a date string')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-string-representation-of-date')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
@@ -12,6 +12,7 @@ export default function (f7) {
       this.updateShape_()
       this.setOutput(true, 'Dictionary')
       this.setMutator(new Blockly.Mutator(['dicts_create_with_item']))
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#dictionary-for-managing-key-value-pairs')
       this.setTooltip('Create a key/value dictionary')
     },
     /**
@@ -187,6 +188,7 @@ export default function (f7) {
         .setCheck('String')
       this.setInputsInline(true)
       this.setOutput(true, 'String')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#get-value-of-key-from-dictionary')
       this.setTooltip('Retrieve a specified attribute from the context that could be set from a calling rule or script')
     }
   }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-ephemeris.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-ephemeris.js
@@ -29,7 +29,7 @@ export default function (f7) {
       this.setInputsInline(true)
       this.setTooltip('checks if the given day is a holiday, weekend or weekday')
       this.setOutput(true, null)
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-ephemeris.html#holiday-weekend-or-weekday-check')
     }
   }
 
@@ -72,7 +72,7 @@ export default function (f7) {
       this.setInputsInline(true)
       this.setTooltip('name of the holiday for the given day')
       this.setOutput(true, null)
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-ephemeris.html#get-the-holiday-name-for-a-particular-date')
     }
   }
 
@@ -100,7 +100,7 @@ export default function (f7) {
       this.setInputsInline(true)
       this.setTooltip('days from today until the given bank holiday name')
       this.setOutput(true, null)
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#ephemeris')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-ephemeris.html#get-the-number-of-days-until-a-specific-holiday')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-eventbus.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-eventbus.js
@@ -18,7 +18,7 @@ export default function (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Send a command to an item')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#event-bus-actions')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#send-command')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -16,7 +16,7 @@ export default function (f7) {
       this.setColour(160)
       this.setInputsInline(true)
       this.setTooltip('Pick an item from the Model')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#item')
       this.setOutput(true, null)
     }
   }
@@ -37,7 +37,7 @@ export default function (f7) {
       this.setOutput(true, 'Array')
       this.setColour(0)
       this.setTooltip('Retrieve the members of a group')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-members-of-group')
       this.setOutput(true, null)
     }
   }
@@ -57,7 +57,7 @@ export default function (f7) {
       this.setOutput(true, 'oh_itemtype')
       this.setColour(0)
       this.setTooltip('Get an item from the item registry')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-item')
     }
   }
 
@@ -77,7 +77,7 @@ export default function (f7) {
       this.setOutput(true, 'String')
       this.setColour(0)
       this.setTooltip('Get an item state from the item registry')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html#state')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-state-of-item')
     }
   }
 
@@ -115,7 +115,7 @@ export default function (f7) {
       this.setOutput(true, 'String')
       this.setColour(0)
       this.setTooltip('Retrieve a specific attribute from the item. Note that groups and tags return a list and should be used with the loops-block \'for each item ... in list\'. ')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/items.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-particular-attributes-of-an-item')
     },
     /**
     * Modify this block to have the correct output type based on the attribute.

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-logging.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-logging.js
@@ -13,7 +13,7 @@ export default function (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Print a message on the console')
-      this.setHelpUrl('https://www.openhab.org/docs/administration/logging.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-logging.html#print-statement')
     }
   }
 
@@ -33,7 +33,7 @@ export default function (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Write a message in the openHAB log')
-      this.setHelpUrl('https://www.openhab.org/docs/administration/logging.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-logging.html#log-statement')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-notifications.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-notifications.js
@@ -16,7 +16,7 @@ export default function defineOHBlocks_Notifications (f7) {
       this.setInputsInline(false)
       this.setColour(0)
       this.setTooltip('Send a notification message to a specific openhab user')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#cloud-notification-actions')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-notifications.html#send-notification-to-specific-cloud-email-user')
     }
   }
 
@@ -43,7 +43,7 @@ export default function defineOHBlocks_Notifications (f7) {
       this.setInputsInline(false)
       this.setColour(0)
       this.setTooltip('send a notification to all clients. Provide icon name without prefix')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#cloud-notification-actions')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-notifications.html#send-notification-to-all-devices-and-users')
     }
   }
 
@@ -71,7 +71,7 @@ export default function defineOHBlocks_Notifications (f7) {
       this.setInputsInline(false)
       this.setColour(0)
       this.setTooltip('Sends a notification to the log only not to any device')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#cloud-notification-actions')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-notifications.html#send-notification-to-log-only')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -45,7 +45,7 @@ export default function defineOHBlocks_Persistence (f7) {
         }
         return TIP[methodName]
       })
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/persistence.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-persistence.html#get-statistical-value-of-an-item')
     }
   }
 
@@ -97,7 +97,7 @@ export default function defineOHBlocks_Persistence (f7) {
         return TIP[methodName]
       })
 
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/persistence.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-persistence.html#check-item-change-update-since-a-point-in-time')
     }
   }
 
@@ -129,7 +129,7 @@ export default function defineOHBlocks_Persistence (f7) {
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(0)
       this.setTooltip('Get the last update time of the provided item')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/persistence.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-persistence.html#provide-last-updated-date-of-an-item')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -22,7 +22,7 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Calls a script file which must be located in the $OPENHAB_CONF/scripts folder')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#openhab-subsystem-actions')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#call-script-file')
     }
   }
 
@@ -57,7 +57,7 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Run a rule or script with a certain UID, and optional parameters')
-      // this.setHelpUrl('') // TODO provide a openhab documentation URL
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#run-rule-or-script-created-in-ui')
     }
   }
 
@@ -182,7 +182,7 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
         }
         return TIP[contextData]
       })
-      this.setHelpUrl('https://www.openhab.org/docs/developer/utils/events.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#retrieve-rule-context-information')
     }
   }
 
@@ -204,6 +204,7 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
       this.setInputsInline(false)
       this.setOutput(true, 'any')
       this.setColour(0)
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#retrieve-context-attribute-from-rule')
       this.setTooltip('Retrieve a specified attribute from the context that could be set from a calling rule or script')
     }
   }
@@ -232,6 +233,7 @@ export default function defineOHBlocks_Scripts (f7, scripts) {
       this.setPreviousStatement(true, null)
       this.setNextStatement(true, null)
       this.setColour(0)
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#inline-script')
       this.setTooltip('Allows inlining arbitrary script code which has to be syntactically correct')
     }
   }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-things.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-things.js
@@ -15,7 +15,7 @@ export default function defineOHBlocks (f7) {
       this.setColour(160)
       this.setInputsInline(true)
       this.setTooltip('Pick a thing from the Thing List')
-      this.setHelpUrl('https://www.openhab.org/docs/concepts/things.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#thing')
       this.setOutput(true, null)
     }
   }
@@ -35,7 +35,7 @@ export default function defineOHBlocks (f7) {
       this.setOutput(true, 'String')
       this.setColour(0)
       this.setTooltip('Gets status information of the given thing, e.g. if the thing is online')
-      this.setHelpUrl('https://www.openhab.org/docs/concepts/things.html#thing-status')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-thing-status')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-timers.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-timers.js
@@ -19,6 +19,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setPreviousStatement(true, null)
       this.setNextStatement(true, null)
       this.setColour(0)
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#wait-for')
       this.setTooltip('Waits for the specified milliseconds')
     }
   }
@@ -59,7 +60,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setPreviousStatement(true, null)
       this.setNextStatement(true, null)
       this.setTooltip('Create a named timer')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#after-period-of-time-do-with-timer')
     }
   }
 
@@ -109,7 +110,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Simple Timer creation with control over rule retriggering action')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#after-period-of-time-do-with-timer-with-options-on-retriggering-rule')
     }
   }
 
@@ -168,7 +169,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setOutput(true, 'Boolean')
       this.setColour(0)
       this.setTooltip('returns true if the timer will be executed as scheduled, i.e. it has not been cancelled or completed')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#timer-is-active')
     }
   }
 
@@ -201,7 +202,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setOutput(true, 'Boolean')
       this.setColour(0)
       this.setTooltip('returns true if the code is currently executing (i.e. the timer activated the code but it is not done running)')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#timer-is-running')
     }
   }
 
@@ -233,7 +234,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setOutput(true, 'Boolean')
       this.setColour(0)
       this.setTooltip('returns true if the code has run and completed.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#timer-has-terminated')
     }
   }
 
@@ -263,7 +264,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('Cancels a named timer')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#cancel-timer')
     }
   }
 
@@ -303,7 +304,7 @@ export default function defineOHBlocks_Timers (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('reschedules the timer to execute at the new time. If the Timer has terminated this method does nothing.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/actions.html#timers')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html#reschedule-timer')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
@@ -20,7 +20,7 @@ export default function defineOHBlocks_Variables (f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip('stores a value with a variable name that can be retrieved on subsequent runs of this rule/script')
-      this.setHelpUrl('')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html#store-value')
     }
   }
 
@@ -42,7 +42,7 @@ export default function defineOHBlocks_Variables (f7) {
       this.setOutput(true, null)
       this.setColour(0)
       this.setTooltip('retrieves the value that was previously stored for that particular script/rule')
-      this.setHelpUrl('')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html#get-stored-value')
     }
   }
 
@@ -61,7 +61,7 @@ export default function defineOHBlocks_Variables (f7) {
       this.setOutput(true, null)
       this.setColour(0)
       this.setTooltip('returns whether the given value is undefined')
-      this.setHelpUrl('')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html#check-if-value-is-undefined')
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

This PR changes all blocks' help URL to point to the official openhab blockly documentation.