### PR TITLE
Addition of page action configuration option to override vars in target page

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -44,6 +44,7 @@ export const actionsMixin = {
         case 'navigate':
           const actionPage = actionConfig[prefix + 'actionPage']
           const actionPageTransition = actionConfig[prefix + 'actionPageTransition']
+          const actionPageVars = actionConfig[prefix + 'actionPageDefineVars']
           console.log('Navigating to ' + actionPage)
           if (actionPage.indexOf('page:') !== 0) {
             console.log('Action target is not of the format page:uid')
@@ -51,6 +52,7 @@ export const actionsMixin = {
           }
           let navigateOptions = { props: { deep: true } }
           if (actionPageTransition) navigateOptions.transition = actionPageTransition
+          if (actionPageVars) navigateOptions.props.defineVars = actionPageVars
           this.$f7.views.main.router.navigate('/page/' + actionPage.substring(5), navigateOptions)
           break
         case 'command':

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -54,7 +54,7 @@ export default {
     'oh-plan-page': () => import(/* webpackChunkName: "plan-page" */ '@/components/widgets/plan/oh-plan-page.vue'),
     'oh-chart-page': () => import(/* webpackChunkName: "chart-page" */ '@/components/widgets/chart/oh-chart-page.vue')
   },
-  props: ['uid', 'deep'],
+  props: ['uid', 'deep', 'defineVars'],
   data () {
     return {
       currentTab: 0,
@@ -71,7 +71,7 @@ export default {
     context () {
       return {
         component: this.page,
-        vars: (this.page && this.page.config && this.page.config.defineVars) ? this.page.config.defineVars : {},
+        vars: Object.assign((this.page && this.page.config && this.page.config.defineVars) ? this.page.config.defineVars : {}, this.defineVars),
         store: this.$store.getters.trackedItems
       }
     },


### PR DESCRIPTION
Provides ability to transmit local context upon page switching. The target page is able to react to the calling page via the contents of the variable.

For example: 
I have a canvas page with different layers for the ground floor (doors, hvac, lights) which visibility is managed through a var and buttons. It also has a button to navigate to the page for the second floor which has similar layers. Using this evolution I can select the same kind of layer when navigating across these 2 pages by overriding the var defining layer visibility.