### PR TITLE
Add a SSE reconnection mechanism

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.js
@@ -73,6 +73,9 @@ function newSSEConnection (path, readyCallback, messageCallback, errorCallback, 
       eventSource.clearKeepalive()
       eventSource.keepaliveTimer = setTimeout(() => {
         console.warn('SSE timeout error')
+        if (heartbeatCallback) {
+          heartbeatCallback(false)
+        }
       }, (seconds + 2) * 1000)
     }
 

--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.js
@@ -5,6 +5,7 @@ let openSSEClients = []
 
 function newSSEConnection (path, readyCallback, messageCallback, errorCallback, heartbeatCallback) {
   let eventSource
+  let reconnectSeconds = 1
   const headers = {}
   if (getAccessToken() && getRequireToken()) {
     if (getTokenInCustomHeader()) {
@@ -43,6 +44,7 @@ function newSSEConnection (path, readyCallback, messageCallback, errorCallback, 
     }
 
     eventSource.onopen = (event) => {
+      reconnectSeconds = 1
     }
 
     eventSource.onerror = () => {
@@ -53,14 +55,16 @@ function newSSEConnection (path, readyCallback, messageCallback, errorCallback, 
       }
       if (eventSource.readyState === 2) {
         console.log('%c=!= Event source connection broken...', 'background-color: red; color: white')
-        console.debug('Attempting SSE reconnection in 10 seconds...')
+        console.debug(`Attempting SSE reconnection in ${reconnectSeconds} seconds...`)
         setTimeout(() => {
           if (eventSource.readyState === 2) {
+            reconnectSeconds = reconnectSeconds * 2
+            if (reconnectSeconds > 10) reconnectSeconds = 10
             eventSource.close()
             eventSource.clearKeepalive()
             eventSource = initEventSource()
           }
-        }, 10000)
+        }, reconnectSeconds * 1000)
       }
     }
 

--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.js
@@ -59,9 +59,6 @@ function newSSEConnection (path, readyCallback, messageCallback, errorCallback, 
     eventSource.clearKeepalive()
     eventSource.keepaliveTimer = setTimeout(() => {
       console.warn('SSE timeout error')
-      if (heartbeatCallback) {
-        heartbeatCallback(false)
-      }
     }, (seconds + 2) * 1000)
     if (heartbeatCallback) {
       heartbeatCallback(true)
@@ -70,6 +67,7 @@ function newSSEConnection (path, readyCallback, messageCallback, errorCallback, 
 
   eventSource.clearKeepalive = () => {
     if (eventSource.keepaliveTimer) clearTimeout(eventSource.keepaliveTimer)
+    delete eventSource.keepaliveTimer
   }
 
   openSSEClients.push(eventSource)


### PR DESCRIPTION
Currently, on SSE failure there is no reliable reconnection mechanism (browsers might try something), e.g. on network failure, and therefore SSE connection is lost forever once an error occurs. To reconnect, the user has to change/reload the page.

This implements a SSE reconnection mechanism, that attempts a SSE reconnection after SSE failure.
The time is increasing from 1 -> 2 -> 4 -> 8 -> 10.