### PR TITLE
[blockly] add bitwise math operators

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -14,7 +14,7 @@ export default function (f7, isGraalJs) {
       this.setColour('%{BKY_MATH_HUE}')
       this.setInputsInline(true)
       this.setTooltip('bitwise not operator')
-      this.setHelpUrl('www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#not')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#not')
       this.setOutput(true, 'Number')
     }
   }
@@ -51,7 +51,7 @@ export default function (f7, isGraalJs) {
           case '>>>': return 'bitwise unsigned shift right'
         }
       })
-      this.setHelpUrl('www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#bitwise')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#bitwise')
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -1,0 +1,82 @@
+/*
+* Adds new bitwise operator blocks to the math section
+*/
+
+import Blockly from 'blockly'
+import { javascriptGenerator } from 'blockly/javascript'
+
+export default function (f7, isGraalJs) {
+  Blockly.Blocks['oh_bit_not'] = {
+    init: function () {
+      this.appendValueInput('value')
+        .setCheck('Number')
+        .appendField('~')
+      this.setColour('%{BKY_MATH_HUE}')
+      this.setInputsInline(true)
+      this.setTooltip('bitwise not operator')
+      this.setHelpUrl('www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#not')
+      this.setOutput(true, 'Number')
+    }
+  }
+
+  javascriptGenerator['oh_bit_not'] = function (block) {
+    const value = javascriptGenerator.valueToCode(block, 'value', javascriptGenerator.ORDER_BITWISE_NOT)
+    return [`~${value}`, 0]
+  }
+
+  Blockly.Blocks['oh_bitwise'] = {
+    init: function () {
+      this.appendValueInput('first')
+        .setCheck('Number')
+      this.appendValueInput('second')
+        .setCheck('Number')
+        .appendField(new Blockly.FieldDropdown([
+          ['&', '&'], ['|', '|'], ['^', '^'],
+          ['<<', '<<'], ['>>', '>>'], ['>>>', '>>>']
+        ]), 'operand')
+
+      this.setInputsInline(true)
+      this.setOutput(true, 'Number')
+      this.setColour('%{BKY_MATH_HUE}')
+
+      let thisBlock = this
+      this.setTooltip(function () {
+        const operand = thisBlock.getFieldValue('operand')
+        switch (operand) {
+          case '&': return 'bitwise and-operator'
+          case '|': return 'bitwise or-operator'
+          case '^': return 'bitwise xor-operator'
+          case '<<': return 'bitwise shift left'
+          case '>>': return 'bitwise shift right'
+          case '>>>': return 'bitwise unsigned shift right'
+        }
+      })
+      this.setHelpUrl('www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#bitwise')
+    }
+  }
+
+  javascriptGenerator['oh_bitwise'] = function (block) {
+    const first = javascriptGenerator.valueToCode(block, 'first', javascriptGenerator.ORDER_BITWISE_SHIFT)
+    const second = javascriptGenerator.valueToCode(block, 'second', javascriptGenerator.ORDER_NONE)
+    const operand = block.getFieldValue('operand')
+
+    let parentheses = 0
+    switch (operand) {
+      case '<<':
+      case '>>':
+      case '>>>':
+        parentheses = javascriptGenerator.ORDER_BITWISE_SHIFT
+        break
+      case '&':
+        parentheses = javascriptGenerator.ORDER_BITWISE_AND
+        break
+      case '|':
+        parentheses = javascriptGenerator.ORDER_BITWISE_OR
+        break
+      case '^':
+        parentheses = javascriptGenerator.ORDER_BITWISE_XOR
+        break
+    }
+    return [`${first} ${operand} ${second}`, parentheses]
+  }
+}

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
@@ -1,5 +1,5 @@
 /*
-* Adds new blocks to the colour section
+* Adds new blocks to the unit of measurement section
 * supports jsscripting
 */
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
@@ -16,6 +16,7 @@ import defineTextBlocks from './blocks-text'
 import defineListBlocks from './blocks-list'
 import defineUomBlocks from './blocks-uom'
 import defineMetaBlocks from './blocks-metadata'
+import defineMathBlocks from './blocks-math'
 
 import { defineLibraries } from './libraries'
 
@@ -39,6 +40,7 @@ export default function (f7, libraryDefinitions, data, isGraalJs) {
   defineTextBlocks(f7, isGraalJs)
   defineListBlocks(f7, isGraalJs)
   defineUomBlocks(f7, isGraalJs)
+  defineMathBlocks(f7, isGraalJs)
   defineMetaBlocks(f7, isGraalJs)
   defineLibraries(libraryDefinitions)
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -59,6 +59,25 @@
             </shadow>
           </value>
         </block>
+        <block type="oh_bitwise">
+          <value name="first">
+            <shadow type="math_number">
+              <field name="NUM">1</field>
+            </shadow>
+          </value>
+          <value name="second">
+            <shadow type="math_number">
+              <field name="NUM">1</field>
+            </shadow>
+          </value>
+        </block>
+        <block type="oh_bit_not">
+          <value name="value">
+            <shadow type="math_number">
+              <field name="NUM">1</field>
+            </shadow>
+          </value>
+        </block>
         <block type="math_single">
           <value name="NUM">
             <shadow type="math_number">


### PR DESCRIPTION
as requested in https://community.openhab.org/t/fleet-management-using-openhab/141928/8 

two new math blocks were added for bitwise operations:

- not
-  and, or, xor
- shifts <<, >>, >>>

<img width="322" alt="image" src="https://user-images.githubusercontent.com/5937600/219807939-ebb35a8b-86ad-4d88-af5c-85fbc408c3e7.png">
