### PR TITLE
add doc link to state/commandDescription edit form

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -14,6 +14,14 @@
         <small>Enter each option on a separate line.<br>Use <code>value=label</code> format to provide a label different than the option.</small>
       </f7-block-footer>
     </f7-list>
+    <p class="padding">
+      <f7-link v-if="namespace === 'stateDescription'" color="blue" external target="_blank" :href="docLink">
+        State Description Documentation
+      </f7-link>
+      <f7-link v-if="namespace === 'commandDescription'" color="blue" external target="_blank" :href="docLink">
+        Command Description Documentation
+      </f7-link>
+    </p>
   </div>
 </template>
 
@@ -33,13 +41,22 @@ export default {
         { type: 'TEXT', name: 'min', label: 'Min', description: 'Minimum allowed value' },
         { type: 'TEXT', name: 'max', label: 'Max', description: 'Maximum allowed value' },
         { type: 'TEXT', name: 'step', label: 'Step', description: 'Minimum interval between values' }
-      ]
+      ],
+      docUrl: `https://${this.$store.state.runtimeInfo?.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org` +
+        '/link/thing'
     }
   },
   computed: {
     options () {
       if (!this.metadata.config.options) return []
       return this.metadata.config.options.trim().split(',').map((s) => s.trim()).join('\n')
+    },
+    docLink () {
+      if (this.namespace === 'stateDescription') {
+        return `${this.docUrl}#state-description`
+      } else {
+        return `${this.docUrl}#command-description`
+      }
     }
   },
   methods: {


### PR DESCRIPTION
Signed-off-by: Stefan Höhn <mail@stefanhoehn.com>

Add documentation url link to stateDescription and commandDescription edit form. 

requires https://github.com/openhab/website/pull/392