### PR TITLE
Prevent some undesired 'NULL' labels in lists for un-typed Groups.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -101,7 +101,9 @@ export default function itemDefaultListComponent (item, itemNameAsFooterOrLocati
   if (item.label && itemNameAsFooterOrLocation === true) component.config.footer = item.name
   else if (item.label && itemNameAsFooterOrLocation) component.config.footer = itemNameAsFooterOrLocation
   if (!item.category) component.config.fallbackIconToInitial = true
-
+  if (component.component === 'oh-label-item' && item.type.indexOf('Group') === 0 && !item.groupType && component.config.after === undefined) {
+    component.config.after = null // Hide 'NULL' label for standard (non-typed) groups with no 'after' metadata defined
+  }
   return component
 }
 


### PR DESCRIPTION
When non-typed Group items are rendered automatically in lists as oh-label-item, or following listWidget metadata application, the label displayed is 'NULL'. On these un-typed Group items this can be corrected without hiding information side-effect since there will never be a state with any meaning. It will always be NULL.

This PR forces the label not to be displayed.

Combined with last PR #1396, it allows automatic generation of Model UI that makes sense and does not require manual metadata adjustment when equipment are configured as accordion. This also fixes automatically generated hierarchical Group browsing list pages. For typed groups, manual setting of metadata (PR #1285) is still required if needed.