### PR TITLE
Save changed rule/scene on runNow & Fix keyboard shortcuts in scene editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -444,6 +444,16 @@ export default {
       if ((ev.ctrlKey || ev.metaKey) && !(ev.altKey || ev.shiftKey)) {
         if (this.currentModule) return
         switch (ev.keyCode) {
+          case 68:
+            this.toggleDisabled()
+            ev.stopPropagation()
+            ev.preventDefault()
+            break
+          case 82:
+            this.runNow()
+            ev.stopPropagation()
+            ev.preventDefault()
+            break
           case 83:
             this.save()
             ev.stopPropagation()

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -299,11 +299,12 @@ export default {
     save (noToast) {
       if (!this.isEditable) return
       if (this.rule.status.status === 'RUNNING') {
-        return this.$f7.toast.create({
+        this.$f7.toast.create({
           text: `${this.isScriptRule ? 'Script' : 'Rule'} cannot be updated while running, please wait!`,
           destroyOnClose: true,
           closeTimeout: 2000
         }).open()
+        return Promise.reject()
       }
       if (this.isBlockly) {
         try {


### PR DESCRIPTION
This:

- makes rule and scene editor automatically save the rule/scene when "Run Now" is clicked and the rule/scene was modified.
- fixes the keyboard shortcuts for "Run Now" and "Enable/Disable" in the scene editor

Both were reported/discussed in https://github.com/openhab/openhab-webui/pull/1662#issuecomment-1434132699.

/cc @stefan-hoehn 