### PR TITLE
[MainUI] `oh-sipclient`: Fix microphone access stays active when foreground is left on iOS

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -67,7 +67,8 @@ export default {
       remoteParty: '',
       phonebook: new Map(),
       loggerPrefix: 'oh-sipclient',
-      showLocalVideo: false
+      showLocalVideo: false,
+      stream: null
     }
   },
   mixins: [mixin, foregroundService, actionsMixin],
@@ -93,6 +94,9 @@ export default {
       } else {
         navigator.mediaDevices.getUserMedia({ audio: true, video: this.config.enableVideo })
           .then((stream) => {
+            // Store MediaDevices access here to stop it when foreground is left
+            // Do NOT stop MediaDevices access here (keep Mic/Camera access) to improve call startup time
+            this.stream = stream
             // Start SIP connection
             this.sipStart()
           })
@@ -103,6 +107,8 @@ export default {
       }
     },
     stopForegroundActivity () {
+      // Stop MediaDevices access here, otherwise Mic/Camera access will stay active on iOS
+      this.stream.getTracks().forEach((track) => track.stop())
       if (this.phone) this.phone.stop()
     },
     /**

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -105,6 +105,9 @@ export default {
     stopForegroundActivity () {
       if (this.phone) this.phone.stop()
     },
+    /**
+     * Starts the JsSIP UserAgent and connects to the SIP server.
+     */
     sipStart () {
       if (this.phone) this.phone.stop() // reconnect to reload config
       this.context.component.config = { ...this.config, ...this.localConfig } // merge local device configuration
@@ -171,6 +174,10 @@ export default {
         this.phone.start()
       })
     },
+    /**
+     * Plays a given tone. Might not properly work on all browsers and devices.
+     * @param {*} audio file to be played
+     */
     playTone (file) {
       if (this.config.enableTones === true) {
         console.info(this.loggerPrefix + ': Starting to play tone')
@@ -183,12 +190,18 @@ export default {
         })
       }
     },
+    /**
+     * Stops all played tones.
+     */
     stopTones () {
       if (this.config.enableTones === true) {
         console.info(this.loggerPrefix + ': Stop playing tone')
         this.audio.pause()
       }
     },
+    /**
+     * Attaches MediaStreams (remote audio, remote & eventually local video) for the SIP call.
+     */
     attachMedia () {
       this.session.connection.addEventListener('track', (track) => {
         if (this.config.enableVideo) {
@@ -206,6 +219,9 @@ export default {
         }
       })
     },
+    /**
+     * Stops all MediaStreams (remote audio, remote & eventually local video) of the SIP call.
+     */
     stopMedia () {
       if (this.config.enableVideo) this.$refs.remoteVideo.srcObject = null
       if (this.config.enableLocalVideo) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -85,7 +85,7 @@ export default {
         }
       }
 
-      if (this.context.editmode) return // do not connect SIP while editing
+      if (this.context.editmode) return // Do not connect SIP while editing
 
       // Make sure we have Mic/Camera permissions
       if (!navigator.mediaDevices) {
@@ -97,7 +97,7 @@ export default {
             this.sipStart()
           })
           .catch((err) => {
-            console.log('could not access microphone/camera', err)
+            console.log('Could not access microphone/camera', err)
             this.$f7.dialog.alert('To use the SIP widget you must allow microphone/camera access in your browser and reload this page.')
           })
       }
@@ -109,10 +109,10 @@ export default {
      * Starts the JsSIP UserAgent and connects to the SIP server.
      */
     sipStart () {
-      if (this.phone) this.phone.stop() // reconnect to reload config
-      this.context.component.config = { ...this.config, ...this.localConfig } // merge local device configuration
+      if (this.phone) this.phone.stop() // Reconnect to reload config
+      this.context.component.config = { ...this.config, ...this.localConfig } // Merge local device configuration
 
-      import(/* webpackChunkName: "jssip" */ 'jssip').then((JsSIP) => { // lazy load jssip
+      import(/* webpackChunkName: "jssip" */ 'jssip').then((JsSIP) => { // Lazy load jssip
         this.config.enableSIPDebug ? JsSIP.debug.enable('JsSIP:*') : JsSIP.debug.disable()
         // SIP user agent setup
         this.remoteAudio = new window.Audio()

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -231,6 +231,8 @@ export default {
     stopMedia () {
       if (this.config.enableVideo) this.$refs.remoteVideo.srcObject = null
       if (this.config.enableLocalVideo) {
+        // Make sure all tracks are stopped
+        this.$refs.localVideo.srcObject.getTracks().forEach((track) => track.stop())
         this.$refs.localVideo.srcObject = null
         this.showLocalVideo = false
       }


### PR DESCRIPTION
## Description

This PR fixes an issue on iOS devices, where microphone access stayed active when the `oh-sipclient` component left the foreground. Microphone access could only be stopped by reloading MainUI.
It also included a small change to avoid having the same issue when using a video call and accessing the local video (I haven't experienced this because I don't use video calls).

Moreover, comments are changed to uppercase and JSDoc is added for some methods.

## Testing

I have deployed this to my production system and it works fine now. Microphone access stops when I switch to another part of MainUI or switch, but keeps active when I leave Safari or change to another tab (I guess because `stopForegroundActivity()` is not called here). When I use the openHAB iOS, microphone access also stops when I put the app in the background.

@ghys This can be merged after the feature freeze since it's a bugfix, right?