### PR TITLE
Fix sitemap config boolean attributes

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -9,7 +9,8 @@
     label:            'label=',
     item:             'item=',
     icon:             'icon=',
-    widgetattr:       ['url=', 'refresh=', 'service=', 'period=', 'legend=', 'height=', 'mappings=', 'minValue=', 'maxValue=', 'step=', 'encoding=', 'yAxisDecimalPattern='],
+    widgetattr:       ['url=', 'refresh=', 'service=', 'period=', 'height=', 'mappings=', 'minValue=', 'maxValue=', 'step=', 'encoding=', 'yAxisDecimalPattern='],
+    widgetboolattr:   ['legend='],
     widgetfreqattr:   'sendFrequency=',
     widgetfrcitmattr: 'forceasitem=',
     widgetvisiattr:   'visibility=',
@@ -33,6 +34,7 @@
     equals:           '=',
     comma:            ',',
     NL:               { match: /\n/, lineBreaks: true },
+    boolean:          /(?:true)|(?:false)/,
     identifier:       /(?:[A-Za-z_][A-Za-z0-9_]*)|(?:[0-9]+[A-Za-z_][A-Za-z0-9_]*)/,
     number:           /\-?[0-9]+(?:\.[0-9]*)?/,
     string:           { match: /"(?:\\["\\]|[^\n"\\])*"/, value: x => x.slice(1, -1) }
@@ -94,12 +96,15 @@ Widget -> %nlwidget _ WidgetAttrs:*                                             
 WidgetAttrs -> WidgetAttr                                                         {% (d) => [d[0]] %}
   | WidgetAttrs _ WidgetAttr                                                      {% (d) => d[0].concat([d[2]]) %}
 WidgetAttr -> %widgetswitchattr                                                   {% (d) => ['switchEnabled', true] %}
-  | %widgetfreqattr WidgetAttrValue                                               {% (d) => ['frequency', d[1]] %}
-  | %widgetfrcitmattr WidgetAttrValue                                             {% (d) => ['forceAsItem', d[1]] %}
+| %widgetfrcitmattr WidgetBooleanAttrValue                                        {% (d) => ['forceAsItem', d[1]] %}
+  | %widgetboolattr WidgetBooleanAttrValue                                        {% (d) => [d[0].value, d[1]] %}
+| %widgetfreqattr WidgetAttrValue                                                 {% (d) => ['frequency', d[1]] %}
   | WidgetAttrName WidgetAttrValue                                                {% (d) => [d[0][0].value, d[1]] %}
   | WidgetVisibilityAttrName WidgetVisibilityAttrValue                            {% (d) => [d[0][0].value, d[1]] %}
   | WidgetColorAttrName WidgetColorAttrValue                                      {% (d) => [d[0][0].value, d[1]] %}
 WidgetAttrName -> %item | %label | %icon | %widgetattr
+WidgetBooleanAttrValue -> %boolean                                                {% (d) => (d[0].value === 'true') %}
+  | %string                                                                       {% (d) => (d[0].value === 'true') %}
 WidgetAttrValue -> %number                                                        {% (d) => { return parseFloat(d[0].value) } %}
   | %identifier                                                                   {% (d) => d[0].value %}
   | %string                                                                       {% (d) => d[0].value %}

--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -96,9 +96,9 @@ Widget -> %nlwidget _ WidgetAttrs:*                                             
 WidgetAttrs -> WidgetAttr                                                         {% (d) => [d[0]] %}
   | WidgetAttrs _ WidgetAttr                                                      {% (d) => d[0].concat([d[2]]) %}
 WidgetAttr -> %widgetswitchattr                                                   {% (d) => ['switchEnabled', true] %}
-| %widgetfrcitmattr WidgetBooleanAttrValue                                        {% (d) => ['forceAsItem', d[1]] %}
+  | %widgetfrcitmattr WidgetBooleanAttrValue                                      {% (d) => ['forceAsItem', d[1]] %}
   | %widgetboolattr WidgetBooleanAttrValue                                        {% (d) => [d[0].value, d[1]] %}
-| %widgetfreqattr WidgetAttrValue                                                 {% (d) => ['frequency', d[1]] %}
+  | %widgetfreqattr WidgetAttrValue                                               {% (d) => ['frequency', d[1]] %}
   | WidgetAttrName WidgetAttrValue                                                {% (d) => [d[0][0].value, d[1]] %}
   | WidgetVisibilityAttrName WidgetVisibilityAttrValue                            {% (d) => [d[0][0].value, d[1]] %}
   | WidgetColorAttrName WidgetColorAttrValue                                      {% (d) => [d[0][0].value, d[1]] %}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -34,13 +34,13 @@
           <f7-list-input v-if="supports('step')" label="Step" type="number" :value="widget.config.step" @input="updateParameter('step', $event)" clear-button />
           <f7-list-input v-if="supports('yAxisDecimalPattern')" label="Y-axis decimal pattern" type="text" :value="widget.config.separator" @input="updateParameter('yAxisDecimalPattern', $event)" clear-button />
           <f7-list-item v-if="supports('switchEnabled')" title="Switch enabled">
-            <f7-toggle slot="after" :checked="widget.config.switchEnabled === 'true'" @toggle:change="widget.config.switchEnabled = $event" />
+            <f7-toggle slot="after" :checked="widget.config.switchEnabled" @toggle:change="widget.config.switchEnabled = $event" />
           </f7-list-item>
           <f7-list-item v-if="supports('legend')" title="Legend">
-            <f7-toggle slot="after" :checked="widget.config.legend === 'true'" @toggle:change="widget.config.legend = $event" />
+            <f7-toggle slot="after" :checked="widget.config.legend" @toggle:change="widget.config.legend = $event" />
           </f7-list-item>
           <f7-list-item v-if="supports('forceAsItem')" title="Force as item">
-            <f7-toggle slot="after" :checked="widget.config.forceAsItem === 'true'" @toggle:change="widget.config.forceAsItem = $event" />
+            <f7-toggle slot="after" :checked="widget.config.forceAsItem" @toggle:change="widget.config.forceAsItem = $event" />
           </f7-list-item>
         </ul>
       </f7-list>


### PR DESCRIPTION
This is a fix for the remaining bug in https://github.com/openhab/openhab-webui/pull/1781
Boolean parameters are now properly treated as booleans and not strings (which made the type normalizer fail in core, and blocked the sitemap from being rendered).

See https://github.com/openhab/openhab-webui/pull/1781#issuecomment-1461480369

@florian-h05 This one is required to complete the missed elements in the previous fix.