### PR TITLE
[MainUI] Evaluate expressions in configuration Arrays & Update `actionPhotos` docs

### DIFF
--- a/bundles/org.openhab.ui/doc/components/index.md
+++ b/bundles/org.openhab.ui/doc/components/index.md
@@ -24,7 +24,7 @@ source: https://github.com/openhab/openhab-webui/edit/main/bundles/org.openhab.u
 | [`oh-player`](./oh-player.html) |  [Media player](./oh-player.html) | Media player controls, with previous track/pause/play/next buttons |
 | [`oh-repeater`](./oh-repeater.html) |  [Repeater](./oh-repeater.html) | Iterate over an array and repeat the children components in the default slot |
 | [`oh-rollershutter`](./oh-rollershutter.html) |  [Rollershutter](./oh-rollershutter.html) | Rollershutter control, with up/down/stop buttons |
-| [`oh-sipclient`](./oh-sipclient.html) |  [SIP Client](./oh-sipclient.html) | SIP Client to call and answer SIP calls |
+| [`oh-sipclient`](./oh-sipclient.html) |  [SIP Client](./oh-sipclient.html) | SIP Client to start and answer SIP calls |
 | [`oh-slider`](./oh-slider.html) |  [Slider](./oh-slider.html) | Slider control, allows to pick a number value on a scale |
 | [`oh-stepper`](./oh-stepper.html) |  [Stepper](./oh-stepper.html) | Stepper control, allows to input a number or decrement/increment it using buttons |
 | [`oh-swiper`](./oh-swiper.html) |  [Swiper](./oh-swiper.html) | Swiper control, allows to display multiple swipeable slides |
@@ -48,7 +48,7 @@ source: https://github.com/openhab/openhab-webui/edit/main/bundles/org.openhab.u
 | [`oh-list-card`](./oh-list-card.html) |  [List Card](./oh-list-card.html) | Display a list in a card |
 | [`oh-player-card`](./oh-player-card.html) |  [Player Card](./oh-player-card.html) | Display player controls in a card |
 | [`oh-rollershutter-card`](./oh-rollershutter-card.html) |  [Rollershutter Card](./oh-rollershutter-card.html) | Display rollershutter controls in a card |
-| [`oh-sipclient-card`](./oh-sipclient-card.html) |  [SIP Client Card](./oh-sipclient-card.html) | Client to start and answer SIP calls |
+| [`oh-sipclient-card`](./oh-sipclient-card.html) |  [SIP Client Card](./oh-sipclient-card.html) | SIP Client to start and answer SIP calls |
 | [`oh-slider-card`](./oh-slider-card.html) |  [Slider Card](./oh-slider-card.html) | Display a slider in a card to control an item |
 | [`oh-stepper-card`](./oh-stepper-card.html) |  [Stepper Card](./oh-stepper-card.html) | Display a stepper in a card to control an item |
 | [`oh-swiper-card`](./oh-swiper-card.html) |  [Swiper Card](./oh-swiper-card.html) | Display a swiper allowing to browse slides, in a card |

--- a/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
@@ -148,7 +148,7 @@ prev: /docs/ui/components/
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -178,17 +178,17 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -228,7 +228,7 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -238,12 +238,12 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-button.md
+++ b/bundles/org.openhab.ui/doc/components/oh-button.md
@@ -118,7 +118,7 @@ Button performing an action
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -148,17 +148,17 @@ Button performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -198,7 +198,7 @@ Button performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -208,12 +208,12 @@ Button performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">
@@ -267,7 +267,7 @@ Button performing an action
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -297,17 +297,17 @@ Button performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionRule" label="Rule" context="rule">
@@ -347,7 +347,7 @@ Button performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -357,12 +357,12 @@ Button performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
@@ -65,7 +65,7 @@ prev: /docs/ui/components/
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -95,17 +95,17 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -145,7 +145,7 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -155,12 +155,12 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
@@ -110,7 +110,7 @@ prev: /docs/ui/components/
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -140,17 +140,17 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -190,7 +190,7 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -200,12 +200,12 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -78,7 +78,7 @@ A regular or expandable cell
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -108,17 +108,17 @@ A regular or expandable cell
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -158,7 +158,7 @@ A regular or expandable cell
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -168,12 +168,12 @@ A regular or expandable cell
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-clock-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-clock-card.md
@@ -133,7 +133,7 @@ Display a digital clock in a card
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -163,17 +163,17 @@ Display a digital clock in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -213,7 +213,7 @@ Display a digital clock in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -223,12 +223,12 @@ Display a digital clock in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -107,7 +107,7 @@ A cell expanding to a color picker
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -137,17 +137,17 @@ A cell expanding to a color picker
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -187,7 +187,7 @@ A cell expanding to a color picker
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -197,12 +197,12 @@ A cell expanding to a color picker
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-data-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-data-series.md
@@ -51,7 +51,7 @@ prev: /docs/ui/components/
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -81,17 +81,17 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -131,7 +131,7 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -141,12 +141,12 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
@@ -169,7 +169,7 @@ Display a read-only gauge in a card to visualize a quantifiable item
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -199,17 +199,17 @@ Display a read-only gauge in a card to visualize a quantifiable item
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -249,7 +249,7 @@ Display a read-only gauge in a card to visualize a quantifiable item
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -259,12 +259,12 @@ Display a read-only gauge in a card to visualize a quantifiable item
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-icon.md
+++ b/bundles/org.openhab.ui/doc/components/oh-icon.md
@@ -87,7 +87,7 @@ Display an openHAB icon
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -117,17 +117,17 @@ Display an openHAB icon
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -167,7 +167,7 @@ Display an openHAB icon
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -177,12 +177,12 @@ Display an openHAB icon
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-image-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image-card.md
@@ -99,7 +99,7 @@ Display an image (URL or Image item ) in a card
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -129,17 +129,17 @@ Display an image (URL or Image item ) in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -179,7 +179,7 @@ Display an image (URL or Image item ) in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -189,12 +189,12 @@ Display an image (URL or Image item ) in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-image.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image.md
@@ -67,7 +67,7 @@ Displays an image from a URL or an item
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -97,17 +97,17 @@ Displays an image from a URL or an item
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -147,7 +147,7 @@ Displays an image from a URL or an item
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -157,12 +157,12 @@ Displays an image from a URL or an item
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -154,7 +154,7 @@ A cell expanding to a knob control
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -184,17 +184,17 @@ A cell expanding to a knob control
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -234,7 +234,7 @@ A cell expanding to a knob control
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -244,12 +244,12 @@ A cell expanding to a knob control
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-label-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-card.md
@@ -68,7 +68,7 @@ Display the state of an item in a card
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -98,17 +98,17 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -148,7 +148,7 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -158,12 +158,12 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">
@@ -217,7 +217,7 @@ Display the state of an item in a card
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -247,17 +247,17 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionRule" label="Rule" context="rule">
@@ -297,7 +297,7 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -307,12 +307,12 @@ Display the state of an item in a card
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -94,7 +94,7 @@ A cell with a big label to show a short item state value
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -124,17 +124,17 @@ A cell with a big label to show a short item state value
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -174,7 +174,7 @@ A cell with a big label to show a short item state value
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -184,12 +184,12 @@ A cell with a big label to show a short item state value
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-label-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-item.md
@@ -84,7 +84,7 @@ Display the state of an item in a list
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -114,17 +114,17 @@ Display the state of an item in a list
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -164,7 +164,7 @@ Display the state of an item in a list
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -174,12 +174,12 @@ Display the state of an item in a list
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-link.md
+++ b/bundles/org.openhab.ui/doc/components/oh-link.md
@@ -92,7 +92,7 @@ Link performing an action
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -122,17 +122,17 @@ Link performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -172,7 +172,7 @@ Link performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -182,12 +182,12 @@ Link performing an action
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-list-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-list-item.md
@@ -73,7 +73,7 @@ A list item
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -103,17 +103,17 @@ A list item
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -153,7 +153,7 @@ A list item
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -163,12 +163,12 @@ A list item
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
@@ -86,7 +86,7 @@ A circle on a map, to represent a radius
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -116,17 +116,17 @@ A circle on a map, to represent a radius
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -166,7 +166,7 @@ A circle on a map, to represent a radius
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -176,12 +176,12 @@ A circle on a map, to represent a radius
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-map-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-marker.md
@@ -70,7 +70,7 @@ An icon on a map
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -100,17 +100,17 @@ An icon on a map
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -150,7 +150,7 @@ An icon on a map
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -160,12 +160,12 @@ An icon on a map
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -173,7 +173,7 @@ A marker on a floor plan
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -203,17 +203,17 @@ A marker on a floor plan
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -253,7 +253,7 @@ A marker on a floor plan
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -263,12 +263,12 @@ A marker on a floor plan
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
@@ -139,7 +139,7 @@ A cell expanding to rollershutter controls
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -169,17 +169,17 @@ A cell expanding to rollershutter controls
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -219,7 +219,7 @@ A cell expanding to rollershutter controls
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -229,12 +229,12 @@ A cell expanding to rollershutter controls
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -149,7 +149,7 @@ A cell expanding to a big vertical slider
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -179,17 +179,17 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -229,7 +229,7 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -239,12 +239,12 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-time-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-time-series.md
@@ -102,7 +102,7 @@ prev: /docs/ui/components/
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -132,17 +132,17 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -182,7 +182,7 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -192,12 +192,12 @@ prev: /docs/ui/components/
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/doc/components/oh-video.md
+++ b/bundles/org.openhab.ui/doc/components/oh-video.md
@@ -53,6 +53,11 @@ Displays a video player from a URL or an item
     Does not start playing the video automatically
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="posterURL" label="Poster URL">
+  <PropDescription>
+    URL of an image to use as a poster before the video loads
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="playerType" label="Player Type">
   <PropDescription>
     Select the player type (optional), defualts to Video.js
@@ -86,7 +91,7 @@ Displays a video player from a URL or an item
   <PropOptions>
     <PropOption value="navigate" label="Navigate to page" />
     <PropOption value="command" label="Send command" />
-    <PropOption value="toggle" label="Toggle item" />
+    <PropOption value="toggle" label="Toggle Item" />
     <PropOption value="options" label="Command options" />
     <PropOption value="rule" label="Run rule" />
     <PropOption value="popup" label="Open popup" />
@@ -116,17 +121,17 @@ Displays a video player from a URL or an item
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommand" label="Action Command">
   <PropDescription>
-    Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different
+    Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionCommandAlt" label="Action Toggle Command">
   <PropDescription>
-    Command to send to the item when "toggle item" is selected as the action, and the item's state is equal to the command above
+    Command to send to the Item when "Toggle Item" is selected as the action, and the Item's state is equal to the command above
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionOptions" label="Command Options">
   <PropDescription>
-    Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.
+    Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionRule" label="Rule" context="rule">
@@ -166,7 +171,7 @@ Displays a video player from a URL or an item
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotos" label="Images to show">
   <PropDescription>
-    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
+    Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionPhotoBrowserConfig" label="Photo browser configuration">
@@ -176,12 +181,12 @@ Displays a video player from a URL or an item
 </PropBlock>
 <PropBlock type="TEXT" name="actionGroupPopupItem" label="Group Popup Item" context="item">
   <PropDescription>
-    Group item whose members to show in a popup
+    Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
   <PropDescription>
-    Start analyzing with the specified (set of) item(s)
+    Start analyzing with the specified (set of) Item(s)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionAnalyzerChartType" label="Chart Type">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
@@ -17,7 +17,7 @@ export const actionParams = (groupName, paramPrefix) => {
     po(paramPrefix + 'action', 'Action', 'Type of action to perform', [
       { value: 'navigate', label: 'Navigate to page' },
       { value: 'command', label: 'Send command' },
-      { value: 'toggle', label: 'Toggle item' },
+      { value: 'toggle', label: 'Toggle Item' },
       { value: 'options', label: 'Command options' },
       { value: 'rule', label: 'Run rule' },
       { value: 'popup', label: 'Open popup' },
@@ -41,15 +41,15 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['command', 'toggle', 'options'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pt(paramPrefix + 'actionCommand', 'Action Command', 'Command to send to the item. If "toggle item" is selected as the action, only send the command when the state is different')
+    pt(paramPrefix + 'actionCommand', 'Action Command', 'Command to send to the Item. If "Toogle Item" is selected as the action, only send the command when the state is different')
       .v((value, configuration, configDescription, parameters) => {
         return ['command', 'toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pt(paramPrefix + 'actionCommandAlt', 'Action Toggle Command', 'Command to send to the item when "toggle item" is selected as the action, and the item\'s state is equal to the command above')
+    pt(paramPrefix + 'actionCommandAlt', 'Action Toggle Command', 'Command to send to the Item when "Toggle Item" is selected as the action, and the Item\'s state is equal to the command above')
       .v((value, configuration, configDescription, parameters) => {
         return ['toggle'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pt(paramPrefix + 'actionOptions', 'Command Options', 'Comma-separated list of options; if omitted, retrieve the command options from the item dynamically. Use <code>value=label</code> format to provide a label different than the option.')
+    pt(paramPrefix + 'actionOptions', 'Command Options', 'Comma-separated list of options; if omitted, retrieve the command options from the Item dynamically. Use <code>value=label</code> format to provide a label different than the option.')
       .v((value, configuration, configDescription, parameters) => {
         return ['options'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
@@ -81,7 +81,7 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['navigate', 'popup', 'popover', 'sheet'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pt(paramPrefix + 'actionPhotos', 'Images to show', 'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.')
+    pt(paramPrefix + 'actionPhotos', 'Images to show', 'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.')
       .v((value, configuration, configDescription, parameters) => {
         return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
@@ -89,11 +89,11 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pi(paramPrefix + 'actionGroupPopupItem', 'Group Popup Item', 'Group item whose members to show in a popup')
+    pi(paramPrefix + 'actionGroupPopupItem', 'Group Popup Item', 'Group Item whose members to show in a popup')
       .v((value, configuration, configDescription, parameters) => {
         return ['group'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pi(paramPrefix + 'actionAnalyzerItems', 'Item(s) to Analyze', 'Start analyzing with the specified (set of) item(s)').m()
+    pi(paramPrefix + 'actionAnalyzerItems', 'Item(s) to Analyze', 'Start analyzing with the specified (set of) Item(s)').m()
       .v((value, configuration, configDescription, parameters) => {
         return ['analyzer'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -134,6 +134,12 @@ export default {
           this.$set(evalObj, objKey, this.evaluateExpression(key + '.' + objKey, value[objKey]))
         }
         return evalObj
+      } else if (typeof value === 'object' && Array.isArray(value)) {
+        const evalArr = []
+        for (let i = 0; i < value.length; i++) {
+          this.$set(evalArr, i, this.evaluateExpression(i, value[i]))
+        }
+        return evalArr
       } else {
         return value
       }


### PR DESCRIPTION
@ghys 

This PR brings the docs updates and support for expressions in configuration arrays from PR #1510.

## Improvements

- Update the docs for the `actionPhotos` property to explain how to set up the config Array in YAML syntax.
- Add support for evaluating expressions in config Arrays of custom widgets.