### PR TITLE
[MainUI] Improve sitemap validation

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -16,17 +16,23 @@
         </ul>
         <ul>
           <!-- additional controls -->
-          <f7-list-input v-if="supports('url')" label="URL" type="text" :value="widget.config.url" @input="updateParameter('url', $event)" clear-button />
+          <f7-list-input v-if="supports('url')" label="URL" type="url" :value="widget.config.url" @input="updateParameter('url', $event)" clear-button />
           <f7-list-input v-if="supports('refresh')" label="Refresh interval" type="text" :value="widget.config.refresh" @input="updateParameter('refresh', $event)" clear-button />
           <f7-list-input v-if="supports('encoding')" label="Encoding" type="text" :value="widget.config.encoding" @input="updateParameter('encoding', $event)" clear-button />
           <f7-list-input v-if="supports('service')" label="Service" type="text" :value="widget.config.service" @input="updateParameter('service', $event)" clear-button />
-          <f7-list-input v-if="supports('period')" label="Period" type="text" :value="widget.config.period" @input="updateParameter('period', $event)" clear-button />
+          <f7-list-item v-if="supports('period')" title="Period" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
+            <select name="periods" required :value="widget.config.period" @change="updateParameter('period', $event)">
+              <option v-for="def in periodDefs" :key="def.key" :value="def.key">
+                {{ def.value }}
+              </option>
+            </select>
+          </f7-list-item>
           <f7-list-input v-if="supports('height')" label="Height" type="number" :value="widget.config.height" @input="updateParameter('height', $event)" clear-button />
           <f7-list-input v-if="supports('sendFrequency')" label="Frequency" type="text" :value="widget.config.sendFrequency" @input="updateParameter('sendFrequency', $event)" clear-button />
           <f7-list-input v-if="supports('minValue')" label="Minimum" type="number" :value="widget.config.minValue" @input="updateParameter('minValue', $event)" clear-button />
           <f7-list-input v-if="supports('maxValue')" label="Maximum" type="number" :value="widget.config.maxValue" @input="updateParameter('maxValue', $event)" clear-button />
           <f7-list-input v-if="supports('step')" label="Step" type="number" :value="widget.config.step" @input="updateParameter('step', $event)" clear-button />
-          <f7-list-input v-if="supports('separator')" label="Separator" type="text" :value="widget.config.separator" @input="updateParameter('separator', $event)" clear-button />
+          <f7-list-input v-if="supports('separator')" label="Separator" type="text" required validate pattern=".+" :value="widget.config.separator" @input="updateParameter('separator', $event)" clear-button />
           <f7-list-input v-if="supports('yAxisDecimalPattern')" label="Y-axis decimal pattern" type="text" :value="widget.config.separator" @input="updateParameter('yAxisDecimalPattern', $event)" clear-button />
           <f7-list-item v-if="supports('switchEnabled')" title="Switch enabled">
             <f7-toggle slot="after" :checked="widget.config.switchEnabled" @toggle:change="widget.config.switchEnabled = $event" />
@@ -78,7 +84,22 @@ export default {
         Setpoint: ['minValue', 'maxValue', 'step'],
         Colorpicker: ['sendFrequency'],
         Default: ['height']
-      }
+      },
+      periodDefs: [
+        { key: 'h', value: 'Hour' },
+        { key: '4h', value: '4 Hours' },
+        { key: '8h', value: '8 Hours' },
+        { key: '12h', value: '12 Hours' },
+        { key: 'D', value: 'Day' },
+        { key: '2D', value: '2 Days' },
+        { key: '3D', value: '3 Days' },
+        { key: 'W', value: 'Week' },
+        { key: '2W', value: '2 Weeks' },
+        { key: 'M', value: 'Month' },
+        { key: '2M', value: '2 Months' },
+        { key: '3M', value: '3 Months' },
+        { key: 'Y', value: 'Year' }
+      ]
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -313,7 +313,7 @@ export default {
         })
       }
     },
-    save (stay) {
+    save (stay, force) {
       this.cleanConfig(this.sitemap)
       if (!this.sitemap.uid) {
         this.$f7.dialog.alert('Please give an ID to the sitemap')
@@ -328,8 +328,7 @@ export default {
         return
       }
 
-      // Don't block saving when widget validation checks fail
-      this.validateWidgets()
+      if (!force && !this.validateWidgets(stay)) return
 
       const promise = (this.createMode)
         ? this.$oh.api.postPlain('/rest/ui/components/system:sitemap', JSON.stringify(this.sitemap), 'text/plain', 'application/json')
@@ -361,7 +360,7 @@ export default {
         }).open()
       })
     },
-    validateWidgets () {
+    validateWidgets (stay) {
       if (this.sitemap.slots && Array.isArray(this.sitemap.slots.widgets)) {
         const widgetList = this.sitemap.slots.widgets.reduce(function iter (widgets, widget) {
           widgets.push(widget)
@@ -410,7 +409,16 @@ export default {
           }
         })
         if (validationWarnings.length > 0) {
-          this.$f7.dialog.alert('<b>Sitemap definition will be saved with validation errors:</b><br />' + validationWarnings.join('<br />'))
+          this.$f7.dialog.create({
+            title: 'Validation errors',
+            text: 'Sitemap definition has validation errors:',
+            content: '<ul style="max-height: 100px; overflow-y: scroll"><li>' + validationWarnings.join('</li><li>') + '</li></ul>',
+            buttons: [
+              { text: 'Cancel', color: 'gray', close: true },
+              { text: 'Save Anyway', color: 'red', close: true, onClick: () => this.save(stay, true) }
+            ],
+            destroyOnClose: true
+          }).open()
           return false
         }
         return true

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -252,7 +252,8 @@ export default {
         { type: 'Image', icon: 'photo' },
         { type: 'Video', icon: 'videocam' }
       ],
-      linkableWidgetTypes: ['Sitemap', 'Text', 'Frame', 'Group', 'Image']
+      linkableWidgetTypes: ['Sitemap', 'Text', 'Frame', 'Group', 'Image'],
+      widgetTypesRequiringItem: ['Group', 'Chart', 'Switch', 'Mapview', 'Slider', 'Selection', 'List', 'Setpoint', 'Colorpicker', 'Default']
     }
   },
   created () {
@@ -327,6 +328,9 @@ export default {
         return
       }
 
+      // Don't block saving when widget validation checks fail
+      this.validateWidgets()
+
       const promise = (this.createMode)
         ? this.$oh.api.postPlain('/rest/ui/components/system:sitemap', JSON.stringify(this.sitemap), 'text/plain', 'application/json')
         : this.$oh.api.put('/rest/ui/components/system:sitemap/' + this.sitemap.uid, this.sitemap)
@@ -356,6 +360,61 @@ export default {
           closeTimeout: 2000
         }).open()
       })
+    },
+    validateWidgets () {
+      if (this.sitemap.slots && Array.isArray(this.sitemap.slots.widgets)) {
+        const widgetList = this.sitemap.slots.widgets.reduce(function iter (widgets, widget) {
+          widgets.push(widget)
+          if (widget.slots && Array.isArray(widget.slots.widgets)) {
+            return widget.slots.widgets.reduce(iter, widgets)
+          }
+          return widgets
+        }, [])
+        let validationWarnings = []
+        widgetList.filter(widget => this.widgetTypesRequiringItem.includes(widget.component)).forEach(widget => {
+          if (!(widget.config && widget.config.item)) {
+            let label = widget.config && widget.config.label ? widget.config.label : 'without label'
+            validationWarnings.push(widget.component + ' widget ' + label + ', no item configured')
+          }
+        })
+        widgetList.filter(widget => widget.component === 'List').forEach(widget => {
+          if (!(widget.config && widget.config.separator)) {
+            let label = widget.config && widget.config.label ? widget.config.label : 'without label'
+            validationWarnings.push(widget.component + ' widget ' + label + ', no separator configured')
+          }
+        })
+        widgetList.filter(widget => widget.component === 'Video' || widget.component === 'Webview').forEach(widget => {
+          if (!(widget.config && widget.config.url)) {
+            let label = widget.config && widget.config.label ? widget.config.label : 'without label'
+            validationWarnings.push(widget.component + ' widget ' + label + ', no url configured')
+          }
+        })
+        widgetList.filter(widget => widget.component === 'Chart').forEach(widget => {
+          if (!(widget.config && widget.config.period)) {
+            let label = widget.config && widget.config.label ? widget.config.label : 'without label'
+            validationWarnings.push(widget.component + ' widget ' + label + ', no period configured')
+          }
+        })
+        widgetList.forEach(widget => {
+          if (widget.config) {
+            Object.keys(widget.config).filter(attr => ['mappings', 'visibility', 'valuecolor', 'labelcolor', 'iconcolor'].includes(attr)).forEach(attr => {
+              widget.config[attr].forEach(param => {
+                if (((attr === 'mappings') && !(/^[\w\s]*=("[\w-\s]*"|[\w-\s]*)\s*$/.test(param))) ||
+                    ((attr === 'visibility') && !(/^\s*\w+\s*(==|>=|<=|!=|>|<)\s*("[+-]?\w[\w-\s]*"|[+-]?\w[\w-\s]*)\s*$/.test(param))) ||
+                    ((attr.includes('color')) && !(/^\s*(((\w+\s*)?(==|>=|<=|!=|>|<)\s*)?(("[+-]?\w[\w-\s]*"\s*|[+-]?\w[\w-\s]*)=\s*))?("#?\w+"|#?\w+)\s*$/.test(param)))) {
+                  let label = widget.config && widget.config.label ? widget.config.label : 'without label'
+                  validationWarnings.push(widget.component + ' widget ' + label + ', syntax error in ' + attr + ': ' + param)
+                }
+              })
+            })
+          }
+        })
+        if (validationWarnings.length > 0) {
+          this.$f7.dialog.alert('<b>Sitemap definition will be saved with validation errors:</b><br />' + validationWarnings.join('<br />'))
+          return false
+        }
+        return true
+      }
     },
     cleanConfig (widget) {
       if (widget.config) {


### PR DESCRIPTION
Building upon the more complete support of the sitemap DSL in the UI, this PR adds more validation logic:

Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

- Validate all required parameters are provided when interpreting DSL.
- Validate all required parameters are privded when saving sitemap from sitemap builder (but still save if this is not the case).
- Validate syntax of parameter values when saving in sitemap builder.
- Improved parameter types in sitemap builder, dropdown for some parameters.

@ghys I use the f7.dialog popup to list detected errors in the sitemap, but it becomes too small when there are many. I am not sure this is the best way of doing this. To widen the dialog, I would need to provide a CSS class, but I don't know much about that. Do you have suggestions?