### PR TITLE
add ignore commands checkbox to expire metadata config

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
@@ -15,9 +15,10 @@
         :value="parsedAction.value"
         @blur="(evt) => updateActionValue(evt.target.value)" />
       <f7-list-item title="ignore state updates" checkbox :checked="ignoreStateUpdates" @change="(ev) => metadata.config['ignoreStateUpdates'] = new Boolean(ev.target.checked).toString()" />
+      <f7-list-item title="ignore commands" checkbox :checked="ignoreCommands" @change="(ev) => metadata.config['ignoreCommands'] = new Boolean(ev.target.checked).toString()" />
     </f7-list>
     <f7-block-footer class="param-description padding-left">
-      <small>After a different command or state update is received, perform the chosen action when the duration specified below has passed. The timer is reset if another state update or command is received before it expires. If the ignore state updates checkbox is set, only state changes will reset the timer.</small>
+      <small>After a different command or state update is received, perform the chosen action when the duration specified below has passed. The timer is reset if another state update or command is received before it expires. If the ignore state updates checkbox is set, only state changes will reset the timer. If the ignore commands checkbox is set, only state updates and state changes will reset the timer.</small>
     </f7-block-footer>
     <f7-block-title medium>
       After
@@ -77,6 +78,11 @@ export default {
     },
     ignoreStateUpdates () {
       let configValue = this.metadata.config['ignoreStateUpdates']
+      if (!configValue) return false
+      return typeof (configValue) === 'string' ? configValue === 'true' : configValue
+    },
+    ignoreCommands () {
+      let configValue = this.metadata.config['ignoreCommands']
       if (!configValue) return false
       return typeof (configValue) === 'string' ? configValue === 'true' : configValue
     }


### PR DESCRIPTION
Implement extra checkbox to match new ignoreCommands option for item expire functionality, as implemented in https://github.com/openhab/openhab-core/pull/2954

Similar to https://github.com/openhab/openhab-webui/pull/1325

Signed-off-by: Sami Salonen <ssalonen@gmail.com>