### PR TITLE
[habpanel] Use commandDescription instead of stateDescription for selection list

### DIFF
--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/selection/selection.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/selection/selection.widget.js
@@ -52,7 +52,7 @@
             if (!vm.choices) {
                 switch (vm.widget.choices_source) {
                     case 'server':
-                        vm.choices = vm.item.stateDescription.options.map(function (option) {
+                        vm.choices = vm.item.commandDescription.commandOptions.map(function (option) {
                             return { cmd: option.value, label: option.label };
                         });
                         break;

--- a/bundles/org.openhab.ui.habpanel/web/app/widgets/selection/selection.widget.js
+++ b/bundles/org.openhab.ui.habpanel/web/app/widgets/selection/selection.widget.js
@@ -53,7 +53,7 @@
                 switch (vm.widget.choices_source) {
                     case 'server':
                         vm.choices = vm.item.commandDescription.commandOptions.map(function (option) {
-                            return { cmd: option.value, label: option.label };
+                            return { cmd: option.command, label: option.label };
                         });
                         break;
                     case 'csv':


### PR DESCRIPTION
Fixes #1686

To be consistent with how Basic UI works, use commandDescription to populate the list used by the Selection widget. This will ensure that a selection list will be presented to the user if the item has state options or command options. This works because openHAB internally copies the state options to the command options when command options don't exist on the item.

Signed-off-by: Mark Hilbush <mark@hilbush.com>
