### PR TITLE
Blockly datesupport fix

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
@@ -46,7 +46,7 @@ export function addDateSupport () {
     'getZonedDateTime', [
       '/* Try to detect the format based on its length */',
       'function ' + Blockly.JavaScript.FUNCTION_NAME_PLACEHOLDER_ + '(datetime) {',
-      '  datetime = datetime.replace(\'T\', \' \')',
+      '  datetime = String(datetime).replace(\'T\', \' \')',
       '  switch (datetime.length) {',
       `    case 10: return ${zdt}.parse(datetime + ' 00:00:00+00:00', dtf.ofPattern('yyyy-MM-dd HH:mm:ssz'));`,
       `    case 16: return ${zdt}.parse(datetime + ':00+00:00', dtf.ofPattern('yyyy-MM-dd HH:mm:ssz'));`,

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -48,12 +48,14 @@ export default {
     iconType () {
       const icon = (this.context) ? this.config.icon : this.icon
       if (!icon) return 'oh'
+      if (!(typeof icon === 'string' || icon instanceof String)) return 'oh'
       if (icon.indexOf('f7') === 0 || icon.indexOf('material') === 0) return 'f7'
       if (icon.indexOf('if') === 0 || icon.indexOf('iconify') === 0) return 'iconify'
       return 'oh'
     },
     iconName () {
       const icon = (this.context) ? this.config.icon : this.icon
+      if (!(typeof icon === 'string' || icon instanceof String)) return ''
       if (icon.indexOf(':') >= 0) return icon.substring(icon.indexOf(':') + 1)
       return icon
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -369,12 +369,12 @@
           </block>
           <block type="oh_item" />
           <sep gap="48" />
-          <block type="oh_thing" />
           <block type="oh_getthing_state">
             <value name="thingUid">
               <shadow type="oh_thing" />
             </value>
           </block>
+          <block type="oh_thing" />
         </category>
 
         <category name="Timers &amp; Delays">


### PR DESCRIPTION
fix: when providing an item state to getZonedDateTime() it is not detected as string by ecma-script and replace() fails -> convert explicitly to String first