### PR TITLE
[MainUI] Script Editor: Block runRule and save while rule is running (or uninitialized)

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -329,7 +329,13 @@ export default {
     },
     runNow () {
       if (this.createMode) return
-      if (this.rule.status === 'RUNNING') return
+      if (this.rule.status.status === 'RUNNING' || this.rule.status.status === 'UNINITIALIZED') {
+        return this.$f7.toast.create({
+          text: `Rule cannot be run ${(this.rule.status.status === 'RUNNING') ? 'while already running, please wait' : 'if it is disabled'}!`,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      }
       this.$f7.toast.create({
         text: 'Running rule',
         destroyOnClose: true,
@@ -382,7 +388,7 @@ export default {
         const topicParts = event.topic.split('/')
         switch (topicParts[3]) {
           case 'state':
-            this.$set(this.rule, 'status', JSON.parse(event.payload))
+            this.$set(this.rule, 'status', JSON.parse(event.payload)) // e.g. {"status":"RUNNING","statusDetail":"NONE"}
             break
         }
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -283,6 +283,13 @@ export default {
     },
     save (noToast) {
       if (!this.isEditable) return
+      if (this.rule.status.status === 'RUNNING') {
+        return this.$f7.toast.create({
+          text: 'Rule cannot be updated while running, please wait!',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      }
       if (this.isBlockly) {
         try {
           this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()


### PR DESCRIPTION
## Description

- Fixes blocking of the run rule command while rule is RUNNING or UNINITIALIZED. This was already implemented, but nor working.
- Additionally blocks save rule while a rule is RUNNING to avoid problems with automation engines like JS Scripting (GraalJS)
- Shows toast messages when run rule or save rule is blocked and explains why it is blocked

Note: Block means that a click on the button does not execute the action, the button is still visible and looks normal.