### PR TITLE
fix identification of ruby scripts in editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -137,7 +137,6 @@ export default {
       currentModuleConfig: {},
       scriptModuleType: null,
       languages: null,
-      moduleError: null,
       script: '',
       mode: '',
       eventSource: null,
@@ -257,15 +256,13 @@ export default {
           this.currentModule = this.rule.actions.concat(this.rule.conditions).find((m) => m.id === this.moduleId)
         } else {
           this.currentModule = this.rule.actions.find((m) => m.id === 'script')
+          if (!this.currentModule) {
+            this.currentModule = this.rule.actions.find((m) => m.configuration.script)
+          }
           this.isScriptRule = true
         }
 
-        if (!this.currentModule ||
-            this.currentModule.type.indexOf('script') !== 0 ||
-            (this.currentModule.type === 'jsr223.ScriptedAction' &&
-             this.currentModule.configuration.type === 'application/x-ruby')) {
-          this.moduleError = true
-        } else {
+        if (this.currentModule) {
           this.mode = this.currentModule.configuration.type
           this.script = this.currentModule.configuration.script
         }


### PR DESCRIPTION
I confused the branches of the if-else, and wrote the condition as if
it was the positive branch. now it's "if there is no module, or it's
not a DSL script, or it's not a ruby script, then mark it as error"

I apologize - I've definitely compiled and tested this locally now, since the ruby side is also submitted now and I can test the full stack.