### PR TITLE
Canvas layout bug fixes and edition mode UI improvements

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-item.vue
@@ -7,7 +7,7 @@
     :w="w"
     :h="h"
     :z="active ? 10 : 0"
-    :parent="true"
+    :parent="false"
     :draggable="!!context.editmode"
     :resizable="!!context.editmode && !autosize"
     :class-name="!!context.editmode ? 'oh-canvas-item-editmode' : 'oh-canvas-item-runmode'"

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-item.vue
@@ -250,6 +250,8 @@ export default {
       return this.resizing
     },
     onDragStartCallback (ev) {
+      if (!this.context.editmode) return false
+
       if (this.gridEnable) {
         const snapX = Math.round(this.x / this.gridPitch) * this.gridPitch
         const snapY = Math.round(this.y / this.gridPitch) * this.gridPitch

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layer.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layer.vue
@@ -6,7 +6,9 @@
       :id="obj.id"
       :grid-enable="gridEnable"
       :grid-pitch="gridPitch"
-      :context="childContext(obj.item)" />
+      :prevent-deactivation="preventDeactivation"
+      :context="childContext(obj.item)"
+      v-on="$listeners" />
   </div>
 </template>
 
@@ -32,7 +34,8 @@ export default {
   props: {
     gridPitch: Number,
     gridEnable: Boolean,
-    id: String
+    id: String,
+    preventDeactivation: Boolean
   },
   data () {
     return {
@@ -61,6 +64,7 @@ export default {
           if (item.component === 'oh-canvas-item') {
             layer.push({
               item: item,
+              selected: false,
               id: Math.random().toString(36).substring(2)
             })
           } else {

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="ohCanvasLayout" class="oh-canvas-layout disable-user-select" :class="context.editMode ? 'margin-top' : ''">
+  <div ref="ohCanvasLayout" class="oh-canvas-layout disable-user-select" :class="context.editmode ? 'margin-top' : ''" @keydown="onKeyDown" @keyup="onKeyUp">
     <f7-block v-if="context.editmode">
       <f7-menu class="configure-layout-menu">
         <f7-menu-item
@@ -142,7 +142,12 @@
         :id="obj.id"
         :grid-enable="grid.enable"
         :grid-pitch="grid.pitch"
-        :context="childContext(obj.item)" />
+        :prevent-deactivation="preventDeactivation"
+        :context="childContext(obj.item)"
+        @ociDragged="ociDragged"
+        @ociDragStop="ociDragStop"
+        @ociSelected="ociSelected"
+        @ociDeselected="ociDeselected" />
     </div>
   </div>
 </template>
@@ -195,7 +200,9 @@ export default {
         pitch: Number,
         enable: false
       },
-      actLyrIdx: 0
+      actLyrIdx: 0,
+      preventDeactivation: false,
+      selectedItems: []
     }
   },
   computed: {
@@ -326,6 +333,73 @@ export default {
         })
       }
       this.layout = layout
+    },
+    onKeyDown (ev) {
+      console.log(`Keydown event shift:${ev.shiftKey} meta:${ev.metaKey}`)
+      let moveX = 0, moveY = 0
+      switch (ev.key) {
+        case 'Shift':
+          this.preventDeactivation = true
+          break
+        case 'ArrowDown':
+          moveY = 1
+          break
+        case 'ArrowUp':
+          moveY = -1
+          break
+        case 'ArrowRight':
+          moveX = 1
+          break
+        case 'ArrowLeft':
+          moveX = -1
+          break
+      }
+      if (moveX || moveY) {
+        const moveBy = this.grid.enable ? this.grid.pitch : 1
+        const didMove = this.moveSelectedItems(null, moveX * moveBy, moveY * moveBy)
+        if (didMove) {
+          ev.stopPropagation()
+          ev.preventDefault()
+        }
+      }
+    },
+    onKeyUp (ev) {
+      switch (ev.key) {
+        case 'Shift':
+          this.preventDeactivation = false
+          break
+      }
+    },
+    moveSelectedItems (exceptId, deltaX, deltaY) {
+      let movedSomething = false
+      this.selectedItems.forEach(i => {
+        if (i.id !== exceptId) {
+          i.moveTo(i.x + deltaX, i.y + deltaY)
+          movedSomething = true
+        }
+      })
+      return movedSomething
+    },
+    ociSelected (item) {
+      this.selectedItems.push(item)
+    },
+    ociDeselected (item) {
+      this.selectedItems.splice(this.selectedItems.indexOf(item), 1)
+    },
+    ociDragged (item, deltaX, deltaY) {
+      // Move all selected (active) items, except the source one (already moved)
+      // if there are several objects selected
+      if (this.selectedItems.length > 1) {
+        this.moveSelectedItems(item.id, deltaX, deltaY)
+      }
+    },
+    ociDragStop (itemId) {
+      // Notify items of drag end in case of multiple items selection
+      if (this.selectedItems.length > 1) {
+        this.selectedItems.forEach(item => {
+          item.stopDrag()
+        })
+      }
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -335,7 +335,6 @@ export default {
       this.layout = layout
     },
     onKeyDown (ev) {
-      console.log(`Keydown event shift:${ev.shiftKey} meta:${ev.metaKey}`)
       let moveX = 0, moveY = 0
       switch (ev.key) {
         case 'Shift':

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -77,6 +77,7 @@
         transform: `scale(${style.scale})`,
         'text-align': 'center',
         position: 'relative',
+        overflow: context.editmode ? 'visible' : 'hidden',
         '--oh-canvas-item-box-shadow': config.boxShadow
           ? config.boxShadow
           : '0px 0px 4px 2px #444',


### PR DESCRIPTION
Runtime mode bug fixes:
- prevent widget from snapping to grid upon action in runtime mode

Edition mode bug fixes:
- fix cursor when hovering above drag handle or label
- allow positioning widgets right on the border of canvas
- popup menu always displayed on top of other widgets
- prevent text selection of drag handle and menu button upon dragging of widget

Edition mode improvements:
- display of optional widget id in edition
- display size of widget when resizing
- display position of widget when moving
- allow multiple selection of widgets
- allow moving widgets through arrow keys