### PR TITLE
Equipment as accordion click through fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-button v-bind="config" @click="clicked" @taphold.native="onTaphold($event)" @contextmenu.native="onContextMenu($event)">
+  <f7-button v-bind="config" @click.stop="clicked" @taphold.native="onTaphold($event)" @contextmenu.native="onContextMenu($event)">
     <template v-if="context.component.slots && context.component.slots.default">
       <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
     </template>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
@@ -1,6 +1,6 @@
 <template>
   <knob-control v-bind="config" :text-color="config.textColor || ($f7.data.themeOptions.dark === 'dark') ? '#ffffff' : undefined" :value="value"
-                @input="sendCommandDebounced($event)" @click.native="sendCommandDebounced(value, true)" @touchend.native="sendCommandDebounced(value, true)" />
+                @input="sendCommandDebounced($event)" @click.native.stop="sendCommandDebounced(value, true)" @touchend.native.stop="sendCommandDebounced(value, true)" />
 </template>
 
 <script>


### PR DESCRIPTION
Fixes for click through custom widgets containing either oh-button or oh-knob used in equipment accordion list. Click through leads to both the accordion opening and the action on the widget upon user action.