### PR TITLE
[habot] Add default translations for WebPushNotificationAction

### DIFF
--- a/bundles/org.openhab.ui.habot/src/main/resources/OH-INF/i18n/opennlphli.properties
+++ b/bundles/org.openhab.ui.habot/src/main/resources/OH-INF/i18n/opennlphli.properties
@@ -3,6 +3,15 @@ voice.config.opennlphli.theme.description = The alphanumeric tokenizer removes p
 voice.config.opennlphli.theme.option.whitespace = Whitespace
 voice.config.opennlphli.theme.option.alphanumeric = Alphanumeric
 
+# habot.WebPushNotificationAction
+
+module-type.habot.WebPushNotificationAction.label = send a web push notification to HABot
+module-type.habot.WebPushNotificationAction.description = Push the message to all subscribed HABot clients.
+module-type.habot.WebPushNotificationAction.config.title.description = the title of the notification - only for the native notification, in the chat page the title will NOT appear!
+module-type.habot.WebPushNotificationAction.config.body.description = the body of the native notification message which is also the chat message from HABot (required)
+module-type.habot.WebPushNotificationAction.config.cardUID.description = the explicit UID of a card to make HABot display when the notification is clicked
+module-type.habot.WebPushNotificationAction.config.tags.description = the tags associated with the message, HABot will try to find a matching card with those tags if you don't specify an explicit UID
+
 # service
 
 service.voice.opennlphli.label = OpenNLP Interpreter for HABot


### PR DESCRIPTION
I ran the i18n plugin on the repo and found it generated some more default translations due to https://github.com/openhab/openhab-core/pull/2966.