### PR TITLE
[MainUI] Fix items disappear from model if stateDescription is added

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -394,12 +394,12 @@ export default {
 
       if (this.includeNonSemantic) {
         parent.children.groups = this.items
-          .filter((i) => i.type === 'Group' && (!i.metadata) && i.groupNames.indexOf(parent.item.name) >= 0)
+          .filter((i) => i.type === 'Group' && (!i.metadata || (i.metadata && !i.metadata.semantics)) && i.groupNames.indexOf(parent.item.name) >= 0)
           .map(this.modelItem).sort(compareModelItems)
         parent.children.groups.forEach(this.getChildren)
-        if (parent.item.metadata) {
+        if (parent.item.metadata && parent.item.metadata.semantics) {
           parent.children.items = this.items
-            .filter((i) => i.type !== 'Group' && (!i.metadata) && i.groupNames.indexOf(parent.item.name) >= 0)
+            .filter((i) => i.type !== 'Group' && (!i.metadata || (i.metadata && !i.metadata.semantics)) && i.groupNames.indexOf(parent.item.name) >= 0)
             .map(this.modelItem).sort(compareModelItems)
         } else {
           parent.children.items = this.items


### PR DESCRIPTION
I noticed that an item disappears from the model if the parent item is a semantic item but the current item is a non semantic item with other metadata like stateDescription or commandDescription. The problem is caused by an if clause which just filters for items without metadata, which is incorrect. It should filter for items without metadata or without semantic metadata to fix this problem.

The issue was also reported here  #925
Fixes  #925

Signed-off-by: Florian Michel <florianmichel@hotmail.de>