### PR TITLE
bump compiler tooling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -239,7 +239,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.1</version>
+          <version>3.10.1</version>
           <configuration>
             <compilerId>eclipse</compilerId>
             <compilerArgs>
@@ -253,12 +253,12 @@ Import-Package: \\
             <dependency>
               <groupId>org.codehaus.plexus</groupId>
               <artifactId>plexus-compiler-eclipse</artifactId>
-              <version>2.8.8</version>
+              <version>2.11.1</version>
             </dependency>
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.23.0</version>
+              <version>3.28.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
This brings the build tools to the same versions as in core.

See: https://github.com/openhab/openhab-core/pull/2836

Signed-off-by: Jan N. Klug <github@klug.nrw>