### PR TITLE
[MainUI] Fixes & Enhancements for channel add & edit pages

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -84,7 +84,7 @@ export default {
         this.$f7.dialog.alert('Please give an unique identifier')
         return
       }
-      if (!this.channel.id.match(/^[a-zA-Z0-9_]*$/)) {
+      if (!this.channel.id.match(/^[a-zA-Z0-9_\-]*$/)) {
         this.$f7.dialog.alert('The identifier should only contain alphanumeric characters')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -10,13 +10,8 @@
     </f7-navbar>
     <f7-block class="block-narrow">
       <f7-col>
-        <f7-list inline-labels no-hairlines-md>
-          <f7-list-input type="text" placeholder="Channel Identifier" :value="channel.id"
-                         @input="channel.id = $event.target.value" clear-button
-                         required validate pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only" />
-          <f7-list-input type="text" placeholder="Label" :value="channel.label"
-                         @input="channel.label = $event.target.value" clear-button />
-        </f7-list>
+        <f7-block-title>Channel</f7-block-title>
+        <channel-general-settings :channel="channel" :createMode="true" :ready="ready" />
       </f7-col>
       <f7-col>
         <f7-block-title>Channel type</f7-block-title>
@@ -52,9 +47,11 @@
 
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ChannelGeneralSettings from '@/pages/settings/things/channel/channel-general-settings.vue'
 
 export default {
   components: {
+    ChannelGeneralSettings,
     ConfigSheet
   },
   props: ['thing', 'thingType'],

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -81,7 +81,7 @@ export default {
         this.$f7.dialog.alert('Please give an unique identifier')
         return
       }
-      if (!this.channel.id.match(/^[a-zA-Z0-9_\-]*$/)) {
+      if (!this.channel.id.match(/^[a-zA-Z0-9_-]*$/)) {
         this.$f7.dialog.alert('The identifier should only contain alphanumeric characters')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -11,16 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
         <f7-block-title>Channel</f7-block-title>
-        <f7-list media-list>
-          <f7-list-item media-item class="channel-item"
-                        :title="channel.label"
-                        :footer="channel.description">
-            <div slot="subtitle">
-              {{ channel.uid }}
-              <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
-            </div>
-          </f7-list-item>
-        </f7-list>
+        <channel-general-settings :channel="channel" :createMode="false" :ready="ready" />
       </f7-col>
       <f7-col v-if="channelType != null">
         <f7-block-title v-if="configDescription.parameters">
@@ -41,11 +32,13 @@
 </template>
 
 <script>
+import ChannelGeneralSettings from '@/pages/settings/things/channel/channel-general-settings.vue'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 
 export default {
   components: {
+    ChannelGeneralSettings,
     ConfigSheet,
     ClipboardIcon
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -34,13 +34,11 @@
 <script>
 import ChannelGeneralSettings from '@/pages/settings/things/channel/channel-general-settings.vue'
 import ConfigSheet from '@/components/config/config-sheet.vue'
-import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 
 export default {
   components: {
     ChannelGeneralSettings,
-    ConfigSheet,
-    ClipboardIcon
+    ConfigSheet
   },
   props: ['thing', 'thingType', 'channel', 'channelType', 'channelId'],
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -1,0 +1,32 @@
+<template>
+  <f7-block v-if="ready" class="padding-vertical no-padding-horizontal">
+    <f7-col>
+      <f7-list class="no-margin" inline-labels no-hairlines-md>
+        <f7-list-input v-if="createMode" label="Channel Identifier" type="text" placeholder="Required" :value="channel.id"
+                       info="Note: cannot be changed after the creation"
+                       required validate pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
+                       @input="channel.id = $event.target.value" />
+        <f7-list-item v-if="!createMode" media-item class="channel-item" title="Channel UID">
+          <div slot="subtitle">
+            {{ channel.uid }}
+            <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
+          </div>
+        </f7-list-item>
+        <f7-list-input label="Label" type="text" placeholder="Required" :value="channel.label" required validate
+                       @input="channel.label = $event.target.value" clear-button />
+        <f7-list-input label="Description" type="text" :value="channel.description"
+                       @input="channel.description = $event.target.value" clear-button />
+      </f7-list>
+    </f7-col>
+  </f7-block>
+</template>
+
+<script>
+import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+export default {
+  props: ['channel', 'createMode', 'ready'],
+  components: {
+    ClipboardIcon
+  }
+}
+</script>


### PR DESCRIPTION
Fixes #1630. Fixes #1346. Fixes #1234.

## Description

Copied from my commit messages:

 ### Allow dashes in channel ID

Channel ID in fact allows dashes (it works and the hint in the input field says dashes are allowed), but the check was wrong.

### Refactor channel settings to component

This
- allows setting and modifying channel description
- allows modifying channel label after creation
- unifies design of channel add and channel edit pages
- brings channel settings design closer to script settings design