### PR TITLE
Reverts equipment accordion link styling.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -32,6 +32,12 @@
   .item-link .item-inner:after
     transition-duration 300ms
 
+  > .item-content
+    cursor pointer
+
+    &:active
+      background var(--f7-list-link-pressed-bg-color)
+
   .list,
   .block
     margin-top 0
@@ -95,6 +101,14 @@
 
   &.accordion-item-opened > .item-content > .item-inner > .item-title-row:before
     content var(--f7-accordion-chevron-icon-up)
+
+.aurora
+  .oh-equipment-accordion-item
+    > .item-content
+      &:hover
+        background var(--f7-list-link-hover-bg-color)
+      &:active
+        background var(--f7-list-link-pressed-bg-color)
 
 .item-divider > span
   flex-shrink 1

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -5,7 +5,7 @@
                 :media-item="context.parent.component.config.mediaList && !config.divider"
                 :badge="(config.divider) ? 'Divider' : (config.listButton) ? 'List button' : config.badge"
                 :accordion-item="isRegularAccordion && !config.divider && !context.editmode"
-                :link="(config.action !== undefined && config.action !== '' && !context.editmode) || isEquipmentAccordion ? true : undefined"
+                :link="(config.action !== undefined && config.action !== '' && !context.editmode) ? true : undefined"
                 @click.stop="openAccordionOrPerformAction"
                 :class="{ 'oh-equipment-accordion-item' : isEquipmentAccordion}"
                 ref="f7AccordionContent">


### PR DESCRIPTION
Previous change introduced in PR #1408 with link class for equipment as accordion items caused issue in the events handling, preventing promoted widgets from working (oh-toggle).

@ghys, since the initial PR was only cosmetic and only affects desktop platforms, I propose to revert it while I can find a better solution. It would be a pity not to have promoted items working correctly for accordion equipments in 3.3.
