### PR TITLE
Update jaxb2-maven-plugin dependencies to fix Windows build issues

### DIFF
--- a/bundles/org.openhab.ui.cometvisu/pom.xml
+++ b/bundles/org.openhab.ui.cometvisu/pom.xml
@@ -83,6 +83,23 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>jaxb2-maven-plugin</artifactId>
         <version>2.5.0</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics</artifactId>
+            <version>0.12.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.6</version>
+          </dependency>
+          <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-xjc</artifactId>
+            <version>2.3.6</version>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
On Windows org.openhab.ui.cometvisu fails to build:

`Failed to execute goal org.codehaus.mojo:jaxb2-maven-plugin:2.5.0:xjc (default) on project org.openhab.ui.cometvisu: "file:\C:\Users\runneradmin\.m2\repository\org\glassfish\jaxb\jaxb-xjc\2.3.2\jaxb-xjc-2.3.2.jar!\META-INF\versions\9" is not a valid file name: {1}: Invalid file path -> [Help 1]`