### PR TITLE
Add step parameter to oh-input

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-input-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-card.md
@@ -120,6 +120,11 @@ Display an input in a card
     Use the formatted state as the value for the input control
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="step" label="Step">
+  <PropDescription>
+    Step value when type set to number, any if left empty
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="showTime" label="Show time">
   <PropDescription>
     Display time when type set to datepicker

--- a/bundles/org.openhab.ui/doc/components/oh-input-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-item.md
@@ -125,6 +125,11 @@ Display an input field in a list
     Use the formatted state as the value for the input control
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="step" label="Step">
+  <PropDescription>
+    Step value when type set to number, any if left empty
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="showTime" label="Show time">
   <PropDescription>
     Display time when type set to datepicker

--- a/bundles/org.openhab.ui/doc/components/oh-input.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input.md
@@ -88,6 +88,11 @@ Displays an input field, used to set a variable
     Use the formatted state as the value for the input control
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="step" label="Step">
+  <PropDescription>
+    Step value when type set to number, any if left empty
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="showTime" label="Show time">
   <PropDescription>
     Display time when type set to datepicker

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
@@ -1,4 +1,4 @@
-import { pi, pb, pt } from '../helpers.js'
+import { pi, pb, pt, pd } from '../helpers.js'
 
 export default () => [
   pt('name', 'Name', 'Input name'),
@@ -13,6 +13,7 @@ export default () => [
   pb('validate-on-blur', 'Validate on blur', 'Only validate when focus moves away from input field'),
   pi('item', 'Item', 'Link the input value to the state of this item'),
   pb('useDisplayState', 'Use Display State', 'Use the formatted state as the value for the input control'),
+  pd('step', 'Step', 'Step value when type set to number, any if left empty'),
   pb('showTime', 'Show time', 'Display time when type set to datepicker'),
   pt('defaultValue', 'Default value', 'Default value when not found in item state or variable'),
   pt('variable', 'Variable', 'Name of the variable to set when the input changes'),

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -1,10 +1,10 @@
 <template>
   <f7-input v-if="!config.item || !config.sendButton" class="input-field" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value"
-            :calendar-params="calendarParams"
+            :calendar-params="calendarParams" :step="config.step ? config.step : 'any'"
             @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
   <f7-row no-gap v-else class="oh-input-with-send-button">
     <f7-input class="input-field col-90" ref="input" v-bind="config" :value="(config.type.indexOf('date') === 0) ? valueForDatepicker : value"
-              :calendar-params="calendarParams"
+              :calendar-params="calendarParams" :step="config.step ? config.step : 'any'"
               @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated" />
     <f7-button class="send-button col-10" v-if="this.config.sendButton" @click.stop="sendButtonClicked" v-bind="config.sendButtonConfig || { iconMaterial: 'done', iconColor: 'gray' }" />
   </f7-row>


### PR DESCRIPTION
When using number type in an oh-input card or oh-input-item list item, a default step value of 1 is always respected. This leads to confusion with users not being able to enter fractional numbers.
See [forum post](https://community.openhab.org/t/problems-with-numerical-values-in-input-cards/134774).

This PR makes the step parameter visible, and uses a default of any value (no step check) if no step value is provided. This is a small breaking change, but less confusing to users.