### PR TITLE
[BasicUI] Consider item state for the color picker

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1332,9 +1332,9 @@
 		_t.longPress = false;
 		_t.pressed = false;
 
-		_t.setValue = function(value) {
+		_t.setValue = function(value, itemState) {
 			var
-				t = value.split(","),
+				t = itemState.split(","),
 				hsv = {
 					h: t[0] / 360,
 					s: t[1] / 100,


### PR DESCRIPTION
It was not working if you added a label pattern to your color item

Related to discussion in #427

Signed-off-by: Laurent Garnier <lg.hc@free.fr>