### PR TITLE
[Blockly] Fix date comparison

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
@@ -126,13 +126,13 @@ export function addDateComparisonSupport () {
       '    case \'before\':',
       '      return zdt1.isBefore(zdt2);',
       '    case \'equal\':',
-      '      return zdt1.isEqual(zdt2);',
+      '      return zdt1.equals(zdt2);',
       '    case \'after\':',
       '      return zdt1.isAfter(zdt2);',
       '    case \'beforeEqual\':',
-      '      return zdt1.isBefore(zdt2) || zdt1.isEqual(zdt2);',
+      '      return zdt1.isBefore(zdt2) || zdt1.equals(zdt2);',
       '    case \'afterEqual\':',
-      '      return zdt1.isAfter(zdt2) || zdt1.isEqual(zdt2);',
+      '      return zdt1.isAfter(zdt2) || zdt1.equals(zdt2);',
       '  }',
       '}'
     ])


### PR DESCRIPTION
The `isEqual` method is not known and therefore produces Errors, when the correspondign block is usec.
According to the zdt docs the `equals` method should be feasable for comparison.

Signed-off-by: Jerome Luckenbach <github@luckenba.ch>