### PR TITLE
[MainUI] extend default standalone/item/cell widget selection

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -92,9 +92,9 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
     //   }
     // }
 
-    if(item.type.startsWith('Number') && !stateDescription.readOnly) {
+    if (item.type.startsWith('Number') && !stateDescription.readOnly) {
       if ((semanticClass === 'Control' || semanticClass === 'SetPoint')) {
-        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'Temperature' || semanticProperty === 'SoundVolume') {
+        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'SoundVolume') {
           component = {
             component: 'oh-slider-cell',
             config: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -3,10 +3,14 @@
    in the "cellWidget" metadata namespace of the item
  */
 
+import * as Semantics from '@/assets/semantics.js'
+
 export default function itemDefaultCellComponent (item, itemNameAsFooter) {
   const stateDescription = item.stateDescription || {}
   const metadata = (item.metadata && item.metadata.cellWidget) ? item.metadata.cellWidget : {}
   let component = null
+  let semanticClass = {}
+  let semanticProperty = {}
 
   if (metadata.value && metadata.value !== ' ') {
     component = {
@@ -14,6 +18,15 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
       config: Object.assign({}, metadata.config)
     }
   } else {
+    item.tags.forEach((tag) => {
+      if (Semantics.Points.indexOf(tag) >= 0) {
+        semanticClass = tag
+      }
+      if (Semantics.Properties.indexOf(tag) >= 0) {
+        semanticProperty = tag
+      }
+    })
+
     if (item.type === 'Switch' && !stateDescription.readOnly) {
       component = {
         component: 'oh-cell',
@@ -78,6 +91,51 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
     //     }
     //   }
     // }
+
+    if(item.type.startsWith('Number') && !stateDescription.readOnly) {
+      if ((semanticClass === 'Control' || semanticClass === 'SetPoint')) {
+        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'Temperature' || semanticProperty === 'SoundVolume') {
+          component = {
+            component: 'oh-slider-cell',
+            config: {
+              color: 'blue',
+              action: 'toggle',
+              actionItem: item.name,
+              actionCommand: 'ON',
+              actionCommandAlt: 'OFF',
+              scaleSubSteps: 5,
+              min: stateDescription.minimum,
+              max: stateDescription.maximum,
+              step: stateDescription.step
+            }
+          }
+        }
+        if (semanticProperty === 'Light' || semanticProperty === 'Power' || semanticProperty === 'Energy') {
+          component = {
+            component: 'oh-cell',
+            config: {
+              color: 'blue',
+              action: 'toggle',
+              actionItem: item.name,
+              actionCommand: 'ON',
+              actionCommandAlt: 'OFF'
+            }
+          }
+        }
+      }
+      if (semanticClass === 'Switch') {
+        component = {
+          component: 'oh-cell',
+          config: {
+            color: 'blue',
+            action: 'toggle',
+            actionItem: item.name,
+            actionCommand: 'ON',
+            actionCommandAlt: 'OFF'
+          }
+        }
+      }
+    }
   }
 
   if (!component) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
@@ -3,10 +3,15 @@
    in the "widget" metadata namespace of the item
  */
 
+import { DateTimeFunctions } from '@/assets/item-types'
+import * as Semantics from '@/assets/semantics.js'
+
 export default function itemDefaultStandaloneComponent (item) {
   const stateDescription = item.stateDescription || {}
   const metadata = (item.metadata && item.metadata.widget) ? item.metadata.widget : {}
   let component = null
+  let semanticClass = {}
+  let semanticProperty = {}
 
   if (metadata.value && metadata.value !== ' ') {
     component = {
@@ -14,6 +19,15 @@ export default function itemDefaultStandaloneComponent (item) {
       config: Object.assign({}, metadata.config)
     }
   } else {
+    item.tags.forEach((tag) => {
+      if (Semantics.Points.indexOf(tag) >= 0) {
+        semanticClass = tag
+      }
+      if (Semantics.Properties.indexOf(tag) >= 0) {
+        semanticProperty = tag
+      }
+    })
+
     if (item.type === 'Switch' && !stateDescription.readOnly) {
       component = {
         component: 'oh-toggle-card'
@@ -70,6 +84,55 @@ export default function itemDefaultStandaloneComponent (item) {
           lazyFadeIn: true,
           action: 'photos',
           actionPhotos: [{ item: item.name }]
+        }
+      }
+    }
+
+    if (item.type === 'DateTime' && !stateDescription.readOnly) {
+      component = {
+        component: 'oh-input-card',
+        config: {
+          type: "datetime-local",
+          sendButton: true
+        }
+      }
+    }
+
+    if (item.type === 'Number' && !stateDescription.readOnly) {
+      component = {
+        component: 'oh-input-card',
+        config: {
+          type: "number",
+          inputmode: "decimal",
+          sendButton: true
+        }
+      }
+    }
+
+    if(item.type.startsWith('Number') && !stateDescription.readOnly) {
+      if (semanticClass === 'Control' || semanticClass === 'SetPoint') {
+        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'Temperature' || semanticProperty === 'SoundVolume') {
+          component = {
+            component: 'oh-slider-card',
+            config: {
+              scale: true,
+              label: true,
+              scaleSubSteps: 5,
+              min: stateDescription.minimum,
+              max: stateDescription.maximum,
+              step: stateDescription.step
+            }
+          }
+        }
+        if (semanticProperty === 'Light' || semanticProperty === 'Power' || semanticProperty === 'Energy') {
+          component = {
+            component: 'oh-toggle-card'
+          }
+        }
+      }
+      if (semanticClass === 'Switch') {
+        component = {
+          component: 'oh-toggle-card'
         }
       }
     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
@@ -92,7 +92,7 @@ export default function itemDefaultStandaloneComponent (item) {
       component = {
         component: 'oh-input-card',
         config: {
-          type: "datetime-local",
+          type: 'datetime-local',
           sendButton: true
         }
       }
@@ -102,16 +102,39 @@ export default function itemDefaultStandaloneComponent (item) {
       component = {
         component: 'oh-input-card',
         config: {
-          type: "number",
-          inputmode: "decimal",
+          type: 'number',
+          inputmode: 'decimal',
           sendButton: true
         }
       }
     }
 
-    if(item.type.startsWith('Number') && !stateDescription.readOnly) {
+    if (item.type === 'Number:Temperature' && !stateDescription.readOnly) {
+      component = {
+        component: 'oh-stepper-card',
+        config: {
+          min: stateDescription.minimum,
+          max: stateDescription.maximum,
+          step: stateDescription.step,
+          buttonsOnly: false
+        }
+      }
+    }
+
+    if (item.type.startsWith('Number') && !stateDescription.readOnly) {
       if (semanticClass === 'Control' || semanticClass === 'SetPoint') {
-        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'Temperature' || semanticProperty === 'SoundVolume') {
+        if (semanticProperty === 'Temperature' || item.type === 'Number:Temperature') {
+          component = {
+            component: 'oh-stepper-card',
+            config: {
+              min: stateDescription.minimum,
+              max: stateDescription.maximum,
+              step: stateDescription.step,
+              buttonsOnly: false
+            }
+          }
+        }
+        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'SoundVolume') {
           component = {
             component: 'oh-slider-card',
             config: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -5,10 +5,15 @@
  * @param {object} [footer] configuration of the label of the component footer. If undefined nothing is displayed in the footer.
  * Refer to {@see itemContextLabel} for valid options.
  */
+
+import * as Semantics from '@/assets/semantics.js'
+
 export default function itemDefaultListComponent (item, footer) {
   const stateDescription = item.stateDescription || {}
   const metadata = (item.metadata && item.metadata.listWidget) ? item.metadata.listWidget : {}
   let component = null
+  let semanticClass = {}
+  let semanticProperty = {}
 
   if (metadata.value && metadata.value !== ' ') {
     component = {
@@ -16,6 +21,15 @@ export default function itemDefaultListComponent (item, footer) {
       config: Object.assign({}, metadata.config)
     }
   } else {
+    item.tags.forEach((tag) => {
+      if (Semantics.Points.indexOf(tag) >= 0) {
+        semanticClass = tag
+      }
+      if (Semantics.Properties.indexOf(tag) >= 0) {
+        semanticProperty = tag
+      }
+    })
+
     if (item.type === 'Switch' && !stateDescription.readOnly) {
       component = {
         component: 'oh-toggle-item'
@@ -63,6 +77,54 @@ export default function itemDefaultListComponent (item, footer) {
         config: {
           action: 'photos',
           actionPhotos: [{ item: item.name }]
+        }
+      }
+    }
+
+    if(item.type === 'DateTime' && !stateDescription.readOnly) {
+      component = {
+        component: 'oh-input-item',
+        config: {
+          type: "datetime",
+          sendButton: true,
+          clearButton: true
+        }
+      }
+    }
+
+    if (item.type === 'Number' && !stateDescription.readOnly) {
+      component = {
+        component: 'oh-input-item',
+        config: {
+          type: "number",
+          inputmode: "decimal",
+          sendButton: true
+        }
+      }
+
+      if ((semanticClass === 'Control' || semanticClass === 'SetPoint') && !stateDescription.readOnly) {
+        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'Temperature' || semanticProperty === 'SoundVolume') {
+          component = {
+            component: 'oh-slider-item',
+            config: {
+              scale: true,
+              label: true,
+              scaleSubSteps: 5,
+              min: stateDescription.minimum,
+              max: stateDescription.maximum,
+              step: stateDescription.step
+            }
+          }
+        }
+        if (semanticProperty === 'Light' || semanticProperty === 'Power' || semanticProperty === 'Energy') {
+          component = {
+            component: 'oh-toggle-item'
+          }
+        }
+      }
+      if (semanticClass === 'Switch') {
+        component = {
+          component: 'oh-toggle-item'
         }
       }
     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -81,11 +81,11 @@ export default function itemDefaultListComponent (item, footer) {
       }
     }
 
-    if(item.type === 'DateTime' && !stateDescription.readOnly) {
+    if (item.type === 'DateTime' && !stateDescription.readOnly) {
       component = {
         component: 'oh-input-item',
         config: {
-          type: "datetime",
+          type: 'datetime-local',
           sendButton: true,
           clearButton: true
         }
@@ -96,36 +96,59 @@ export default function itemDefaultListComponent (item, footer) {
       component = {
         component: 'oh-input-item',
         config: {
-          type: "number",
-          inputmode: "decimal",
+          type: 'number',
+          inputmode: 'decimal',
           sendButton: true
         }
       }
+    }
 
-      if ((semanticClass === 'Control' || semanticClass === 'SetPoint') && !stateDescription.readOnly) {
-        if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'Temperature' || semanticProperty === 'SoundVolume') {
-          component = {
-            component: 'oh-slider-item',
-            config: {
-              scale: true,
-              label: true,
-              scaleSubSteps: 5,
-              min: stateDescription.minimum,
-              max: stateDescription.maximum,
-              step: stateDescription.step
-            }
-          }
+    if (item.type === 'Number:Temperature' && !stateDescription.readOnly) {
+      component = {
+        component: 'oh-stepper-item',
+        config: {
+          min: stateDescription.minimum,
+          max: stateDescription.maximum,
+          step: stateDescription.step,
+          buttonsOnly: false
         }
-        if (semanticProperty === 'Light' || semanticProperty === 'Power' || semanticProperty === 'Energy') {
-          component = {
-            component: 'oh-toggle-item'
+      }
+    }
+
+    if ((semanticClass === 'Control' || semanticClass === 'SetPoint') && !stateDescription.readOnly) {
+      if (semanticProperty === 'Temperature') {
+        component = {
+          component: 'oh-stepper-item',
+          config: {
+            min: stateDescription.minimum,
+            max: stateDescription.maximum,
+            step: stateDescription.step,
+            buttonsOnly: false
           }
         }
       }
-      if (semanticClass === 'Switch') {
+      if (semanticProperty === 'ColorTemperature' || semanticProperty === 'Level' || semanticProperty === 'SoundVolume') {
+        component = {
+          component: 'oh-slider-item',
+          config: {
+            scale: true,
+            label: true,
+            scaleSubSteps: 5,
+            min: stateDescription.minimum,
+            max: stateDescription.maximum,
+            step: stateDescription.step
+          }
+        }
+      }
+      if (semanticProperty === 'Light' || semanticProperty === 'Power' || semanticProperty === 'Energy') {
         component = {
           component: 'oh-toggle-item'
         }
+      }
+    }
+    if (semanticClass === 'Switch') {
+      component = {
+        component: 'oh-toggle-item'
       }
     }
   }


### PR DESCRIPTION
This PR extends the default widget selection for standalone, cell and item default widgets to provide better default widgets on DateTime and Number items as requested here #399 and here #1494

Basically the PR adds the following default widgets:
- oh-input for datetime on items of type `DateTime` (standalone, list)
- oh-input for numbers on items of type `Number` (standalone, list)
- oh-stepper on `Number:Temperature` items as well as for items with the semantic class `Control` or `SetPoint` with semantic property `Temperature` (standalone, list)
- oh-slider on `Number:*` items with the semantic class `Control` or `SetPoint` and a semantic property from `ColorTemperature`, `Level`, `SoundVolume` (standalone, list, cell)
- oh-toggle on `Number*` items with the semantic class `Control` or `SetPoint` and a semantic property from `Light`, `Power`, `Energy` (standalone, list, cell)
- oh-toggle on `Number*` items with the semantic class `Switch` (standalone, list, cell)