### PR TITLE
Fix diff_last aggregate calculation

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -135,6 +135,7 @@ export default {
         return Promise.resolve(getter([]))
       }
 
+      let boundary = seriesComponents[component.component].includeBoundary?.(component)
       const itemPromises = neededItems.map((neededItem) => {
         if (this.items[neededItem]) return Promise.resolve(this.items[neededItem])
         return this.$oh.api.get(`/rest/items/${neededItem}`).then((item) => {
@@ -154,7 +155,8 @@ export default {
         let query = {
           serviceId: component.config.service || undefined,
           starttime: seriesStartTime.toISOString(),
-          endtime: seriesEndTime.subtract(1, 'millisecond').toISOString()
+          endtime: seriesEndTime.subtract(1, 'millisecond').toISOString(),
+          boundary: boundary
         }
 
         return Promise.all([itemPromises[neededItem], this.$oh.api.get(url, query)])

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/aggregators.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/aggregators.js
@@ -20,7 +20,11 @@ export default (aggregationFunction, arr, idx, values) => {
       aggregate = idx < 1 ? NaN : arr[1][0] - values[idx - 1][1][0]
       break
     case 'diff_last':
-      aggregate = idx < 1 ? NaN : arr[1][arr[1].length - 1] - values[idx - 1][1][values[idx - 1][1].length - 1]
+      if (idx < 1) {
+        aggregate = arr[1][arr[1].length - 1] - arr[1][0]
+      } else {
+        aggregate = arr[1][arr[1].length - 1] - values[idx - 1][1][values[idx - 1][1].length - 1]
+      }
       break
     case 'average':
       aggregate = arr[1].reduce((sum, state) => sum + parseFloat(state), 0) / arr[1].length


### PR DESCRIPTION
In order to calculate `diff_last` include `boundary=true` parameter when requesting datapoints to read datapoint before requested interval (before datestart), if available. Use that one to calculate diff for first value.

fixes https://github.com/openhab/openhab-webui/issues/912 - partly, only applies for `diff_last`

Signed-off-by: Boris Krivonog boris.krivonog@inova.si