### PR TITLE
Configuration & iPhone style fixes for the `options` widget action

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -103,12 +103,12 @@ export const actionsMixin = {
           const actionsPromise = new Promise((resolve, reject) => {
             if (actionCommandOptions && typeof actionCommandOptions === 'string') {
               resolve(actionCommandOptions.split(',').map((o) => {
-                const parts = o.split('=')
+                const parts = o.trim().split('=')
                 return {
-                  text: parts[1] || parts[0],
+                  text: parts[1].trim() || parts[0].trim(),
                   color: 'blue',
                   onClick: () => {
-                    this.$store.dispatch('sendCommand', { itemName: actionCommandOptionsItem, cmd: parts[0] })
+                    this.$store.dispatch('sendCommand', { itemName: actionCommandOptionsItem, cmd: parts[0].trim() })
                       .then(() => this.showActionFeedback(prefix, actionConfig))
                   }
                 }

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -141,13 +141,8 @@ html
      --f7-bars-link-color #ff3b30
 
 // Fix actions-modal/popup is placed behind the notch or outside of the screen on iPhone in openHAB iOS app
-@media (orientation: portrait)
-  .ios .actions-modal
-    max-height: calc(100% - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))
-
-@media (orientation: landscape)
-  .ios .actions-modal
-    max-height: calc(100% - env(safe-area-inset-left, 0px))
+.device-ios .actions-modal
+  max-height: calc(100% - var(--f7-safe-area-top) - var(--f7-safe-area-bottom))
 
 .md .contextual-toolbar
   --f7-theme-color #474747

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -140,6 +140,14 @@ html
    .delete
      --f7-bars-link-color #ff3b30
 
+@media (orientation: portrait)
+  .ios .actions-modal
+    max-height: calc(100% - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))
+
+@media (orientation: landscape)
+  .ios .actions-modal
+    max-height: calc(100% - env(safe-area-inset-left, 0px))
+
 .md .contextual-toolbar
   --f7-theme-color #474747
   --f7-bars-bg-color #474747

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -140,6 +140,7 @@ html
    .delete
      --f7-bars-link-color #ff3b30
 
+// Fix actions-modal/popup is placed behind the notch or outside of the screen on iPhone in openHAB iOS app
 @media (orientation: portrait)
   .ios .actions-modal
     max-height: calc(100% - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px))


### PR DESCRIPTION
- Fixes the style of the actions popup on iPhones in the openHAB iOS app. It did not respect the safe-area-inlets and therefore large action popups possibly placed behing the notch or outside of the display.
- Fixes #1210: trim whitespaces when parsing the `actionOptions` to avoid having whitespaces in commands sent to the server.