### PR TITLE
[blockly] add zoom controls to workspace

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -10,6 +10,7 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@blockly/field-slider": "^2.1.10",
+        "@blockly/zoom-to-fit": "^2.0.24",
         "blockly": "^6.20210701.0",
         "cronstrue": "^1.100.0",
         "dayjs": "^1.9.6",
@@ -2751,6 +2752,17 @@
       "integrity": "sha512-LeWRhMhOhfuwVWoYpbtwovdMXlP48HRVULBz+a+DwqSIAv3qMArgJtYtPK1SDqOg4MBoqjUUdGkeFJeJ3arcfg==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@blockly/zoom-to-fit": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@blockly/zoom-to-fit/-/zoom-to-fit-2.0.24.tgz",
+      "integrity": "sha512-dbcCjyrH7cgwsLE1e/7Hfh42RN1J0CCGni5/7JgeztpR6POfSlQU7rkElxw4qf9HEkHtJa/qBk0l+VB4lqxDgA==",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": ">=6.20210701.0 <9"
       }
     },
     "node_modules/@bundle-stats/utils": {
@@ -25405,6 +25417,12 @@
       "version": "2.1.29",
       "resolved": "https://registry.npmjs.org/@blockly/field-slider/-/field-slider-2.1.29.tgz",
       "integrity": "sha512-LeWRhMhOhfuwVWoYpbtwovdMXlP48HRVULBz+a+DwqSIAv3qMArgJtYtPK1SDqOg4MBoqjUUdGkeFJeJ3arcfg=="
+    },
+    "@blockly/zoom-to-fit": {
+      "version": "2.0.24",
+      "resolved": "https://registry.npmjs.org/@blockly/zoom-to-fit/-/zoom-to-fit-2.0.24.tgz",
+      "integrity": "sha512-dbcCjyrH7cgwsLE1e/7Hfh42RN1J0CCGni5/7JgeztpR6POfSlQU7rkElxw4qf9HEkHtJa/qBk0l+VB4lqxDgA==",
+      "requires": {}
     },
     "@bundle-stats/utils": {
       "version": "2.7.0",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -62,6 +62,7 @@
   ],
   "dependencies": {
     "@blockly/field-slider": "^2.1.10",
+    "@blockly/zoom-to-fit": "^2.0.24",
     "blockly": "^6.20210701.0",
     "cronstrue": "^1.100.0",
     "dayjs": "^1.9.6",

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -115,6 +115,8 @@ html
 
 .toolbar.toolbar-bottom, .tabbar.tabbar-bottom
   --f7-theme-color #2196f3
+  --f7-theme-color-rgb var(--f7-color-blue-rgb)
+  --f7-theme-color-tint var(--f7-color-blue-tint)
 
 .home-tabs
   --f7-theme-color #2196f3

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -902,7 +902,7 @@
 
 <script>
 import Blockly from 'blockly'
-import {ZoomToFitControl} from '@blockly/zoom-to-fit';
+import { ZoomToFitControl } from '@blockly/zoom-to-fit'
 import Vue from 'vue'
 
 import defineOHBlocks from '@/assets/definitions/blockly'
@@ -988,17 +988,19 @@ export default {
         horizontalLayout: !this.$device.desktop,
         theme: this.$f7.data.themeOptions.dark === 'dark' ? 'dark' : undefined,
         zoom:
-          {controls: true,
-          wheel: true,
-          startScale: 1.0,
-          maxScale: 3,
-          minScale: 0.3,
-          scaleSpeed: 1.2,
-          pinch: true},
+          {
+            controls: true,
+            wheel: true,
+            startScale: 1.0,
+            maxScale: 3,
+            minScale: 0.3,
+            scaleSpeed: 1.2,
+            pinch: true
+          },
         trashcan: false
       })
-      const zoomToFit = new ZoomToFitControl(this.workspace);
-      zoomToFit.init();
+      const zoomToFit = new ZoomToFitControl(this.workspace)
+      zoomToFit.init()
       this.registerLibraryCallbacks(libraryDefinitions)
       const xml = Blockly.Xml.textToDom(this.blocks)
       Blockly.Xml.domToWorkspace(xml, this.workspace)

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -902,6 +902,7 @@
 
 <script>
 import Blockly from 'blockly'
+import {ZoomToFitControl} from '@blockly/zoom-to-fit';
 import Vue from 'vue'
 
 import defineOHBlocks from '@/assets/definitions/blockly'
@@ -986,8 +987,18 @@ export default {
         toolbox: this.$refs.toolbox,
         horizontalLayout: !this.$device.desktop,
         theme: this.$f7.data.themeOptions.dark === 'dark' ? 'dark' : undefined,
+        zoom:
+          {controls: true,
+          wheel: true,
+          startScale: 1.0,
+          maxScale: 3,
+          minScale: 0.3,
+          scaleSpeed: 1.2,
+          pinch: true},
         trashcan: false
       })
+      const zoomToFit = new ZoomToFitControl(this.workspace);
+      zoomToFit.init();
       this.registerLibraryCallbacks(libraryDefinitions)
       const xml = Blockly.Xml.textToDom(this.blocks)
       Blockly.Xml.domToWorkspace(xml, this.workspace)

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -18,7 +18,7 @@
       <span class="display-flex flex-direction-row align-items-center">
         <f7-link :icon-color="(rule.status.statusDetail === 'DISABLED') ? 'orange' : 'gray'" :tooltip="((rule.status.statusDetail === 'DISABLED') ? 'Enable' : 'Disable') + (($device.desktop) ? ' (Ctrl-D)' : '')" icon-ios="f7:pause_circle" icon-md="f7:pause_circle" icon-aurora="f7:pause_circle" color="orange" @click="toggleDisabled" />
         <f7-link v-if="!$theme.aurora" :tooltip="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" color="blue" @click="runNow" />
-        <f7-link v-else-if="$device.desktop" class="margin-left" :text="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" color="blue" @click="runNow" />
+        <f7-link v-else class="margin-left" :text="($device.desktop) ? 'Run Now (Ctrl-R)' : ''" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" color="blue" @click="runNow" />
         <f7-chip class="margin-left" v-if="currentModule && currentModule.configuration.script"
                  :text="ruleStatusBadgeText(rule.status)"
                  :color="ruleStatusBadgeColor(rule.status)"

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -15,16 +15,20 @@
       </f7-nav-right>
     </f7-navbar>
     <f7-toolbar v-if="!newScript && ready" position="bottom">
-      <span class="display-flex flex-direction-row">
+      <span class="display-flex flex-direction-row align-items-center">
         <f7-link :icon-color="(rule.status.statusDetail === 'DISABLED') ? 'orange' : 'gray'" :tooltip="((rule.status.statusDetail === 'DISABLED') ? 'Enable' : 'Disable') + (($device.desktop) ? ' (Ctrl-D)' : '')" icon-ios="f7:pause_circle" icon-md="f7:pause_circle" icon-aurora="f7:pause_circle" color="orange" @click="toggleDisabled" />
         <f7-link v-if="!$theme.aurora" :tooltip="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" color="blue" @click="runNow" />
-        <f7-link v-else class="margin-left" :text="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" color="blue" @click="runNow" />
-      </span>
-      <span class="display-flex flex-direction-row align-items-center">
-        <f7-chip class="margin-right"
+        <f7-link v-else-if="$device.desktop" class="margin-left" :text="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" color="blue" @click="runNow" />
+        <f7-chip class="margin-left" v-if="currentModule && currentModule.configuration.script"
                  :text="ruleStatusBadgeText(rule.status)"
                  :color="ruleStatusBadgeColor(rule.status)"
                  :tooltip="rule.status.description" />
+      </span>
+      <span class="display-flex flex-direction-row align-items-center">
+        <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
+          <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
+          <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
+        </f7-segmented>
         <f7-link v-if="isScriptRule" class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
       </span>
     </f7-toolbar>
@@ -66,12 +70,6 @@
       </div>
     </div>
 
-    <f7-fab v-show="!newScript && isBlockly && !blocklyCodePreview" position="right-bottom" slot="fixed" color="blue" @click="showBlocklyCode">
-      <f7-icon f7="doc_text" />
-    </f7-fab>
-    <f7-fab v-show="!newScript && isBlockly && blocklyCodePreview" position="right-bottom" slot="fixed" color="blue" @click="blocklyCodePreview = false">
-      <f7-icon f7="ticket" />
-    </f7-fab>
     <f7-fab v-show="!newScript && !script && mode === 'application/javascript' && !isBlockly" position="center-bottom" slot="fixed" color="blue" @click="convertToBlockly" text="Design with Blockly">
       <f7-icon f7="ticket_fill" />
     </f7-fab>


### PR DESCRIPTION

Add zoom controls to blockly workspace including zoom-to-fit, center, pinch support:

<img width="74" alt="image" src="https://user-images.githubusercontent.com/5937600/174456717-dd6921ba-cdb0-4a1c-8552-46fdd9464f45.png">

@ghys code-button needs to be slightly moved out of the way as discussed

Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>