### PR TITLE
Page loading message fix

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -30,10 +30,12 @@
         <f7-preloader :size="30" />
         <div>Loading...</div>
       </f7-block-title>
-      <f7-block-title v-if="loopError">
-        <div>Error!</div>
-      </f7-block-title>
-      {{ loopError }}. Please correct and refresh.
+      <f7-block v-if="loopError">
+        <f7-block-title>
+          <div>Error!</div>
+        </f7-block-title>
+        {{ loopError }}. Please correct and refresh.
+      </f7-block>
     </f7-block>
     <f7-tabs v-else>
       <f7-tab id="tab-overview" :tab-active="currentTab === 'overview'" @tab:show="() => this.currentTab = 'overview'">


### PR DESCRIPTION
Fixes the end of the message about loop error in model appearing while page loading indicator is displayed (without actual loop error). This message was introduced in PR #1307 