### PR TITLE
add Command-Click for MacOs to select list entries

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -67,6 +67,7 @@
             :checkbox="showCheckboxes"
             :checked="isChecked(b.uid)"
             @click.ctrl="(e) => ctrlClick(e, b)"
+            @click.meta="(e) => ctrlClick(e, b)"
             @click.exact="(e) => click(e, b)"
             link=""
             :title="b.uid">

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -67,6 +67,7 @@
             :checkbox="showCheckboxes"
             :checked="isChecked(widget.uid)"
             @click.ctrl="(e) => ctrlClick(e, widget)"
+            @click.meta="(e) => ctrlClick(e, widget)"
             @click.exact="(e) => click(e, widget)"
             link=""
             :title="widget.uid">

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -69,6 +69,7 @@
               :checkbox="showCheckboxes"
               :checked="isChecked(item.name)"
               @click.ctrl="(e) => ctrlClick(e, item)"
+              @click.meta="(e) => ctrlClick(e, item)"
               @click.exact="(e) => click(e, item)"
               link=""
               :title="(item.label) ? item.label : item.name"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -89,6 +89,7 @@
               :checked="isChecked(((page.component === 'Sitemap') ? 'system:sitemap:' : 'ui:page:') + page.uid)"
               :disabled="showCheckboxes && page.uid === 'overview'"
               @click.ctrl="(e) => ctrlClick(e, page)"
+              @click.meta="(e) => ctrlClick(e, page)"
               @click.exact="(e) => click(e, page)"
               link=""
               :title="page.config.label"

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -92,6 +92,7 @@
               :checkbox="showCheckboxes"
               :checked="isChecked(rule.uid)"
               @click.ctrl="(e) => ctrlClick(e, rule)"
+              @click.meta="(e) => ctrlClick(e, rule)"
               @click.exact="(e) => click(e, rule)"
               link=""
               :title="rule.name"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -85,6 +85,7 @@
                           :checked="isChecked(entry.thingUID)"
                           @change="(e) => toggleItemCheck(e, entry.thingUID)"
                           @click.ctrl="(e) => ctrlClick(e, entry)"
+                          @click.meta="(e) => ctrlClick(e, entry)"
                           @click.exact="(e) => click(e, entry)"
                           :title="entry.label"
                           :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -85,6 +85,7 @@
               :checkbox="showCheckboxes"
               :checked="isChecked(thing.UID)"
               @click.ctrl="(e) => ctrlClick(e, thing)"
+              @click.meta="(e) => ctrlClick(e, thing)"
               @click.exact="(e) => click(e, thing)"
               link=""
               :title="thing.label || thing.UID">


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <mail@stefanhoehn.com>

I only learned today from @JustinGeorgi that on Windows and Linux Ctrl-Click allows to directly entries of a list (usually to remove entries of that list). However, Ctrl-Click isn't supported on MacOS which is a pity now that I know that feature. Therefore I added Cmd-Click instead to allow the selection on MacOS.

Note that I used "click.meta" which is the Command-Key on MacOS. This would be also the Windows-Key on Windows which I think shouldn't be an issue (it is hardly used and only for very special case IMHO) but I wanted to mention it in case someone has doubts.