### PR TITLE
Fix missing diagram lines for groups

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -21,7 +21,14 @@ const target = process.env.TARGET || 'web'
 const buildSourceMaps = process.env.SOURCE_MAPS || false
 const isCordova = target === 'cordova'
 
-const apiBaseUrl = process.env.OH_APIBASE || 'http://localhost:8080'
+const proxyConfig = {
+  context: ['/auth', '/rest', '/chart', '/proxy', '/icon', '/static', '/changePassword', '/createApiToken', '/audio'],
+  target: process.env.OH_APIBASE || 'http://localhost:8080'
+}
+if (proxyConfig.target && proxyConfig.target.startsWith('https://')) {
+  proxyConfig['secure'] = true
+  proxyConfig['changeOrigin'] = true
+}
 
 module.exports = {
   mode: env,
@@ -53,10 +60,7 @@ module.exports = {
     // watchOptions: {
     //   poll: 1000,
     // },
-    proxy: [{
-      context: ['/auth', '/rest', '/chart', '/proxy', '/icon', '/static', '/changePassword', '/createApiToken', '/audio'],
-      target: apiBaseUrl
-    }]
+    proxy: [proxyConfig]
   },
   performance: {
     maxAssetSize: 2048000,

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -349,7 +349,8 @@ export default {
       seriesOptions.name = item.label || item.name
       seriesOptions.type = 'line'
       seriesOptions.discrete = false
-      if ((item.type.indexOf('Number') !== 0 && item.type.indexOf('Dimmer') !== 0)) seriesOptions.discrete = true
+      if ((item.type.indexOf('Number') !== 0 && item.type.indexOf('Dimmer') !== 0 &&
+         ((item.groupType.indexOf('Number') !== 0 && item.groupType.indexOf('Dimmer') !== 0) || item.groupType === undefined))) seriesOptions.discrete = true
       if (!seriesOptions.discrete && this.coordSystem === 'aggregate' && this.aggregateDimensions === 1) seriesOptions.type = 'bar'
       if (!seriesOptions.discrete && (this.coordSystem === 'calendar' || (this.coordSystem === 'aggregate' && this.aggregateDimensions === 2))) seriesOptions.type = 'heatmap'
       if (seriesOptions.discrete) seriesOptions.type = 'area'


### PR DESCRIPTION
Like others, I've noted that the analyzer will not show the data if the source is a group that derives its state from its members (https://github.com/openhab/openhab-webui/issues/1365 ).
With this PR the analyzer will also respect groups of numbers or dimmers.

Thanks to @ghys for the hint on where to look at.

I've messed up the rebase @florian-h05 suggested in #1758 and so I had to open another - sorry for that.