### PR TITLE
Allow actions on chart series

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -1,6 +1,8 @@
 // definitions for the chart widgets
 // TODO: migrate to WidgetDefinition & use helpers
 
+import { actionGroup, actionParams } from '../actions'
+
 const positionGroup = {
   name: 'position',
   label: 'Position',
@@ -366,11 +368,12 @@ export default {
     label: 'Calendar',
     docLink: 'https://echarts.apache.org/en/option.html#calendar',
     props: {
-      parameterGroups: [nameDisplayGroup, componentRelationsGroup],
+      parameterGroups: [nameDisplayGroup, componentRelationsGroup, actionGroup()],
       parameters: [
         ...positionParameters,
         orientParameter,
-        gridIndexParameter
+        gridIndexParameter,
+        ...actionParams()
       ]
     }
   },
@@ -379,9 +382,10 @@ export default {
     label: 'Data Series',
     docLink: 'https://echarts.apache.org/en/option.html#series',
     props: {
-      parameterGroups: [],
+      parameterGroups: [actionGroup()],
       parameters: [
-        seriesTypeParameter('gauge', 'pie')
+        seriesTypeParameter('gauge', 'pie'),
+        ...actionParams()
       ]
     }
   },
@@ -390,12 +394,13 @@ export default {
     label: 'Time Series',
     docLink: 'https://echarts.apache.org/en/option.html#series',
     props: {
-      parameterGroups: [componentRelationsGroup],
+      parameterGroups: [componentRelationsGroup, actionGroup()],
       parameters: [
         ...seriesParameters,
         seriesTypeParameter('line', 'bar', 'heatmap', 'scatter'),
         xAxisIndexParameter,
-        yAxisIndexParameter
+        yAxisIndexParameter,
+        ...actionParams()
       ]
     }
   },
@@ -404,7 +409,7 @@ export default {
     label: 'Aggregate Series',
     docLink: 'https://echarts.apache.org/en/option.html#series',
     props: {
-      parameterGroups: [componentRelationsGroup],
+      parameterGroups: [componentRelationsGroup, actionGroup()],
       parameters: [
         ...seriesParameters,
         seriesTypeParameter('line', 'bar', 'heatmap', 'scatter'),
@@ -432,7 +437,8 @@ export default {
         },
         aggregationFunctionParameter,
         xAxisIndexParameter,
-        yAxisIndexParameter
+        yAxisIndexParameter,
+        ...actionParams()
       ]
     }
   },
@@ -441,12 +447,13 @@ export default {
     label: 'Calendar Series',
     docLink: 'https://echarts.apache.org/en/option.html#series',
     props: {
-      parameterGroups: [componentRelationsGroup],
+      parameterGroups: [componentRelationsGroup, actionGroup()],
       parameters: [
         ...seriesParameters,
         seriesTypeParameter('heatmap', 'scatter'),
         aggregationFunctionParameter,
-        calendarIndexParameter
+        calendarIndexParameter,
+        ...actionParams()
       ]
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue
@@ -5,6 +5,7 @@
       v-if="ready"
       :options="options"
       class="oh-chart"
+      @click="handleClick"
       :class="{ 'with-tabbar': context.tab, 'with-toolbar': context.analyzer }"
       :theme="$f7.data.themeOptions.dark === 'dark' ? 'dark' : undefined" autoresize />
     <f7-menu class="padding float-right" v-if="periodVisible">
@@ -35,6 +36,7 @@
 <script>
 import mixin from '../widget-mixin'
 import chart from '../chart/chart-mixin'
+import { actionsMixin } from '../widget-actions'
 
 import dayjs from 'dayjs'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
@@ -62,7 +64,7 @@ import 'echarts/lib/component/calendar'
 import ECharts from 'vue-echarts/components/ECharts'
 
 export default {
-  mixins: [mixin, chart],
+  mixins: [mixin, chart, actionsMixin],
   components: {
     'chart': ECharts
   },
@@ -113,6 +115,14 @@ export default {
     if (this.calendarPicker) this.calendarPicker.destroy()
   },
   methods: {
+    handleClick (evt) {
+      if (evt.seriesIndex !== undefined) {
+        if (this.context.component.slots && this.context.component.slots.series && Array.isArray(this.context.component.slots.series) && this.context.component.slots.series.length) {
+          let series = this.context.component.slots.series[evt.seriesIndex]
+          this.performAction(evt.event, null, series.config, null)
+        }
+      }
+    },
     pickFixedStartDate (evt) {
       const self = this
       const value = this.startTime.toDate()


### PR DESCRIPTION
Add optional performAction args to accept an arbitrary config and/or context.

Supersedes #1392.
Closes #1391.

Signed-off-by: Yannick Schaus <github@schaus.net>
Also-by: Łukasz Dywicki <luke@code-house.org>
