### PR TITLE
Hide 'NULL' group labels in oh-label-item, second take.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -105,9 +105,6 @@ export default function itemDefaultListComponent (item, footer) {
     if (text) component.config.footer = text
   }
   if (!item.category) component.config.fallbackIconToInitial = true
-  if (component.component === 'oh-label-item' && item.type.indexOf('Group') === 0 && !item.groupType && component.config.after === undefined) {
-    component.config.after = null // Hide 'NULL' label for standard (non-typed) groups with no 'after' metadata defined
-  }
   return component
 }
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
@@ -1,6 +1,6 @@
 <template>
   <oh-list-item :context="context">
-    <div slot="after" v-if="config.after === undefined">
+    <div slot="after" v-if="(config.after === undefined) && (context.store[config.item].state !== 'NULL')">
       {{ context.store[config.item].displayState || context.store[config.item].state }}
     </div>
   </oh-list-item>


### PR DESCRIPTION
Hides 'NULL' labels in oh-label-item while not preventing display of labels for Group where the item to display option has been set.

Reverts undesired effect of PR #1398.