### PR TITLE
`oh-knob`: Change dottedPath prop to text

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-knob-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-card.md
@@ -144,7 +144,7 @@ Display a knob in a card to visualize and control a quantifiable item
     butt, round, square, none - slider control only!
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="dottedPath" label="Dotted Path">
+<PropBlock type="TEXT" name="dottedPath" label="Dotted Path">
   <PropDescription>
     Length of dotted path segments (css stroke-dasharray) - slider control only!
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -153,7 +153,7 @@ A cell expanding to a knob control
     butt, round, square, none - slider control only!
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="dottedPath" label="Dotted Path">
+<PropBlock type="TEXT" name="dottedPath" label="Dotted Path">
   <PropDescription>
     Length of dotted path segments (css stroke-dasharray) - slider control only!
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-knob.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob.md
@@ -111,7 +111,7 @@ Knob control, allow to change a number value on a circular track
     butt, round, square, none - slider control only!
   </PropDescription>
 </PropBlock>
-<PropBlock type="INTEGER" name="dottedPath" label="Dotted Path">
+<PropBlock type="TEXT" name="dottedPath" label="Dotted Path">
   <PropDescription>
     Length of dotted path segments (css stroke-dasharray) - slider control only!
   </PropDescription>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
@@ -18,7 +18,7 @@ export default () => [
   pn('borderWidth', 'Border Width', 'Indicates the border width of the slider - slider control only!').a(),
   pn('strokeWidth', 'Stroke Width', 'Thickness of the arcs (default 17)'),
   pt('lineCap', 'Line End Type', 'butt, round, square, none - slider control only!').a(),
-  pn('dottedPath', 'Dotted Path', 'Length of dotted path segments (css stroke-dasharray) - slider control only!').a(),
+  pt('dottedPath', 'Dotted Path', 'Length of dotted path segments (css stroke-dasharray) - slider control only!').a(),
   pb('responsive', 'Responsive', 'Size the control using percentages instead of pixels'),
   pb('releaseOnly', 'Send command only on release', 'If enabled, no commands are sent during sliding'),
   pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),


### PR DESCRIPTION
property needs to be text to be able to add the css stroke-dasharray style