### PR TITLE
Dummy and Clock widget improvements

### DIFF
--- a/bundles/org.openhab.ui.habpanel/doc/habpanel.md
+++ b/bundles/org.openhab.ui.habpanel/doc/habpanel.md
@@ -168,7 +168,7 @@ The following built-in widgets are available:
 
 ![Dummy widget](images/habpanel_widget-dummy.png)
 
-The so-called dummy widget (whose name is explained by historical reasons - it evolved from the first developed widget) displays the current state of an item without any interactivity, along with a label and an optional icon. It has a few options to customize it's appeareance.
+The so-called dummy widget (whose name is explained by historical reasons - it evolved from the first developed widget) displays the current state of an item without any interactivity, along with a label and an optional icon.
 
 #### Switch (switch)
 
@@ -230,7 +230,7 @@ The frame widget displays an external web page in a HTML `<iframe>`.
 
 ![Clock widget](images/habpanel_widget-clock.png)
 
-The clock widget displays an analog or digital clock with color customization. It can also be used to display the current date.
+The clock widget displays an analog or digital clock. It can also be used to display the current date.
 
 #### Chart (chart)
 

--- a/bundles/org.openhab.ui.habpanel/doc/habpanel.md
+++ b/bundles/org.openhab.ui.habpanel/doc/habpanel.md
@@ -168,7 +168,7 @@ The following built-in widgets are available:
 
 ![Dummy widget](images/habpanel_widget-dummy.png)
 
-The so-called dummy widget (whose name is explained by historical reasons - it evolved from the first developed widget) displays the current state of an item without any interactivity, along with a label and an optional icon.
+The so-called dummy widget (whose name is explained by historical reasons - it evolved from the first developed widget) displays the current state of an item without any interactivity, along with a label and an optional icon. It has a few options to customize it's appeareance.
 
 #### Switch (switch)
 
@@ -230,7 +230,7 @@ The frame widget displays an external web page in a HTML `<iframe>`.
 
 ![Clock widget](images/habpanel_widget-clock.png)
 
-The clock widget displays an analog or digital clock. It can also be used to display the current date.
+The clock widget displays an analog or digital clock with color customization. It can also be used to display the current date.
 
 #### Chart (chart)
 

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/clock/clock.settings.tpl.html
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/clock/clock.settings.tpl.html
@@ -65,6 +65,13 @@
 -->
 
 
+            <div class="form-group" ng-class="{error: _form.digital_color.$error && _form.submitted}">
+                <label class="control-label col-lg-2 col-md-2" translate-keep-content translate="widget.clock.digital_color">Digital Color</label>
+                <div class="col-lg-4 col-md-4">
+                    <div dab-model="form.digital_color" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                        show-grayscale="true"></div>
+                </div>
+            </div>
 
 
         </div>

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/clock/clock.tpl.html
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/clock/clock.tpl.html
@@ -11,7 +11,7 @@
 	    <div ng-switch-default>
                <div ng-switch-on="vm.widget.font_size">
                   <div ng-switch-when!="">
-	            <ds-widget-clock show-secs="true" show-digital ng-style="{ 'font-size': vm.widget.font_size + 'pt' }" digital-format="vm.widget.digital_format"/>
+	            <ds-widget-clock show-secs="true" show-digital ng-style="{ 'color': vm.widget.digital_color, 'font-size': vm.widget.font_size + 'pt' }" digital-format="vm.widget.digital_format"/>
                   </div>
 
                   <div ng-switch-default>

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/clock/clock.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/clock/clock.widget.js
@@ -76,7 +76,8 @@
             analog_theme: widget.analog_theme,
             font_size: widget.font_size,
             nobackground: widget.nobackground,
-            digital_format: widget.digital_format
+            digital_format: widget.digital_format,
+            digital_color: widget.digital_color
         };
 
         $scope.dismiss = function() {

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.settings.tpl.html
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.settings.tpl.html
@@ -100,8 +100,14 @@
                 </div>
             </div>
 
+            <div class="form-group" ng-class="{error: _form.value_color.$error && _form.submitted}">
+                <label class="control-label col-lg-2 col-md-2" translate-keep-content translate="widget.dummy.value_color">Value color</label>
+                <div class="col-lg-4 col-md-4">
+                    <div dab-model="form.value_color" web-colorpicker dab-width="20" dab-height="20" dab-radius="50" dab-vertical="4" dab-rotate="0"
+                        show-grayscale="true"></div>
+                </div>
+            </div>
         </div>
-
 
         <div class="modal-footer">
             <a ng-click="remove()" class="btn btn-danger pull-left" tabindex="-1"><i class="glyphicon glyphicon-trash"></i>&nbsp;<span translate>Delete</span></a>

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.settings.tpl.html
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.settings.tpl.html
@@ -39,6 +39,16 @@
                     <input name="col" ng-disabled="form.useserverformat" ng-model="form.unit" class="form-control" />
                 </div>
             </div>
+            <div class="form-group" ng-class="{error: _form.unit.$error && _form.submitted}">
+                <label class="control-label col-xs-3" translate-keep-content translate="widget.dummy.state">State</label>
+                <div class="col-lg-9 col-md-9">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" name="usedescription" ng-model="form.usedescription" /> <span translate-keep-content translate="widget.dummy.state.description">Use state description</span>
+                        </label>
+                    </div>
+                </div>
+            </div>
             <div class="form-group" ng-class="{error: _form.format.$error && _form.submitted}">
                 <label class="control-label col-xs-3" translate-keep-content translate="widget.common.format">Format</label>
                 <div class="col-xs-7">

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.tpl.html
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.tpl.html
@@ -8,6 +8,6 @@
         <span ng-if="!vm.widget.nolinebreak" ng-if="vm.widget.name">{{vm.widget.name}}</span>
         <br ng-if="!vm.widget.nolinebreak && vm.widget.name" />
         <widget-icon ng-if="vm.widget.icon && !vm.widget.icon_nolinebreak" size="vm.widget.icon_size" iconset="vm.widget.iconset" icon="vm.widget.icon" inline="vm.widget.icon_nolinebreak" state="vm.state"></widget-icon>
-        <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'font-size': vm.widget.font_size + 'pt' }" ng-class="{ 'dummy-value-right': vm.widget.nolinebreak }" class="value">{{vm.value}}<small ng-if="vm.widget.unit">{{vm.widget.unit}}</small></span>
+        <span ng-hide="vm.widget.icon && vm.widget.icon_replacestext" ng-style="{ 'color': vm.widget.value_color, 'font-size': vm.widget.font_size + 'pt' }" ng-class="{ 'dummy-value-right': vm.widget.nolinebreak }" class="value">{{vm.value}}<small ng-if="vm.widget.unit">{{vm.widget.unit}}</small></span>
     </div>
 </div>

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.widget.js
@@ -105,7 +105,8 @@
             icon             : widget.icon,
             icon_size        : widget.icon_size,
             icon_nolinebreak : widget.icon_nolinebreak,
-            icon_replacestext: widget.icon_replacestext
+            icon_replacestext: widget.icon_replacestext,
+            value_color      : widget.value_color
         };
 
         $scope.dismiss = function() {

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.widget.js
@@ -47,7 +47,21 @@
                 vm.value = "N/A";
                 return;
             }
-            var value = item.transformedState || item.state;
+
+            if (vm.widget.usedescription) {
+                var options = item.stateDescription.options;
+                if (Array.isArray(options)) {
+                    var option = options.find((element) => element.value === item.state);
+                    if (option) {
+                        var value = option.label;
+                    } else {
+                        var value = item.state;
+                    }
+                }
+            } else {
+                var value = item.transformedState || item.state;
+            }
+
             if (vm.widget.format) {
                 if (item.type === "DateTime" || item.type === "DateTimeItem") {
                     value = $filter('date')(value, vm.widget.format);
@@ -106,7 +120,8 @@
             icon_size        : widget.icon_size,
             icon_nolinebreak : widget.icon_nolinebreak,
             icon_replacestext: widget.icon_replacestext,
-            value_color      : widget.value_color
+            value_color      : widget.value_color,
+            usedescription   : widget.usedescription
         };
 
         $scope.dismiss = function() {

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/af.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/af.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/af.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/af.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr ""
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Uitleg"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ar.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ar.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr ""
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ar.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ar.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/bg.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/bg.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr ""
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/bg.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/bg.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ca.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ca.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Format digital"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Ajustos de Nul"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Disposició"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ca.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ca.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/cs.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/cs.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digitální formát"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Nastavení univerzálního Widgetu"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Rozvržení"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/cs.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/cs.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/da.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/da.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digital format"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Dummy indstilinger"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Opsætning"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/da.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/da.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/de.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/de.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digitales Format"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Dummyeinstellungen"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Layout"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/de.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/de.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/el.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/el.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Μορφή ψηφίων"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Ρυθμίσεις Dummy"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Διάταξη"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/el.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/el.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/en.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/en.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr ""
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/en.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/en.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/es.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/es.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Formato digital"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Ajustes ficticios"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Disposición"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/es.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/es.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fi.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fi.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digitaalisen muoto"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Yleiswidgetin asetukset"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Asettelu"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fi.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fi.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fr.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fr.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Format (digital)"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Paramètres du widget dummy"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Apparence"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fr.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/fr.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/he.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/he.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "בפורמט דיגיטלי"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "הגדרות דמה"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "פריסה"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/he.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/he.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/hu.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/hu.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digitális formátum"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Dummy beállítások"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Elrendezés"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/hu.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/hu.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/id.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/id.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr "Pengaturan Model"
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/id.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/id.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/it.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/it.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Formato Digitale"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Impostazioni del widget temporaneo"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Layout"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/it.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/it.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ja.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ja.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "デジタルフォーマット"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "ダミー設定"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "レイアウト"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ja.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ja.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ko.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ko.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "더미 설정"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "레이아웃"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ko.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ko.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/lt.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/lt.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr ""
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/lt.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/lt.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.json
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.json
@@ -94,6 +94,7 @@
     "widget.clock.theme.light": "licht",
     "widget.clock.theme.dark": "donker",
     "widget.clock.digital_format": "Digitaal formaat",
+    "widget.clock.digital_color": "Digitaal kleur",
     "widget.clock.font_size": "Lettergrootte digitale font",
     "widget.colorpicker": "Kleurenkiezer",
     "widget.colorpicker.description": "Toont een kleurenkiezer",

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.json
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.json
@@ -108,6 +108,8 @@
     "widget.dummy.description": "Een dummy widget - toont de waarde van een openHAB item",
     "widget.dummy.settings.header": "Dummy Instellingen",
     "widget.dummy.layout": "Opmaak",
+    "widget.dummy.state": "Status",
+    "widget.dummy.state.description": "Toon beschrijving",
     "widget.frame": "Kader",
     "widget.frame.description": "Ingesloten website van vooraf gedefinieerde URL of openHAB item.",
     "widget.frame.settings.header": "Instellingen kader",

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr "Waarde kleur"
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/nl.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digitaal formaat"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Format"
+msgstr "Digitaal kleur"
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Dummy Instellingen"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Opmaak"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr "Waarde kleur"
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/no.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/no.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digitalt Format"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Dummy Instillinger"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Utforming"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/no.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/no.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pl.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pl.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Format Cyfrowy"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Ustawienia Makiety"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Układ"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pl.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pl.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pt.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pt.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Formato digital"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Configurações do Dummy"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Layout"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pt.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/pt.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ro.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ro.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Format digital"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Setări fictive"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Aspect"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ro.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ro.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ru.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ru.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Цифровой формат"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Параметры Модели"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Расположение"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ru.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/ru.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sr.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sr.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr ""
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sr.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sr.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sv.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sv.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Format (digital)"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Inställningar för dummy"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Layout"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sv.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/sv.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tl.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tl.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Digital na Format"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Mga setting ng Dummy"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Pagkakalatag"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tl.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tl.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tr.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tr.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Dijital Format"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Yapay Ayarlar"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Düzen"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tr.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/tr.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/uk.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/uk.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/uk.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/uk.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "Цифровий формат"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "Приклад налаштуваннь"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "Розкладка"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/vi.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/vi.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -470,6 +475,11 @@ msgstr ""
 #. Checkboxes header
 msgctxt "widget.dummy.layout"
 msgid "Layout"
+msgstr ""
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
 msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/vi.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/vi.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/widgets.pot
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/widgets.pot
@@ -412,6 +412,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr ""
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -485,6 +490,11 @@ msgstr ""
 
 
 # FRAME (WEB) WIDGET
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/widgets.pot
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/widgets.pot
@@ -496,6 +496,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/zh.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/zh.po
@@ -407,6 +407,11 @@ msgctxt "widget.clock.digital_format"
 msgid "Digital Format"
 msgstr "数字格式"
 
+#. Color picker header
+msgctxt "widget.clock.digital_color"
+msgid "Digital Color"
+msgstr ""
+
 #. Textbox header
 msgctxt "widget.clock.font_size"
 msgid "Digital Font Size"
@@ -471,6 +476,11 @@ msgstr "虚拟设置"
 msgctxt "widget.dummy.layout"
 msgid "Layout"
 msgstr "布局"
+
+#. Color picker header
+msgctxt "widget.dummy.value_color"
+msgid "Value color"
+msgstr ""
 
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"

--- a/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/zh.po
+++ b/bundles/org.openhab.ui.habpanel/web/assets/i18n/widgets/zh.po
@@ -482,6 +482,16 @@ msgctxt "widget.dummy.value_color"
 msgid "Value color"
 msgstr ""
 
+#. Checkboxes header
+msgctxt "widget.dummy.state"
+msgid "State"
+msgstr ""
+
+#. Checkbox label
+msgctxt "widget.dummy.state.description"
+msgid "Use state description"
+msgstr ""
+
 #. Display name of the widget (appears in the Add Widget dropdown menu in the designer)
 msgctxt "widget.frame"
 msgid "Frame"


### PR DESCRIPTION
Signed-off-by: Bastiaan an Haastrecht b.vanhaastrecht@gmail.com
Adds color customization to Clock and Dummy widget.
Adds option to show state description in Dummy widget.

Closes: #1349
Closes: #1293
Closes: #1294
