### PR TITLE
Show Basic UI and CometVisu intros in Main UI

### DIFF
--- a/bundles/org.openhab.ui.basic/README.md
+++ b/bundles/org.openhab.ui.basic/README.md
@@ -1,14 +1,14 @@
-## Basic UI
+# Basic UI
 
 The Basic UI is a web interface based on Material Design Lite from Google.
 
-### Features
+## Features
 
 - Responsive layout suitable for various screen sizes
 - AJAX navigation
 - Live update
 
-### Configuration
+## Configuration
 
 ```
 org.openhab.basicui:defaultSitemap=demo
@@ -19,7 +19,7 @@ org.openhab.basicui:enableIcons=true
 org.openhab.basicui:iconType=svg
 ```
 
-### Accessing Sitemaps
+## Accessing Sitemaps
 
 The Basic UI has a default layout showing all things and their corresponding items. You may create your own sitemaps and access them through the basic UI in 2 ways.
 
@@ -30,7 +30,7 @@ The Basic UI has a default layout showing all things and their corresponding ite
 Example: http://hostname:8080/basicui/app?sitemap=sitemapname
 
 
-### Screenshots:
+## Screenshots:
 
 [![Screenshot 1](doc/screenshot-1.png)](doc/screenshot-1-full.png)
 [![Screenshot 2](doc/screenshot-2.png)](doc/screenshot-2-full.png)

--- a/bundles/org.openhab.ui.cometvisu/README.md
+++ b/bundles/org.openhab.ui.cometvisu/README.md
@@ -1,7 +1,5 @@
 # CometVisu Backend for openHAB
 
-## Introduction
-
 This adds a backend for the web based visualization CometVisu <http://www.cometvisu.org>.
 The CometVisu is a highly customizable visualization, that runs in any browser.
 Unlike the browser based UI´s in openHAB, the CometVisu does not rely on sitemaps.


### PR DESCRIPTION
Using these Markdown tweaks a small intro will show in Main UI instead of emptiness and a "more" button:

![Screenshot from 2022-12-17 21-59-40](https://user-images.githubusercontent.com/12213581/208265839-30ba87df-03af-4298-aeee-f7c9839a8bc7.png)
