### PR TITLE
Fixes item value hidden for equipment accordion button

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -143,7 +143,6 @@ export function itemAccordionEquipmentComponent (item, config, itemNameAsFooterO
 
   let c = promoted ? promotedEquipmentContext(promoted, config, itemNameAsFooterOrLocation) : itemDefaultListComponent(item, itemNameAsFooterOrLocation)
   c.config.action = undefined
-  c.config.after = ''
   c.slots = {
     accordion: [
       {


### PR DESCRIPTION
Value was hard coded to avoid the infamous NULL on groups (PR #1285) without having to configure items, but this causes issues for legitimate uses where you'd want to see the value displayed.