### PR TITLE
Fixes to canvas layout display in full screen.

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-canvas-layout.md
+++ b/bundles/org.openhab.ui/doc/components/oh-canvas-layout.md
@@ -61,7 +61,28 @@ Position widgets on a canvas layout with arbitrary position and size down to pix
 </PropBlock>
 <PropBlock type="TEXT" name="imageSrcSet" label="Image Source Set">
   <PropDescription>
-    The src-set attribute of background image element to take into account mulitple device resolutions. For example: "/static/floorplans/floor-0.jpg, /static/floorplans/floor-0@2x.jpg 2x"
+    The src-set attribute of background image element to take into account multiple device resolutions. For example: "/static/floorplans/floor-0.jpg, /static/floorplans/floor-0@2x.jpg 2x"
+  </PropDescription>
+</PropBlock>
+</PropGroup>
+</div>
+
+### Appearance
+<div class="props">
+<PropGroup name="appearance" label="Appearance">
+<PropBlock type="BOOLEAN" name="hideNavbar" label="Hide Navigation bar">
+  <PropDescription>
+    Hide navigation bar on top when page is displayed (You can additionally hide the sidebar using its pin icon) (default false)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="hideSidebarIcon" label="Hide Sidebar Icon">
+  <PropDescription>
+    Don't show a menu icon in the top left corner when the sidebar is closed (default false)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="showFullscreenIcon" label="Show Fullscreen Icon">
+  <PropDescription>
+    Show a fullscreen icon on the top right corner (default false)
   </PropDescription>
 </PropBlock>
 </PropGroup>
@@ -80,7 +101,7 @@ Position widgets on a canvas layout with arbitrary position and size down to pix
     Shadow applied to text elements or font icons (text-shadow CSS syntax)
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="filterShadow" label="Fitler Shadow">
+<PropBlock type="TEXT" name="filterShadow" label="Filter Shadow">
   <PropDescription>
     Shadow applied to raster or SVG image elements (filter: drop-shadow() CSS syntax)
   </PropDescription>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/layout/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/layout/index.js
@@ -88,12 +88,19 @@ export function OhCanvasLayoutDefinition () {
       pn('screenHeight', 'Screen Height', 'Screen width in pixels (default 720)'),
       pb('scale', 'Scaling', 'Scale content to screen width (can lead to unexpected styling issues) (default false)'),
       pt('imageUrl', 'Image URL', 'The URL of the image to display as background').c('url'),
-      pt('imageSrcSet', 'Image Source Set', 'The src-set attribute of background image element to take into account mulitple device resolutions. For example: "/static/floorplans/floor-0.jpg, /static/floorplans/floor-0@2x.jpg 2x"')
+      pt('imageSrcSet', 'Image Source Set', 'The src-set attribute of background image element to take into account multiple device resolutions. For example: "/static/floorplans/floor-0.jpg, /static/floorplans/floor-0@2x.jpg 2x"')
+    ])
+    .paramGroup(pg('appearance', 'Appearance'), [
+      pb('hideNavbar', 'Hide Navigation bar', 'Hide navigation bar on top when page is displayed (You can additionally hide the sidebar using its pin icon) (default false)')
+        .v((value, configuration, configDescription, parameters) => { return configuration.layoutType === 'fixed' }),
+      pb('hideSidebarIcon', 'Hide Sidebar Icon', 'Don\'t show a menu icon in the top left corner when the sidebar is closed (default false)')
+        .v((value, configuration, configDescription, parameters) => { return configuration.hideNavbar === true }),
+      pb('showFullscreenIcon', 'Show Fullscreen Icon', 'Show a fullscreen icon on the top right corner (default false)')
     ])
     .paramGroup(pg('shadow', 'Canvas items shadow'), [
       pt('boxShadow', 'Box shadow', 'Shadow applied to box elements (box-shadow CSS syntax).').a(),
       pt('textShadow', 'Text shadow', 'Shadow applied to text elements or font icons (text-shadow CSS syntax)').a(),
-      pt('filterShadow', 'Fitler Shadow', 'Shadow applied to raster or SVG image elements (filter: drop-shadow() CSS syntax)').a()
+      pt('filterShadow', 'Filter Shadow', 'Shadow applied to raster or SVG image elements (filter: drop-shadow() CSS syntax)').a()
     ])
 }
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -114,15 +114,6 @@
           'background-size': `${grid.pitch}px ${grid.pitch}px, ${grid.pitch}px ${grid.pitch}px`,
           visibility: context.editmode && grid.enable ? 'inherit' : 'hidden',
         }" />
-      <f7-button
-        v-if="!context.editmode"
-        @click="toggleFullscreen"
-        class="fullscreen-icon"
-        :icon-f7="
-          fullscreen
-            ? 'arrow_down_right_arrow_up_left'
-            : 'arrow_up_left_arrow_down_right'
-        " />
       <div
         v-if="context.editmode"
         style="
@@ -165,12 +156,6 @@
     height 100%
     width 100%
     object-fit contain
-
-  .fullscreen-icon
-    position absolute
-    top 2px
-    right 2px
-    z-index 1000
 </style>
 
 <script>
@@ -225,7 +210,7 @@ export default {
         window.addEventListener('resize', this.setDimensions)
       }
     }
-
+    this.$fullscreen.support = true
     this.canvasLayoutStyle()
     this.computeLayout()
   },
@@ -296,15 +281,6 @@ export default {
       this.context.component.slots.canvas.forEach((layer, idx) => {
         if (idx !== this.actLyrIdx) {
           layer.config.editVisible = true
-        }
-      })
-    },
-    toggleFullscreen () {
-      this.$fullscreen.toggle(this.$refs.ohCanvasLayout, {
-        wrap: false,
-        callback: (fullscreen) => {
-          this.canvasLayoutStyle()
-          this.fullscreen = fullscreen
         }
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -9,13 +9,13 @@
         <f7-link v-if="isAdmin" icon-md="material:edit" :href="'/settings/pages/' + pageType + '/' + uid">
           {{ $theme.md ? '' : $t('page.navbar.edit') }}
         </f7-link>
+        <f7-link v-if="fullscreenIcon" class="fullscreen-icon-navbar" :icon-f7="fullscreenIcon" @click="toggleFullscreen" />
       </f7-nav-right>
     </f7-navbar>
-
-    <f7-link v-else-if="!page.config.hideSidebarIcon" class="sidebar-icon" icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
-
-    <f7-link v-if="page && $fullscreen.support && page.config.showFullscreenIcon" class="fullscreen-icon" :icon-f7="fullscreen ? 'rectangle_arrow_up_right_arrow_down_left_slash' : 'rectangle_arrow_up_right_arrow_down_left'" @click="toggleFullscreen" />
-
+    <template v-else>
+      <f7-link v-if="!page.config.hideSidebarIcon" class="sidebar-icon" icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
+      <f7-link v-if="fullscreenIcon" class="fullscreen-icon" :icon-f7="fullscreenIcon" @click="toggleFullscreen" />
+    </template>
     <f7-toolbar tabbar labels bottom v-if="page && pageType === 'tabs' && visibleToCurrentUser">
       <f7-link v-for="(tab, idx) in page.slots.default" :key="idx" tab-link @click="onTabChange(idx)" :tab-link-active="currentTab === idx" :icon-ios="tab.config.icon" :icon-md="tab.config.icon" :icon-aurora="tab.config.icon" :text="tab.config.title" />
     </f7-toolbar>
@@ -37,6 +37,8 @@
   position fixed
   top 8px
   left 8px
+.fullscreen-icon-navbar
+  margin-left: 20px !important
 .fullscreen-icon
   position absolute
   top 8px
@@ -109,6 +111,11 @@ export default {
     },
     showBackButton () {
       return this.deep && (!this.page || !this.page.config.sidebar)
+    },
+    fullscreenIcon () {
+      if (this.page && this.$fullscreen.support && this.page.config.showFullscreenIcon) {
+        return this.fullscreen ? 'rectangle_arrow_up_right_arrow_down_left_slash' : 'rectangle_arrow_up_right_arrow_down_left'
+      } else return null
     }
   },
   methods: {


### PR DESCRIPTION
This fixes an issue noted by some users where in full screen popups would not be displayed. [Expandable widgets in fixed canvas layout](https://community.openhab.org/t/expandable-widgets-in-fixed-canvas-layout/128670)

Some improvements relative to full screen were made at the same time:
	Switching to full screen seems faster.
	Uses the shared page fullscreen button
	Full screen switching button is now visible even if navigation bar is not hidden (should fix it for grid layouts as well). It can be useful to have fullscreen but still keep the nav bar.
	Small typos in parameters' description fixed.