### PR TITLE
Remove Blockly GraalJS dependency on prepended code

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-audio.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-audio.js
@@ -99,7 +99,7 @@ export default function (f7, isGraalJs, sinks, voices) {
     let volume = javascriptGenerator.valueToCode(block, 'volume', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
 
     if (isGraalJs) {
-      return `actions.Audio.playSound(${sinkName}, ${fileName}, new runtime.PercentType(${volume}));\n`
+      return `actions.Audio.playSound(${sinkName}, ${fileName}, (${volume}/100));\n`
     } else {
       const audio = addAudio()
       return `${audio}.playSound(${sinkName}, ${fileName}, new PercentType(${volume}));\n`

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -979,13 +979,6 @@ Vue.config.ignoredElements = [
   'sep'
 ]
 
-// Code to prepend when running on GraalJS. When all Blocks are migrated to native GraalJS code, this can be removed.
-const prependCode = `var runtime = require('@runtime');
-var itemRegistry = runtime.itemRegistry;
-var events = runtime.events;
-
-`
-
 export default {
   props: ['blocks', 'libraryDefinitions', 'isGraalJs'],
   data () {
@@ -1123,7 +1116,7 @@ export default {
       return Blockly.Xml.domToText(xml)
     },
     getCode () {
-      return (this.isGraalJs === true ? prependCode : '') + javascriptGenerator.workspaceToCode(this.workspace)
+      return javascriptGenerator.workspaceToCode(this.workspace)
     },
     onChange (event) {
       if (event.type === Blockly.Events.FINISHED_LOADING) {


### PR DESCRIPTION
The prepended code that made runtime, itemRegistry and events available in Blockly on GraalJS is not required anymore. The only dependency was the PercentType volume in Audio/Voice actions, but https://github.com/openhab/openhab-core/pull/3352 fixed this.

/cc @stefan-hoehn 