### PR TITLE
Allow changing log-levels for add-ons

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-config.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-config.vue
@@ -116,12 +116,11 @@ export default {
 
     this.$oh.api.get(requestUri).then(data => {
       this.addon = data
-      let configDescriptionURI = this.addon.configDescriptionURI
+      let configDescriptionURI = this.addon.configDescriptionURI || ''
       if (configDescriptionURI) {
         this.$oh.api.get('/rest/config-descriptions/' + configDescriptionURI).then(data2 => {
           this.configDescription = data2
-
-          this.bindingId = this.strippedAddonId
+          this.bindingId = configDescriptionURI.substring(configDescriptionURI.indexOf(':') + 1)
           this.$oh.api.get('/rest/addons/' + this.bindingId + '/config').then(data3 => {
             this.config = data3
           })


### PR DESCRIPTION
Closes #1351 

Depends on https://github.com/openhab/openhab-core/pull/3045

As discussed the gear wheel is now shown on each add-on page if either a config-description URI or a set of logger-packages is found.

Signed-off-by: Jan N. Klug <github@klug.nrw>