### PR TITLE
Scene editor: Fix triggers/conditions & Remove enable/disable and status

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -21,10 +21,10 @@
       <f7-link color="red" v-show="selectedItems.length" v-if="!$theme.md" class="delete" icon-ios="f7:trash" icon-aurora="f7:trash" @click="removeSelected">
         Remove {{ selectedItems.length }}
       </f7-link>
-      <f7-link color="orange" v-show="selectedItems.length" v-if="!$theme.md" class="disable" @click="doDisableEnableSelected(false)" icon-ios="f7:pause_circle" icon-aurora="f7:pause_circle">
+      <f7-link color="orange" v-show="selectedItems.length" v-if="!$theme.md && !showScenes" class="disable" @click="doDisableEnableSelected(false)" icon-ios="f7:pause_circle" icon-aurora="f7:pause_circle">
         &nbsp;Disable {{ selectedItems.length }}
       </f7-link>
-      <f7-link color="green" v-show="selectedItems.length" v-if="!$theme.md" class="enable" @click="doDisableEnableSelected(true)" icon-ios="f7:play_circle" icon-aurora="f7:play_circle">
+      <f7-link color="green" v-show="selectedItems.length" v-if="!$theme.md && !showScenes" class="enable" @click="doDisableEnableSelected(true)" icon-ios="f7:play_circle" icon-aurora="f7:play_circle">
         &nbsp;Enable {{ selectedItems.length }}
       </f7-link>
       <f7-link v-if="$theme.md" icon-md="material:close" icon-color="white" @click="showCheckboxes = false" />
@@ -32,8 +32,8 @@
         {{ selectedItems.length }} selected
       </div>
       <div class="right" v-if="$theme.md">
-        <f7-link v-show="selectedItems.length" tooltip="Disable selected" icon-md="material:pause_circle_outline" icon-color="white" @click="doDisableEnableSelected(false)" />
-        <f7-link v-show="selectedItems.length" tooltip="Enable selected" icon-md="material:play_circle_outline" icon-color="white" @click="doDisableEnableSelected(true)" />
+        <f7-link v-if="!showScenes" v-show="selectedItems.length" tooltip="Disable selected" icon-md="material:pause_circle_outline" icon-color="white" @click="doDisableEnableSelected(false)" />
+        <f7-link v-if="!showScenes" v-show="selectedItems.length" tooltip="Enable selected" icon-md="material:play_circle_outline" icon-color="white" @click="doDisableEnableSelected(true)" />
         <f7-link v-show="selectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected" />
       </div>
     </f7-toolbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:afterout="stopEventSource">
-    <f7-navbar :title="(showScripts) ? 'Scripts' : 'Rules'" back-link="Settings" back-link-url="/settings/" back-link-force>
+    <f7-navbar :title="(showScripts) ? 'Scripts' : ((showScenes) ? 'Scenes' : 'Rules')" back-link="Settings" back-link-url="/settings/" back-link-force>
       <f7-nav-right>
         <f7-link icon-md="material:done_all" @click="toggleCheck()"
                  :text="(!$theme.md) ? ((showCheckboxes) ? 'Done' : 'Select') : ''" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -609,10 +609,11 @@ export default {
       try {
         const updatedRule = YAML.parse(this.ruleYaml)
         const actions = []
-        let idx = 0
+        let moduleId = 1
+        for (; ['triggers', 'actions', 'conditions'].some((s) => this.rule[s].some((m) => m.id === moduleId.toString())); moduleId++);
         for (let item in updatedRule.items) {
           actions.push({
-            id: (idx++).toString(),
+            id: (moduleId++).toString(),
             configuration: {
               itemName: item,
               command: updatedRule.items[item]

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -608,6 +608,8 @@ export default {
       if (!this.isEditable) return
       try {
         const updatedRule = YAML.parse(this.ruleYaml)
+        if (updatedRule.triggers === null) updatedRule.triggers = []
+        if (updatedRule.conditions === null) updatedRule.conditions = []
         const actions = []
         let moduleId = 1
         for (; ['triggers', 'actions', 'conditions'].some((s) => this.rule[s].some((m) => m.id === moduleId.toString())); moduleId++);

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -347,6 +347,11 @@ export default {
     },
     save (noToast) {
       if (!this.isEditable) return Promise.reject()
+      if (this.currentTab === 'code') {
+        if (!this.fromYaml()) {
+          return Promise.reject()
+        }
+      }
       if (!this.rule.uid) {
         this.$f7.dialog.alert('Please give an ID to the scene')
         return Promise.reject()
@@ -643,6 +648,7 @@ export default {
         this.$set(this.rule, 'triggers', updatedRule.triggers)
         this.$set(this.rule, 'conditions', updatedRule.conditions)
         this.$set(this.rule, 'actions', actions)
+        console.debug(this.rule)
         return true
       } catch (e) {
         this.$f7.dialog.alert(e).open()

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -18,36 +18,16 @@
     </f7-toolbar>
     <f7-tabs class="scene-editor-tabs">
       <f7-tab id="design" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
-        <f7-block v-if="ready && rule.status && !createMode" class="block-narrow padding-left padding-right" strong>
-          <f7-col v-if="!createMode">
+        <f7-block v-if="ready && !createMode" class="block-narrow padding-left padding-right" strong>
+          <f7-col v-if="!createMode" style="height: 32px">
             <div class="float-right align-items-flex-start align-items-center">
-              <!-- <f7-toggle class="enable-toggle"></f7-toggle> -->
-              <f7-link :icon-color="(rule.status.statusDetail === 'DISABLED') ? 'orange' : 'gray'" :tooltip="((rule.status.statusDetail === 'DISABLED') ? 'Enable' : 'Disable') + (($device.desktop) ? ' (Ctrl-D)' : '')" icon-ios="f7:pause_circle" icon-md="f7:pause_circle" icon-aurora="f7:pause_circle" icon-size="32" color="orange" @click="toggleDisabled" />
               <f7-link :tooltip="'Run Now' + (($device.desktop) ? ' (Ctrl-R)' : '')" icon-ios="f7:play_round" icon-md="f7:play_round" icon-aurora="f7:play_round" icon-size="32" color="blue" @click="runNow" />
-            </div>
-            Status:
-            <f7-chip class="margin-left"
-                     :text="rule.status.status"
-                     :color="ruleStatusBadgeColor(rule.status)" />
-            <div>
-              <strong>{{ (rule.status.statusDetail !== 'NONE') ? rule.status.statusDetail : '&nbsp;' }}</strong>
-              <br>
-              <div v-if="rule.status.description">
-                {{ rule.status.description }}
-              </div>
             </div>
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
         <f7-block v-else-if="!createMode" class="block-narrow padding-left padding-right skeleton-text skeleton-effect-blink" strong>
-          <f7-col>
-            ______:
-            <f7-chip class="margin-left" text="________" />
-            <div>
-              <strong>____ _______</strong>
-              <br>
-            </div>
-          </f7-col>
+          <f7-col style="height: 32px"/>
         </f7-block>
 
         <!-- skeletons -->
@@ -228,12 +208,11 @@ import TagInput from '@/components/tags/tag-input.vue'
 
 import SceneConfigureItemPopup from './scene-configure-item-popup.vue'
 
-import RuleStatus from '@/components/rule/rule-status-mixin'
 import DirtyMixin from '../../dirty-mixin'
 import fastDeepEqual from 'fast-deep-equal/es6'
 
 export default {
-  mixins: [RuleStatus, DirtyMixin],
+  mixins: [DirtyMixin],
   components: {
     SemanticsPicker,
     TagInput,
@@ -385,23 +364,6 @@ export default {
         }).open()
       })
     },
-    toggleDisabled () {
-      if (this.createMode) return
-      const enable = (this.rule.status.statusDetail === 'DISABLED')
-      this.$oh.api.postPlain('/rest/rules/' + this.rule.uid + '/enable', enable.toString()).then((data) => {
-        this.$f7.toast.create({
-          text: (enable) ? 'Scene enabled' : 'Scene disabled',
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-      }).catch((err) => {
-        this.$f7.toast.create({
-          text: 'Error while disabling or enabling: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-      })
-    },
     runNow () {
       if (this.createMode) return
       if (this.rule.status.status === 'RUNNING' || this.rule.status.status === 'UNINITIALIZED') {
@@ -444,11 +406,6 @@ export default {
       if ((ev.ctrlKey || ev.metaKey) && !(ev.altKey || ev.shiftKey)) {
         if (this.currentModule) return
         switch (ev.keyCode) {
-          case 68:
-            this.toggleDisabled()
-            ev.stopPropagation()
-            ev.preventDefault()
-            break
           case 82:
             this.runNow()
             ev.stopPropagation()


### PR DESCRIPTION
This:

- Fixes an issue where adding triggers and conditions to scenes using the YAML code tab was not possible (reported in https://github.com/openhab/openhab-webui/pull/1662#issuecomment-1435019).
- Fixes an issue where `null` was entered as triggers or conditions and saving the scene failed.
- Fixes SSE event subscription for rule status inside scene editor.
- Removes the disable and enable actions from the scene the scenes list as there are no status badges.