### PR TITLE
Speed up devserver hot reload, CSS cache invalidation

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -220,7 +220,7 @@ module.exports = {
       } : false
     }),
     new MiniCssExtractPlugin({
-      filename: 'css/app.css'
+      filename: 'css/app.[hash].css'
     }),
     new CopyWebpackPlugin([
       {
@@ -241,23 +241,25 @@ module.exports = {
         swSrc: resolvePath('src/service-worker.js')
       })
     ] : []),
-     new CompressionPlugin({
-      filename: '[path][base].gz',
-      algorithm: 'gzip',
-      test: /\.js$|\.css$|\.html$/,
-      threshold: 0,
-      minRatio: Infinity,
-    }),
-    new CompressionPlugin({
-      filename: '[path][base].br',
-      algorithm: 'brotliCompress',
-      test: /\.(js|css|html|svg)$/,
-      compressionOptions: {
-        level: 11,
-      },
-      threshold: 0,
-      minRatio: Infinity,
-    }),
+    ...(env === 'production' ? [
+      new CompressionPlugin({
+        filename: '[path][base].gz',
+        algorithm: 'gzip',
+        test: /\.js$|\.css$|\.html$/,
+        threshold: 0,
+        minRatio: Infinity,
+      }),
+      new CompressionPlugin({
+        filename: '[path][base].br',
+        algorithm: 'brotliCompress',
+        test: /\.(js|css|html|svg)$/,
+        compressionOptions: {
+          level: 11,
+        },
+        threshold: 0,
+        minRatio: Infinity,
+      })
+    ] : []),
     ...(process.env.WEBPACK_ANALYZER ? [
       new WebpackAnalyzerPlugin(process.env.WEBPACK_ANALYZER_REPORT ? {
         analyzerMode: 'static',


### PR DESCRIPTION
Only use CompressionPlugin in production mode as it was slowing down the
hot reloading in development mode to a crawl.

Add hashs to built CSS files to avoid caching problems
(and be consistent with the naming scheme of JS files).

Signed-off-by: Yannick Schaus <github@schaus.net>