### PR TITLE
Fix Cordova build documentation

### DIFF
--- a/bundles/org.openhab.ui/CONTRIBUTING.md
+++ b/bundles/org.openhab.ui/CONTRIBUTING.md
@@ -37,6 +37,7 @@ This is a PWA. Don't forget to check what is inside of your `service-worker.js`.
 ## Cordova
 
 The Cordova project is located in the `cordova` folder. You shouldn't modify content of the `cordova/www` folder. Its content will be correctly generated when you call `npm run build-cordova-prod` (see [NPM Scripts](#npm-scripts)).
+git 
 ## Documentation & Resources
 
 The openHAB docs provide a [Component Reference](https://www.openhab.org/docs/ui/components/) as well as docs for each component.

--- a/bundles/org.openhab.ui/CONTRIBUTING.md
+++ b/bundles/org.openhab.ui/CONTRIBUTING.md
@@ -37,7 +37,7 @@ This is a PWA. Don't forget to check what is inside of your `service-worker.js`.
 ## Cordova
 
 The Cordova project is located in the `cordova` folder. You shouldn't modify content of the `cordova/www` folder. Its content will be correctly generated when you call `npm run build-cordova-prod` (see [NPM Scripts](#npm-scripts)).
-git 
+
 ## Documentation & Resources
 
 The openHAB docs provide a [Component Reference](https://www.openhab.org/docs/ui/components/) as well as docs for each component.

--- a/bundles/org.openhab.ui/CONTRIBUTING.md
+++ b/bundles/org.openhab.ui/CONTRIBUTING.md
@@ -36,8 +36,7 @@ This is a PWA. Don't forget to check what is inside of your `service-worker.js`.
 
 ## Cordova
 
-The Cordova project is located in the `cordova` folder. You shouldn't modify content of the `cordova/www` folder. Its content will be correctly generated when you call `npm run cordova-build-prod`.
-
+The Cordova project is located in the `cordova` folder. You shouldn't modify content of the `cordova/www` folder. Its content will be correctly generated when you call `npm run build-cordova-prod` (see [NPM Scripts](#npm-scripts)).
 ## Documentation & Resources
 
 The openHAB docs provide a [Component Reference](https://www.openhab.org/docs/ui/components/) as well as docs for each component.


### PR DESCRIPTION
Fixes the npm script name in the Cordova build documentation.