### PR TITLE
Fixes the stepper from making phantom commands when a value is outside of the min/max

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -16,7 +16,9 @@ export default {
   computed: {
     value () {
       if (this.config.variable) return this.context.vars[this.config.variable]
-      const value = this.toStepFixed(parseFloat(this.context.store[this.config.item].state))
+      let value = this.toStepFixed(parseFloat(this.context.store[this.config.item].state))
+      if (this.config.min !== undefined) value = Math.max(value, this.config.min)
+      if (this.config.max !== undefined) value = Math.min(value, this.config.max)
       return value
     }
   },


### PR DESCRIPTION


Signed-off-by: Dan Cunningham <dan@digitaldan.com>