### PR TITLE
[widget] add metadata support for oh-input

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-input-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-card.md
@@ -115,6 +115,11 @@ Display an input in a card
     Link the input value to the state of this item
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="metaconfig" label="Name of metadata config property">
+  <PropDescription>
+    Use namespacename.value or namespacename.propertyname
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="useDisplayState" label="Use Display State">
   <PropDescription>
     Use the formatted state as the value for the input control

--- a/bundles/org.openhab.ui/doc/components/oh-input-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-item.md
@@ -120,6 +120,11 @@ Display an input field in a list
     Link the input value to the state of this item
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="metaconfig" label="Name of metadata config property">
+  <PropDescription>
+    Use namespacename.value or namespacename.propertyname
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="useDisplayState" label="Use Display State">
   <PropDescription>
     Use the formatted state as the value for the input control

--- a/bundles/org.openhab.ui/doc/components/oh-input.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input.md
@@ -83,6 +83,11 @@ Displays an input field, used to set a variable
     Link the input value to the state of this item
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="metaconfig" label="Name of metadata config property">
+  <PropDescription>
+    Use namespacename.value or namespacename.propertyname
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="useDisplayState" label="Use Display State">
   <PropDescription>
     Use the formatted state as the value for the input control

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
@@ -12,6 +12,7 @@ export default () => [
   pb('validate', 'Validate', 'When enabled, input value will be validated based on input type'),
   pb('validate-on-blur', 'Validate on blur', 'Only validate when focus moves away from input field'),
   pi('item', 'Item', 'Link the input value to the state of this item'),
+  pt('metaconfig', 'Name of metadata config property', 'Use namespacename.value or namespacename.propertyname'),
   pb('useDisplayState', 'Use Display State', 'Use the formatted state as the value for the input control'),
   pb('showTime', 'Show time', 'Display time when type set to datepicker'),
   pt('defaultValue', 'Default value', 'Default value when not found in item state or variable'),


### PR DESCRIPTION
This PR allows to show and edit metadata via the oh-input component:

Here are two examples: (1) access the value of the namespace controlheating and (2) a config property

(1) accessing the value
```
- component: oh-input-card
  config:
    inputmode: text
    item: testString
    metaconfig: controlheating.value
    outline: true
    sendButton: true
    title: controlheating.value
    type: text
    useDisplayState: false
```

Accessing a particular property:

```
- component: oh-input-card
    config:
      title: Zeit morgens
      item: F2_Office_Heating_Temp
      type: text
      inputmode: text
      metaconfig: controlheating.default.setpoint2.time
      outline: true
      sendButton: true
      useDisplayState: false
```

metadata namespace controlheating of item F2_Office_Heating_Temp

```
value: ON
config:
  default:
    setpoint2:
      degrees: 22
      time: 08:00
    setpoints: 2
```
