### PR TITLE
[habpanel] Remove ES6 syntax in dummy widget

### DIFF
--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/dummy/dummy.widget.js
@@ -48,18 +48,20 @@
                 return;
             }
 
+            var value = item.transformedState || item.state;
+            
+            function filterOption(option, i, options) {
+                if (option.value === item.state) return true;
+                return false;
+            }
             if (vm.widget.usedescription) {
                 var options = item.stateDescription.options;
-                if (Array.isArray(options)) {
-                    var option = options.find((element) => element.value === item.state);
-                    if (option) {
-                        var value = option.label;
-                    } else {
-                        var value = item.state;
+                if (angular.isArray(options) && $filter('filter')(options, filterOption, true).length > 0) {
+                    var option = $filter('filter')(options, filterOption, true)[0];
+                    if (option.label) {
+                        value = option.label;
                     }
                 }
-            } else {
-                var value = item.transformedState || item.state;
             }
 
             if (vm.widget.format) {


### PR DESCRIPTION
#1380 introduced new code with ES6 syntax (arrow functions) that isn't supported in older browsers.
See https://github.com/openhab/openhab-webui/pull/1380#issuecomment-1166344112

Reimplement using the code from the selection widget to determine the option
(uses angularJS helpers)

Signed-off-by: Yannick Schaus <github@schaus.net>