### PR TITLE
Fixes evaluating arrays - cached expressions can be overwritten

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-data-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-data-series.js
@@ -8,22 +8,6 @@ export default {
     if (!component.config || typeof component.config !== 'object') return {}
 
     const dataSeriesId = ComponentId.get(component)
-    let series = chart.evaluateExpression(dataSeriesId, component.config)
-
-    if (series.data && Array.isArray(series.data)) {
-      series.data = series.data.map((v, index) => {
-        const item = chart.evaluateExpression(dataSeriesId + 'data.' + index, v)
-        return Number.isNaN(item.value) ? {} : item
-      })
-    }
-
-    if (series.axisLine && series.axisLine.lineStyle && series.axisLine.lineStyle.color && Array.isArray(series.axisLine.lineStyle.color)) {
-      series.axisLine.lineStyle.color = series.axisLine.lineStyle.color.map((v, index) => {
-        if (!Array.isArray(v)) return v
-        return v.map((s, subindex) => chart.evaluateExpression(dataSeriesId + 'axisLine.lineStyle.color.' + index + '.' + subindex, s))
-      })
-    }
-
-    return series
+    return chart.evaluateExpression(dataSeriesId, component.config)
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -155,7 +155,7 @@ export default {
       } else if (typeof value === 'object' && Array.isArray(value)) {
         const evalArr = []
         for (let i = 0; i < value.length; i++) {
-          this.$set(evalArr, i, this.evaluateExpression(i, value[i]))
+          this.$set(evalArr, i, this.evaluateExpression(key + '.' + i, value[i]))
         }
         return evalArr
       } else {


### PR DESCRIPTION
Seems as there is an issue in https://github.com/openhab/openhab-webui/pull/1519 that can cause cached expressions to override each-other (some of my existing widgets are broken in latest snapshot).

Also removed what seems obsolete since arrays are now parsed as part of `evaluateExpression` itself.

