### PR TITLE
[MainUI] Add robots.txt to disallow search crawler

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -230,6 +230,10 @@ module.exports = {
       {
         from: resolvePath('src/manifest.json'),
         to: resolvePath('www/manifest.json')
+      },
+      {
+        from: resolvePath('src/robots.txt'),
+        to: resolvePath('www/robots.txt')
       }
     ]),
     ...(!isCordova ? [

--- a/bundles/org.openhab.ui/web/src/robots.txt
+++ b/bundles/org.openhab.ui/web/src/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This PR adds a robots.txt file to disallow search engines as requested here:  #1532 

**This implementation will not protect your instance on the public internet** nor block malicious crawlers from scanning you. The robots.txt file is considered by known "good" search engine crawlers which will not index the web server due to the disallow statement in the robots.txt file. Malicious crawlers don't care about your your privacy concerns and will scan your instance in any case!

Signed-off-by: Florian Michel <florianmichel@hotmail.de>