### PR TITLE
Fix undefined in widget expression evaluation

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -187,24 +187,24 @@
           <f7-list>
             <f7-list-item divider title="Things" />
             <f7-list-button href="/settings/things/add" color="blue" :animate="false">
-              Add Thing
+              Add thing
             </f7-list-button>
             <f7-list-button @click="quickAddThing" color="blue">
-              Add Thing (quick)
+              Add thing (quick)
             </f7-list-button>
             <f7-list-button href="/settings/things/inbox" color="blue" :animate="false">
               Inbox
             </f7-list-button>
             <f7-list-item divider title="Items" />
             <f7-list-button href="/settings/items/add" color="blue" :animate="false">
-              Create Item
+              Create item
             </f7-list-button>
             <f7-list-button href="/settings/items/add-from-textual-definition" color="blue" :animate="false">
-              Add Items (textual)
+              Add items (textual)
             </f7-list-button>
             <f7-list-item divider title="Pages" />
             <f7-list-button href="/settings/pages/layout/add" color="blue" :animate="false">
-              Create layout page
+              Create layout
             </f7-list-button>
             <f7-list-button href="/settings/pages/tabs/add" color="blue" :animate="false">
               Create tabbed page

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -194,7 +194,7 @@
             </f7-list-button>
             <f7-list-item divider title="Pages" />
             <f7-list-button href="/settings/pages/layout/add" color="blue" :animate="false">
-              Create layout
+              Create layout page
             </f7-list-button>
             <f7-list-button href="/settings/pages/tabs/add" color="blue" :animate="false">
               Create tabbed page

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -154,17 +154,7 @@
             Code Tools
           </f7-block-title>
         </f7-block>
-        <f7-block class="no-margin no-padding">
-          <f7-block-title class="padding-horizontal">
-            Widgets Expression Tester
-          </f7-block-title>
-          <f7-list media-list>
-            <f7-list-input type="textarea" title="Expression" placeholder="Try '=2+3' or '=items.MyItem.state'" :value="testExpression" @input="(evt) => testExpression = evt.target.value" />
-          </f7-list>
-          <f7-block strong v-if="testExpression">
-            <generic-widget-component :context="expressionTesterContext" />
-          </f7-block>
-        </f7-block>
+        <expression-tester />
         <f7-block class="no-margin no-padding">
           <f7-block-title class="padding-horizontal">
             Scripting Scratchpad
@@ -287,6 +277,7 @@ import Item from '@/components/item/item.vue'
 import ItemStandaloneControl from '@/components/item/item-standalone-control.vue'
 import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 import SearchResults from './search-results.vue'
+import ExpressionTester from './expression-tester.vue'
 
 import RuleStatus from '@/components/rule/rule-status-mixin'
 import ThingStatus from '@/components/thing/thing-status-mixin'
@@ -296,7 +287,8 @@ export default {
   components: {
     Item,
     ItemStandaloneControl,
-    SearchResults
+    SearchResults,
+    ExpressionTester
   },
   data () {
     return {
@@ -339,24 +331,6 @@ export default {
   computed: {
     context () {
       return {
-        store: this.$store.getters.trackedItems
-      }
-    },
-    expressionTesterContext () {
-      return {
-        component: {
-          component: 'Label',
-          config: {
-            style: {
-              fontFamily: 'monospace'
-            },
-            noBorder: true,
-            noShadow: true,
-            text: this.testExpression.toString()
-          }
-        },
-        editmode: true,
-        vars: {},
         store: this.$store.getters.trackedItems
       }
     }

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -187,20 +187,20 @@
           <f7-list>
             <f7-list-item divider title="Things" />
             <f7-list-button href="/settings/things/add" color="blue" :animate="false">
-              Add thing
+              Add Thing
             </f7-list-button>
             <f7-list-button @click="quickAddThing" color="blue">
-              Add thing (quick)
+              Add Thing (quick)
             </f7-list-button>
             <f7-list-button href="/settings/things/inbox" color="blue" :animate="false">
               Inbox
             </f7-list-button>
             <f7-list-item divider title="Items" />
             <f7-list-button href="/settings/items/add" color="blue" :animate="false">
-              Create item
+              Create Item
             </f7-list-button>
             <f7-list-button href="/settings/items/add-from-textual-definition" color="blue" :animate="false">
-              Add items (textual)
+              Add Items (textual)
             </f7-list-button>
             <f7-list-item divider title="Pages" />
             <f7-list-button href="/settings/pages/layout/add" color="blue" :animate="false">

--- a/bundles/org.openhab.ui/web/src/components/developer/expression-tester.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/expression-tester.vue
@@ -1,0 +1,47 @@
+<template>
+  <f7-block class="no-margin no-padding">
+    <f7-block-title class="padding-horizontal">
+      Widgets Expression Tester
+    </f7-block-title>
+    <f7-list media-list>
+      <f7-list-input type="textarea" title="Expression" placeholder="Try '=2+3' or '=items.MyItem.state'" :value="testExpression" @input="(evt) => testExpression = evt.target.value" />
+    </f7-list>
+    <f7-block strong v-if="testExpression">
+      <div :class="config.class" :style="config.style">
+        {{ (config.text === undefined) ? 'undefined' : config.text }}
+      </div>
+    </f7-block>
+  </f7-block>
+</template>
+
+<script>
+import Mixin from '@/components/widgets/widget-mixin'
+
+export default {
+  mixins: [Mixin],
+  data () {
+    return {
+      testExpression: ''
+    }
+  },
+  computed: {
+    context () {
+      return {
+        component: {
+          config: {
+            style: {
+              fontFamily: 'monospace'
+            },
+            noBorder: true,
+            noShadow: true,
+            text: this.testExpression.toString()
+          }
+        },
+        editmode: true,
+        vars: {},
+        store: this.$store.getters.trackedItems
+      }
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -128,7 +128,7 @@ export default {
           if (!this.exprAst[key] || ctx.editmode) {
             this.exprAst[key] = expr.parse(value.substring(1))
           }
-          const evalExpr = expr.evaluate(this.exprAst[key], {
+          return expr.evaluate(this.exprAst[key], {
             items: ctx.store,
             props: this.props,
             config: ctx.component.config,
@@ -144,7 +144,6 @@ export default {
             dayjs: dayjs,
             user: this.$store.getters.user
           })
-          return (evalExpr === undefined) ? 'undefined' : evalExpr
         } catch (e) {
           return e
         }


### PR DESCRIPTION
Regression from #1696.

The widget expression evaluator returns undefined a string to make it appear in the widget expression tester etc. 
This has unattended side effects because the UI internally relies on undefined checks.

This fixes the regression by reverting the change and instead extracting the widget-expression tester to its own component, which will display `undefined` as string.