### PR TITLE
[BasicUI] Remove unused formats for font MaterialIcons-Regular

### DIFF
--- a/bundles/org.openhab.ui.basic/gulpfile.js
+++ b/bundles/org.openhab.ui.basic/gulpfile.js
@@ -16,7 +16,8 @@
 	
 	var paths = {
 	        FontLibs: [
-                './node_modules/material-design-icons/iconfont/MaterialIcons-Regular.*'
+			'./node_modules/material-design-icons/iconfont/MaterialIcons-Regular.woff*',
+			'./node_modules/material-design-icons/iconfont/MaterialIcons-Regular.ttf'
 	        ]
 	    };
 	


### PR DESCRIPTION
Only 3 formats were/are set in @font-face rule: ttf, woff and woff2. These 3 formats are sufficient to cover all current WEB browsers. Keep only these formats and remove the other formats: eot, jmap and svg.

JAR file size is reduced by almost 20%.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>