### PR TITLE
Adds WebRTC support to video widget

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
@@ -10,6 +10,5 @@ export default () => [
     { value: 'videojs', label: 'Video.js (Dash, HLS, Others)' },
     { value: 'webrtc', label: 'WebRTC' }
   ], true, false).a(),
-  pt('stunServer', 'Stun Server', 'WebRTC stun server (optional), defaults to \'stun:stun.l.google.com:19302\'').a(),
-  pb('enableTrickleIce', 'Enable Trickle ICE', 'Enables Trickle ICE candiddates for WebRTC servers that support it').a()
+  pt('stunServer', 'Stun Server', 'WebRTC stun server (optional), defaults to \'stun:stun.l.google.com:19302\'').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
@@ -5,9 +5,11 @@ export default () => [
   pt('url', 'URL', 'URL to show (if item if not specified)'),
   pt('type', 'Type', 'Content Type of the video, for example <em>video/mp4</em> (optional)'),
   pb('hideControls', 'Hide Controls', 'Hide the control buttons of the video'),
-  pb('startManually', 'Start manually', 'Does not start playing the video automatically'),
-  pt('playerType', 'Player Type', 'Select the player type (optional)').o([
+  pb('startManually', 'Start Manually', 'Does not start playing the video automatically'),
+  pt('playerType', 'Player Type', 'Select the player type (optional), defualts to Video.js').o([
     { value: 'videojs', label: 'Video.js (Dash, HLS, Others)' },
     { value: 'webrtc', label: 'WebRTC' }
-  ], true, false)
+  ], true, false).a(),
+  pt('stunServer', 'Stun Server', 'WebRTC stun server (optional), defaults to \'stun:stun.l.google.com:19302\'').a(),
+  pb('enableTrickleIce', 'Enable Trickle ICE', 'Enables Trickle ICE candiddates for WebRTC servers that support it').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
@@ -5,5 +5,9 @@ export default () => [
   pt('url', 'URL', 'URL to show (if item if not specified)'),
   pt('type', 'Type', 'Content Type of the video, for example <em>video/mp4</em> (optional)'),
   pb('hideControls', 'Hide Controls', 'Hide the control buttons of the video'),
-  pb('startManually', 'Start manually', 'Does not start playing the video automatically')
+  pb('startManually', 'Start manually', 'Does not start playing the video automatically'),
+  pt('playerType', 'Player Type', 'Select the player type (optional)').o([
+    { value: 'videojs', label: 'Video.js (Dash, HLS, Others)' },
+    { value: 'webrtc', label: 'WebRTC' }
+  ], true, false)
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
@@ -1,4 +1,4 @@
-import { pi, pt, pb } from '../helpers.js'
+import { pi, pt, pb, pd } from '../helpers.js'
 
 export default () => [
   pi('item', 'Item', 'Item containing the address of the video'),
@@ -10,5 +10,6 @@ export default () => [
     { value: 'videojs', label: 'Video.js (Dash, HLS, Others)' },
     { value: 'webrtc', label: 'WebRTC' }
   ], true, false).a(),
-  pt('stunServer', 'Stun Server', 'WebRTC stun server (optional), defaults to \'stun:stun.l.google.com:19302\'').a()
+  pt('stunServer', 'Stun Server', 'WebRTC stun server (optional), defaults to \'stun:stun.l.google.com:19302\'').a(),
+  pd('candidatesTimeout', 'ICE candidates timeout', 'WebRTC ICE candidates discovery timeout length in milliseconds (optional), defaults to \'2000\', \'0\' to disable').a()
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -24,8 +24,7 @@ export default {
   },
   data () {
     return {
-      webrtc: null,
-      pageEl: null
+      webrtc: null
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -35,7 +35,7 @@ export default {
   },
   methods: {
     stopStream () {
-      console.debug("WebRTC Closing Connection")
+      console.debug('WebRTC Closing Connection')
       if (this.webrtc) {
         this.webrtc.isClosed = true
         this.webrtc.close()
@@ -44,8 +44,8 @@ export default {
       }
     },
     startStream () {
-      if(!this.inForeground || !this.src){
-        return;
+      if (!this.inForeground || !this.src) {
+        return
       }
       this.stopStream()
       const self = this

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -30,17 +30,11 @@ export default {
   },
   watch: {
     src (value) {
-      this.startPlay()
+      this.startStream()
     }
   },
-  mounted () {
-    this.startPlay();
-  },
-  beforeDestroy () {
-    this.closeConnection()
-  },
   methods: {
-    closeConnection () {
+    stopStream () {
       console.debug("WebRTC Closing Connection")
       if (this.webrtc) {
         this.webrtc.isClosed = true
@@ -49,11 +43,11 @@ export default {
         this.webrtc = null
       }
     },
-    startPlay () {
+    startStream () {
       if(!this.inForeground || !this.src){
         return;
       }
-      this.closeConnection()
+      this.stopStream()
       const self = this
       const webrtc = new RTCPeerConnection({
         iceServers: [
@@ -128,16 +122,16 @@ export default {
         // if we did not close this, restart the stream
         if (!webrtc.isClosed) {
           console.warn(`${webrtcSendChannel.label} closed prematurely, restarting`)
-          self.startPlay()
+          self.startStream()
         }
       }
       this.webrtc = webrtc
     },
     startForegroundActivity () {
-      this.startPlay()
+      this.startStream()
     },
     stopForegroundActivity () {
-      this.closeConnection()
+      this.stopStream()
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -10,7 +10,10 @@
 </template>
 
 <script>
+import foregroundService from '../widget-foreground-service'
+
 export default {
+  mixins: [foregroundService],
   name: 'OhVideoWebRTC',
   props: {
     src: { type: String },
@@ -21,7 +24,8 @@ export default {
   },
   data () {
     return {
-      webrtc: null
+      webrtc: null,
+      pageEl: null
     }
   },
   watch: {
@@ -30,15 +34,14 @@ export default {
     }
   },
   mounted () {
-    if (this.src) {
-      this.startPlay()
-    }
+    this.startPlay();
   },
   beforeDestroy () {
     this.closeConnection()
   },
   methods: {
     closeConnection () {
+      console.debug("WebRTC Closing Connection")
       if (this.webrtc) {
         this.webrtc.isClosed = true
         this.webrtc.close()
@@ -47,10 +50,10 @@ export default {
       }
     },
     startPlay () {
-      this.closeConnection()
-      if (!this.src) {
-        return
+      if(!this.inForeground || !this.src){
+        return;
       }
+      this.closeConnection()
       const self = this
       const webrtc = new RTCPeerConnection({
         iceServers: [
@@ -129,6 +132,12 @@ export default {
         }
       }
       this.webrtc = webrtc
+    },
+    startForegroundActivity () {
+      this.startPlay()
+    },
+    stopForegroundActivity () {
+      this.closeConnection()
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -14,7 +14,8 @@ export default {
   name: 'OhVideoWebRTC',
   props: {
     src: { type: String },
-    config: { type: Object },
+    stunServer: { type: String },
+    enableTrickleIce: { type: Boolean },
     startManually: { type: Boolean },
     hideControls: { type: Boolean }
   },
@@ -47,14 +48,14 @@ export default {
     startPlay () {
       this.closeConnection()
       this.isClosed = false
-      const self = this
-      if (!self.src) {
+      if (!this.src) {
         return
       }
+      const self = this
       self.webrtc = new RTCPeerConnection({
         iceServers: [
           {
-            urls: ['stun:stun.l.google.com:19302']
+            urls: [self.stunServer || 'stun:stun.l.google.com:19302']
           }
         ],
         sdpSemantics: 'unified-plan'
@@ -68,39 +69,48 @@ export default {
       self.webrtc.onnegotiationneeded = function handleNegotiationNeeded () {
         self.webrtc.createOffer().then(offer => {
           self.webrtc.setLocalDescription(offer).then(() => {
-            let candidates = ''
-            // we don't support trickle ice, so do this manually
-            self.webrtc.addEventListener('icecandidate', (event) => {
-              if (!event.candidate) {
-                console.log('Offer: ', self.webrtc.localDescription.sdp)
-                fetch(self.src, {
-                  method: 'POST',
-                  body: new URLSearchParams({
-                    data: btoa(self.webrtc.localDescription.sdp + candidates)
-                  })
-                })
-                  .then(response => response.text())
-                  .then(data => {
-                    const answer = atob(data)
-                    console.log('Answer: ', answer)
-                    try {
-                      self.webrtc.setRemoteDescription(
-                        new RTCSessionDescription({ type: 'answer', sdp: answer })
-                      )
-                    } catch (e) {
-                      console.warn(e)
-                    }
-                  })
-                return
-              }
-              candidates += `a=${event.candidate['candidate']} + \r\n`
-            })
+            if (self.enableTrickleIce) {
+              postOffer()
+            } else {
+              let candidates = ''
+              // theres not a good way to detect trickle ice support before we send our offer, so collect candiates manually
+              // see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/canTrickleIceCandidates
+              self.webrtc.addEventListener('icecandidate', (event) => {
+                if (!event.candidate) {
+                  postOffer(candidates)
+                  return
+                }
+                candidates += `a=${event.candidate['candidate']} + \r\n`
+              })
+            }
           })
         })
       }
 
+      function postOffer (candidates) {
+        console.log('Offer: ', self.webrtc.localDescription.sdp)
+        fetch(self.src, {
+          method: 'POST',
+          body: new URLSearchParams({
+            data: btoa(self.webrtc.localDescription.sdp + (candidates || ''))
+          })
+        })
+          .then(response => response.text())
+          .then(data => {
+            const answer = atob(data)
+            console.log('Answer: ', answer)
+            try {
+              self.webrtc.setRemoteDescription(
+                new RTCSessionDescription({ type: 'answer', sdp: answer })
+              )
+            } catch (e) {
+              console.warn(e)
+            }
+          })
+      }
+      // creates a dummy channel to detect stream interuptions on media
       const webrtcSendChannel = this.webrtc.createDataChannel(
-        'rtsptowebSendChannel'
+        'heartbeatchannel'
       )
       webrtcSendChannel.onopen = event => {
         console.log(`${webrtcSendChannel.label} has opened`)
@@ -113,7 +123,6 @@ export default {
           this.startPlay()
         }
       }
-      webrtcSendChannel.onmessage = event => console.log(event.data)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -1,0 +1,108 @@
+<template>
+  <video
+    ref="videoPlayer"
+    :autoplay="this.startManually ? false : true"
+    :controls="this.hideControls ? false : true"
+    playsinline
+    style="max-width: 100%; max-height: 100%;"
+  >
+    Sorry, your browser doesn't support embedded videos.
+  </video>
+</template>
+
+<script>
+
+export default {
+  name: 'OhVideoWebRTC',
+  props: {
+    src: { type: String },
+    config: { type: Object },
+    startManually: { type: Boolean },
+    hideControls: { type: Boolean }
+  },
+  data () {
+    return {
+      webrtc: null,
+      isClosed: false //if we closed the webrtc stream
+    }
+  },
+  watch: {
+    src (value) {
+      this.startPlay();
+    }
+  },
+  mounted () {
+    if (this.src) {
+      this.startPlay();
+    }
+  },
+  beforeDestroy () {
+    this.closeConnection();
+  },
+  methods: {
+    closeConnection () {
+      this.isClosed = true;
+      if (this.webrtc) {
+        this.webrtc.close();
+      }
+    },
+    startPlay () {
+      this.closeConnection();
+      this.isClosed = false;
+      const self = this;
+      if (!self.src) {
+        return;
+      }
+      self.webrtc = new RTCPeerConnection({
+        iceServers: [{
+          urls: ['stun:stun.l.google.com:19302']
+        }],
+        sdpSemantics: 'unified-plan'
+      })
+      self.webrtc.ontrack = function (event) {
+        console.log(event.streams.length + ' track is delivered')
+        self.$refs.videoPlayer.srcObject = event.streams[0]
+        self.$refs.videoPlayer.play();
+      }
+      self.webrtc.addTransceiver('video', { direction: 'sendrecv' })
+      self.webrtc.onnegotiationneeded = function handleNegotiationNeeded () {
+        self.webrtc.createOffer().then(offer => {
+          self.webrtc.setLocalDescription(offer).then(() => {
+            console.log("Offer: ", self.webrtc.localDescription.sdp)
+            fetch(self.src, {
+              method: 'POST',
+              body: new URLSearchParams({ data: btoa(self.webrtc.localDescription.sdp) })
+            })
+              .then(response => response.text())
+              .then(data => {
+                const answer = atob(data);
+                console.log("Answer: ", answer);
+                try {
+                  self.webrtc.setRemoteDescription(
+                    new RTCSessionDescription({ type: 'answer', sdp: answer })
+                  )
+                } catch (e) {
+                  console.warn(e)
+                }
+              })
+          })
+        })
+      }
+
+      const webrtcSendChannel = this.webrtc.createDataChannel('rtsptowebSendChannel')
+      webrtcSendChannel.onopen = (event) => {
+        console.log(`${webrtcSendChannel.label} has opened`)
+        webrtcSendChannel.send('ping')
+      }
+      webrtcSendChannel.onclose = (_event) => {
+        console.log(`${webrtcSendChannel.label} has closed`)
+        //if we did not close this, restart the stream
+        if(!self.isClosed){
+          startPlay()
+        }
+      }
+      webrtcSendChannel.onmessage = event => console.log(event.data)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -4,7 +4,6 @@
       v-if="config.playerType === 'webrtc'"
       :src="src"
       :stunServer="config.stunServer"
-      :enableTrickleIce="config.enableTrickleIce"
       :startManually="config.startManually"
       :hideControls="config.hideControls" />
     <oh-video-videojs

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -1,6 +1,13 @@
 <template>
   <div class="player">
+    <oh-video-webrtc
+      v-if="config.playerType === 'webrtc'"
+      :src="src"
+      :config="config.videoOptions"
+      :startManually="config.startManually"
+      :hideControls="config.hideControls" />
     <oh-video-videojs
+      v-else
       :src="src"
       :type="config.type"
       :config="config.videoOptions"
@@ -17,7 +24,8 @@ export default {
   mixins: [mixin],
   widget: OhVideoDefinition,
   components: {
-    'oh-video-videojs': () => import(/* webpackChunkName: "oh-video-videojs" */ './oh-video-videojs.vue')
+    'oh-video-videojs': () => import(/* webpackChunkName: "oh-video-videojs" */ './oh-video-videojs.vue'),
+    'oh-video-webrtc': () => import(/* webpackChunkName: "oh-video-webrtc" */ './oh-video-webrtc.vue')
   },
   data () {
     return {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -4,6 +4,7 @@
       v-if="config.playerType === 'webrtc'"
       :src="src"
       :stunServer="config.stunServer"
+      :candidatesTimeout="config.candidatesTimeout"
       :startManually="config.startManually"
       :hideControls="config.hideControls" />
     <oh-video-videojs

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -3,7 +3,8 @@
     <oh-video-webrtc
       v-if="config.playerType === 'webrtc'"
       :src="src"
-      :config="config.videoOptions"
+      :stunServer="config.stunServer"
+      :enableTrickleIce="config.enableTrickleIce"
       :startManually="config.startManually"
       :hideControls="config.hideControls" />
     <oh-video-videojs


### PR DESCRIPTION
This adds WebRTC support to the video widget for 3rd party systems that support posting a SDP offer and returning a SDP answer.  There are a number of system this may work with including some nest cameras and RTSPtoWeb (https://github.com/deepch/RTSPtoWeb)  

Signed-off-by: Dan Cunningham <dan@digitaldan.com>