### PR TITLE
UI: Thing configuration: Mask passwords in configuration read from files

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -2,6 +2,7 @@
   <f7-list ref="parameter" class="config-parameter" :no-hairlines-md="configDescription.type !== 'BOOLEAN' && (!configDescription.options || !configDescription.options.length) && ['item'].indexOf(configDescription.context) < 0"
            v-show="(configDescription.visible) ? configDescription.visible(value, configuration, configDescription, parameters) : true">
     <component v-if="!readOnly && !configDescription.readOnly" :is="control" :config-description="configDescription" :value="value" :parameters="parameters" :configuration="configuration" :title="configDescription.title" @input="updateValue" />
+    <f7-list-item v-else-if="readOnly && (configDescription.context === 'password')" :is="passwords" :config-description="configDescription" :value="value" :parameters="parameters" :configuration="configuration" :title="configDescription.title" />
     <f7-list-item v-else :title="configDescription.label" :after="(value !== undefined && value !== null) ? value.toString() : 'N/A'" />
     <f7-block-footer slot="after-list" class="param-description">
       <div v-if="status" class="param-status-info">
@@ -50,6 +51,11 @@ export default {
     }
   },
   computed: {
+    passwords () {
+      const configDescription = this.configDescription
+      configDescription.readOnly = true
+      return ParameterText
+    },
     control () {
       const configDescription = this.configDescription
       if (configDescription.options && configDescription.options.length && configDescription.limitToOptions && !configDescription.context) {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -12,6 +12,7 @@
       :required="configDescription.required" validate
       :clear-button="!configDescription.required && configDescription.context !== 'password'"
       @input="updateValue"
+      :readonly="configDescription.readOnly"
       :type="controlType">
       <div v-if="configDescription.context === 'password'" class="padding-left" slot="content-end">
         <f7-link class="margin" color="gray" slot="content-end" @click="showPassword = !showPassword">


### PR DESCRIPTION
For things configured via configuration files, the UI now masks passwords
by default. The behavior is now similar to things created in
the UI: passwords are only displayed after a click on the icon.

Signed-off-by: Holger Friedrich <mail@holger-friedrich.de>