### PR TITLE
Show warning if SSE connection or send command fails

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -41,5 +41,5 @@
   "page.navbar.back": "Back",
   "page.navbar.edit": "Edit",
   "admin.notTranslatedYet": "The administration area is not translated yet.",
-  "server.sseConnectionFailed": "Server connection (SSE) failed!"
+  "server.sseConnectionFailed": "SSE connection failed!"
 }

--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -41,8 +41,6 @@
   "page.navbar.back": "Back",
   "page.navbar.edit": "Edit",
   "admin.notTranslatedYet": "The administration area is not translated yet.",
-  "error.sseConnectionFailed": "SSE connection failed!",
-  "error.itemNotFound": "Item not found",
-  "error.sendCommandFailed": "Sending command to {} failed:",
-  "error.reloadRecommended": "Reload recommended"
+  "error.communicationFailure": "Communication failure",
+  "error.itemNotFound": "%s not found"
 }

--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -7,10 +7,11 @@
   "dialogs.close": "Close",
   "dialogs.copy": "Copy",
   "dialogs.delete": "Delete",
+  "dialogs.reload": "Reload",
   "dialogs.search": "Search",
   "dialogs.search.items": "Search items",
-  "dialogs.search.things": "Search things",  
-  "dialogs.search.rules": "Search rules",  
+  "dialogs.search.things": "Search things",
+  "dialogs.search.rules": "Search rules",
   "dialogs.search.nothingFound": "Nothing found",
   "home.overview.title": "Overview",
   "home.overview.tab": "Overview",
@@ -39,5 +40,6 @@
   "sidebar.tip.signIn": "Sign in as an administrator to access settings",
   "page.navbar.back": "Back",
   "page.navbar.edit": "Edit",
-  "admin.notTranslatedYet": "The administration area is not translated yet."
+  "admin.notTranslatedYet": "The administration area is not translated yet.",
+  "server.sseConnectionFailed": "Server connection (SSE) failed!"
 }

--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -41,5 +41,8 @@
   "page.navbar.back": "Back",
   "page.navbar.edit": "Edit",
   "admin.notTranslatedYet": "The administration area is not translated yet.",
-  "server.sseConnectionFailed": "SSE connection failed!"
+  "error.sseConnectionFailed": "SSE connection failed!",
+  "error.itemNotFound": "Item not found",
+  "error.sendCommandFailed": "Sending command to {} failed:",
+  "error.reloadRecommended": "Reload recommended"
 }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -402,15 +402,6 @@ export default {
           try {
             window.OHApp.sseConnected(connected)
           } catch {}
-        } else if (this.$f7) {
-          if (connected === false) {
-            this.sseFailureToast = this.displayFailureToast(this.$t('error.sseConnectionFailed'), true, false)
-          } else if (connected === true) {
-            if (this.sseFailureToast !== null) {
-              this.sseFailureToast.close()
-              this.sseFailureToast = null
-            }
-          }
         }
       },
       immediate: true // provides initial (not changed yet) state
@@ -785,6 +776,23 @@ export default {
       this.$f7.on('smartSelectOpened', (smartSelect) => {
         if (smartSelect && smartSelect.searchbar && this.$device.desktop) {
           smartSelect.searchbar.$inputEl.focus()
+        }
+      })
+
+      this.$store.subscribe((mutation, state) => {
+        if (mutation.type === 'sseConnected') {
+          if (!window.OHApp && this.$f7) {
+            if (mutation.payload === false) {
+              if (this.sseFailureToast === null) this.sseFailureToast = this.displayFailureToast(this.$t('error.sseConnectionFailed'), true, false)
+              this.sseFailureToast.open()
+            } else if (mutation.payload === true) {
+              if (this.sseFailureToast !== null) {
+                this.sseFailureToast.close()
+                this.sseFailureToast.destroy()
+                this.sseFailureToast = null
+              }
+            }
+          }
         }
       })
 

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -380,7 +380,9 @@ export default {
       showSettingsSubmenu: false,
       showDeveloperSubmenu: false,
       showDeveloperSidebar: false,
-      currentUrl: ''
+      currentUrl: '',
+
+      sseFailureToast: null
     }
   },
   computed: {
@@ -400,6 +402,23 @@ export default {
           try {
             window.OHApp.sseConnected(connected)
           } catch {}
+        } else if (this.$f7) {
+          if (connected === false) {
+            this.sseFailureToast = this.$f7.toast.create({
+              text: this.$t('server.sseConnectionFailed'),
+              closeButton: true,
+              closeButtonText: this.$t('dialogs.reload'),
+              destroyOnClose: true
+            }).open()
+            this.sseFailureToast.on('closed', () => {
+              window.location.reload()
+            })
+          } else if (connected === true) {
+            if (this.sseFailureToast !== null) {
+              this.sseFailureToast.off('closed')
+              this.sseFailureToast.close()
+            }
+          }
         }
       },
       immediate: true // provides initial (not changed yet) state

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -788,6 +788,28 @@ export default {
         }
       })
 
+      this.$store.subscribeAction({
+        error: (action, state, error) => {
+          if (action.type === 'sendCommand') {
+            let reloadButton = true
+            let msg = error
+            switch (error) {
+              case 0:
+              case 302:
+              case 'Found':
+                msg = this.$t('error.reloadRecommended')
+                break
+              case 404:
+              case 'Not Found':
+                msg = this.$t('error.itemNotFound')
+                reloadButton = false
+                break
+            }
+            this.displayFailureToast(this.$t('error.sendCommandFailed').replace('{}', action.payload.itemName) + ' ' + msg, reloadButton)
+          }
+        }
+      })
+
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -404,22 +404,11 @@ export default {
           } catch {}
         } else if (this.$f7) {
           if (connected === false) {
-            this.sseFailureToast = this.$f7.toast.create({
-              text: this.$t('server.sseConnectionFailed'),
-              closeButton: true,
-              closeButtonText: this.$t('dialogs.reload'),
-              destroyOnClose: true,
-              position: 'bottom',
-              horizontalPosition: 'bottom',
-              cssClass: 'toast-sse-connection-failed button-outline'
-            }).open()
-            this.sseFailureToast.on('closeButtonClick', () => {
-              window.location.reload()
-            })
+            this.sseFailureToast = this.displayFailureToast(this.$t('error.sseConnectionFailed'), true, false)
           } else if (connected === true) {
             if (this.sseFailureToast !== null) {
-              this.sseFailureToast.off('closeButtonClick')
               this.sseFailureToast.close()
+              this.sseFailureToast = null
             }
           }
         }
@@ -677,6 +666,30 @@ export default {
         function unlock () { audioContext.resume().then(clean) }
         function clean () { events.forEach(e => b.removeEventListener(e, unlock)) }
       }
+    },
+    /**
+     * Creates and opens a toast message that indicates a failure, e.g. of SSE connection
+     * @param {string} message message to show
+     * @param {boolean} [reloadButton=false] displays a reload button
+     * @param {boolean} [autoClose=true] closes toast automatically
+     * @returns {Toast.Toast}
+     */
+    displayFailureToast (message, reloadButton = false, autoClose = true) {
+      const toast = this.$f7.toast.create({
+        text: message,
+        closeButton: reloadButton,
+        closeButtonText: this.$t('dialogs.reload'),
+        destroyOnClose: autoClose,
+        closeTimeout: (autoClose) ? 5000 : undefined,
+        position: 'bottom',
+        horizontalPosition: 'bottom',
+        cssClass: 'failure-toast button-outline'
+      })
+      toast.on('closeButtonClick', () => {
+        window.location.reload()
+      })
+      toast.open()
+      return toast
     }
   },
   created () {

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -136,11 +136,7 @@
       <developer-sidebar />
     </f7-panel>
 
-    <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'">
-      <f7-fab v-if="sseFailure" position="center-bottom" href="javascript:window.location.reload()" :text="$t('server.sseConnectionFailed')">
-        <f7-icon f7="wifi_exclamationmark" />
-      </f7-fab>
-    </f7-view>
+    <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
 
   <!-- <f7-login-screen id="my-login-screen" :opened="loginScreenOpened">
     <f7-view name="login" v-if="$device.cordova">
@@ -386,7 +382,7 @@ export default {
       showDeveloperSidebar: false,
       currentUrl: '',
 
-      sseFailure: false
+      sseFailureToast: null
     }
   },
   computed: {
@@ -407,7 +403,25 @@ export default {
             window.OHApp.sseConnected(connected)
           } catch {}
         } else if (this.$f7) {
-          this.sseFailure = !connected
+          if (connected === false) {
+            this.sseFailureToast = this.$f7.toast.create({
+              text: this.$t('server.sseConnectionFailed'),
+              closeButton: true,
+              closeButtonText: this.$t('dialogs.reload'),
+              destroyOnClose: true,
+              position: 'bottom',
+              horizontalPosition: 'bottom',
+              cssClass: 'toast-sse-connection-failed button-outline'
+            }).open()
+            this.sseFailureToast.on('closeButtonClick', () => {
+              window.location.reload()
+            })
+          } else if (connected === true) {
+            if (this.sseFailureToast !== null) {
+              this.sseFailureToast.off('closeButtonClick')
+              this.sseFailureToast.close()
+            }
+          }
         }
       },
       immediate: true // provides initial (not changed yet) state

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -136,7 +136,11 @@
       <developer-sidebar />
     </f7-panel>
 
-    <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
+    <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'">
+      <f7-fab v-if="sseFailure" position="center-bottom" href="javascript:window.location.reload()" :text="$t('server.sseConnectionFailed')">
+        <f7-icon f7="wifi_exclamationmark" />
+      </f7-fab>
+    </f7-view>
 
   <!-- <f7-login-screen id="my-login-screen" :opened="loginScreenOpened">
     <f7-view name="login" v-if="$device.cordova">
@@ -382,7 +386,7 @@ export default {
       showDeveloperSidebar: false,
       currentUrl: '',
 
-      sseFailureToast: null
+      sseFailure: false
     }
   },
   computed: {
@@ -403,25 +407,7 @@ export default {
             window.OHApp.sseConnected(connected)
           } catch {}
         } else if (this.$f7) {
-          if (connected === false) {
-            this.sseFailureToast = this.$f7.toast.create({
-              text: this.$t('server.sseConnectionFailed'),
-              closeButton: true,
-              closeButtonText: this.$t('dialogs.reload'),
-              destroyOnClose: true,
-              position: 'bottom',
-              horizontalPosition: 'bottom',
-              cssClass: 'toast-sse-connection-failed button-outline'
-            }).open()
-            this.sseFailureToast.on('closeButtonClick', () => {
-              window.location.reload()
-            })
-          } else if (connected === true) {
-            if (this.sseFailureToast !== null) {
-              this.sseFailureToast.off('closeButtonClick')
-              this.sseFailureToast.close()
-            }
-          }
+          this.sseFailure = !connected
         }
       },
       immediate: true // provides initial (not changed yet) state

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -408,14 +408,17 @@ export default {
               text: this.$t('server.sseConnectionFailed'),
               closeButton: true,
               closeButtonText: this.$t('dialogs.reload'),
-              destroyOnClose: true
+              destroyOnClose: true,
+              position: 'bottom',
+              horizontalPosition: 'bottom',
+              cssClass: 'toast-sse-connection-failed button-outline'
             }).open()
-            this.sseFailureToast.on('closed', () => {
+            this.sseFailureToast.on('closeButtonClick', () => {
               window.location.reload()
             })
           } else if (connected === true) {
             if (this.sseFailureToast !== null) {
-              this.sseFailureToast.off('closed')
+              this.sseFailureToast.off('closeButtonClick')
               this.sseFailureToast.close()
             }
           }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -382,7 +382,7 @@ export default {
       showDeveloperSidebar: false,
       currentUrl: '',
 
-      sseFailureToast: null
+      communicationFailureToast: null
     }
   },
   computed: {
@@ -672,9 +672,9 @@ export default {
         closeButtonText: this.$t('dialogs.reload'),
         destroyOnClose: autoClose,
         closeTimeout: (autoClose) ? 5000 : undefined,
+        cssClass: 'failure-toast button-outline',
         position: 'bottom',
-        horizontalPosition: 'bottom',
-        cssClass: 'failure-toast button-outline'
+        horizontalPosition: 'center'
       })
       toast.on('closeButtonClick', () => {
         window.location.reload()
@@ -783,13 +783,13 @@ export default {
         if (mutation.type === 'sseConnected') {
           if (!window.OHApp && this.$f7) {
             if (mutation.payload === false) {
-              if (this.sseFailureToast === null) this.sseFailureToast = this.displayFailureToast(this.$t('error.sseConnectionFailed'), true, false)
-              this.sseFailureToast.open()
+              if (this.communicationFailureToast === null) this.communicationFailureToast = this.displayFailureToast(this.$t('error.communicationFailure'), true, false)
+              this.communicationFailureToast.open()
             } else if (mutation.payload === true) {
-              if (this.sseFailureToast !== null) {
-                this.sseFailureToast.close()
-                this.sseFailureToast.destroy()
-                this.sseFailureToast = null
+              if (this.communicationFailureToast !== null) {
+                this.communicationFailureToast.close()
+                this.communicationFailureToast.destroy()
+                this.communicationFailureToast = null
               }
             }
           }
@@ -800,20 +800,20 @@ export default {
         error: (action, state, error) => {
           if (action.type === 'sendCommand') {
             let reloadButton = true
-            let msg = error
+            let msg = this.$t('error.communicationFailure')
             switch (error) {
-              case 0:
-              case 302:
-              case 'Found':
-                msg = this.$t('error.reloadRecommended')
-                break
               case 404:
               case 'Not Found':
-                msg = this.$t('error.itemNotFound')
+                msg = this.$t('error.itemNotFound').replace('%s', action.payload.itemName)
                 reloadButton = false
-                break
+                return this.displayFailureToast(msg, reloadButton)
             }
-            this.displayFailureToast(this.$t('error.sendCommandFailed').replace('{}', action.payload.itemName) + ' ' + msg, reloadButton)
+            if (this.communicationFailureToast === null) {
+              this.communicationFailureToast = this.displayFailureToast(this.$t('error.communicationFailure'), true, true)
+              this.communicationFailureToast.on('closed', () => {
+                this.communicationFailureToast = null
+              })
+            }
           }
         }
       })

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -286,7 +286,7 @@ html
 .disable-user-drag
   user-drag none
 
-.toast-sse-connection-failed
+.failure-toast
   --f7-toast-bg-color var(--f7-theme-color)
   --f7-toast-text-color white
   --f7-button-text-color white

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -287,7 +287,8 @@ html
   user-drag none
 
 .failure-toast
-  --f7-toast-bg-color var(--f7-theme-color)
+  background-color #e64a19 !important
+  font-size 22px !important
   --f7-toast-text-color white
   --f7-button-text-color white
   --f7-button-border-color white

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -287,7 +287,7 @@ html
   user-drag none
 
 .failure-toast
-  background-color #e64a19 !important
+  background-color var(--f7-theme-color) !important
   font-size 22px !important
   --f7-toast-text-color white
   --f7-button-text-color white

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -285,3 +285,9 @@ html
 // Disable user dragging of background images in canvas layouts
 .disable-user-drag
   user-drag none
+
+.toast-sse-connection-failed
+  --f7-toast-bg-color var(--f7-theme-color)
+  --f7-toast-text-color white
+  --f7-button-text-color white
+  --f7-button-border-color white

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -285,9 +285,3 @@ html
 // Disable user dragging of background images in canvas layouts
 .disable-user-drag
   user-drag none
-
-.toast-sse-connection-failed
-  --f7-toast-bg-color var(--f7-theme-color)
-  --f7-toast-text-color white
-  --f7-button-text-color white
-  --f7-button-border-color white


### PR DESCRIPTION
Depends on #1807.

Currently, SSE connection and sending commands fail silently, which makes the user think that everything is fine, but instead outdated values are displayed and commands are not sent.

This implements user warnings for such cases, a large openHAB orange toast "Communication failure" with the option to reload is displayed at the bottom center: 
- as long as SSE connection is broken
- when sending a command to an Item failed for 5 sec

If the Item does not exist (error code 404), "<Itemname> not found" is displayed for 5 sec