### PR TITLE
[Blockly] Add workspace search

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@blockly/field-slider": "^4.0.3",
         "@blockly/plugin-cross-tab-copy-paste": "^2.0.4",
+        "@blockly/plugin-workspace-search": "^6.0.7",
         "@blockly/theme-dark": "^4.0.1",
         "@blockly/zoom-to-fit": "^3.0.3",
         "@jsep-plugin/arrow": "^1.0.5",
@@ -2773,6 +2774,17 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@blockly/plugin-cross-tab-copy-paste/-/plugin-cross-tab-copy-paste-2.0.4.tgz",
       "integrity": "sha512-dznGTmY+wdUdFDhoAl9BK5c6TLXTa6u6W4t0I2oQq4oaJwXflY/lQraEmBTF7+1UTHsEBh2sOH9j2cHO6Xo2nA==",
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^9.0.0"
+      }
+    },
+    "node_modules/@blockly/plugin-workspace-search": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@blockly/plugin-workspace-search/-/plugin-workspace-search-6.0.7.tgz",
+      "integrity": "sha512-MXMR5pgbFCm47QZ5cyFVyF4TwP6bIP0Po59/Sp3QzlutD+OTiecLolXivBYXGriQfBYpNzlD5BQvWD0UtoDDXA==",
       "engines": {
         "node": ">=8.17.0"
       },
@@ -26564,6 +26576,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@blockly/plugin-cross-tab-copy-paste/-/plugin-cross-tab-copy-paste-2.0.4.tgz",
       "integrity": "sha512-dznGTmY+wdUdFDhoAl9BK5c6TLXTa6u6W4t0I2oQq4oaJwXflY/lQraEmBTF7+1UTHsEBh2sOH9j2cHO6Xo2nA==",
+      "requires": {}
+    },
+    "@blockly/plugin-workspace-search": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@blockly/plugin-workspace-search/-/plugin-workspace-search-6.0.7.tgz",
+      "integrity": "sha512-MXMR5pgbFCm47QZ5cyFVyF4TwP6bIP0Po59/Sp3QzlutD+OTiecLolXivBYXGriQfBYpNzlD5BQvWD0UtoDDXA==",
       "requires": {}
     },
     "@blockly/theme-dark": {

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -63,6 +63,7 @@
   "dependencies": {
     "@blockly/field-slider": "^4.0.3",
     "@blockly/plugin-cross-tab-copy-paste": "^2.0.4",
+    "@blockly/plugin-workspace-search": "^6.0.7",
     "@blockly/theme-dark": "^4.0.1",
     "@blockly/zoom-to-fit": "^3.0.3",
     "@jsep-plugin/arrow": "^1.0.5",

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -1002,8 +1002,10 @@
   z-index 9000
 </style>
 
+<script src="./node_modules/@blockly/plugin-workspace-search/dist/index.js"></script>
 <script>
 import Blockly from 'blockly'
+import { WorkspaceSearch } from '@blockly/plugin-workspace-search';
 import { javascriptGenerator } from 'blockly/javascript'
 import DarkTheme from '@blockly/theme-dark'
 import { CrossTabCopyPaste } from '@blockly/plugin-cross-tab-copy-paste'
@@ -1111,6 +1113,8 @@ export default {
           },
         trashcan: false
       })
+      const workspaceSearch = new WorkspaceSearch(this.workspace);
+      workspaceSearch.init();
 
       Blockly.HSV_SATURATION = 0.45 // default
       Blockly.HSV_VALUE = 0.65 // a little bit more contract for the different colors

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -1000,9 +1000,13 @@
       stroke inherit
 .blocklyDropDownDiv
   z-index 9000
+.blockly-ws-search
+  background var(--blockly-ws-search-bg-color)
+  border-color var(--blockly-ws-search-border-color)
+  box-shadow none
+  color var(--blockly-ws-search-text-color)
 </style>
 
-<script src="./node_modules/@blockly/plugin-workspace-search/dist/index.js"></script>
 <script>
 import Blockly from 'blockly'
 import { WorkspaceSearch } from '@blockly/plugin-workspace-search';
@@ -1042,6 +1046,15 @@ export default {
   watch: {
     isGraalJs: function () {
       this.initBlockly(this.blockLibraries)
+    }
+  },
+  computed: {
+    cssVars () {
+      return {
+        '--blockly-ws-search-bg-color': this.$f7.data.themeOptions.dark === 'dark' ? '#1e1e1e' : 'white',
+        '--blockly-ws-search-border-color': this.$f7.data.themeOptions.dark === 'dark' ? 'lightgrey' : 'grey',
+        '--blockly-ws-search-text-color': this.$f7.data.themeOptions.dark === 'dark' ? 'white' : 'black'
+      }
     }
   },
   mounted () {
@@ -1113,8 +1126,8 @@ export default {
           },
         trashcan: false
       })
-      const workspaceSearch = new WorkspaceSearch(this.workspace);
-      workspaceSearch.init();
+      const workspaceSearch = new WorkspaceSearch(this.workspace)
+      workspaceSearch.init()
 
       Blockly.HSV_SATURATION = 0.45 // default
       Blockly.HSV_VALUE = 0.65 // a little bit more contract for the different colors

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/blockly-editor.vue
@@ -1009,7 +1009,7 @@
 
 <script>
 import Blockly from 'blockly'
-import { WorkspaceSearch } from '@blockly/plugin-workspace-search';
+import { WorkspaceSearch } from '@blockly/plugin-workspace-search'
 import { javascriptGenerator } from 'blockly/javascript'
 import DarkTheme from '@blockly/theme-dark'
 import { CrossTabCopyPaste } from '@blockly/plugin-cross-tab-copy-paste'


### PR DESCRIPTION
this adds a really helpful plugin that allows to search within the blockly workspace via Cmd/Ctrl-F

it is based on https://github.com/google/blockly-samples/tree/master/plugins/workspace-search

it opens up a small search window at the top right and blackens the blocks that match the search string

<img width="894" alt="image" src="https://user-images.githubusercontent.com/5937600/219813158-80865338-610b-4985-976c-c566eb794ae8.png">
