### PR TITLE
Display `undefined` correctly in widget expressions

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -197,14 +197,14 @@
             </f7-list-button>
             <f7-list-item divider title="Items" />
             <f7-list-button href="/settings/items/add" color="blue" :animate="false">
-              Create item
+              Create Item
             </f7-list-button>
             <f7-list-button href="/settings/items/add-from-textual-definition" color="blue" :animate="false">
-              Add items (textual)
+              Add Items (textual)
             </f7-list-button>
             <f7-list-item divider title="Pages" />
             <f7-list-button href="/settings/pages/layout/add" color="blue" :animate="false">
-              Create layout
+              Create layout page
             </f7-list-button>
             <f7-list-button href="/settings/pages/tabs/add" color="blue" :animate="false">
               Create tabbed page

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -187,10 +187,10 @@
           <f7-list>
             <f7-list-item divider title="Things" />
             <f7-list-button href="/settings/things/add" color="blue" :animate="false">
-              Add thing
+              Add Thing
             </f7-list-button>
             <f7-list-button @click="quickAddThing" color="blue">
-              Add thing (quick)
+              Add Thing (quick)
             </f7-list-button>
             <f7-list-button href="/settings/things/inbox" color="blue" :animate="false">
               Inbox

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -128,7 +128,7 @@ export default {
           if (!this.exprAst[key] || ctx.editmode) {
             this.exprAst[key] = expr.parse(value.substring(1))
           }
-          return expr.evaluate(this.exprAst[key], {
+          const evalExpr = expr.evaluate(this.exprAst[key], {
             items: ctx.store,
             props: this.props,
             vars: ctx.vars,
@@ -143,6 +143,7 @@ export default {
             dayjs: dayjs,
             user: this.$store.getters.user
           })
+          return (evalExpr === undefined) ? 'undefined' : evalExpr
         } catch (e) {
           return e
         }


### PR DESCRIPTION
The widget expressions (can be tested using the expression tester) did display undefined as an empty string, which was quite confusing and a bug. Now undefined is displayed as undefined string.

Fixes #1026.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>