### PR TITLE
[MainUI] Fix oh-trend sampling property

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-trend.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-trend.vue
@@ -43,7 +43,7 @@ export default {
       this.trendData = []
       this.showTrend = false
       if (!this.trendItem) return []
-      const sampling = this.config.trendSampling || 60
+      const sampling = typeof this.config.trendSampling === 'number' ? this.config.trendSampling : 60
       return this.$oh.api.get('/rest/persistence/items/' + this.config.trendItem).then((resp) => {
         if (resp.data && resp.data.length) {
           let data = []


### PR DESCRIPTION
I noticed that the `trendSampling` option was ignored and instead the value was always set to 60. This was causing troubles as I was using the persistence strategie `everyChange` and not `everyMinute` on my persistence provider. This PR fixes this issue by adapting the variable assignment.

Signed-off-by: Florian Michel <florianmichel@hotmail.de>