### PR TITLE
[mainui] Adds the "handleSize" config for the knob control.  

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
@@ -19,6 +19,7 @@ export default () => [
   pn('strokeWidth', 'Stroke Width', 'Thickness of the arcs (default 17)'),
   pt('lineCap', 'Line End Type', 'butt, round, square, none - slider control only!').a(),
   pt('dottedPath', 'Dotted Path', 'Length of dotted path segments (css stroke-dasharray) - slider control only!').a(),
+  pn('handleSize', 'Handle Size', 'Indicates the size of the slider handle - slider control only!').a(),
   pb('responsive', 'Responsive', 'Size the control using percentages instead of pixels'),
   pb('releaseOnly', 'Send command only on release', 'If enabled, no commands are sent during sliding'),
   pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
@@ -10,6 +10,7 @@
                   :disabled="config.disabled" :width="config.strokeWidth" :line-cap="config.lineCap"
                   :startAngle="config.startAngle" :endAngle="config.endAngle"
                   :borderWidth="config.borderWidth" :borderColor="config.borderColor" :circleShape="config.circleShape"
+                  :handleSize="config.handleSize"
                   @input="sendCommandDebounced($event)" @click.native.stop="sendCommandDebounced(value, true)" @touchend.native.stop="sendCommandDebounced(value, true)" />
   </div>
 </template>


### PR DESCRIPTION
By default it looks like the handleSize uses the strokeWidth if not set.

So with `handleSize` set:

```yaml
strokeWidth: 5
handleSize: 20
```
<img width="198" alt="image" src="https://user-images.githubusercontent.com/1903737/223203046-f6a0b5fd-aaee-4b7b-a9bb-126a8bbc1dda.png">

and with no `handleSize` (so how it works now)
```yaml
strokeWidth: 5
```

<img width="198" alt="image" src="https://user-images.githubusercontent.com/1903737/223203435-18d179fb-a651-4875-a556-bde3c7ddaeda.png">


