### PR TITLE
[MainUI] Access page-content dimensions

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
@@ -110,7 +110,7 @@ function hintExpression (cm, line) {
         { text: 'theme', displayText: 'theme', description: 'The current theme: aurora, ios, or md' },
         { text: 'themeOptions', displayText: 'themeOptions', description: 'Object with current theme options' },
         { text: 'device', displayText: 'device', description: 'Object with information about the current device & browser' },
-        { text: 'screen', displayText: 'screen', description: 'Object with information about the page content\' size' },
+        { text: 'screen', displayText: 'screen', description: 'Object with information about the screen and available view area' },
         { text: 'dayjs', displayText: 'dayjs', description: 'Access to the Day.js object for date manipulation & formatting' }
       ]
     }

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-components.js
@@ -110,6 +110,7 @@ function hintExpression (cm, line) {
         { text: 'theme', displayText: 'theme', description: 'The current theme: aurora, ios, or md' },
         { text: 'themeOptions', displayText: 'themeOptions', description: 'Object with current theme options' },
         { text: 'device', displayText: 'device', description: 'Object with information about the current device & browser' },
+        { text: 'screen', displayText: 'screen', description: 'Object with information about the page content\' size' },
         { text: 'dayjs', displayText: 'dayjs', description: 'Access to the Day.js object for date manipulation & formatting' }
       ]
     }
@@ -243,8 +244,8 @@ function hintSlots (cm, line, parentLineNr) {
   let completions = definitions.map((c) => {
     return {
       text: ' '.repeat(indent + 2) + `- component: ${c.name}\n` +
-        // ' '.repeat(indent + 4) + 'config:\n' +
-        ' '.repeat(indent + 4),
+// ' '.repeat(indent + 4) + 'config:\n' +
+' '.repeat(indent + 4),
       displayText: c.name,
       componentName: c.name,
       className: `${cls}completion ${cls}completion-unknown`,

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -122,7 +122,7 @@ export default {
             theme: this.$theme,
             themeOptions: this.$f7.data.themeOptions,
             device: this.$device,
-            screen: this.getPageContentRect(),
+            screen: this.getScreenInfo(),
             JSON: JSON,
             dayjs: dayjs
           })
@@ -145,14 +145,20 @@ export default {
         return value
       }
     },
-    getPageContentRect () {
+    getScreenInfo () {
       const pageCurrent = document.getElementsByClassName('page-current').item(0)
       const pageContent = pageCurrent.getElementsByClassName('page-content').item(0)
       const pageContentStyle = window.getComputedStyle(pageContent)
 
       return {
-        width: pageContent.clientWidth - parseFloat(pageContentStyle.paddingLeft) - parseFloat(pageContentStyle.paddingRight),
-        height: pageContent.clientHeight - parseFloat(pageContentStyle.paddingTop) - parseFloat(pageContentStyle.paddingBottom)
+        width: window.screen.width,
+        height: window.screen.height,
+        availWidth: window.screen.availWidth,
+        availHeight: window.screen.availHeight,
+        colorDepth: window.screen.colorDepth,
+        pixelDepth: window.screen.pixelDepth,
+        viewAreaWidth: pageContent.clientWidth - parseFloat(pageContentStyle.paddingLeft) - parseFloat(pageContentStyle.paddingRight),
+        viewAreaHeight: pageContent.clientHeight - parseFloat(pageContentStyle.paddingTop) - parseFloat(pageContentStyle.paddingBottom)
       }
     },
     childContext (component) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -122,6 +122,7 @@ export default {
             theme: this.$theme,
             themeOptions: this.$f7.data.themeOptions,
             device: this.$device,
+            screen: this.getPageContentRect(),
             JSON: JSON,
             dayjs: dayjs
           })
@@ -142,6 +143,16 @@ export default {
         return evalArr
       } else {
         return value
+      }
+    },
+    getPageContentRect () {
+      const pageCurrent = document.getElementsByClassName('page-current').item(0)
+      const pageContent = pageCurrent.getElementsByClassName('page-content').item(0)
+      const pageContentStyle = window.getComputedStyle(pageContent)
+
+      return {
+        width: pageContent.clientWidth - parseFloat(pageContentStyle.paddingLeft) - parseFloat(pageContentStyle.paddingRight),
+        height: pageContent.clientHeight - parseFloat(pageContentStyle.paddingTop) - parseFloat(pageContentStyle.paddingBottom)
       }
     },
     childContext (component) {


### PR DESCRIPTION
## Improvements

- ~~Update the docs for the `actionPhotos` property to explain how to set up the config Array in YAML syntax.~~ (See #1519)
- ~~Add support for evaluating expressions in config Arrays of custom widgets.~~ (See #1519)
- Access the current dimensions (height; width) available for a page's content (useful for building widgets with dynamic height ...).