### PR TITLE
[MainUI] Pass slot names down in generic-widget-component (#1129)

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -3,9 +3,9 @@
     <!-- eslint-disable-next-line vue/no-unused-vars -->
     <template v-for="(slotComponents, slotName) in context.component.slots" #[slotName]>
       <ul :key="slotName" v-if="componentType === 'f7-list'">
-        <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in slotComponents" :key="slotName + '-' + idx" @command="onCommand" />
+        <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in slotComponents" :slot="slotName" :key="slotName + '-' + idx" @command="onCommand" />
       </ul>
-      <generic-widget-component v-else :context="childContext(slotComponent)" v-for="(slotComponent, idx) in slotComponents" :key="slotName + '-' + idx" @command="onCommand" />
+      <generic-widget-component v-else :context="childContext(slotComponent)" v-for="(slotComponent, idx) in slotComponents" :slot="slotName" :key="slotName + '-' + idx" @command="onCommand" />
     </template>
   </component>
   <generic-widget-component v-else-if="componentType && componentType.startsWith('widget:') && visible" :context="childWidgetContext()" @command="onCommand" />


### PR DESCRIPTION
Without this custom widgets based on f7-list-item can not pass components to slots other than inner.

This is based on @arroyoj's  suggestion https://github.com/openhab/openhab-webui/issues/1129. I've been using it in my openhab installation for about month and half, I've seen nothing break in the standard widgets and it allowed some custom widgets that weren't possible before.