### PR TITLE
Remove openhab-iconset-classic feature

### DIFF
--- a/features/src/main/feature/feature.xml
+++ b/features/src/main/feature/feature.xml
@@ -17,7 +17,6 @@
 
 	<feature name="openhab-ui-basic" description="Basic UI" version="${project.version}">
 		<feature>openhab-core-ui</feature>
-		<feature>openhab-iconset-classic</feature>
 		<feature>openhab-core-io-rest-sitemap</feature>
 		<bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.basic/${project.version}</bundle>
 	</feature>
@@ -73,13 +72,7 @@
 
 	<feature name="openhab-ui-habpanel" description="HABPanel" version="${project.version}">
 		<feature>openhab-core-ui</feature>
-		<feature>openhab-iconset-classic</feature>
 		<bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.habpanel/${project.version}</bundle>
-	</feature>
-
-	<feature name="openhab-iconset-classic" version="${project.version}">
-		<feature>openhab-core-ui-icon</feature>
-		<bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.iconset.classic/${project.version}</bundle>
 	</feature>
 
 </features>


### PR DESCRIPTION
The bundle of this feature is now part of the openhab-runtime-ui feature.

See openhab/openhab-distro#1371