### PR TITLE
[blockly] fix dt block type, add missing options to dt block, add help urls

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
@@ -67,7 +67,7 @@ export default function (f7) {
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(70)
       this.setTooltip('Obtains the current date-time from the system clock in the default time-zone.\nReturns: ZonedDateTime')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-datetime-now')
     }
   }
 
@@ -129,7 +129,7 @@ export default function (f7) {
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(70)
       this.setTooltip('Creates a ZonedDateTime based on the given input for date and time with nanos set to 0 and the system\'s time-zone. The values need to be valid.\nReturns: ZonedDateTime')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#datetime-with-date-and-time-values')
     },
     updateShape_: function () {
       let year = this.appendValueInput('year')
@@ -252,8 +252,8 @@ export default function (f7) {
         .setCheck('String')
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(70)
-      this.setTooltip('ZonedDateTime from a DateItem Item')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setTooltip('ZonedDateTime from a datetime item')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#datetime-from-item')
     }
   }
 
@@ -288,7 +288,7 @@ export default function (f7) {
       this.setOutput(true, 'zdtTemporalUnit')
       this.setColour(120)
       this.setTooltip('click arrow to scroll through year, month, day, hour, minute, second, milli, nano, day of year')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#create-datetime-based-on-a-specific-date-copy-of')
     },
     onClick (nextField) {
       let block = this.getSourceBlock()
@@ -357,7 +357,7 @@ export default function (f7) {
       this.setOutput(true, 'zdtTemporalUnit')
       this.setColour(120)
       this.setTooltip('click arrow to scroll through year, month, day, hour, minute, second, milli, nano, day of year')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#create-datetime-based-on-a-specific-date-copy-of')
     },
     onClick (nextField) {
       let block = this.getSourceBlock()
@@ -427,7 +427,7 @@ export default function (f7) {
 
       this.setMutator(new Blockly.Mutator(['oh_zdt_amend_item']))
       this.setTooltip('Use a ZonedDateTime as a basis and amend it via particular temporal blocks')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#create-datetime-based-on-a-specific-date-copy-of')
     },
     mutationToDom: function () {
       let container = Blockly.utils.xml.createElement('mutation')
@@ -505,7 +505,7 @@ export default function (f7) {
             .setAlign(Blockly.ALIGN_RIGHT)
             .setCheck('zdtTemporalUnit')
           if (i === 0) {
-            input.appendField(new Blockly.FieldDropdown([['set', 'with'], ['add', 'plus'], ['substract', 'minus']]), 'operation')
+            input.appendField(new Blockly.FieldDropdown([['set', 'with'], ['add', 'plus'], ['subtract', 'minus']]), 'operation')
           }
         }
       }
@@ -658,7 +658,7 @@ export default function (f7) {
       this.setInputsInline(true)
       this.setColour('%{BKY_LOGIC_HUE}')
       this.setTooltip('Compares two ZonedDateTimes with each other')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#date-comparison')
     }
   }
 
@@ -702,7 +702,7 @@ export default function (f7) {
       this.setInputsInline(true)
       this.setColour('%{BKY_LOGIC_HUE}')
       this.setTooltip('Compares two ZonedDateTimes with each other')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-string-representation-of-date')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#date-comparison-between')
     }
   }
 
@@ -731,15 +731,15 @@ export default function (f7) {
   Blockly.Blocks['oh_get_zdt_part'] = {
     init: function () {
       this.appendDummyInput()
-        .appendField(new Blockly.FieldDropdown([['year', 'getYear'], ['month', 'getMonthValue'], ['day', 'getDayOfMonth'], ['hour', 'getHour'], ['minute', 'getMinute'], ['second', 'getSecond'], ['milli', 'getMilli'], ['micro', 'getMicro'], ['nano', 'getNano']]), 'temporalPart')
+        .appendField(new Blockly.FieldDropdown([['year', 'getYear'], ['month', 'getMonthValue'], ['day of month', 'getDayOfMonth'], ['day of week', 'getDayOfWeek'], ['day of year', 'getDayOfYear'], ['hour', 'getHour'], ['minute', 'getMinute'], ['second', 'getSecond'], ['milli', 'getMilli'], ['micro', 'getMicro'], ['nano', 'getNano']]), 'temporalPart')
         .appendField('of')
       this.appendValueInput('date')
         .setCheck('ZonedDateTime')
       this.setInputsInline(true)
-      this.setOutput(true, 'ZonedDateTime')
+      this.setOutput(true, 'Number')
       this.setColour(230)
       this.setTooltip('Returns the selected field as Number.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-part-of-datetime')
     }
   }
 
@@ -778,21 +778,22 @@ export default function (f7) {
     init: function () {
       this.appendDummyInput()
         .appendField(new Blockly.FieldDropdown([['years', 'YEARS'], ['months', 'MONTHS'], ['weeks', 'WEEKS'], ['days', 'DAYS'], ['hours', 'HOURS'], ['minutes', 'MINUTES'], ['seconds', 'SECONDS'], ['millis', 'MILLIS'], ['micros', 'MICROS'], ['nanos', 'NANOS']]), 'temporalPart')
+        .appendField('between')
       this.appendValueInput('zdtOne')
         .setCheck('ZonedDateTime')
       this.appendValueInput('zdtTwo')
         .setCheck('ZonedDateTime')
-        .appendField('between')
+        .appendField('and')
       this.setInputsInline(true)
-      this.setOutput(true, 'ZonedDateTime')
+      this.setOutput(true, 'Number')
       this.setColour(230)
       this.setTooltip('Returns the selected field as Number.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-difference-between-datetimes')
     }
   }
 
   /*
-  * Computes the number of temporal unit between two zonedDateTimes
+  * Computes the number of temporal units between two zonedDateTimes
   * Code part
   */
   Blockly.JavaScript['oh_get_time_between'] = function (block) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -333,17 +333,6 @@
             helpUrl="https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html"
             text="Help"
             callbackKey="ohBlocklyHelp" />
-          <block type="oh_item" />
-          <block type="oh_getitem">
-            <value name="itemName">
-              <shadow type="oh_item" />
-            </value>
-          </block>
-          <block type="oh_groupmembers">
-            <value name="groupName">
-              <shadow type="oh_item" />
-            </value>
-          </block>
           <block type="oh_getitem_state">
             <value name="itemName">
               <shadow type="oh_item" />
@@ -358,6 +347,16 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_getitem">
+            <value name="itemName">
+              <shadow type="oh_item" />
+            </value>
+          </block>
+          <block type="oh_groupmembers">
+            <value name="groupName">
+              <shadow type="oh_item" />
+            </value>
+          </block>
           <block type="oh_event">
             <value name="value">
               <shadow type="text">
@@ -368,6 +367,7 @@
               <shadow type="oh_item" />
             </value>
           </block>
+          <block type="oh_item" />
           <sep gap="48" />
           <block type="oh_thing" />
           <block type="oh_getthing_state">


### PR DESCRIPTION
- fix block type to number for oh_get_zdt_part and oh_get_time_between
- add day of week, day of year, day of month to oh_get_zdt_part
- change labels for oh_get_time_between
- add precise block help urls for new datetime blocks
- rearrange item blocks to reduce use of wrong blocks
- typos

Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>