### PR TITLE
[MainUI] Update JS Scripting tern definitions

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -350,17 +350,31 @@
               }
         },
         "CacheNamespace": {
+            "shared": {
+                "!doc": "Shared cache that is shared across all rules and scripts, it can therefore be accessed from any automation language. A key is removed when all scripts that ever accessed it are unloaded, if the key stores a timer, the timer is cancelled.",
+                "!type": "JSCache"
+            },
+            "private": {
+                "!doc": "Private cache for each script. It can only be accessed by the same script and is cleared when the script is unloaded. When the script is unloaded, all timers in the script are cancelled.",
+                "!type": "JSCache"
+            }
+        },
+        "JSCache": {
             "get": {
-                "!doc": "Returns the value to which the specified key is mapped",
+                "!doc": "Returns the value to which the specified key is mapped. The optional defaultSupplier will return a default value if the key has no associated value.",
                 "!type": "fn(key: string, defaultSupplier?: fn()) -> ?"
             },
             "put": {
-                "!doc": "Associates the specified value with the specified key",
+                "!doc": "Associates the specified value with the specified key.",
                 "!type": "fn(key: string, value: ?) -> ?"
             },
             "remove": {
-                "!doc": "Removes the mapping for a key from this map if it is present",
+                "!doc": "Removes the mapping for a key from this map if it is present.",
                 "!type": "fn(key: string) -> ?"
+            },
+            "exists": {
+                "!doc": "Checks whether a value is associated with the given key.",
+                "!type": "fn(key: string) -> boolean"
             }
         },
         "Timer": {
@@ -637,7 +651,7 @@
         "!type": "ThingsNamespace"
     },
     "cache": {
-        "!doc": "Shared cache namespace. This namespace provides a default cache that can be use to set and retrieve objects that will be persisted between reloads of scripts.",
+        "!doc": "Cache namespace. This namespace provides caches that can be used to set and retrieve objects that will be persisted between reloads of scripts.",
         "!type": "CacheNamespace"
     },
     "log": {


### PR DESCRIPTION
Reference
https://github.com/openhab/openhab-js/compare/v3.0.0...v3.1.2.

## Description

This updated the tern definitions for the current openhab-js version included in the addon (3.1.2).

The tern definitions for the `cache` namespace were updated to allow access to the `shared` and the `private` caches from core.

## Testing

I need to check whether autocompletion for `cache` works correctly.

@ghys This should go into 3.4.0. Since the feature freeze is already active, this should get merged as bugfix. 
It indeed fixes deprecation warnings that will be logged when someone tries to use something like `cache.get()` (which now would be `cache.private.get()` or `cache.shared.get()`).

