### PR TITLE
Validate Widget UID & page ID on creation

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -1,9 +1,10 @@
 <template>
   <f7-col>
     <f7-list inline-labels accordion-list no-hairline-md>
-      <f7-list-input label="ID" type="text" placeholder="ID" :value="page.uid" @input="page.uid = $event.target.value"
-                     required validate pattern="[A-Za-z0-9_]+" error-message="Required. Alphanumeric &amp; underscores only" :disabled="!createMode" />
-      <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" clear-button />
+      <f7-list-input label="ID" type="text" placeholder="Required" :value="page.uid" @input="page.uid = $event.target.value"
+                     :clear-button="createMode" :info="(createMode) ? 'Note: cannot be changed after the creation' : ''"
+                     required validate pattern="[A-Za-z0-9_]+" error-message="Required. A-Z,a-z,0-9,_ only" :disabled="!createMode" />
+      <f7-list-input label="Label" type="text" placeholder="Label" :value="page.config.label" @input="page.config.label = $event.target.value" required validate clear-button />
       <f7-list-item accordion-item title="Sidebar &amp; Visibility" :disabled="page.uid === 'overview'">
         <f7-accordion-content>
           <f7-list-item ref="pageVisibility" title="Visible only to" smart-select :smart-select-params="{openIn: 'popover'}">

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -250,7 +250,10 @@ export default {
     },
     save (stay) {
       if (!this.widget.uid) {
-        this.$f7.dialog.alert('Please give an ID to the widget')
+        this.$f7.dialog.alert('Please give an UID to the widget')
+        return
+      } else if (!/^[A-Za-z0-9_]+$/.test(this.widget.uid)) {
+        this.$f7.dialog.alert('Widget UID is only allowed to contain A-Z,a-z,0-9,_')
         return
       }
       // if (!this.widget.config.label) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -126,6 +126,9 @@ export default {
       if (!this.page.uid) {
         this.$f7.dialog.alert('Please give an ID to the page')
         return
+      } else if (!/^[A-Za-z0-9_]+$/.test(this.page.uid)) {
+        this.$f7.dialog.alert('Page ID is only allowed to contain A-Z,a-z,0-9,_')
+        return
       }
       if (!this.page.config.label) {
         this.$f7.dialog.alert('Please give a label to the page')


### PR DESCRIPTION
Fixes #1689.

Also mark label as required because the pagedesigner-mixin.js alerts if label is not set.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>