### PR TITLE
Allow resource overrides for main UI.

### DIFF
--- a/bundles/org.openhab.ui/bnd.bnd
+++ b/bundles/org.openhab.ui/bnd.bnd
@@ -1,2 +1,3 @@
 Bundle-SymbolicName: ${project.artifactId}
 Service-Component: OSGI-INF/*.xml
+Bundle-ClassPath: /patch,.


### PR DESCRIPTION
This commit solves #551 where user requested a way to customize UI colors or logo.
Now, with OSGi bundle fragment, just like in OH 2.5 it is possible to put new/additional resources.
Just create an OSGi fragment with patch/app/index.html, patch/app/css/xyz.css.
After reload of system, if fragment is matched properly, patched index will take a rule over default one.