### PR TITLE
Improvements for Eclipse provisioned add-ons

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/addon-store.js
+++ b/bundles/org.openhab.ui/web/src/assets/addon-store.js
@@ -25,6 +25,7 @@ export const Formats = {
   'json_download_url': 'Linked JSON File',
   'jar_download_url': 'Linked JAR file',
   'kar_download_url': 'Linked KAR file',
+  'eclipse': 'Eclipse',
   'karaf': 'Karaf'
 }
 

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -5,7 +5,7 @@
         <div>{{ headline || autoHeadline || "&nbsp;" }}</div>
       </div>
       <div class="addon-card-title">
-        <div class="addon-card-title-after">
+        <div v-if="showInstallActions" class="addon-card-title-after">
           <f7-preloader v-if="addon.pending" color="blue" />
           <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove"
                      color="red" round small @click="buttonClicked" />
@@ -146,6 +146,10 @@ export default {
       let docsBranch = 'final'
       if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
       return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
+    },
+    showInstallActions () {
+      let splitted = this.addon.uid.split(':')
+      return splitted.length < 2 || splitted[0] !== 'eclipse'
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -46,7 +46,7 @@ export default {
       let sourceName = 'openHAB Distribution'
       if (source === 'marketplace') {
         sourceName = 'Community Marketplace'
-      } else if (source !== 'karaf') {
+      } else if (source !== 'eclipse' && source !== 'karaf') {
         sourceName = '3rd Party (' + source + ')'
       }
       info.push({
@@ -82,8 +82,12 @@ export default {
         value: ContentTypes[this.addon.contentType] || this.addon.contentType
       })
 
-      let format = Formats.karaf
-      if (source !== 'karaf' && Object.keys(this.addon.properties).length > 0) {
+      let format
+      if (source === 'eclipse') {
+        format = Formats.eclipse
+      } else if (source === 'karaf') {
+        format = Formats.karaf
+      } else if (Object.keys(this.addon.properties).length > 0) {
         for (const property in this.addon.properties) {
           if (Formats[property]) format = Formats[property]
         }
@@ -118,7 +122,7 @@ export default {
           afterIcon: 'chat_bubble_2_fill',
           linkUrl: this.addon.link
         })
-      } else if (source === 'karaf') {
+      } else if (source === 'eclipse' || source === 'karaf') {
         info.push({
           id: 'documentationLink',
           title: 'Documentation',

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -15,7 +15,7 @@
     <div class="item-logo" slot="media">
       <img v-if="!logoError" class="lazy" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo" width="54" :data-src="imageUrl">
     </div>
-    <div slot="after">
+    <div v-if="showInstallActions" slot="after">
       <f7-preloader v-if="addon.pending" color="blue" />
       <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />
       <f7-button v-else class="install-button prevent-active-state-propagation" :text="installActionText || 'Install'" color="blue" round small @click="buttonClicked" />
@@ -77,6 +77,10 @@ export default {
       let docsBranch = 'final'
       if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
       return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
+    },
+    showInstallActions () {
+      let splitted = this.addon.uid.split(':')
+      return splitted.length < 2 || splitted[0] !== 'eclipse'
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addon-details.vue
@@ -25,9 +25,11 @@
                 <addon-stats-line :addon="addon" :iconSize="15" />
               </div>
               <div class="addon-header-actions">
-                <f7-preloader v-if="isPending(addon)" color="blue" />
-                <f7-button v-else-if="addon.installed" class="install-button" text="Remove" color="red" round small fill @click="openAddonPopup" />
-                <f7-button v-else class="install-button" :text="installableAddon(addon) ? 'Install' : 'Add'" color="blue" round small fill @click="openAddonPopup" />
+                <div v-if="showInstallActions">
+                  <f7-preloader v-if="isPending(addon)" color="blue" />
+                  <f7-button v-else-if="addon.installed" class="install-button" text="Remove" color="red" round small fill @click="openAddonPopup" />
+                  <f7-button v-else class="install-button" :text="installableAddon(addon) ? 'Install' : 'Add'" color="blue" round small fill @click="openAddonPopup" />
+                </div>
                 <f7-link v-if="showConfig" icon-f7="gears" tooltip="Configure add-on" color="blue" :href="'/settings/addons/' + addonId + '/config'" round small />
               </div>
             </div>
@@ -239,6 +241,10 @@ export default {
         `/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}` +
         `/${this.addon.id}`
       return url
+    },
+    showInstallActions () {
+      let splitted = this.addon.uid.split(':')
+      return splitted.length < 2 || splitted[0] !== 'eclipse'
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/addons/addons-store.vue
@@ -50,9 +50,9 @@
     <f7-tabs>
       <f7-tab :tab-active="currentTab === 'bindings'">
         <addons-section
-          v-if="addons && addons.karaf"
+          v-if="officialAddons"
           @addonButtonClick="addonButtonClick"
-          :addons="addons.karaf.filter((a) => a.type === 'binding')"
+          :addons="officialAddons.filter((a) => a.type === 'binding')"
           :title="'openHAB Distribution'"
           :subtitle="'Official bindings maintained by the openHAB project'" />
         <addons-section
@@ -100,7 +100,7 @@
           :title="'Widgets for the Main UI'"
           :subtitle="'Extend your pages with these community-designed widgets'" />
         <addons-section
-          v-if="addons && addons.karaf" :show-all="true"
+          v-if="addons && officialAddons" :show-all="true"
           @addonButtonClick="addonButtonClick"
           :addons="allAddons.filter((a) => a.type === 'ui' && a.contentType !== 'application/vnd.openhab.uicomponent;type=widget')"
           :title="'Other UI Add-ons'"
@@ -108,28 +108,28 @@
       </f7-tab>
       <f7-tab :tab-active="currentTab === 'other'">
         <addons-section
-          v-if="addons && addons.karaf" :show-all="true"
+          v-if="addons && officialAddons" :show-all="true"
           @addonButtonClick="addonButtonClick"
           :addons="allAddons.filter((a) => a.type === 'misc')"
           :title="'System Integrations'"
           :featured="['misc-openhabcloud', 'misc-homekit', 'misc-metrics']"
           :subtitle="'Integrate openHAB with external systems'" />
         <addons-section
-          v-if="addons && addons.karaf"
+          v-if="addons && officialAddons"
           @addonButtonClick="addonButtonClick"
           :addons="allAddons.filter((a) => a.type === 'persistence')" :show-all="true"
           :featured="['persistence-rrd4j', 'persistence-influxdb', 'persistence-mongodb']"
           :title="'Persistence Services'"
           :subtitle="'Backend connectors to store historical data'" />
         <addons-section
-          v-if="addons && addons.karaf"
+          v-if="addons && officialAddons"
           @addonButtonClick="addonButtonClick"
           :addons="allAddons.filter((a) => a.type === 'transformation')" :show-all="true"
           :featured="['transformation-jsonpath', 'transformation-javascript', 'transformation-regex']"
           :title="'Transformation Add-ons'"
           :subtitle="'Translate raw values into processed or human-readable representations'" />
         <addons-section
-          v-if="addons && addons.karaf" :show-all="true"
+          v-if="addons && officialAddons" :show-all="true"
           @addonButtonClick="addonButtonClick"
           :addons="allAddons.filter((a) => a.type === 'voice')"
           :featured="['voice-googletts', 'voice-pollytts', 'voice-voicerss']"
@@ -189,8 +189,11 @@ export default {
     allAddons () {
       return Object.keys(this.addons).flatMap((k) => this.addons[k])
     },
+    officialAddons () {
+      return Object.keys(this.addons).filter((k) => k === 'eclipse' || k === 'karaf').flatMap((k) => this.addons[k])
+    },
     otherAddons () {
-      return Object.keys(this.addons).filter((k) => k !== 'karaf' && k !== 'marketplace').flatMap((k) => this.addons[k])
+      return Object.keys(this.addons).filter((k) => k !== 'eclipse' && k !== 'karaf' && k !== 'marketplace').flatMap((k) => this.addons[k])
     }
   },
   methods: {


### PR DESCRIPTION
This improves the UI when working with add-ons that are provisioned using Eclipse.

* Show these add-ons in the "openHAB Distribution" section
* Show in the add-on details when add-ons are provisioned with Eclipse
* Show the add-on documentation and issue links when add-ons are provisioned with Eclipse
* Hide Install/Uninstall buttons when add-ons are provisioned with Eclipse

Related to openhab/openhab-core#3406