### PR TITLE
Fix z-index of oh-masonry component (#1466)

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
@@ -15,7 +15,7 @@
       </f7-block>
 
       <hr v-if="context.editmode">
-      <f7-block v-if="context.component.slots.masonry && context.component.slots.masonry.length">
+      <f7-block v-if="context.component.slots.masonry && context.component.slots.masonry.length" style="z-index: auto !important">
         <oh-masonry
           :context="childContext(context.component.slots.masonry[0])"
           v-on="$listeners" />


### PR DESCRIPTION
This fix sets the z-index for the parent of the oh-masonry component in the oh-layout-page.  This was necessary to ensure that when an f7-card was expanded, the focus was on the expanded card.

Signed-off-by: Jeff James <jeff@james-online.com>