### PR TITLE
Add delete button for custom metadata namespaces

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -16,6 +16,11 @@
         Code
       </f7-link>
     </f7-toolbar>
+    <f7-toolbar v-if="ready && generic" position="bottom">
+      <f7-button color="red" v-if="!creationMode" @click="remove()" class="width-100">
+        Remove metadata
+      </f7-button>
+    </f7-toolbar>
     <f7-tabs class="metadata-editor-tabs">
       <f7-tab id="config" class="metadata-editor-config-tab" @tab:show="() => this.currentTab = 'config'" :tab-active="currentTab === 'config'">
         <f7-block class="block-narrow" v-if="ready && currentTab === 'config'">


### PR DESCRIPTION
Due to the missing "Config" tab for custom metadata namespaces, there was no way to delete them from the UI.
 This adds a button to the bottom of the code editor of custom metadata namespaces to delete them.

The ability to see and edit custom metadata namespaces was added in #1623, this is therefore type of a follow-up PR.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>