### PR TITLE
Add context parameter to rule action

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
@@ -196,6 +196,11 @@ prev: /docs/ui/components/
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-button.md
+++ b/bundles/org.openhab.ui/doc/components/oh-button.md
@@ -176,6 +176,11 @@ Button performing an action
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to
@@ -328,6 +333,11 @@ Button performing an action
 <PropBlock type="TEXT" name="taphold_actionRule" label="Rule" context="rule">
   <PropDescription>
     Rule to run
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="taphold_actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionPage" label="Page" context="page">

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
@@ -113,6 +113,11 @@ prev: /docs/ui/components/
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
@@ -158,6 +158,11 @@ prev: /docs/ui/components/
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -126,6 +126,11 @@ A regular or expandable cell
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-clock-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-clock-card.md
@@ -181,6 +181,11 @@ Display a digital clock in a card
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -155,6 +155,11 @@ A cell expanding to a color picker
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-data-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-data-series.md
@@ -99,6 +99,11 @@ prev: /docs/ui/components/
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
@@ -217,6 +217,11 @@ Display a read-only gauge in a card to visualize a quantifiable item
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-icon.md
+++ b/bundles/org.openhab.ui/doc/components/oh-icon.md
@@ -135,6 +135,11 @@ Display an openHAB icon
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-image-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image-card.md
@@ -147,6 +147,11 @@ Display an image (URL or Image item ) in a card
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-image.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image.md
@@ -115,6 +115,11 @@ Displays an image from a URL or an item
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -202,6 +202,11 @@ A cell expanding to a knob control
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-label-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-card.md
@@ -116,6 +116,11 @@ Display the state of an item in a card
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to
@@ -268,6 +273,11 @@ Display the state of an item in a card
 <PropBlock type="TEXT" name="taphold_actionRule" label="Rule" context="rule">
   <PropDescription>
     Rule to run
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="taphold_actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionPage" label="Page" context="page">

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -142,6 +142,11 @@ A cell with a big label to show a short item state value
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-label-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-item.md
@@ -132,6 +132,11 @@ Display the state of an item in a list
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-link.md
+++ b/bundles/org.openhab.ui/doc/components/oh-link.md
@@ -150,6 +150,11 @@ Link performing an action
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-list-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-list-item.md
@@ -121,6 +121,11 @@ A list item
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
@@ -134,6 +134,11 @@ A circle on a map, to represent a radius
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-map-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-marker.md
@@ -118,6 +118,11 @@ An icon on a map
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -221,6 +221,11 @@ A marker on a floor plan
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
@@ -187,6 +187,11 @@ A cell expanding to rollershutter controls
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -197,6 +197,11 @@ A cell expanding to a big vertical slider
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-time-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-time-series.md
@@ -150,6 +150,11 @@ prev: /docs/ui/components/
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/doc/components/oh-video.md
+++ b/bundles/org.openhab.ui/doc/components/oh-video.md
@@ -139,6 +139,11 @@ Displays a video player from a URL or an item
     Rule to run
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="actionRuleContext" label="Rule Context" context="script">
+  <PropDescription>
+    Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="actionPage" label="Page" context="page">
   <PropDescription>
     Page to navigate to

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
@@ -57,6 +57,10 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['rule'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
+    pt(paramPrefix + 'actionRuleContext', 'Rule Context', 'Object representing the optional context to pass to the rule. Edit in YAML or provide a JSON object, e.g. <code>{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }</code>.').c('script')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['rule'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
     pt(paramPrefix + 'actionPage', 'Page', 'Page to navigate to').c('page')
       .v((value, configuration, configDescription, parameters) => {
         return ['navigate'].indexOf(configuration[paramPrefix + 'action']) >= 0

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -144,8 +144,10 @@ export const actionsMixin = {
           break
         case 'rule':
           const actionRule = actionConfig[prefix + 'actionRule']
+          let actionRuleContext = actionConfig[prefix + 'actionRuleContext']
+          if (typeof actionRuleContext === 'object') actionRuleContext = JSON.stringify(actionRuleContext)
           if (!actionRule) break
-          this.$oh.api.postPlain('/rest/rules/' + actionRule + '/runnow', '')
+          this.$oh.api.postPlain('/rest/rules/' + actionRule + '/runnow', actionRuleContext || '', 'text/plain', 'application/json')
             .then(() => this.showActionFeedback(prefix, actionConfig))
             .catch((err) => {
               this.$f7.toast.create({


### PR DESCRIPTION
This adds the ability for "run rules" actions to pass a context to the rule.
See https://github.com/openhab/openhab-core/pull/3160 & https://github.com/openhab/openhab-core/pull/3160#issuecomment-1348505543

The context can be passed as a JSON string, or as a YAML structure (allowing to include expressions more easily), as illustrated below, the 2 versions are roughly equivalent except the second one includes an expression:

```yaml
action: rule
actionRule: dump_context
actionRuleContext: '{ "param1": "value1", "param2": { "subkey1": "testing", "subkey2": 123 } }'


action: rule
actionRule: dump_context
actionRuleContext:
 param1: value1
 param2:
   subkey1: testing
   subkey2: 123
   computed: =2+3
```

The dump_context can be as simple as a JS (Nashorn or JS Scripting) script with the following code:
```
print(ctx);
```
which outputs:
```
{param1=value1, ruleUID=dump_context, param2={subkey1=testing, subkey2=123.0, computed=5.0}}
```
