### PR TITLE
Filter rules/scripts by id and rule status

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -13,7 +13,7 @@
           :init="initSearchbar"
           search-container=".rules-list"
           search-item=".rulelist-item"
-          search-in=".item-title, .item-subtitle, .item-header, .item-footer"
+          search-in=".item-title, .item-text, .item-after, .item-subtitle, .item-header, .item-footer"
           :disable-button="!$theme.aurora" />
       </f7-subnavbar>
     </f7-navbar>


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <mail@stefanhoehn.com>

I always missed the possibility to filter rules by 

- rule status (enabled, disabled, idle, running) -> item-text
- rule id -> item-after

as they are shown in the list but not taken into account during the filtering.

hence, I have added these (item-text and item-after) to the searchbar field list.