### PR TITLE
Draft: Add style property to oh-card

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
@@ -8,6 +8,7 @@ export const CardParameterGroup = () => pg('card', 'Card', 'Parameters of the ca
 export const CardParameters = () => [
   pt('title', 'Title', 'Title of the card'),
   pt('footer', 'Footer text', 'Footer of the card'),
+  pt('style', 'style', 'CSS style for the card'),
   pb('noBorder', 'No Border', 'Do not render the card border').a(),
   pb('noShadow', 'No Shadow', 'Do not render a shadow effect to the card').a(),
   pb('outline', 'Outline', 'Show the card outline').a()

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/rollershutter.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/rollershutter.js
@@ -2,6 +2,7 @@ import { pt, pi, pb } from '../helpers.js'
 
 export default () => [
   pi('item', 'Item', 'Rollershutter item to control'),
+  pt('buttonStyle', 'style', 'CSS style for buttons'),
   pt('dirIconsStyle', 'Direction Icons Style', 'Icons to use for the UP/DOWN buttons').o([
     'arrowtriangle_{dir}',
     'arrowtriangle_{dir}_fill',

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-rollershutter-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-rollershutter-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-card :no-border="config.noBorder" :no-shadow="config.noShadow" :outline="config.outline">
+  <f7-card :no-border="config.noBorder" :no-shadow="config.noShadow" :outline="config.outline" :style="config.style">
     <f7-card-header v-if="config.title">
       <div>{{ config.title }}</div>
     </f7-card-header>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-rollershutter.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-segmented round outline strong class="rollershutter-controls">
+  <f7-segmented round outline strong class="rollershutter-controls" :style="config.buttonStyle">
     <f7-button @click.stop="up()" large :icon-ios="upIcon" :icon-md="upIcon" :icon-aurora="upIcon" icon-size="24" icon-color="gray" />
     <f7-button v-if="config.stateInCenter" @click.stop="stop()" large class="state">
       <small>{{ context.store[config.item].state }}</small>


### PR DESCRIPTION
This adds the style property to an oh-card widget.

The PR is not yet done and is meant to be as proposal to get feedback if this is actually wanted and done the right way.

It adds  the style attribute to a card which is currently only also added to the rollershutter card as an example (all other cards would not to be adapted as well). This would allow for example to add a background image to any card which was my original intention. I could have added a background-image property like it is available on the oh-label-card but then I thought I would rather add a general style property which would be more versatile.

I also added a button-style to the rollershutter card itself that would allow additional styling to the buttons (also up to discussion).

in case the property "style" would "collide" with other components "style"-property, we could call this cardStyle instead or something else.

I have seen that people have asked for this now and then but maybe there was a reason not to add it intentionally from the start. 

So, let me know what you think