### PR TITLE
[homekit] add support for parameter groups

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
@@ -226,7 +226,7 @@ export const accessories = {
   'Battery': [
     { label: 'BatteryLevel', mandatory: true },
     { label: 'BatteryLowStatus', mandatory: true },
-    { label: 'BatteryChargingState', mandatory: true }
+    { label: 'BatteryChargingState', mandatory: false }
   ],
   'Filter': [
     { label: 'FilterChangeIndication', mandatory: true },
@@ -261,6 +261,17 @@ const invertedParameter = {
   label: 'inverted',
   type: 'TEXT',
   description: 'invert the value for HomeKit (default is true)',
+  limitToOptions: true,
+  options: [
+    { value: 'false', label: 'false' },
+    { value: 'true', label: 'true' }
+  ]
+}
+const chargeableParameter = {
+  name: 'chargeable',
+  label: 'chargeable',
+  type: 'TEXT',
+  description: 'mark battery as chargeable battery',
   limitToOptions: true,
   options: [
     { value: 'false', label: 'false' },
@@ -344,6 +355,7 @@ export const homekitParameters = {
   'Window': [invertedParameter],
   'Door': [invertedParameter],
   'WindowCovering': [invertedParameter],
+  'Battery': [chargeableParameter],
   'Thermostat.CurrentTemperature': [minValue, maxValue, stepValue],
   'Thermostat.TargetTemperature': [minValue, maxValue, stepValue],
   'Thermostat.CoolingThresholdTemperature': [minValue, maxValue, stepValue],

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -25,7 +25,7 @@
       </f7-list-item>
     </f7-list>
     <div>
-      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
+      <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" />
     </div>
     <f7-block class="padding-top no-padding no-margin" v-if="itemType === 'Group' && classes.length">
       <f7-block-title class="padding-left">
@@ -87,13 +87,29 @@ export default {
       if (!this.multiple) return this.metadata.value
       return (this.metadata.value) ? this.metadata.value.split(',') : []
     },
+    parametersGroups () {
+      if ((!this.classes) || (!this.multiple)) return []
+      let parametersGroups = []
+      this.classesAsArray.forEach(aType => {
+        parametersGroups.push({ name: aType, label: aType })
+      })
+      return parametersGroups
+    },
     parameters () {
       if (!this.classes) return []
       if (!this.multiple) return homekitParameters[this.classes]
       if ((this.multiple) && (this.itemType === 'Group') && (this.classesAsArray.length > 1)) {
+        let options = []
         let primaryOptions = []
-        this.classesAsArray.forEach(aType => primaryOptions.push({ value: aType, label: aType }))
-        return [{ name: 'primary', label: 'Primary Accessory Type', type: 'TEXT', limitToOptions: true, options: primaryOptions }]
+        this.classesAsArray.forEach(aType => {
+          primaryOptions.push({ value: aType, label: aType })
+          homekitParameters[aType].forEach(opt => {
+            opt.groupName = aType
+            options.push(opt)
+          })
+        })
+        options.push({ name: 'primary', label: 'Primary Accessory Type', type: 'TEXT', limitToOptions: true, options: primaryOptions })
+        return options
       }
       return []
     }


### PR DESCRIPTION
this PR

- adds missing parameter for homekit accessory of type battery
- adds support for parameters groups at complex accessories so that it is clear to which accessory parameter belongs



Signed-off-by: Eugen Freiter <freiter@gmx.de>