### PR TITLE
Add .gradle/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.iml
 .idea/
+.gradle/
 .DS_Store
 target/
 src-gen/


### PR DESCRIPTION
IntelliJ IDEA adds files in .gradle/. These should be ignored.

Signed-off-by: Jan N. Klug <github@klug.nrw>