### PR TITLE
Fix add-on information issues

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -123,19 +123,35 @@ export default {
           id: 'documentationLink',
           title: 'Documentation',
           afterIcon: 'question_circle_fill',
-          linkUrl: `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}` // this.addon.link
+          linkUrl: `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id.split('-')[1]}` // this.addon.link
         })
+
+        let repository
+        let issueFilter = 'q=is%3Aopen'
+        if (this.addon.id === 'binding-zigbee') {
+          repository = 'org.openhab.binding.zigbee'
+        } else if (this.addon.id === 'binding-zwave') {
+          repository = 'org.openhab.binding.zwave'
+        } else {
+          if (this.addon.type === 'ui') {
+            repository = 'openhab-webui'
+          } else {
+            repository = 'openhab-addons'
+          }
+          issueFilter += `+${this.addon.id.split('-')[1]}`
+        }
+
         info.push({
           id: 'issuesLink',
           title: 'Issues',
           afterIcon: 'exclamationmark_bubble_fill',
-          linkUrl: 'https://github.com/openhab/openhab-addons/issues?q=is%3Aopen+' + this.addon.id.substring(this.addon.id.indexOf('-') + 1)
+          linkUrl: `https://github.com/openhab/${repository}/issues?${issueFilter}`
         })
         info.push({
           id: 'discussionsLink',
           title: 'Community Discussions',
           afterIcon: 'chat_bubble_2_fill',
-          linkUrl: 'https://community.openhab.org/search?q=' + this.addon.id.substring(this.addon.id.indexOf('-') + 1)
+          linkUrl: 'https://community.openhab.org/search?q=' + this.addon.id.split('-')[1]
         })
       } else {
         info.push({

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -236,7 +236,7 @@ export default {
       if (this.addon.id.indexOf('-') > 0) {
         let url = `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org` +
           `/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}` +
-          `/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}`
+          `/${this.addon.id.split('-')[1]}`
         return url
       }
       return ''
@@ -293,7 +293,7 @@ export default {
         let addonTypeFolder = '_addons_' + this.addon.type
         if (this.addon.type === 'misc') addonTypeFolder = '_addons_io'
         if (this.addon.type !== 'automation') addonTypeFolder += 's'
-        let addonId = this.addon.id.substring(this.addon.id.indexOf('-') + 1)
+        let addonId = this.addon.id.split('-')[1]
         let docUrl = (this.$store.state.runtimeInfo.buildString === 'Release Build') ? 'https://www.openhab.org' : 'https://next.openhab.org'
         docUrl += `/addons/${this.addon.type}/${addonId}`
         let docSrcUrl = `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/${addonTypeFolder}/${addonId}`


### PR DESCRIPTION
Fixes the following issues:

* Markdown documentation for JDBC features does not show
* Documentation link for JDBC features results in 404 not found
* Issue links always point to openhab-addons repository (also for UI add-ons and Zigbee, Zwave)
  This causes users not to find exising issues and causes them to create issues in the wrong repository