### PR TITLE
[MainUI] Update JS Scripting tern definitions

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -23,7 +23,7 @@
                 "!type": "ItemHistory"
             },
             "semantics": {
-                "!doc:": "Access the sementic features for this Item",
+                "!doc": "Access the semantic features for this Item",
                 "!type": "ItemSemantics"
             },
             "rawState": {
@@ -386,7 +386,7 @@
             },
             "reschedule": {
                 "!doc": "Reschedules a timer to a new starting time. This can also be called after a timer has terminated, which will result in another execution of the same code.",
-                "!type": "fn(time.ZonedDateTime) -> boolean"
+                "!type": "fn(zonedDateTime: time.ZonedDateTime) -> boolean"
             }
         },
         "TimeNamespace": {

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -92,37 +92,69 @@
             }
         },
         "ItemHistory": {
+            "averageBetween": {
+                "!doc": "Gets the average value of the state of a given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
             "averageSince": {
                 "!doc": "Gets the average value of the state of a given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
+            "changedBetween": {
+                "!doc": "Checks if the state of a given Item has changed between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
             "changedSince": {
                 "!doc": "Checks if the state of a given Item has changed since a certain point in time.",
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
+            "deltaBetween": {
+                "!doc": "Gets the difference value of the state of a given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
             "deltaSince": {
                 "!doc": "Gets the difference value of the state of a given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
+            "deviationBetween": {
+                "!doc": "Gets the standard deviation of the state of the given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "deviationSince": {
                 "!doc": "Gets the standard deviation of the state of the given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
-            "evolutionRate": {
+            "evolutionRateBetween": {
+                "!doc": "Gets the evolution rate of the state of a given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
+            "evolutionRateSince": {
                 "!doc": "Gets the evolution rate of the state of a given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "historicState": {
                 "!doc": "Retrieves the historic Item state for a given Item at a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> ?"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> string|null"
             },
             "lastUpdate": {
                 "!doc": "Query the last update time of a given item.",
-                "!type": "fn(serviceId?: string) -> Date?"
+                "!type": "fn(serviceId?: string) -> ZonedDateTime|null"
+            },
+            "latestState": {
+                "!doc": "Retrieves the historic Item state for a given Item at the current point in time.",
+                "!type": "fn(serviceId?: string) -> string|null"
+            },
+            "maximumBetween": {
+                "!doc": "Gets the maximum value of the historic state of a given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "maximumSince": {
                 "!doc": "Gets the historic Item with the maximum value of the state of a given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
+            "minimumBetween": {
+                "!doc": "Gets the minimum value of the historic state of a given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "minimumSince": {
                 "!doc": "Gets the historic Item with the minimum value of the state of a given Item since a certain point in time.",
@@ -134,15 +166,27 @@
             },
             "previousState": {
                 "!doc": "Returns the previous state of a given item.",
-                "!type": "fn(skipEqual?: boolean, serviceId?: string) -> ?"
+                "!type": "fn(skipEqual?: boolean, serviceId?: string) -> string|null"
+            },
+            "sumBetween": {
+                "!doc": "Gets the sum of the states of a given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "sumSince": {
                 "!doc": "Gets the sum of the state of a given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
+            },
+            "updatedBetween": {
+                "!doc": "Checks if the state of a given Item has been updated between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
             "updatedSince": {
                 "!doc": "Checks if the state of a given Item has been updated since a certain point in time.",
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
+            },
+            "varianceBetween": {
+                "!doc": "Gets the variance of the state of the given Item between two certain points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "varianceSince": {
                 "!doc": "Gets the variance of the state of the given Item since a certain point in time.",

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -609,6 +609,10 @@
             "Voice": {
                 "!doc": "Voice Actions. The static methods of this class are made available as functions in the scripts. This allows a script to use voice features.",
                 "!type": "VoiceActions"
+            },
+            "thingActions": {
+                "!doc": "Get the ThingActions of a given Thing.",
+                "!type": "fn(bindingId: string, thingUid: string) -> ?"
             }
         }
     },

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -554,6 +554,16 @@
             "getActions": { "!type": "fn(scope: string, thingUid: string) -> ?" },
             "getThingStatusInfo": { "!type": "fn(thingUid: string) -> ?" }
         },
+        "TransformationActions": {
+            "transform": {
+                "!doc": "Applies a transformation of a given type with some function to a value. Returns the original value if the transformation fails.",
+                "!type": "fn(type: string, fn: string, value: string) -> string"
+            },
+            "transformRaw": {
+                "!doc": "Applies a transformation of a given type with some function to a value. Throws an error if the transformation fails.",
+                "!type": "fn(type: string, fn: string, value: string) -> string"
+            }
+        },
         "VoiceActions": {
             "interpret": { "!type": "fn(text: string, interpreter?: string, sink?: string) -> ?" },
             "say": { "!type": "fn(text: string, interpreter?: string, sink?: string, volume?: ?)" }
@@ -603,6 +613,10 @@
             "Things": {
                 "!doc": "Things Actions. This class provides static methods that can be used in automation rules for getting thing's status info.",
                 "!type": "ThingsActions"
+            },
+            "Transformation": {
+                "!doc": "Transformation Actions. The static methods of this class allow rules to execute transformations using one of the various data transformation services.",
+                "!type": "TransformationActions"
             },
             "Voice": {
                 "!doc": "Voice Actions. The static methods of this class are made available as functions in the scripts. This allows a script to use voice features.",

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -450,34 +450,6 @@
                 "!type": "fn(message: string, args?: ?)"
             }
         },
-        "BusEvent": {
-            "getSource": {
-                "!doc": "The source of the event",
-                "!type": "fn() -> string"
-            },
-            "getType": {
-                "!doc": "The type of the event",
-                "!type": "fn() -> string"
-            },
-            "getTopic": {
-                "!doc": "The topic of the event",
-                "!type": "fn() -> string"
-            },
-            "getPayload": {
-                "!doc": "The payload of the event",
-                "!type": "fn() -> string"
-            },
-            "toString": {
-                "!doc": "Returns a string representation of the event",
-                "!type": "fn() -> string"
-            }
-        },
-        "State": {
-            "toString": {
-                "!doc": "Returns a string representation of the state",
-                "!type": "fn() -> string"
-            }
-        },
         "EventData": {
             "itemName": {
                 "!doc": "The name of the Item that triggered the event (core.ItemStateUpdateTrigger, core.ItemStateChangeTrigger, core.ItemCommandTrigger). Attention: Java type!",

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -337,6 +337,32 @@
                 "!type": "fn(key: string) -> ?"
             }
         },
+        "Timer": {
+            "cancel": {
+                "!doc": "Cancels the timer.",
+                "!type": "fn() -> boolean"
+            },
+            "getExecutionTime": {
+                "!doc": "The scheduled execution time or null if timer was cancelled.",
+                "!type": "fn() -> time.ZonedDateTime|null"
+            },
+            "isActive": {
+                "!doc": "Whether the scheduled execution is yet to happen.",
+                "!type": "fn() -> boolean"
+            },
+            "isCancelled": {
+                "!doc": "Whether the timer has been cancelled.",
+                "!type": "fn() -> boolean"
+            },
+            "hasTerminated": {
+                "!doc": "Whether the scheduled execution has already terminated.",
+                "!type": "fn() -> boolean"
+            },
+            "reschedule": {
+                "!doc": "Reschedules a timer to a new starting time. This can also be called after a timer has terminated, which will result in another execution of the same code.",
+                "!type": "fn(time.ZonedDateTime) -> boolean"
+            }
+        },
         "TimeNamespace": {
             "toZDT": {
                 "!doc": "Converts nearly any representation of a time to a time.ZonedDateTime (see JS Scripting Docs/Standard Library/Time)",
@@ -510,8 +536,10 @@
         },
         "ScriptExecutionActions": {
             "callScript": { "!type": "fn(scriptName: string)" },
-            "createTimer": { "!type": "fn(instant, function: fn()) -> ?" },
-            "createTimerWithArgument": { "!type": "fn(instant, arg, function: fn()) -> ?" }
+            "createTimer": {
+                "!doc": "Schedules a function for later execution.",
+                "!type": "fn(identifier?: string, zonedDateTime: time.ZonedDateTime, function: fn()) -> Timer"
+              }
         },
         "SemanticsActions": {
             "getEquipment": { "!type": "fn(rawItem: ?) -> ?" },

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -22,6 +22,10 @@
                 "!doc": "Access historical states for this item",
                 "!type": "ItemHistory"
             },
+            "semantics": {
+                "!doc:": "Access the sementic features for this Item",
+                "!type": "ItemSemantics"
+            },
             "rawState": {
                 "!doc": "The raw state of the item, as a java object.",
                 "!type": "?"
@@ -195,6 +199,28 @@
             "latestState": {
                 "!doc": "Retrieves the historic Item state for a given Item at the current point in time.",
                 "!type": "fn(serviceId?: string) -> ?"
+            }
+        },
+        "ItemSemantics": {
+            "equipmentType": {
+                "!doc": "The type of the semantic equipment.",
+                "!type": "string|null"
+            },
+            "locationType": {
+                "!doc": "The type of the semantic location.",
+                "!type": "string|null"
+            },
+            "pointType": {
+                "!doc": "The type of the semantic point.",
+                "!type": "string|null"
+            },
+            "propertyType": {
+                "!doc": "The type of the semantic property.",
+                "!type": "string|null"
+            },
+            "semanticType": {
+                "!doc": "Determines the semantic type (i.e. a sub-type of Location, Equipment or Point).",
+                "!type": "string|null"
             }
         },
         "ItemConfig": {


### PR DESCRIPTION
Fixes #1550.

## Description

The tern definitions for JS Scripting were updated in https://github.com/openhab/openhab-webui/pull/1421 to address the openhab-js release 2.0.0.

Since then, we had numerous improvements and changes to the openhab-js library: https://github.com/openhab/openhab-js/compare/v2.0.0...v2.1.1.

This updates the JS Scripting tern definitions:
- `ItemHistory`: Add new methods
- `ScriptExecution`: Remove `createTimerWithArgument` & Add `Timer`
- `actions`: Add `thingActions`
- Add Item semantics
- Add Transformation actions

## Testing

I have tested it, all changes work fine.