### PR TITLE
[mainui] add visibility to floorplan marker

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-map-page.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-page.md
@@ -52,12 +52,12 @@ Displays markers on a map
 </PropBlock>
 <PropBlock type="TEXT" name="tileLayerProvider" label="Provider for the background tiles">
   <PropDescription>
-    The provider of tiles to use for the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="http://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>tileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. The default is CartoDB, the variant depending on the dark mode setting.
+    The provider of tiles to use for the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>tileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. The default is CartoDB, the variant depending on the dark mode setting.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="overlayTileLayerProvider" label="Provider for the overlay tiles">
   <PropDescription>
-    The provider of tiles to use for the overlay layer above the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="http://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>overlayTileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. 
+    The provider of tiles to use for the overlay layer above the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>overlayTileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. 
   </PropDescription>
 </PropBlock>
 </PropGroup>

--- a/bundles/org.openhab.ui/doc/components/oh-map-page.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-page.md
@@ -52,12 +52,12 @@ Displays markers on a map
 </PropBlock>
 <PropBlock type="TEXT" name="tileLayerProvider" label="Provider for the background tiles">
   <PropDescription>
-    The provider of tiles to use for the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>tileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. The default is CartoDB, the variant depending on the dark mode setting.
+    The provider of tiles to use for the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="http://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>tileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. The default is CartoDB, the variant depending on the dark mode setting.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="overlayTileLayerProvider" label="Provider for the overlay tiles">
   <PropDescription>
-    The provider of tiles to use for the overlay layer above the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>overlayTileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. 
+    The provider of tiles to use for the overlay layer above the background of the map. Use one from <a class="external text-color-blue" target="_blank" href="http://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>, Some providers will not work until you set options, like access tokens, in the <code>overlayTileLayerProviderOptions</code> parameter (in Code view). See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. 
   </PropDescription>
 </PropBlock>
 </PropGroup>

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -82,6 +82,11 @@ Example: (note that you must not have semicolons at the end of the css style):
     Height of the icon in pixels (for openHAB icons only, 40 by default)
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="iconVisibility" label="Icon Visibility">
+  <PropDescription>
+    Enter an expression to show/hide the icon conditionally
+  </PropDescription>
+</PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">
   <PropDescription>
     Color of the icon (for Framework7/Material/certain Iconify icons); use expression for dynamic colors

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -43,6 +43,11 @@ A marker on a floor plan
     The item whose state to display on this marker
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="visibility" label="Marker Visibility">
+  <PropDescription>
+    Enter an expression to show/hide the marker conditionally
+  </PropDescription>
+</PropBlock>
 </PropGroup>
 </div>
 
@@ -73,11 +78,6 @@ A marker on a floor plan
 <PropBlock type="INTEGER" name="iconHeight" label="Icon Height">
   <PropDescription>
     Height of the icon in pixels (for openHAB icons only, 40 by default)
-  </PropDescription>
-</PropBlock>
-<PropBlock type="TEXT" name="iconVisibility" label="Icon Visibility">
-  <PropDescription>
-    Enter an expression to show/hide the icon conditionally
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="iconColor" label="Icon Color">

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -49,14 +49,7 @@ A marker on a floor plan
 ### Icon
 <div class="props">
 <PropGroup name="icon" label="Icon">
-  You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)
-Example: (note that you must not have semicolons at the end of the css style):
-
-    iconStyle:
-      padding: 10px
-      border-radius: 4px
-      border: 5px solid #f00  
-
+  You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only) - see example below
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
     Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)
@@ -103,14 +96,7 @@ Example: (note that you must not have semicolons at the end of the css style):
 ### Tooltip
 <div class="props">
 <PropGroup name="tooltip" label="Tooltip">
-  You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)
-Example: (note that you must not have semicolons at the end of the css style):
-
-    tooltipStyle:
-      textShadow: 0 0 15px red
-      fontSize: 40px
-      color: yellow
-
+  You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only) - see example below
 <PropBlock type="TEXT" name="tooltip" label="Tooltip Text">
   <PropDescription>
     The tooltip text - leave blank to display the state of the item
@@ -342,6 +328,28 @@ Example: (note that you must not have semicolons at the end of the css style):
 
 
 <!-- GENERATED /props -->
+
+## Examples
+
+note that you must not have semicolons at the end of the css style
+
+### iconStyle: 
+
+```yaml
+iconStyle:
+  padding: 10px
+  border-radius: 4px
+  border: 5px solid #f00
+```
+
+### tooltipStyle:
+
+```yaml
+tooltipStyle:
+  textShadow: 0 0 15px red
+  fontSize: 40px
+  color: yellow
+```
 
 <!-- If applicable describe how properties are forwarded to a underlying component from Framework7, ECharts, etc.:
 ### Inherited Properties

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -43,9 +43,9 @@ A marker on a floor plan
     The item whose state to display on this marker
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="visibility" label="Marker Visibility">
+<PropBlock type="TEXT" name="visible" label="Visibility">
   <PropDescription>
-    Enter an expression to show/hide the marker conditionally
+    Enter an expression to dynamically show the marker, see <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/building-pages.html#widgets-definition-usage">Building Pages: <code>visible</code></a>
   </PropDescription>
 </PropBlock>
 </PropGroup>

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -49,7 +49,7 @@ A marker on a floor plan
 ### Icon
 <div class="props">
 <PropGroup name="icon" label="Icon">
-  You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only) - see example below
+  You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
     Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)
@@ -96,7 +96,7 @@ A marker on a floor plan
 ### Tooltip
 <div class="props">
 <PropGroup name="tooltip" label="Tooltip">
-  You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only) - see example below
+  You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)
 <PropBlock type="TEXT" name="tooltip" label="Tooltip Text">
   <PropDescription>
     The tooltip text - leave blank to display the state of the item

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -50,6 +50,13 @@ A marker on a floor plan
 <div class="props">
 <PropGroup name="icon" label="Icon">
   You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)
+Example: (note that you must not have semicolons at the end of the css style):
+
+    iconStyle:
+      padding: 10px
+      border-radius: 4px
+      border: 5px solid #f00  
+
 <PropBlock type="TEXT" name="icon" label="Icon">
   <PropDescription>
     Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)
@@ -92,6 +99,13 @@ A marker on a floor plan
 <div class="props">
 <PropGroup name="tooltip" label="Tooltip">
   You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)
+Example: (note that you must not have semicolons at the end of the css style):
+
+    tooltipStyle:
+      textShadow: 0 0 15px red
+      fontSize: 40px
+      color: yellow
+
 <PropBlock type="TEXT" name="tooltip" label="Tooltip Text">
   <PropDescription>
     The tooltip text - leave blank to display the state of the item

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -37,7 +37,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
     pn('iconWidth', 'Icon Width', 'Width of the icon in pixels (for openHAB icons only, 40 by default)').a(),
     pn('iconHeight', 'Icon Height', 'Height of the icon in pixels (for openHAB icons only, 40 by default)').a(),
-    pt('iconVisibility', 'Icon Visibility', 'Enter an expression to hide the icon conditionally or false to never display it'),
+    pt('iconVisibility', 'Icon Visibility', 'Enter an expression to show/hide the icon conditionally'),
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material/certain Iconify icons); use expression for dynamic colors'),
     pn('iconRotation', 'Icon Rotation', 'Rotation of the icon in degrees')
   ])

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -31,7 +31,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('coords', 'Coordinates', 'The coordinates of this marker in the floor plan Coordinate Reference System; usually set by dragging the marker at design time').a(),
     pi('item', 'Item', 'The item whose state to display on this marker')
   ])
-  .paramGroup(pg('icon', 'Icon', 'You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)'), [
+  .paramGroup(pg('icon', 'Icon', 'You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only) - see example below'), [
     pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),
     pb('iconUseState', 'Icon depends on state', 'Use the state of the item to get a dynamic icon (for openHAB icons only)'),
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
@@ -41,7 +41,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material/certain Iconify icons); use expression for dynamic colors'),
     pn('iconRotation', 'Icon Rotation', 'Rotation of the icon in degrees')
   ])
-  .paramGroup(pg('tooltip', 'Tooltip', 'You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)'), [
+  .paramGroup(pg('tooltip', 'Tooltip', 'You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only) - see example below'), [
     pt('tooltip', 'Tooltip Text', 'The tooltip text - leave blank to display the state of the item'),
     pb('tooltipPermanent', 'Always display the tooltip'),
     pb('useTooltipAsLabel', 'Use Tooltip as Label', 'Put the tooltip text directly over the plan instead of displaying an icon'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -37,6 +37,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
     pn('iconWidth', 'Icon Width', 'Width of the icon in pixels (for openHAB icons only, 40 by default)').a(),
     pn('iconHeight', 'Icon Height', 'Height of the icon in pixels (for openHAB icons only, 40 by default)').a(),
+    pt('iconVisibility', 'Icon Visibility', 'Enter an expression to hide the icon conditionally or false to never display it'),
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material/certain Iconify icons); use expression for dynamic colors'),
     pn('iconRotation', 'Icon Rotation', 'Rotation of the icon in degrees')
   ])

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -30,7 +30,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('name', 'Name', 'The name of the marker (for identification)'),
     pt('coords', 'Coordinates', 'The coordinates of this marker in the floor plan Coordinate Reference System; usually set by dragging the marker at design time').a(),
     pi('item', 'Item', 'The item whose state to display on this marker'),
-    pt('visibility', 'Marker Visibility', 'Enter an expression to show/hide the marker conditionally')
+    pt('visible', 'Visibility', 'Enter an expression to dynamically show the marker, see <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/building-pages.html#widgets-definition-usage">Building Pages: <code>visible</code></a>')
   ])
   .paramGroup(pg('icon', 'Icon', 'You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)'), [
     pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -31,7 +31,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('coords', 'Coordinates', 'The coordinates of this marker in the floor plan Coordinate Reference System; usually set by dragging the marker at design time').a(),
     pi('item', 'Item', 'The item whose state to display on this marker')
   ])
-  .paramGroup(pg('icon', 'Icon', 'You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only) - see example below'), [
+  .paramGroup(pg('icon', 'Icon', 'You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)'), [
     pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),
     pb('iconUseState', 'Icon depends on state', 'Use the state of the item to get a dynamic icon (for openHAB icons only)'),
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
@@ -41,7 +41,7 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material/certain Iconify icons); use expression for dynamic colors'),
     pn('iconRotation', 'Icon Rotation', 'Rotation of the icon in degrees')
   ])
-  .paramGroup(pg('tooltip', 'Tooltip', 'You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only) - see example below'), [
+  .paramGroup(pg('tooltip', 'Tooltip', 'You can customize the styles further with CSS attributes in the <code>tooltipStyle</code> parameter (in YAML only)'), [
     pt('tooltip', 'Tooltip Text', 'The tooltip text - leave blank to display the state of the item'),
     pb('tooltipPermanent', 'Always display the tooltip'),
     pb('useTooltipAsLabel', 'Use Tooltip as Label', 'Put the tooltip text directly over the plan instead of displaying an icon'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.js
@@ -29,7 +29,8 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
   .paramGroup(pg('marker', 'Marker Settings'), [
     pt('name', 'Name', 'The name of the marker (for identification)'),
     pt('coords', 'Coordinates', 'The coordinates of this marker in the floor plan Coordinate Reference System; usually set by dragging the marker at design time').a(),
-    pi('item', 'Item', 'The item whose state to display on this marker')
+    pi('item', 'Item', 'The item whose state to display on this marker'),
+    pt('visibility', 'Marker Visibility', 'Enter an expression to show/hide the marker conditionally')
   ])
   .paramGroup(pg('icon', 'Icon', 'You can customize the styles further with CSS attributes in the <code>iconStyle</code> parameter (in YAML only)'), [
     pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),
@@ -37,7 +38,6 @@ export const OhPlanMarkerDefinition = () => new WidgetDefinition('oh-plan-marker
     pn('iconSize', 'Icon Size', 'Size of the icon in pixels (40 by default)'),
     pn('iconWidth', 'Icon Width', 'Width of the icon in pixels (for openHAB icons only, 40 by default)').a(),
     pn('iconHeight', 'Icon Height', 'Height of the icon in pixels (for openHAB icons only, 40 by default)').a(),
-    pt('iconVisibility', 'Icon Visibility', 'Enter an expression to show/hide the icon conditionally'),
     pt('iconColor', 'Icon Color', 'Color of the icon (for Framework7/Material/certain Iconify icons); use expression for dynamic colors'),
     pn('iconRotation', 'Icon Rotation', 'Rotation of the icon in degrees')
   ])

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -1,5 +1,5 @@
 <template>
-  <l-marker ref="marker" v-if="coords" :key="markerKey" :draggable="context.editmode != undefined" :lat-lng="coords"
+  <l-marker ref="marker" v-if="coords && visible" :key="markerKey" :draggable="context.editmode != undefined" :lat-lng="coords"
             @update:latLng="onMove" @click="onClick">
     <l-tooltip v-if="tooltip && !config.useTooltipAsLabel" :options="tooltipOptions" @click="() => {}">
       <div style="white-space: nowrap" :style="tooltipStyle">
@@ -82,9 +82,14 @@ export default {
     },
     iconStyle () {
       return Object.assign({
-        transform: 'rotate(' + this.config.iconRotation + 'deg)',
-        visibility: this.config.iconVisibility
+        transform: 'rotate(' + this.config.iconRotation + 'deg)'
       }, this.config.iconStyle)
+    },
+    visible () {
+      let visible = this.config.visibility
+      if (this.context.editmode || !this.config) return true
+      if (visible === false || visible === 'false') return false
+      return true
     }
   },
   asyncComputed: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -1,5 +1,5 @@
 <template>
-  <l-marker ref="marker" v-if="coords && visible" :key="markerKey" :draggable="context.editmode != undefined" :lat-lng="coords"
+  <l-marker ref="marker" v-if="visible && coords" :key="markerKey" :draggable="context.editmode != undefined" :lat-lng="coords"
             @update:latLng="onMove" @click="onClick">
     <l-tooltip v-if="tooltip && !config.useTooltipAsLabel" :options="tooltipOptions" @click="() => {}">
       <div style="white-space: nowrap" :style="tooltipStyle">
@@ -84,12 +84,6 @@ export default {
       return Object.assign({
         transform: 'rotate(' + this.config.iconRotation + 'deg)'
       }, this.config.iconStyle)
-    },
-    visible () {
-      let visible = this.config.visibility
-      if (this.context.editmode || !this.config) return true
-      if (visible === false || visible === 'false') return false
-      return true
     }
   },
   asyncComputed: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -82,7 +82,8 @@ export default {
     },
     iconStyle () {
       return Object.assign({
-        transform: 'rotate(' + this.config.iconRotation + 'deg)'
+        transform: 'rotate(' + this.config.iconRotation + 'deg)',
+        visibility: this.config.iconVisibility
       }, this.config.iconStyle)
     }
   },


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <mail@stefanhoehn.com>

fixes #845 

I am finally able to fix my own issues 😀

As described in the issue above, I added a visibility property to allow the floorplan icon to be visible via an expression. I also added some example documentation how to use the iconStyle and tooltipStyle as this was asked a few times in the forum.

I could easily change the property to become an advanced property - just let me know if this would make sense.
