### PR TITLE
Provide access to widget configuration from widget expressions

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -58,11 +58,11 @@ export default {
     },
     config () {
       if (!this.context || !this.context.component) return null
-      const sourceConfig = this.context.component.config
       let evalConfig = {}
       if (this.context.component.config) {
-        if (typeof this.context.component.config !== 'object') return {}
-        for (const key in this.context.component.config) {
+        const sourceConfig = this.context.component.config
+        if (typeof sourceConfig !== 'object') return {}
+        for (const key in sourceConfig) {
           if (key === 'visible' || key === 'visibleTo' || key === 'stylesheet') continue
           this.$set(evalConfig, key, this.evaluateExpression(key, sourceConfig[key]))
         }
@@ -131,6 +131,7 @@ export default {
           return expr.evaluate(this.exprAst[key], {
             items: ctx.store,
             props: this.props,
+            config: ctx.component.config,
             vars: ctx.vars,
             loop: ctx.loop,
             Math: Math,


### PR DESCRIPTION
Fixes #1025.

This introduces a new object for component configuration expressions to access the configuration of the component itself.

After this got merged, I can provide the docs update as well.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>