### PR TITLE
Remove HABot service configuration

### DIFF
--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/tile/internal/HABotTile.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/tile/internal/HABotTile.java
@@ -33,8 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Yannick Schaus - Initial contribution
  */
-@Component(service = Tile.class, immediate = true, name = "org.openhab.habot", property = {
-        "service.config.description.uri=ui:habot", "service.config.label=HABot", "service.config.category=ui" })
+@Component(service = Tile.class, immediate = true, name = "org.openhab.habot")
 @NonNullByDefault
 public class HABotTile implements Tile {
 


### PR DESCRIPTION
There is now a "HABot" service configuration entry without any configuration parameters because those got removed in #1031.

![habot](https://user-images.githubusercontent.com/12213581/159463988-b086fc43-cdec-430e-9356-2010295cf203.png)

