### PR TITLE
allow customisation of temperature, humidity and luminance badges too

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
@@ -28,7 +28,7 @@
 import { allEquipmentPoints, findPoints } from '../glance-helpers'
 
 export default {
-  props: ['element', 'type', 'customConfig', 'invertColor', 'store'],
+  props: ['element', 'type', 'badgeOverrides', 'customConfig', 'invertColor', 'store'],
   data () {
     return {
       badgeConfigs: {
@@ -40,6 +40,12 @@ export default {
   },
   computed: {
     config () {
+      if (this.badgeOverrides) {
+        const override = this.badgeOverrides[this.type]
+        if (override && override.badge) {
+          return Object.assign(this.badgeConfigs[this.type], override.badge)
+        }
+      }
       return this.badgeConfigs[this.type]
     },
     query () {

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -16,7 +16,7 @@
       <div class="location-stats margin-top-half" v-if="!config.disableBadges">
         <span v-for="badgeType in ['temperature', 'humidity', 'luminance']" :key="badgeType">
           <measurement-badge v-if="!config.badges || !config.badges.length || config.badges.indexOf(badgeType) >= 0"
-                             :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" />
+                             :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" :badgeOverrides="badgeOverrides" />
         </span>
       </div>
     </template>


### PR DESCRIPTION
On `oh-locations-tab` it's not possible to override `temperature`, `humidity` and `luminance` since they are handled a bit differently, as per https://community.openhab.org/t/not-all-custom-badges-are-working-what-am-i-doing-wrong-temperature-and-humidity-wont-change/143434.

Signed-off-by: Boris Krivonog [boris.krivonog@inova.si](mailto:boris.krivonog@inova.si)