### PR TITLE
[blockly] fix help urls

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -58,7 +58,7 @@ export default function (f7) {
       this.setOutput(true, 'Array')
       this.setColour(0)
       this.setTooltip('Retrieve the items that have all the given tags')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-tagged-items')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-items-with-tag')
       this.setOutput(true, null)
     }
   }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-text.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-text.js
@@ -17,7 +17,7 @@ export default function (f7) {
       this.setOutput(true, 'String')
       this.setColour('%{BKY_TEXTS_HUE}')
       this.setTooltip('Returns a carriage return line feed (\\r\\n).')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#crlf')
     }
   }
 
@@ -47,7 +47,7 @@ export default function (f7) {
       this.setOutput(true, 'String')
       this.setColour('%{BKY_TEXTS_HUE}')
       this.setTooltip('returns a new string with one, some, or all matches of a pattern replaced by a replacement. The pattern can be a string or a RegEx. If it is a string, all occurences are replaced.')
-      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#concatenate-list')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#text-replace')
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan@andreaundstefanhoehn.de>

fixes help urls to be consistent with https://github.com/openhab/openhab-docs/pull/1955 for the final blockly release of 3.4

@ghys please merge this small PR - thx