### PR TITLE
Blockly: Fix UoM on Nashorn message & Adjust to library change

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
@@ -6,6 +6,8 @@
 import Blockly from 'blockly'
 import { javascriptGenerator } from 'blockly/javascript'
 
+const unavailMsg = 'Units of Measurements blocks aren\'t supported in "application/javascript;version=ECMAScript-5.1"'
+
 export default function (f7, isGraalJs) {
   Blockly.Blocks['oh_quantity'] = {
     init: function () {
@@ -21,7 +23,11 @@ export default function (f7, isGraalJs) {
 
   javascriptGenerator['oh_quantity'] = function (block) {
     const quantity = javascriptGenerator.valueToCode(block, 'quantity', javascriptGenerator.ORDER_NONE)
-    return [`Quantity(${quantity})`, 0]
+    if (isGraalJs) { 
+      return [`Quantity(${quantity})`, 0]
+    } else {
+      throw new Error(unavailMsg)
+    }
   }
 
   Blockly.Blocks['oh_quantity_arithmetic'] = {
@@ -50,7 +56,7 @@ export default function (f7, isGraalJs) {
       const operand = block.getFieldValue('operand')
       return [`${first}.${operand}(${second})`, javascriptGenerator.ORDER_NONE]
     } else {
-      console.warn('arithmetic function unit of measurement only supported with jsscripting')
+      throw new Error(unavailMsg)
     }
   }
 
@@ -85,7 +91,7 @@ export default function (f7, isGraalJs) {
       const operand = block.getFieldValue('operand')
       return [`${first}.${operand}(${second})`, javascriptGenerator.ORDER_NONE]
     } else {
-      console.warn('compare function unit of measurement only supported with jsscripting')
+      throw new Error(unavailMsg)
     }
   }
 
@@ -107,6 +113,10 @@ export default function (f7, isGraalJs) {
   javascriptGenerator['oh_quantity_to_unit'] = function (block) {
     const quantity = javascriptGenerator.valueToCode(block, 'quantity', javascriptGenerator.ORDER_NONE)
     const unit = javascriptGenerator.valueToCode(block, 'unit', javascriptGenerator.ORDER_NONE)
-    return [`${quantity}.toUnit(${unit})`, javascriptGenerator.ORDER_NONE]
+    if (isGraalJs) {
+      return [`${quantity}.toUnit(${unit})`, javascriptGenerator.ORDER_NONE]
+    } else {
+      throw new Error(unavailMsg)
+    }
   }
 }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
@@ -23,7 +23,7 @@ export default function (f7, isGraalJs) {
 
   javascriptGenerator['oh_quantity'] = function (block) {
     const quantity = javascriptGenerator.valueToCode(block, 'quantity', javascriptGenerator.ORDER_NONE)
-    if (isGraalJs) { 
+    if (isGraalJs) {
       return [`Quantity(${quantity})`, 0]
     } else {
       throw new Error(unavailMsg)
@@ -69,10 +69,10 @@ export default function (f7, isGraalJs) {
         .appendField(new Blockly.FieldDropdown([
           ['=', 'equal'],
           // ['\u2260', 'NEQ'], // maybe later by adding a not
-          ['\u200F<', 'smallerThan'],
-          ['\u200F\u2264', 'smallerThanOrEqual'],
-          ['\u200F>', 'largerThan'],
-          ['\u200F\u2265', 'largerThanOrEqual']
+          ['\u200F<', 'lessThan'],
+          ['\u200F\u2264', 'lessThanOrEqual'],
+          ['\u200F>', 'greaterThan'],
+          ['\u200F\u2265', 'greaterThanOrEqual']
         ]), 'operand')
 
       this.setInputsInline(true)


### PR DESCRIPTION
Follow-up PR for #1617.

### Description

- Fixes the alert message that will appear when attempting to use UoM blocks on NashornJS, see https://github.com/openhab/openhab-webui/pull/1617#issuecomment-1399464064 for discussion
- Adjusts the UoM comparison block to the breaking changes from https://github.com/openhab/openhab-js/pull/211 (unreleased yet).

Note that this PR depends on a new release of the openhab-js library.