### PR TITLE
Add ManagedProvider components for storing configurations

### DIFF
--- a/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/ManagedHABPanelProvider.java
+++ b/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/ManagedHABPanelProvider.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.ui.habpanel.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.storage.StorageService;
+import org.openhab.core.ui.components.UIComponentProvider;
+import org.openhab.core.ui.components.UIProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A managed habpanel provider which stores their definition in storage layer.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })
+public class ManagedHABPanelProvider extends UIComponentProvider {
+
+    @Activate
+    public ManagedHABPanelProvider(@Reference StorageService storageService) {
+        super("habpanel:panelconfig", storageService);
+    }
+}

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/ManagedBlocksProvider.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/ManagedBlocksProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.ui.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.storage.StorageService;
+import org.openhab.core.ui.components.UIComponentProvider;
+import org.openhab.core.ui.components.UIProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A managed blocks provider which stores their definition in storage layer.
+ *
+ * @author Jan N. Klug - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })
+public class ManagedBlocksProvider extends UIComponentProvider {
+    @Activate
+    public ManagedBlocksProvider(@Reference StorageService storageService) {
+        super("ui:blocks", storageService);
+    }
+}

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/ManagedPageProvider.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/ManagedPageProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.ui.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.storage.StorageService;
+import org.openhab.core.ui.components.UIComponentProvider;
+import org.openhab.core.ui.components.UIProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A managed page provider which uses storage layer to keep defined pages.
+ *
+ * @author Łukasz Dywicki - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })
+public class ManagedPageProvider extends UIComponentProvider {
+    @Activate
+    public ManagedPageProvider(@Reference StorageService storageService) {
+        super("ui:page", storageService);
+    }
+}

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/ManagedWidgetProvider.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/ManagedWidgetProvider.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2010-2022 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.ui.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.core.common.registry.ManagedProvider;
+import org.openhab.core.common.registry.Provider;
+import org.openhab.core.storage.StorageService;
+import org.openhab.core.ui.components.UIComponentProvider;
+import org.openhab.core.ui.components.UIProvider;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * A managed widget provider which stores their definition in storage layer.
+ *
+ * @author Łukasz Dywicki - Initial contribution
+ */
+@NonNullByDefault
+@Component(service = { Provider.class, ManagedProvider.class, UIProvider.class })
+public class ManagedWidgetProvider extends UIComponentProvider {
+    @Activate
+    public ManagedWidgetProvider(@Reference StorageService storageService) {
+        super("ui:widget", storageService);
+    }
+}


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/2947

Due to the changes in https://github.com/openhab/openhab-core/pull/2617 storing configurations on server-side now requires a `ManagedProvider`.  

Also-By: Łukasz Dywicki <luke@code-house.org>
Signed-off-by: Jan N. Klug <github@klug.nrw>