### PR TITLE
Add a code tab to the Item editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -94,6 +94,7 @@ import NashornDefs from '@/assets/nashorn-tern-defs.json'
 import OpenhabJsDefs from '@/assets/openhab-js-tern-defs.json'
 
 import componentsHint from '../editor/hint-components'
+import itemsHint from '../editor/hint-items'
 import rulesHint from '../editor/hint-rules'
 import thingsHint from '../editor/hint-things'
 import pythonHint from '../editor/hint-python'
@@ -267,6 +268,8 @@ export default {
           hint (cm, option) {
             if (self.mode.indexOf('application/vnd.openhab.uicomponent') === 0) {
               return componentsHint(cm, option, self.mode)
+            } else if (self.mode === 'application/vnd.openhab.item+yaml') {
+              return itemsHint(cm, option, self.mode)
             } else if (self.mode === 'application/vnd.openhab.rule+yaml') {
               return rulesHint(cm, option, self.mode)
             } else if (self.mode === 'application/vnd.openhab.thing+yaml') {

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-items.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-items.js
@@ -1,0 +1,108 @@
+import { findParent } from './yaml-utils'
+import { filterPartialCompletions, addTooltipHandlers } from './hint-utils'
+import * as Types from '@/assets/item-types.js'
+import Metadata from '@/assets/definitions/metadata/namespaces'
+
+let itemsCache = null
+
+function hintItemTypes (cm, line) {
+  if (!cm.state.$oh) return
+  let ret = {
+    list: Types.ItemTypes.map((t) => {
+      return {
+        text: t,
+        displayText: t
+      }
+    })
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list, 'text', /^type:( )?/)
+  if (line.indexOf('Number:') !== -1) {
+    ret.list = Types.Dimensions.map((t) => {
+      return {
+        text: t,
+        displayText: t
+      }
+    })
+    ret.list = filterPartialCompletions(cm, line, ret.list, 'text', /^type: Number:/)
+  }
+  addTooltipHandlers(cm, ret)
+  return ret
+}
+
+function hintItems (cm, line, onlyGroups) {
+  if (!cm.state.$oh) return
+  const promise = (itemsCache) ? Promise.resolve(itemsCache) : cm.state.$oh.api.get('/rest/items')
+  return promise.then((data) => {
+    if (!itemsCache) itemsCache = data
+    if (onlyGroups) {
+      data = data.filter((item) => item.type === 'Group')
+    }
+    let ret = {
+      list: data.map((item) => {
+        return {
+          text: item.name,
+          displayText: item.name,
+          description: `${(item.label) ? item.label + ' ' : ''}(${item.type})<br />${item.state}`
+        }
+      }).sort((i1, i2) => i1.text.localeCompare(i2.text))
+    }
+    ret.list = filterPartialCompletions(cm, line, ret.list)
+    addTooltipHandlers(cm, ret)
+    return ret
+  })
+}
+
+function hintGroupTypes (cm, line) {
+  if (!cm.state.$oh) return
+  let ret = {
+    list: Types.GroupTypes.map((t) => {
+      return {
+        text: t,
+        displayText: t
+      }
+    })
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list, 'text', /^groupType:( )?/)
+  addTooltipHandlers(cm, ret)
+  return ret
+}
+
+function hintMetadata (cm, line) {
+  if (!cm.state.$oh) return
+  let ret = {
+    list: Metadata.map((m) => {
+      return {
+        text: m.name + ':\n    value: ""\n    configuration: {}',
+        displayText: m.label
+      }
+    })
+  }
+  ret.list = filterPartialCompletions(cm, line, ret.list)
+  addTooltipHandlers(cm, ret)
+  return ret
+}
+
+export default function hint (cm, option, mode) {
+  const cursor = cm.getCursor()
+  const line = cm.getLine(cursor.line)
+  console.debug(`line: ${line}`)
+
+  const parentLineNr = findParent(cm, cursor.line)
+  const parentLine = cm.getLine(parentLineNr)
+  console.debug(`parent line (${parentLineNr}): ${parentLine}`)
+
+  let ret
+  if (line && line.match(/^type:/)) {
+    ret = hintItemTypes(cm, line)
+  } else if (line && line.match(/^groupType:/)) {
+    ret = hintGroupTypes(cm, line)
+  } else if (parentLine && parentLine.match(/^groupNames:/)) {
+    ret = hintItems(cm, line, true)
+  } else if (parentLine && parentLine.match(/^metadata:/)) {
+    ret = hintMetadata(cm, line)
+  }
+
+  if (!(ret instanceof Promise)) addTooltipHandlers(cm, ret)
+
+  return ret
+}

--- a/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/hint-utils.js
@@ -28,9 +28,10 @@ export function remove (node) {
   if (p) p.removeChild(node)
 }
 
-export function filterPartialCompletions (cm, line, completions, property = 'text') {
+export function filterPartialCompletions (cm, line, completions, property = 'text', remover) {
   const cursor = cm.getCursor()
-  const lineBeforeCursor = line.substring(0, cursor.ch)
+  let lineBeforeCursor = line.substring(0, cursor.ch)
+  if (remover) lineBeforeCursor = lineBeforeCursor.replace(remover, '')
   const completionBeginPos = Math.max(lineBeforeCursor.lastIndexOf(' '), lineBeforeCursor.lastIndexOf('.'), lineBeforeCursor.lastIndexOf('@'))
   const partialCompletion = lineBeforeCursor.substring(completionBeginPos + 1)
   return completions.filter((c) => c[property] && c[property].toLowerCase().indexOf(partialCompletion.toLowerCase()) >= 0)

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
     <f7-navbar :title="createMode ? 'Create New Item': 'Edit Item'" back-link="Cancel">
-      <f7-nav-right v-if="!$theme.aurora || !createMode">
+      <f7-nav-right v-if="createMode || item.editable">
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only />
         <f7-link @click="save()" v-if="!$theme.md">
           Save<span v-if="$device.desktop">&nbsp;(Ctrl-S)</span>
@@ -50,7 +50,7 @@
       </f7-tab>
     </f7-tabs>
 
-    <div v-if="ready && createMode" class="if-aurora display-flex justify-content-center margin padding">
+    <div v-if="ready && createMode && currentTab === 'design'" class="if-aurora display-flex justify-content-center margin padding">
       <div class="flex-shrink-0">
         <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">
           Create

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -8,38 +8,47 @@
         </f7-link>
       </f7-nav-right>
     </f7-navbar>
-    <f7-block class="block-narrow" v-if="item.name || item.created === false">
-      <f7-col v-if="item.editable === false">
-        <div class="padding-left">
-          Note: this item is not editable because it has been created with textual configuration.
-        </div>
-      </f7-col>
-      <f7-col>
-        <item-form :item="item" :items="items" :enable-name="createMode" />
-      </f7-col>
-      <f7-col>
-        <f7-block-title>Group Membership</f7-block-title>
-        <f7-list v-if="ready">
-          <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" @input="(value) => item.groupNames = value" :items="items" :multiple="true" filterType="Group" />
-        </f7-list>
-      </f7-col>
-      <f7-col v-if="item && item.type === 'Group'">
-        <f7-block-title>Group Settings</f7-block-title>
-        <group-form :item="item" />
-      </f7-col>
-      <f7-col class="tags-editor">
-        <f7-block-title>Non-Semantic Tags</f7-block-title>
-        <tag-input :item="item" />
-      </f7-col>
-      <f7-col>
-        <!-- <f7-list>
-          <f7-list-button color="blue" title="Edit Channel Links"></f7-list-button>
-        </f7-list> -->
-        <!-- <f7-list>
-          <f7-list-button color="red" title="Delete this Item"></f7-list-button>
-        </f7-list> -->
-      </f7-col>
-    </f7-block>
+    <f7-toolbar tabbar position="top">
+      <f7-link @click="switchTab('design', fromYaml)" :tab-link-active="currentTab === 'design'" class="tab-link">
+        Design
+      </f7-link>
+      <f7-link @click="switchTab('code', toYaml)" :tab-link-active="currentTab === 'code'" class="tab-link">
+        Code
+      </f7-link>
+    </f7-toolbar>
+    <f7-tabs class="sitemap-editor-tabs">
+      <f7-tab id="design" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
+        <f7-block class="block-narrow" v-if="item.name || item.created === false">
+          <f7-col v-if="item.editable === false">
+            <div class="padding-left">
+              Note: this item is not editable because it has been created with textual configuration.
+            </div>
+          </f7-col>
+          <f7-col>
+            <item-form :item="item" :items="items" :enable-name="createMode" />
+          </f7-col>
+          <f7-col>
+            <f7-block-title>Group Membership</f7-block-title>
+            <f7-list v-if="ready">
+              <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" @input="(value) => item.groupNames = value" :items="items" :multiple="true" filterType="Group" />
+            </f7-list>
+          </f7-col>
+          <f7-col v-if="item && item.type === 'Group'">
+            <f7-block-title>Group Settings</f7-block-title>
+            <group-form :item="item" />
+          </f7-col>
+          <f7-col class="tags-editor">
+            <f7-block-title>Non-Semantic Tags</f7-block-title>
+            <tag-input :item="item" />
+          </f7-col>
+        </f7-block>
+      </f7-tab>
+      <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
+        <f7-icon v-if="ready && !isEditable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray"
+                 tooltip="This Item is not editable because it has been provisioned from a file" />
+        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :read-only="!isEditable" />
+      </f7-tab>
+    </f7-tabs>
 
     <div v-if="ready && createMode" class="if-aurora display-flex justify-content-center margin padding">
       <div class="flex-shrink-0">
@@ -51,9 +60,23 @@
   </f7-page>
 </template>
 
+<style lang="stylus">
+.rule-code-editor.vue-codemirror
+  display block
+  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+  height calc(100% - 2*var(--f7-navbar-height))
+  width 100%
+.yaml-message
+  display block
+  position absolute
+  top 80%
+  white-space pre-wrap
+</style>
+
 <script>
 import * as Types from '@/assets/item-types.js'
 import * as SemanticClasses from '@/assets/semantics.js'
+import YAML from 'yaml'
 
 import ItemForm from '@/components/item/item-form.vue'
 import GroupForm from '@/components/item/group-form.vue'
@@ -68,21 +91,27 @@ export default {
     ItemPicker,
     ItemForm,
     GroupForm,
-    TagInput
+    TagInput,
+    'editor': () => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue')
   },
   data () {
     return {
       ready: false,
       item: {},
+      itemYaml: '',
       items: [],
       types: Types,
       semanticClasses: SemanticClasses,
       semanticClass: '',
       semanticProperty: '',
-      pendingTag: ''
+      pendingTag: '',
+      currentTab: 'design'
     }
   },
-  created () {
+  computed: {
+    isEditable () {
+      return this.item && this.item.editable !== false
+    }
   },
   watch: {
     item: {
@@ -112,7 +141,7 @@ export default {
           this.ready = true
         })
       } else {
-        const loadItem = this.$oh.api.get('/rest/items/' + this.itemName + '?metadata=semantics')
+        const loadItem = this.$oh.api.get('/rest/items/' + this.itemName + '?metadata=.*')
         loadItem.then((data) => {
           if (!data.groupType) data.groupType = 'None'
           this.item = data
@@ -138,10 +167,14 @@ export default {
       }
     },
     save () {
-      // TODO properly validate item
-      if (!this.item.name) return
+      if (this.currentTab === 'code') {
+        if (!this.fromYaml()) return Promise.reject()
+      }
+      if (!this.item.name) return // user cannot change name
+      if (!this.item.type || !this.types.ItemTypes.includes(this.item.type.split(':')[0])) return this.$f7.dialog.alert('Please give Item a valid type').open()
       if (this.item.groupType === 'None') delete this.item.groupType
 
+      // TODO: Add support for saving metadata
       this.$oh.api.put('/rest/items/' + this.item.name, this.item).then((data) => {
         if (this.createMode) {
           this.$f7.toast.create({
@@ -167,6 +200,41 @@ export default {
           closeTimeout: 2000
         }).open()
       })
+    },
+    onEditorInput (value) {
+      this.itemYaml = value
+      this.dirty = true
+    },
+    toYaml () {
+      this.itemYaml = YAML.stringify({
+        label: this.item.label,
+        type: this.item.type,
+        category: this.item.category,
+        groupNames: this.item.groupNames,
+        groupType: this.item.groupType,
+        function: this.item.function,
+        tags: this.item.tags
+        // metadata: this.item.metadata
+      })
+    },
+    fromYaml () {
+      if (!this.item.editable) return false
+      try {
+        const updatedItem = YAML.parse(this.itemYaml)
+        if (updatedItem === null) return false
+        this.$set(this.item, 'label', updatedItem.label)
+        this.$set(this.item, 'type', updatedItem.type)
+        this.$set(this.item, 'category', updatedItem.category)
+        this.$set(this.item, 'groupNames', updatedItem.groupNames)
+        this.$set(this.item, 'groupType', updatedItem.groupType)
+        this.$set(this.item, 'function', updatedItem.function)
+        this.$set(this.item, 'tags', updatedItem.tags)
+        // this.$set(this.item, 'metadata', updatedItem.metadata)
+        return true
+      } catch (e) {
+        this.$f7.dialog.alert(e).open()
+        return false
+      }
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -21,7 +21,7 @@
         <f7-block class="block-narrow" v-if="item.name || item.created === false">
           <f7-col v-if="item.editable === false">
             <div class="padding-left">
-              Note: this item is not editable because it has been created with textual configuration.
+              Note: {{ itemNotEditableMgs }}
             </div>
           </f7-col>
           <f7-col>
@@ -45,8 +45,8 @@
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
         <f7-icon v-if="ready && !isEditable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray"
-                 tooltip="This Item is not editable because it has been provisioned from a file" />
-        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :read-only="!isEditable" />
+                 :tooltip="itemNotEditableMgs" />
+        <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :read-only="item.editable === false" />
       </f7-tab>
     </f7-tabs>
 
@@ -105,12 +105,8 @@ export default {
       semanticClass: '',
       semanticProperty: '',
       pendingTag: '',
-      currentTab: 'design'
-    }
-  },
-  computed: {
-    isEditable () {
-      return this.item && this.item.editable !== false
+      currentTab: 'design',
+      itemNotEditableMgs: 'This Item is not editable because it has been provisioned from a file.'
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -21,7 +21,7 @@
         <f7-block class="block-narrow" v-if="item.name || item.created === false">
           <f7-col v-if="item.editable === false">
             <div class="padding-left">
-              Note: {{ itemNotEditableMgs }}
+              Note: {{ notEditableMgs }}
             </div>
           </f7-col>
           <f7-col>
@@ -44,8 +44,7 @@
         </f7-block>
       </f7-tab>
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
-        <f7-icon v-if="ready && !isEditable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray"
-                 :tooltip="itemNotEditableMgs" />
+        <f7-icon v-if="ready && !isEditable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" :tooltip="notEditableMgs" />
         <editor v-if="currentTab === 'code'" class="rule-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :read-only="item.editable === false" />
       </f7-tab>
     </f7-tabs>
@@ -106,7 +105,7 @@ export default {
       semanticProperty: '',
       pendingTag: '',
       currentTab: 'design',
-      itemNotEditableMgs: 'This Item is not editable because it has been provisioned from a file.'
+      notEditableMgs: 'This Item is not editable because it has been provisioned from a file.'
     }
   },
   watch: {


### PR DESCRIPTION
Closes #728.
See discussion in https://github.com/openhab/openhab-webui/discussions/1737#discussioncomment-5130752.

Adds a YAML code tab to the Item editor as requested several times on various places.
Editor hints are provided for Item types, groupTypes, groupNames and metadata namespaces.

If the Item has been provisioned from file, the editor is read-only and a big lock icon is displayed.

Note that metadata is currently not displayed, because mass-saving metadata is not supported yet.