### PR TITLE
Change lazy loading config

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -336,6 +336,11 @@ export default {
         },
         touch: {
           tapHold: true
+        },
+        // Lazy loading settings
+        lazy: {
+          threshold: 50,
+          sequential: false
         }
 
         // smartSelect: {


### PR DESCRIPTION
The add-on image downloading is a lot faster when using non-sequential lazy loading.

The images on GitHub are downloaded using HTTP/2 which allows for a lot of concurrency. :slightly_smiling_face: 

See: https://framework7.io/docs/lazy-load#lazy-load-app-parameters

Did you ever test such a configuration @ghys?