### PR TITLE
Upgrade node to v16, npm to v8

### DIFF
--- a/bundles/org.openhab.ui.basic/pom.xml
+++ b/bundles/org.openhab.ui.basic/pom.xml
@@ -35,8 +35,8 @@
         <version>1.9.0</version>
 
         <configuration>
-          <nodeVersion>v12.16.1</nodeVersion>
-          <npmVersion>6.14.3</npmVersion>
+          <nodeVersion>v16.14.2</nodeVersion>
+          <npmVersion>8.6.0</npmVersion>
           <environmentVariables>
             <npm_config_cache>${project.basedir}/npm_cache</npm_config_cache>
             <npm_config_tmp>${project.basedir}/npm_tmp</npm_config_tmp>

--- a/bundles/org.openhab.ui.habot/pom.xml
+++ b/bundles/org.openhab.ui.habot/pom.xml
@@ -72,8 +72,8 @@
         <version>1.9.0</version>
 
         <configuration>
-          <nodeVersion>v12.16.1</nodeVersion>
-          <npmVersion>6.14.3</npmVersion>
+          <nodeVersion>v16.14.2</nodeVersion>
+          <npmVersion>8.6.0</npmVersion>
           <workingDirectory>web</workingDirectory>
         </configuration>
 

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -38,8 +38,8 @@
         <version>1.9.0</version>
 
         <configuration>
-          <nodeVersion>v12.16.1</nodeVersion>
-          <npmVersion>6.14.3</npmVersion>
+          <nodeVersion>v16.14.2</nodeVersion>
+          <npmVersion>8.6.0</npmVersion>
           <workingDirectory>web</workingDirectory>
         </configuration>
 


### PR DESCRIPTION
(DRAFT)

As Node.js v12 is becoming EOL at the end of the month (https://nodejs.org/en/about/releases/), upgrade the version used for the Maven builds (as well as npm) keeping it consistent for all UIs: main, Basic, HABot.

Closes #1165.