### PR TITLE
[MainUI] input elements fix datetime-local and add datepicker time

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-input-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-card.md
@@ -67,7 +67,7 @@ Display an input in a card
 </PropBlock>
 <PropBlock type="TEXT" name="type" label="Type">
   <PropDescription>
-    Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)
+    Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a> or datepicker)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="inputmode" label="Input Mode">
@@ -118,6 +118,11 @@ Display an input in a card
 <PropBlock type="BOOLEAN" name="useDisplayState" label="Use Display State">
   <PropDescription>
     Use the formatted state as the value for the input control
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="showTime" label="Show time">
+  <PropDescription>
+    Display time when type set to datepicker
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="defaultValue" label="Default value">

--- a/bundles/org.openhab.ui/doc/components/oh-input-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-item.md
@@ -72,7 +72,7 @@ Display an input field in a list
 </PropBlock>
 <PropBlock type="TEXT" name="type" label="Type">
   <PropDescription>
-    Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)
+    Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a> or datepicker)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="inputmode" label="Input Mode">
@@ -123,6 +123,11 @@ Display an input field in a list
 <PropBlock type="BOOLEAN" name="useDisplayState" label="Use Display State">
   <PropDescription>
     Use the formatted state as the value for the input control
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="showTime" label="Show time">
+  <PropDescription>
+    Display time when type set to datepicker
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="defaultValue" label="Default value">

--- a/bundles/org.openhab.ui/doc/components/oh-input.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input.md
@@ -35,7 +35,7 @@ Displays an input field, used to set a variable
 </PropBlock>
 <PropBlock type="TEXT" name="type" label="Type">
   <PropDescription>
-    Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)
+    Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a> or datepicker)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="inputmode" label="Input Mode">
@@ -86,6 +86,11 @@ Displays an input field, used to set a variable
 <PropBlock type="BOOLEAN" name="useDisplayState" label="Use Display State">
   <PropDescription>
     Use the formatted state as the value for the input control
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="showTime" label="Show time">
+  <PropDescription>
+    Display time when type set to datepicker
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="defaultValue" label="Default value">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
@@ -2,7 +2,7 @@ import { pi, pb, pt } from '../helpers.js'
 
 export default () => [
   pt('name', 'Name', 'Input name'),
-  pt('type', 'Type', 'Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a>)'),
+  pt('type', 'Type', 'Type of input (see <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/inputs.html#supported-inputs">f7 input docs</a> or datepicker)'),
   pt('inputmode', 'Input Mode', 'Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)'),
   pt('placeholder', 'Placeholder', 'Placeholder text'),
   pb('sendButton', 'Send button', 'Display Send button to update the state with a command (needs a configured item)'),
@@ -13,6 +13,7 @@ export default () => [
   pb('validate-on-blur', 'Validate on blur', 'Only validate when focus moves away from input field'),
   pi('item', 'Item', 'Link the input value to the state of this item'),
   pb('useDisplayState', 'Use Display State', 'Use the formatted state as the value for the input control'),
+  pb('showTime', 'Show time', 'Display time when type set to datepicker'),
   pt('defaultValue', 'Default value', 'Default value when not found in item state or variable'),
   pt('variable', 'Variable', 'Name of the variable to set when the input changes')
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -1,7 +1,11 @@
 <template>
-  <f7-input v-if="!config.item || !config.sendButton" class="input-field" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value" @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
+  <f7-input v-if="!config.item || !config.sendButton" class="input-field" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value"
+            :calendar-params="calendarParams"
+            @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
   <f7-row no-gap v-else class="oh-input-with-send-button">
-    <f7-input class="input-field col-90" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value" @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
+    <f7-input class="input-field col-90" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value"
+              :calendar-params="calendarParams"
+              @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
     <f7-button class="send-button col-10" v-if="this.config.sendButton" @click.stop="sendButtonClicked" v-bind="config.sendButtonConfig || { iconMaterial: 'done', iconColor: 'gray' }" />
   </f7-row>
 </template>
@@ -45,16 +49,27 @@ export default {
       }
       return this.config.defaultValue
     },
+    calendarParams () {
+      if (this.config.type !== 'datepicker') return null
+      let params = { dateFormat: { year: 'numeric', month: 'numeric', day: 'numeric' } }
+      if (this.config.showTime) {
+        params.timePicker = true
+        params.dateFormat.hour = 'numeric'
+        params.dateFormat.minute = 'numeric'
+      }
+      return params
+    },
     valueForDatepicker () {
-      const value = this.value
+      const value = Array.isArray[this.value] ? this.value[0] : this.value
+      const datetime = new Date(value)
+      if (isNaN(datetime)) return null
       switch (this.config.type) {
         case 'datepicker':
-          if (Array.isArray(value)) return value
-          const date = new Date(value)
-          if (isNaN(date)) return null
-          return [date]
+          return [datetime]
         case 'date':
-          return (Date.parse(value) > 0) ? value.split('T')[0] : null
+          return dayjs(datetime).format('YYYY-MM-DD')
+        case 'datetime-local':
+          return dayjs(datetime).format('YYYY-MM-DDTHH:mm')
         default:
           return null
       }


### PR DESCRIPTION
Currently, input elements don't allow date with time input.

This PR:

- Fixes input elements with type set to datetime-local to correctly show date and time. It is not shown in the current version (tested on Chrome).
- Adds a showTime parameter to the input element configuration for use with type set to datepicker. If set to true, the input element will show time and allow setting time through the calendar popup.
- Add possible use of datepicker type to parameter description.

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>