### PR TITLE
Sitemap editor: Fix attribute value capturing in parser & string value handling in widget detail view

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -94,8 +94,8 @@ Widget -> %nlwidget _ WidgetAttrs:*                                             
 WidgetAttrs -> WidgetAttr                                                         {% (d) => [d[0]] %}
   | WidgetAttrs _ WidgetAttr                                                      {% (d) => d[0].concat([d[2]]) %}
 WidgetAttr -> %widgetswitchattr                                                   {% (d) => ['switchEnabled', true] %}
-  | %widgetfreqattr                                                               {% (d) => ['frequency', d[1]] %}
-  | %widgetfrcitmattr                                                             {% (d) => ['forceAsItem', d[1]] %}
+  | %widgetfreqattr WidgetAttrValue                                               {% (d) => ['frequency', d[1]] %}
+  | %widgetfrcitmattr WidgetAttrValue                                             {% (d) => ['forceAsItem', d[1]] %}
   | WidgetAttrName WidgetAttrValue                                                {% (d) => [d[0][0].value, d[1]] %}
   | WidgetVisibilityAttrName WidgetVisibilityAttrValue                            {% (d) => [d[0][0].value, d[1]] %}
   | WidgetColorAttrName WidgetColorAttrValue                                      {% (d) => [d[0][0].value, d[1]] %}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -13,7 +13,7 @@ function writeWidget (widget, indent) {
         dsl += ' forceasitem=' + widget.config[key]
       } else {
         dsl += ` ${key}=`
-        if (key === 'item' || key === 'period' || Number.isFinite(widget.config[key])) {
+        if (key === 'item' || key === 'period' || key === 'legend' || Number.isFinite(widget.config[key])) {
           dsl += widget.config[key]
         } else if (key === 'mappings') {
           dsl += '['

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -34,10 +34,13 @@
           <f7-list-input v-if="supports('step')" label="Step" type="number" :value="widget.config.step" @input="updateParameter('step', $event)" clear-button />
           <f7-list-input v-if="supports('yAxisDecimalPattern')" label="Y-axis decimal pattern" type="text" :value="widget.config.separator" @input="updateParameter('yAxisDecimalPattern', $event)" clear-button />
           <f7-list-item v-if="supports('switchEnabled')" title="Switch enabled">
-            <f7-toggle slot="after" :checked="widget.config.switchEnabled" @toggle:change="widget.config.switchEnabled = $event" />
+            <f7-toggle slot="after" :checked="widget.config.switchEnabled === 'true'" @toggle:change="widget.config.switchEnabled = $event" />
+          </f7-list-item>
+          <f7-list-item v-if="supports('legend')" title="Legend">
+            <f7-toggle slot="after" :checked="widget.config.legend === 'true'" @toggle:change="widget.config.legend = $event" />
           </f7-list-item>
           <f7-list-item v-if="supports('forceAsItem')" title="Force as item">
-            <f7-toggle slot="after" :checked="widget.config.forceAsItem" @toggle:change="widget.config.forceAsItem = $event" />
+            <f7-toggle slot="after" :checked="widget.config.forceAsItem === 'true'" @toggle:change="widget.config.forceAsItem = $event" />
           </f7-list-item>
         </ul>
       </f7-list>


### PR DESCRIPTION
See comments in https://github.com/openhab/openhab-webui/pull/1745

Fix attribute values for `forceasitem` and `sendFrequency` not being captured properly in code tab.
Fix boolean parameters `legend`, `forceasitem` and `switchSupport` not interpreting string value correctly in widget detail view.