### PR TITLE
[blockly] add help button to OH docs, provide blockly source maps for debugging

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -86,7 +86,11 @@ module.exports = {
           resolvePath('node_modules/ssr-window')
         ]
       },
-
+      {
+        test: /(blockly\/.*\.js)$/,
+        enforce: "pre",
+        use: ["source-map-loader"],
+      },
       {
         test: /\.vue$/,
         use: 'vue-loader'

--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = {
       {
         test: /(blockly\/.*\.js)$/,
         enforce: "pre",
-        use: ["source-map-loader"],
+        use: (env === 'development' || buildSourceMaps) ? ["source-map-loader"] : [],
       },
       {
         test: /\.vue$/,

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -321,6 +321,10 @@
 
       <category name="openHAB" colour="0" :expanded="$f7.device.desktop">
         <category name="Items &amp; Things">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html"
+            text="Items &amp; Things Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_item" />
           <block type="oh_getitem">
             <value name="itemName">
@@ -366,6 +370,10 @@
         </category>
 
         <category name="Timers &amp; Delays">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html"
+            text="Timers &amp; Delays Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_sleep" />
           <sep gap="48" />
           <block type="oh_timer">
@@ -435,6 +443,10 @@
         </category>
 
         <category name="Voice &amp; Multimedia">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html"
+            text="Voice &amp; Multimedia Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_playmedia_sink">
             <value name="fileName">
               <shadow type="text">
@@ -491,6 +503,10 @@
           </block>
         </category>
         <category name="Dates &amp; Times">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html"
+            text="Dates & Times Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_zdt_now" />
           <block type="oh_zdt_plusminus">
             <value name="offset">
@@ -608,6 +624,10 @@
         </category>
 
         <category name="Ephemeris">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-ephemeris.html"
+            text="Ephemeris Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_ephemeris_check">
             <value name="dayInfo">
               <shadow type="oh_dayoffset_today" />
@@ -628,6 +648,10 @@
         </category>
 
         <category name="Notifications">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-notifications.html"
+            text="Notifications Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_sendNotification">
             <value name="email">
               <shadow type="text">
@@ -670,6 +694,10 @@
         </category>
 
         <category name="Persistence">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-persistence.html"
+            text="Persistence Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_zdt_plusminus">
             <value name="offset">
               <shadow type="math_number">
@@ -692,7 +720,6 @@
               <shadow type="oh_zdt" />
             </value>
           </block>
-          <sep gap="48" />
           <block type="oh_get_persistvalue">
             <value name="itemName">
               <shadow type="oh_item" />
@@ -737,6 +764,10 @@
         </category>
 
         <category name="Value Storage">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html"
+            text="Value Storage Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_store_value">
             <value name="value">
               <shadow type="text">
@@ -766,6 +797,10 @@
         </category>
 
         <category name="Run &amp; Process">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html"
+            text="Run &amp; Process Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_callscriptfile">
             <value name="scriptfile">
               <shadow type="text">
@@ -812,6 +847,10 @@
         </category>
 
         <category name="Logging &amp; Output">
+          <button
+            helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-logging.html"
+            text="Logging &amp; Output Help"
+            callbackKey="ohBlocklyHelp" />
           <block type="oh_log">
             <value name="message">
               <shadow type="text">
@@ -944,6 +983,12 @@ export default {
       const xml = Blockly.Xml.textToDom(this.blocks)
       Blockly.Xml.domToWorkspace(xml, this.workspace)
       this.workspace.addChangeListener(this.onChange)
+
+      // Open specific help page for category via flyout button
+      // see https://developers.google.com/blockly/guides/configure/web/toolbox?hl=en#buttons_and_labels
+      this.workspace.registerButtonCallback('ohBlocklyHelp', function (button) {
+        window.open(button.info.helpurl, '_blank')
+      })
     },
     addLibraryToToolbox (definitions) {
       const library = this.$refs.libraryCategory

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -213,6 +213,10 @@
       </category>
 
       <category name="Lists" colour="%{BKY_LISTS_HUE}">
+        <button
+          helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#lists"
+          text="List Help"
+          callbackKey="ohBlocklyHelp" />
         <block type="lists_create_with">
           <mutation items="0" />
         </block>
@@ -274,6 +278,10 @@
       </category>
 
       <category name="Color" colour="%{BKY_COLOUR_HUE}">
+        <button
+          helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#colors"
+          text="Color Help"
+          callbackKey="ohBlocklyHelp" />
         <block type="colour_picker" />
         <block type="colour_random" />
         <block type="colour_rgb">
@@ -505,7 +513,7 @@
         <category name="Dates &amp; Times">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html"
-            text="Dates & Times Help"
+            text="Dates &amp; Times Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_zdt_now" />
           <block type="oh_zdt_plusminus">
@@ -720,6 +728,7 @@
               <shadow type="oh_zdt" />
             </value>
           </block>
+          <sep gap="48" />
           <block type="oh_get_persistvalue">
             <value name="itemName">
               <shadow type="oh_item" />
@@ -984,8 +993,6 @@ export default {
       Blockly.Xml.domToWorkspace(xml, this.workspace)
       this.workspace.addChangeListener(this.onChange)
 
-      // Open specific help page for category via flyout button
-      // see https://developers.google.com/blockly/guides/configure/web/toolbox?hl=en#buttons_and_labels
       this.workspace.registerButtonCallback('ohBlocklyHelp', function (button) {
         window.open(button.info.helpurl, '_blank')
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -215,7 +215,7 @@
       <category name="Lists" colour="%{BKY_LISTS_HUE}">
         <button
           helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#lists"
-          text="List Help"
+          text="Help"
           callbackKey="ohBlocklyHelp" />
         <block type="lists_create_with">
           <mutation items="0" />
@@ -280,7 +280,7 @@
       <category name="Color" colour="%{BKY_COLOUR_HUE}">
         <button
           helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#colors"
-          text="Color Help"
+          text="Help"
           callbackKey="ohBlocklyHelp" />
         <block type="colour_picker" />
         <block type="colour_random" />
@@ -331,7 +331,7 @@
         <category name="Items &amp; Things">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html"
-            text="Items &amp; Things Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_item" />
           <block type="oh_getitem">
@@ -380,7 +380,7 @@
         <category name="Timers &amp; Delays">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-timers-and-delays.html"
-            text="Timers &amp; Delays Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_sleep" />
           <sep gap="48" />
@@ -453,7 +453,7 @@
         <category name="Voice &amp; Multimedia">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-voice-and-multimedia.html"
-            text="Voice &amp; Multimedia Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_playmedia_sink">
             <value name="fileName">
@@ -513,7 +513,7 @@
         <category name="Dates &amp; Times">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html"
-            text="Dates &amp; Times Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_zdt_now" />
           <block type="oh_zdt_plusminus">
@@ -634,7 +634,7 @@
         <category name="Ephemeris">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-ephemeris.html"
-            text="Ephemeris Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_ephemeris_check">
             <value name="dayInfo">
@@ -658,7 +658,7 @@
         <category name="Notifications">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-notifications.html"
-            text="Notifications Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_sendNotification">
             <value name="email">
@@ -704,7 +704,7 @@
         <category name="Persistence">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-persistence.html"
-            text="Persistence Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_zdt_plusminus">
             <value name="offset">
@@ -775,7 +775,7 @@
         <category name="Value Storage">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html"
-            text="Value Storage Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_store_value">
             <value name="value">
@@ -808,7 +808,7 @@
         <category name="Run &amp; Process">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html"
-            text="Run &amp; Process Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_callscriptfile">
             <value name="scriptfile">
@@ -858,7 +858,7 @@
         <category name="Logging &amp; Output">
           <button
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-logging.html"
-            text="Logging &amp; Output Help"
+            text="Help"
             callbackKey="ohBlocklyHelp" />
           <block type="oh_log">
             <value name="message">


### PR DESCRIPTION
1) Add a help button to the category flyouts that directly opens the respective help page on openhab-docs, e.g. like so

![image](https://user-images.githubusercontent.com/5937600/170978854-37b3dadd-bd03-449c-ae27-cf49e9f24376.png)

This is available for all openhab categories as well as in the list and color category
It will most likely lead the blockly users much quicker to the help pages as the experience in the forum shows that the help link of the context menu of an individual block is easily overlooked.

2) Allow better debugging for blockly code by resolving the source maps for blockly.

It allows much easier development of further blockly functionality as the debugger will now resolve and show the non-minified javascript code when stepping into it.

To be able to use that, source-map-loader (at least 1.1.3) should be installed via NPM.  

Signed-off-by: Stefan Höhn <stefan.hoehn@nfon.com>
Again big thanks goes to @tweini within the blockly community.