### PR TITLE
Allow setting gradientDirection for oh-trend component

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -250,6 +250,17 @@ A regular or expandable cell
     Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="trendGradientDirection" label="Trend Line Gradient Direction">
+  <PropDescription>
+    Direction of the trend line gradient (default: top)
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="top" label="top" />
+    <PropOption value="bottom" label="bottom" />
+    <PropOption value="left" label="left" />
+    <PropOption value="right" label="right" />
+  </PropOptions>
+</PropBlock>
 <PropBlock type="TEXT" name="trendSampling" label="Trend Line Sampling">
   <PropDescription>
     Amount of minutes between each point of the trendline (default: 60). Affected by persistence strategies different from "every minute"

--- a/bundles/org.openhab.ui/doc/components/oh-label-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-card.md
@@ -456,6 +456,17 @@ Display the state of an item in a card
     Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="trendGradientDirection" label="Trend Line Gradient Direction">
+  <PropDescription>
+    Direction of the trend line gradient (default: top)
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="top" label="top" />
+    <PropOption value="bottom" label="bottom" />
+    <PropOption value="left" label="left" />
+    <PropOption value="right" label="right" />
+  </PropOptions>
+</PropBlock>
 <PropBlock type="TEXT" name="trendSampling" label="Trend Line Sampling">
   <PropDescription>
     Amount of minutes between each point of the trendline (default: 60). Affected by persistence strategies different from "every minute"

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -266,6 +266,17 @@ A cell with a big label to show a short item state value
     Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="trendGradientDirection" label="Trend Line Gradient Direction">
+  <PropDescription>
+    Direction of the trend line gradient (default: top)
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="top" label="top" />
+    <PropOption value="bottom" label="bottom" />
+    <PropOption value="left" label="left" />
+    <PropOption value="right" label="right" />
+  </PropOptions>
+</PropBlock>
 <PropBlock type="TEXT" name="trendSampling" label="Trend Line Sampling">
   <PropDescription>
     Amount of minutes between each point of the trendline (default: 60). Affected by persistence strategies different from "every minute"

--- a/bundles/org.openhab.ui/doc/components/oh-trend.md
+++ b/bundles/org.openhab.ui/doc/components/oh-trend.md
@@ -48,6 +48,17 @@ Trend line to display the overall recent evolution of an item
     Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="trendGradientDirection" label="Trend Line Gradient Direction">
+  <PropDescription>
+    Direction of the trend line gradient (default: top)
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="top" label="top" />
+    <PropOption value="bottom" label="bottom" />
+    <PropOption value="left" label="left" />
+    <PropOption value="right" label="right" />
+  </PropOptions>
+</PropBlock>
 <PropBlock type="TEXT" name="trendSampling" label="Trend Line Sampling">
   <PropDescription>
     Amount of minutes between each point of the trendline (default: 60). Affected by persistence strategies different from "every minute"

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/trend.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/trend.js
@@ -1,10 +1,15 @@
-import { pi, pt } from '../helpers.js'
+import { pi, pt, po } from '../helpers.js'
 
 export default () => [
   pi('trendItem', 'Trend Line Item', 'Item to show as a trend line in the background'),
   pt('trendStrokeWidth', 'Trend Stroke Width', 'Thickness of the trend line').a(),
   pt('trendWidth', 'Trend Line Width', 'Width of the trend line (leave blank to set automatically)').a(),
   pt('trendGradient', 'Trend Line Gradient', 'Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)').a(),
-  pt('trendGradientDirection', 'Trend Line Gradient Direction', 'Direction of the trend line gradient (default: top). Possible values "top", "bottom", "left", "right".').a(),
+  po('trendGradientDirection', 'Trend Line Gradient Direction', 'Direction of the trend line gradient (default: top)', [
+    { value: 'top', label: 'top' },
+    { value: 'bottom', label: 'bottom' },
+    { value: 'left', label: 'left' },
+    { value: 'right', label: 'right' }
+  ]).a(),
   pt('trendSampling', 'Trend Line Sampling', 'Amount of minutes between each point of the trendline (default: 60). Affected by persistence strategies different from "every minute"').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/trend.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/trend.js
@@ -5,5 +5,6 @@ export default () => [
   pt('trendStrokeWidth', 'Trend Stroke Width', 'Thickness of the trend line').a(),
   pt('trendWidth', 'Trend Line Width', 'Width of the trend line (leave blank to set automatically)').a(),
   pt('trendGradient', 'Trend Line Gradient', 'Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)').a(),
+  pt('trendGradientDirection', 'Trend Line Gradient Direction', 'Direction of the trend line gradient (default: top). Possible values "top", "bottom", "left", "right".').a(),
   pt('trendSampling', 'Trend Line Sampling', 'Amount of minutes between each point of the trendline (default: 60). Affected by persistence strategies different from "every minute"').a()
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-trend.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-trend.vue
@@ -1,5 +1,5 @@
 <template>
-  <trend :key="'trend' + config.item" v-if="showTrend" :style="config.style" :width="trendWidth" class="trend" :data="trendData" :gradient="trendGradient" :stroke-width="trendStrokeWidth" auto-draw smooth />
+  <trend :key="'trend' + config.item" v-if="showTrend" :style="config.style" :width="trendWidth" class="trend" :data="trendData" :gradient="trendGradient" :gradientDirection="trendGradientDirection" :stroke-width="trendStrokeWidth" auto-draw smooth />
 </template>
 
 <script>
@@ -25,6 +25,9 @@ export default {
     },
     trendGradient () {
       return this.config.trendGradient || ['#2196f3', '#5ac8fa']
+    },
+    trendGradientDirection () {
+      return this.config.trendGradientDirection || 'top'
     },
     trendStrokeWidth () {
       return this.config.trendStrokeWidth || 3


### PR DESCRIPTION
Allow the option for setting the gradientDirection for the oh-trend. Personally I use this so I can use the gradients to visualize the time of day for changes. i.e. yellow for day time, and blue for night time. That requires the gradient to be horizontal. 

![image](https://user-images.githubusercontent.com/2478689/224378705-cacc7d56-2974-4bdd-b74b-34b011e81586.png)
