### PR TITLE
show custom namespaces for items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -1,25 +1,21 @@
 <template>
   <f7-card>
-    <f7-card-content v-if="item.metadata && Object.keys(item.metadata).filter((n) => n !== 'semantics').length > 0">
+    <f7-card-content v-if="item.metadata && Object.keys(item.metadata).filter((n) => n !== 'semantics2').length > 0">
       <f7-list>
         <ul>
           <f7-list-item
-            v-for="namespace in standardNamespaces" :key="namespace"
-            :link="'/settings/items/' + item.name + '/metadata/' + item.metadata[namespace].id"
-            :title="item.metadata[namespace].label"
-            :after="(item.metadata[namespace].id) ? item.metadata[namespace].id : 'Not Set'" />
+            v-for="namespace in wellKnownNamespaces" :key="namespace"
+            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+            :title="namespace.label"
+            :after="namespace.value || 'Not Set'" />
         </ul>
-      </f7-list>
-    </f7-card-content>
-    <hr>
-    <f7-card-content v-if="item.metadata && Object.keys(item.metadata).filter((n) => n !== 'semantics').length > 0">
-      <f7-list>
-        <ul>
+        <ul v-if="customNamespaces.length > 0">
+          <f7-list-item divider />
           <f7-list-item
             v-for="namespace in customNamespaces" :key="namespace"
-            :link="'/settings/items/' + item.name + '/metadata/' + item.metadata[namespace].id"
-            :title="item.metadata[namespace].label"
-            :after="(item.metadata[namespace].id) ? item.metadata[namespace].id : 'Not Set'" />
+            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+            :title="namespace.label"
+            :after="namespace.value || 'Not Set'" />
         </ul>
       </f7-list>
     </f7-card-content>
@@ -42,11 +38,39 @@ export default {
     }
   },
   computed: {
-    standardNamespaces () {
-      return Object.keys(this.item.metadata).filter((n) => !this.item.metadata[n].custom)
+    editableNamespaces () {
+      if (!this.item.metadata) return []
+      // TODO: determine somehow if other MetadataProviders are not editable
+      // for now we'll assume they're all editable except "semantics"
+      return Object.keys(this.item.metadata)
+        .filter((n) => n !== 'semantics')
+        .map((n) => {
+          return {
+            name: n,
+            value: this.item.metadata[n].value
+          }
+        })
+    },
+    wellKnownNamespaces () {
+      return this.editableNamespaces
+        .filter((n) => MetadataNamespaces.some((wk) => wk.name === n.name))
+        .map((n) => {
+          const wellKnown = MetadataNamespaces.find((wk) => wk.name === n.name)
+          return {
+            ...n,
+            label: wellKnown.label
+          }
+        })
     },
     customNamespaces () {
-      return Object.keys(this.item.metadata).filter((n) => this.item.metadata[n].custom)
+      return this.editableNamespaces
+        .filter((n) => !MetadataNamespaces.some((wk) => wk.name === n.name))
+        .map((n) => {
+          return {
+            ...n,
+            label: n.name
+          }
+        })
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -40,7 +40,8 @@ export default {
   computed: {
     editableNamespaces () {
       if (!this.item.metadata) return []
-      // TODO: determine somehow if other MetadataProviders are not editable
+      // TODO: determine somehow if other namespaces are not editable
+      // (non-managed MetadataProvider)
       // for now we'll assume they're all editable except "semantics"
       return Object.keys(this.item.metadata)
         .filter((n) => n !== 'semantics')

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -4,11 +4,10 @@
       <f7-list>
         <ul>
           <f7-list-item
-            v-for="namespace in item.metadata" :key="namespace"
-            v-if="!namespace.custom"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.id"
-            :title="namespace.label"
-            :after="(item.metadata[namespace.id]) ? item.metadata[namespace.id].value : 'Not Set'" />
+            v-for="namespace in standardNamespaces" :key="namespace"
+            :link="'/settings/items/' + item.name + '/metadata/' + item.metadata[namespace].id"
+            :title="item.metadata[namespace].label"
+            :after="(item.metadata[namespace].id) ? item.metadata[namespace].id : 'Not Set'" />
         </ul>
       </f7-list>
     </f7-card-content>
@@ -17,11 +16,10 @@
       <f7-list>
         <ul>
           <f7-list-item
-            v-for="namespace in item.metadata" :key="namespace"
-            v-if="namespace.custom"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.id"
-            :title="namespace.label"
-            :after="(item.metadata[namespace.id]) ? item.metadata[namespace.id].value : 'Not Set'" />
+            v-for="namespace in customNamespaces" :key="namespace"
+            :link="'/settings/items/' + item.name + '/metadata/' + item.metadata[namespace].id"
+            :title="item.metadata[namespace].label"
+            :after="(item.metadata[namespace].id) ? item.metadata[namespace].id : 'Not Set'" />
         </ul>
       </f7-list>
     </f7-card-content>
@@ -41,6 +39,14 @@ export default {
   data () {
     return {
       metadataNamespaces: MetadataNamespaces
+    }
+  },
+  computed: {
+    standardNamespaces () {
+      return Object.keys(this.item.metadata).filter((n) => !this.item.metadata[n].custom)
+    },
+    customNamespaces () {
+      return Object.keys(this.item.metadata).filter((n) => this.item.metadata[n].custom)
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-card>
-    <f7-card-content v-if="item.metadata && Object.keys(item.metadata).filter((n) => n !== 'semantics2').length > 0">
+    <f7-card-content v-if="this.editableNamespaces.length > 0">
       <f7-list>
         <ul>
           <f7-list-item

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -5,6 +5,20 @@
         <ul>
           <f7-list-item
             v-for="namespace in item.metadata" :key="namespace"
+            v-if="!namespace.custom"
+            :link="'/settings/items/' + item.name + '/metadata/' + namespace.id"
+            :title="namespace.label"
+            :after="(item.metadata[namespace.id]) ? item.metadata[namespace.id].value : 'Not Set'" />
+        </ul>
+      </f7-list>
+    </f7-card-content>
+    <hr>
+    <f7-card-content v-if="item.metadata && Object.keys(item.metadata).filter((n) => n !== 'semantics').length > 0">
+      <f7-list>
+        <ul>
+          <f7-list-item
+            v-for="namespace in item.metadata" :key="namespace"
+            v-if="namespace.custom"
             :link="'/settings/items/' + item.name + '/metadata/' + namespace.id"
             :title="namespace.label"
             :after="(item.metadata[namespace.id]) ? item.metadata[namespace.id].value : 'Not Set'" />

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -4,10 +4,10 @@
       <f7-list>
         <ul>
           <f7-list-item
-            v-for="namespace in metadataNamespaces.filter((n) => item.metadata[n.name])" :key="namespace.name"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+            v-for="namespace in item.metadata" :key="namespace"
+            :link="'/settings/items/' + item.name + '/metadata/' + namespace.id"
             :title="namespace.label"
-            :after="(item.metadata[namespace.name]) ? item.metadata[namespace.name].value : 'Not Set'" />
+            :after="(item.metadata[namespace.id]) ? item.metadata[namespace.id].value : 'Not Set'" />
         </ul>
       </f7-list>
     </f7-card-content>

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -49,8 +49,6 @@
 <script>
 import ModelTreeview from '@/components/model/model-treeview.vue'
 
-import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
-
 import { compareItems } from '@/components/widgets/widget-order'
 
 function compareModelItems (o1, o2) {
@@ -151,7 +149,7 @@ export default {
     load (update) {
       // if (this.ready) return
       this.loading = true
-      const items = this.$oh.api.get('/rest/items?metadata=semantics,' + MetadataNamespaces.map((n) => n.name).join(','))
+      const items = this.$oh.api.get('/rest/items?metadata=.+')
       const links = this.$oh.api.get('/rest/links')
       Promise.all([items, links]).then((data) => {
         this.items = data[0]

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -147,8 +147,6 @@ import LinkDetails from '@/components/model/link-details.vue'
 import GroupMembers from '@/components/item/group-members.vue'
 import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 
-import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
-
 export default {
   props: ['itemName'],
   components: {
@@ -185,12 +183,6 @@ export default {
     },
     load () {
       this.$oh.api.get(`/rest/items/${this.itemName}?metadata=.+`).then((data) => {
-        Object.keys(data.metadata).forEach(namespace => {
-          let rs = MetadataNamespaces.find(ns => ns.name === namespace)
-          data.metadata[namespace].id = namespace
-          data.metadata[namespace].label = (rs === undefined) ? namespace : rs.label
-          data.metadata[namespace].custom = (rs === undefined)
-        })
         this.item = data
         this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -185,15 +185,15 @@ export default {
     },
     load () {
       this.$oh.api.get(`/rest/items/${this.itemName}?metadata=.+`).then((data) => {
-          Object.keys(data.metadata).forEach(namespace => {
-            let rs = MetadataNamespaces.find(ns => ns.name === namespace)
-            data.metadata[namespace].id = namespace
-            data.metadata[namespace].label = (rs === undefined) ? namespace : rs.label
-            data.metadata[namespace].custom = (rs === undefined) ? true : false
-          })
-          this.item = data
-          this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
+        Object.keys(data.metadata).forEach(namespace => {
+          let rs = MetadataNamespaces.find(ns => ns.name === namespace)
+          data.metadata[namespace].id = namespace
+          data.metadata[namespace].label = (rs === undefined) ? namespace : rs.label
+          data.metadata[namespace].custom = (rs === undefined)
         })
+        this.item = data
+        this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
+      })
     },
     deleteItem () {
       this.$f7.dialog.confirm(

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -185,8 +185,8 @@ export default {
     },
     load () {
       let metadataNamespacesList = MetadataNamespaces.map((n) => n.name).join(',')
-      this.$oh.api.getPlain(`/rest/items/${this.itemName}/metadata/namespaces?exclude=${metadataNamespacesList}`, 'text/plain').then((customNamespaces) => {
-        this.$oh.api.get(`/rest/items/${this.itemName}?metadata=semantics,${metadataNamespacesList},${customNamespaces}`).then((data) => {
+      this.$oh.api.get(`/rest/items/${this.itemName}/metadata/namespaces`).then((itemNamespaces) => {
+        this.$oh.api.get(`/rest/items/${this.itemName}?metadata=${itemNamespaces.join(',')}`).then((data) => {
           // map the labels of the known namespaces or add "custom:" to the user defined namespaces
           Object.keys(data.metadata).forEach(namespace => {
             let rs = MetadataNamespaces.find(ns => ns.name === namespace)

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -184,19 +184,16 @@ export default {
       this.$store.dispatch('stopTrackingStates')
     },
     load () {
-      let metadataNamespacesList = MetadataNamespaces.map((n) => n.name).join(',')
-      this.$oh.api.get(`/rest/items/${this.itemName}/metadata/namespaces`).then((itemNamespaces) => {
-        this.$oh.api.get(`/rest/items/${this.itemName}?metadata=${itemNamespaces.join(',')}`).then((data) => {
-          // map the labels of the known namespaces or add "custom:" to the user defined namespaces
+      this.$oh.api.get(`/rest/items/${this.itemName}?metadata=.+`).then((data) => {
           Object.keys(data.metadata).forEach(namespace => {
             let rs = MetadataNamespaces.find(ns => ns.name === namespace)
             data.metadata[namespace].id = namespace
-            data.metadata[namespace].label = (rs === undefined) ? 'custom: ' + namespace : rs.label
+            data.metadata[namespace].label = (rs === undefined) ? namespace : rs.label
+            data.metadata[namespace].custom = (rs === undefined) ? true : false
           })
           this.item = data
           this.iconUrl = (localStorage.getItem('openhab.ui:serverUrl') || '') + '/icon/' + this.item.category + '?format=svg'
         })
-      })
     },
     deleteItem () {
       this.$f7.dialog.confirm(

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -192,8 +192,6 @@ import ItemDetails from '@/components/model/item-details.vue'
 import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 import LinkDetails from '@/components/model/link-details.vue'
 
-import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
-
 import { compareItems } from '@/components/widgets/widget-order'
 
 function compareModelItems (o1, o2) {
@@ -290,7 +288,7 @@ export default {
     load (update) {
       // if (this.ready) return
       this.loading = true
-      const items = this.$oh.api.get('/rest/items?metadata=semantics,' + MetadataNamespaces.map((n) => n.name).join(','))
+      const items = this.$oh.api.get('/rest/items?metadata=.+')
       const links = this.$oh.api.get('/rest/links')
       Promise.all([items, links]).then((data) => {
         this.items = data[0]


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <stefan.hoehn@nfon.com>

depends on https://github.com/openhab/openhab-core/pull/3298

Shows even the custom namespaces created by a user in the UI of the item

<img width="763" alt="image" src="https://user-images.githubusercontent.com/5937600/211194834-4fdc74ce-b362-478d-8746-ba7b6d8e8cd8.png">


