### PR TITLE
Use channelType label & description as placeholder for channel details

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -11,7 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col>
         <f7-block-title>Channel</f7-block-title>
-        <channel-general-settings :channel="channel" :createMode="true" :ready="ready" />
+        <channel-general-settings :channel="channel" :channelType="currentChannelType" :createMode="true" :ready="ready" />
       </f7-col>
       <f7-col>
         <f7-block-title>Channel type</f7-block-title>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -11,7 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col>
         <f7-block-title>Channel</f7-block-title>
-        <channel-general-settings :channel="channel" :channelType="currentChannelType" :createMode="true" :ready="ready" />
+        <channel-general-settings v-if="ready" :channel="channel" :channelType="currentChannelType" :createMode="true" />
       </f7-col>
       <f7-col>
         <f7-block-title>Channel type</f7-block-title>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -11,7 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
         <f7-block-title>Channel</f7-block-title>
-        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" :ready="ready" />
+        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" ready="true" />
       </f7-col>
       <f7-col v-if="channelType != null">
         <f7-block-title v-if="configDescription.parameters">
@@ -43,7 +43,6 @@ export default {
   props: ['thing', 'thingType', 'channel', 'channelType', 'channelId'],
   data () {
     return {
-      ready: false,
       configDescription: {},
       config: {},
       noConfig: false
@@ -54,11 +53,9 @@ export default {
       this.config = Object.assign({}, this.channel.configuration)
       this.$oh.api.get(`/rest/config-descriptions/channel:${this.thing.UID}:${this.channelId.replace('#', '%23')}`).then((ct) => {
         this.configDescription = ct
-        this.ready = true
       }).catch((err) => {
         if (err === 'Not Found' || err === 404) {
           this.noConfig = true
-          this.ready = true
         }
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -11,7 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
         <f7-block-title>Channel</f7-block-title>
-        <channel-general-settings :channel="channel" :createMode="false" :ready="ready" />
+        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" :ready="ready" />
       </f7-col>
       <f7-col v-if="channelType != null">
         <f7-block-title v-if="configDescription.parameters">
@@ -45,7 +45,6 @@ export default {
     return {
       ready: false,
       configDescription: {},
-      currentChannelType: null,
       config: {},
       noConfig: false
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -11,7 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
         <f7-block-title>Channel</f7-block-title>
-        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" ready="true" />
+        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" />
       </f7-col>
       <f7-col v-if="channelType != null">
         <f7-block-title v-if="configDescription.parameters">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-block v-if="ready" class="padding-vertical no-padding-horizontal">
+  <f7-block class="padding-vertical no-padding-horizontal">
     <f7-col>
       <f7-list class="no-margin" inline-labels no-hairlines-md>
         <f7-list-input v-if="createMode" label="Channel Identifier" type="text" placeholder="Required" :value="channel.id"
@@ -24,7 +24,7 @@
 <script>
 import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 export default {
-  props: ['channel', 'channelType', 'createMode', 'ready'],
+  props: ['channel', 'channelType', 'createMode'],
   components: {
     ClipboardIcon
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -12,9 +12,9 @@
             <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
           </div>
         </f7-list-item>
-        <f7-list-input label="Label" type="text" placeholder="Required" :value="channel.label" required validate
+        <f7-list-input label="Label" type="text" :placeholder="(channelType !== null) ? channelType.label : 'Required'" :value="channel.label" required validate
                        @input="channel.label = $event.target.value" clear-button />
-        <f7-list-input label="Description" type="text" :value="channel.description"
+        <f7-list-input label="Description" type="text" :placeholder="(channelType !== null) ? channelType.description : ''" :value="channel.description"
                        @input="channel.description = $event.target.value" clear-button />
       </f7-list>
     </f7-col>
@@ -24,7 +24,7 @@
 <script>
 import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 export default {
-  props: ['channel', 'createMode', 'ready'],
+  props: ['channel', 'channelType', 'createMode', 'ready'],
   components: {
     ClipboardIcon
   }


### PR DESCRIPTION
Use the `channelType`’s label and description as placeholder inside the `channel-general-settings` component if they are available and no explicit label or description is set.

Remove the `ready` var from the `channel-edit` component as is is only used by the `channel-general-settings` component, for which all required data are passed to `channel-edit` and therefore independent from the API request inside `channel-edit`.