### PR TITLE
Fixes the parsing of the model for Location cards following PR #1307.

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/home/homecards-mixin.js
@@ -58,12 +58,12 @@ export default {
       if (!item.metadata || !item.metadata.semantics) return
       if (item.modelPath) return item.modelPath
       let parent = null
-      if (item.metadata.semantics.config && item.metadata.semantics.config.isPointOf) {
+      if (item.metadata.semantics.config && item.metadata.semantics.config.hasLocation) {
+        parent = (this.items.find((i) => i.name === item.metadata.semantics.config.hasLocation))
+      } else if (item.metadata.semantics.config && item.metadata.semantics.config.isPointOf) {
         parent = (this.items.find((i) => i.name === item.metadata.semantics.config.isPointOf))
       } else if (item.metadata.semantics.config && item.metadata.semantics.config.isPartOf) {
         parent = (this.items.find((i) => i.name === item.metadata.semantics.config.isPartOf))
-      } else if (item.metadata.semantics.config && item.metadata.semantics.config.hasLocation) {
-        parent = (this.items.find((i) => i.name === item.metadata.semantics.config.hasLocation))
       }
       if (parent && parent.semanticLoopDetector) {
         this.loopError = `A a loop has been detected in the semantic model: ${parent.name} is both descendant and parent of ${item.name}`


### PR DESCRIPTION
Changes the parsing of the model so that Equipment or Points that are respectively sub-Equipment or Part Of an Equipment while having a Location parent can be displayed in the relevant Location tab card.

This fixes the issue described there: PR https://github.com/openhab/openhab-webui/pull/1307#issuecomment-1115416483

No changes are performed on the labelling.