### PR TITLE
Configuration of context labels in Equipment and Properties card of homepage tabs.

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
@@ -43,11 +43,31 @@ const EquipmentListParameters = () => [
     })
 ]
 
+const ItemSubtitleParameterGroup = () => pg('label', 'Item context label', 'Settings for context label of items displayed in this tab')
+
+const ItemSubtitleParameters = () => [
+  pt('contextLabelSource', 'Label for providing context of items', 'Choose what to display as the context label of items (either in footer or in dividers). This can be used for dis-ambiguation if several items share the same label.')
+    .o([
+      { value: 'path', label: 'Path in model (default)' },
+      { value: 'parent', label: 'Label of parent in model' },
+      { value: 'itemName', label: 'Item name' },
+      { value: 'none', label: 'None' }
+    ]),
+  pn('contextLabelPathTrimStart', 'Trim start of path', 'Number of parents of the item to trim from the start of the path')
+    .v((value, configuration, configDescription, parameters) => { return configuration.contextLabelSource === 'path' }),
+  pn('contextLabelPathTrimEnd', 'Trim end of path', 'Number of parents of the item to trim from the end of the path')
+    .v((value, configuration, configDescription, parameters) => { return configuration.contextLabelSource === 'path' })
+]
+
 export const OhLocationsTabParameters = () => new WidgetDefinition('oh-locations-tab', 'Locations Tab', 'The tab showing all locations of the installation')
   .paramGroup(EquipmentListParameterGroup(), EquipmentListParameters())
 
 export const OhEquipmentTabParameters = () => new WidgetDefinition('oh-equipment-tab', 'Equipment Tab', 'The tab showing all equipment of the installation, by category')
   .paramGroup(EquipmentListParameterGroup(), EquipmentListParameters())
+  .paramGroup(ItemSubtitleParameterGroup(), ItemSubtitleParameters())
+
+export const OhPropertiesTabParameters = () => new WidgetDefinition('oh-properties-tab', 'Properties Tab', 'The tab showing all properties of the installation, by category')
+  .paramGroup(ItemSubtitleParameterGroup(), ItemSubtitleParameters())
 
 const ModelCardParameterGroup = () => pg('card', 'Model Card', 'General settings for this card')
 

--- a/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/equipment-card.vue
@@ -36,9 +36,10 @@ export default {
   },
   computed: {
     listContext () {
+      const contextLabelDefaults = { contextLabelSource: 'path' }
       return {
         store: this.$store.getters.trackedItems,
-        component: equipmentListComponent(this.element.equipment, this.tabContext, false)
+        component: equipmentListComponent(this.element.equipment, { ...contextLabelDefaults, ...this.tabContext }, false)
       }
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/property-card.vue
@@ -36,6 +36,7 @@ import { loadLocaleMessages } from '@/js/i18n'
 
 export default {
   mixins: [mixin, CardMixin],
+  props: ['tabContext'],
   i18n: {
     messages: loadLocaleMessages(require.context('@/assets/i18n/semantics'))
   },
@@ -44,6 +45,7 @@ export default {
   },
   computed: {
     listContext () {
+      const footerDefaults = { contextLabelSource: 'path' }
       let pointsByType = []
       for (let pointType in this.itemsByPointType) {
         pointsByType.push([
@@ -54,7 +56,7 @@ export default {
               divider: true
             }
           },
-          ...this.itemsByPointType[pointType].map((p) => itemDefaultListComponent(p, itemPathLabel(p)))
+          ...this.itemsByPointType[pointType].map((p) => itemDefaultListComponent(p, { ...footerDefaults, ...this.tabContext }))
         ])
       }
 

--- a/bundles/org.openhab.ui/web/src/components/home/habot.vue
+++ b/bundles/org.openhab.ui/web/src/components/home/habot.vue
@@ -293,7 +293,7 @@ export default {
               mediaList: true
             },
             slots: {
-              default: items.map((i) => itemDefaultListComponent(i, true))
+              default: items.map((i) => itemDefaultListComponent(i, { contextLabelSource: 'itemName' }))
             }
           }
           this.busy = false

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -11,7 +11,7 @@
           <equipment-card v-if="type === 'equipment' && !element.separator" :key="element.key"
                           type="equipment" :element="element" :context="cardContext(element)" :tab-context="tabContext(type)" />
           <property-card v-if="type === 'properties' && !element.separator" :key="element.key"
-                         type="property" :element="element" :context="cardContext(element)" />
+                         type="property" :element="element" :context="cardContext(element)" :tab-context="tabContext(type)" />
         </div>
       </div>
     </div>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -99,6 +99,14 @@
                 :configuration="page.slots.equipment[0].config"
                 @updated="dirty = true" />
             </div>
+
+            <div v-if="currentModelTab === 'properties'">
+              <config-sheet
+                :parameterGroups="propertiesTabParameters.props.parameterGroups || []"
+                :parameters="propertiesTabParameters.props.parameters || []"
+                :configuration="page.slots.properties[0].config"
+                @updated="dirty = true" />
+            </div>
           </f7-col>
         </f7-block>
         <div v-else-if="ready && previewMode && currentTab === 'design'" :context="context" :key="pageKey">
@@ -140,7 +148,7 @@ import HomeCards from '../../../home/homecards-mixin'
 
 import YAML from 'yaml'
 
-import { OhHomePageDefinition, OhLocationsTabParameters, OhEquipmentTabParameters, OhLocationCardParameters, OhEquipmentCardParameters, OhPropertyCardParameters } from '@/assets/definitions/widgets/home'
+import { OhHomePageDefinition, OhLocationsTabParameters, OhEquipmentTabParameters, OhPropertiesTabParameters, OhLocationCardParameters, OhEquipmentCardParameters, OhPropertyCardParameters } from '@/assets/definitions/widgets/home'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import ModelTab from '@/pages/home/model-tab.vue'
@@ -164,6 +172,7 @@ export default {
       pageWidgetDefinition: OhHomePageDefinition(),
       locationsTabParameters: OhLocationsTabParameters(),
       equipmentTabParameters: OhEquipmentTabParameters(),
+      propertiesTabParameters: OhPropertiesTabParameters(),
       currentModelTab: 'locations',
       modelTabs: [],
       showCardControls: false,


### PR DESCRIPTION
Addition of configuration options available are the path in model (joining parents label), the parent label, the item name or nothing. The possibility to trim beginning or end of path is also configurable.
If nothing is selected, will display the footer defined in metadata (if any).

This should hopefully satisfy users who complained about the lack of configurability when the improvements of PR #1264 were introduced.