### PR TITLE
oh-icon: Verify icon property is a string before performing string operations.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-icon.vue
@@ -48,12 +48,14 @@ export default {
     iconType () {
       const icon = (this.context) ? this.config.icon : this.icon
       if (!icon) return 'oh'
+      if (!(typeof icon === 'string' || icon instanceof String)) return 'oh'
       if (icon.indexOf('f7') === 0 || icon.indexOf('material') === 0) return 'f7'
       if (icon.indexOf('if') === 0 || icon.indexOf('iconify') === 0) return 'iconify'
       return 'oh'
     },
     iconName () {
       const icon = (this.context) ? this.config.icon : this.icon
+      if (!(typeof icon === 'string' || icon instanceof String)) return ''
       if (icon.indexOf(':') >= 0) return icon.substring(icon.indexOf(':') + 1)
       return icon
     },


### PR DESCRIPTION
When the value of the icon property in the oh-icon component does not evaluate to a string, an exception is thrown. Subsequent updates to the underlying data are not evaluated, leaving the icon absent. This change checks the type of the icon property before performing substring operations.

Tested on OH 3.3.0-SNAPSHOT on MacOS and illumos. 

Fixes #1411.