### PR TITLE
Sitemap editor: Support `inputHint` config of Input element

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -9,7 +9,7 @@
     label:            'label=',
     item:             'item=',
     icon:             'icon=',
-    widgetattr:       ['url=', 'refresh=', 'service=', 'period=', 'height=', 'mappings=', 'minValue=', 'maxValue=', 'step=', 'encoding=', 'yAxisDecimalPattern='],
+    widgetattr:       ['url=', 'refresh=', 'service=', 'period=', 'height=', 'mappings=', 'minValue=', 'maxValue=', 'step=', 'encoding=', 'yAxisDecimalPattern=', 'inputHint='],
     widgetboolattr:   ['legend='],
     widgetfreqattr:   'sendFrequency=',
     widgetfrcitmattr: 'forceasitem=',

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -110,11 +110,11 @@ export default {
         { key: 'Y', value: 'Year' }
       ],
       inputHintDefs: [
-        { key: 'text', value: 'Text'},
-        { key: 'number', value: 'Number'},
-        { key: 'date', value: 'Date'},
-        { key: 'time', value: 'Time'},
-        { key: 'datetime', value: 'Date and Time'}
+        { key: 'text', value: 'Text' },
+        { key: 'number', value: 'Number' },
+        { key: 'date', value: 'Date' },
+        { key: 'time', value: 'Time' },
+        { key: 'datetime', value: 'Date and Time' }
       ]
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -42,6 +42,13 @@
           <f7-list-item v-if="supports('forceAsItem')" title="Force as item">
             <f7-toggle slot="after" :checked="widget.config.forceAsItem" @toggle:change="widget.config.forceAsItem = $event" />
           </f7-list-item>
+          <f7-list-item v-if="supports('inputHint')" title="Hint" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
+            <select name="inputHints" required :value="widget.config.inputHint" @change="updateParameter('inputHint', $event)">
+              <option v-for="def in inputHintDefs" :key="def.key" :value="def.key">
+                {{ def.value }}
+              </option>
+            </select>
+          </f7-list-item>
         </ul>
       </f7-list>
     </f7-card-content>
@@ -84,6 +91,7 @@ export default {
         Slider: ['sendFrequency', 'switchEnabled', 'minValue', 'maxValue', 'step'],
         Setpoint: ['minValue', 'maxValue', 'step'],
         Colorpicker: ['sendFrequency'],
+        Input: ['inputHint'],
         Default: ['height']
       },
       periodDefs: [
@@ -100,6 +108,13 @@ export default {
         { key: '2M', value: '2 Months' },
         { key: '3M', value: '3 Months' },
         { key: 'Y', value: 'Year' }
+      ],
+      inputHintDefs: [
+        { key: 'text', value: 'Text'},
+        { key: 'number', value: 'Number'},
+        { key: 'date', value: 'Date'},
+        { key: 'time', value: 'Time'},
+        { key: 'datetime', value: 'Date and Time'}
       ]
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -394,6 +394,12 @@ export default {
             validationWarnings.push(widget.component + ' widget ' + label + ', no period configured')
           }
         })
+        widgetList.filter(widget => widget.component === 'Input').forEach(widget => {
+          if (!widget.config && widget.config.inputHint && ['text', 'number', 'date', 'time', 'datetime'].contains(widget.config.inputHint)) {
+            let label = widget.config && widget.config.label ? widget.config.label : 'without label'
+            validationWarnings.push(widget.component + ' widget ' + label + ', invalid inputHint configured ' + widget.config.inputHint)
+          }
+        })
         widgetList.forEach(widget => {
           if (widget.config) {
             Object.keys(widget.config).filter(attr => ['mappings', 'visibility', 'valuecolor', 'labelcolor', 'iconcolor'].includes(attr)).forEach(attr => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -395,9 +395,9 @@ export default {
           }
         })
         widgetList.filter(widget => widget.component === 'Input').forEach(widget => {
-          if (!widget.config && widget.config.inputHint && ['text', 'number', 'date', 'time', 'datetime'].contains(widget.config.inputHint)) {
+          if (!(widget.config && widget.config.inputHint && ['text', 'number', 'date', 'time', 'datetime'].includes(widget.config.inputHint))) {
             let label = widget.config && widget.config.label ? widget.config.label : 'without label'
-            validationWarnings.push(widget.component + ' widget ' + label + ', invalid inputHint configured ' + widget.config.inputHint)
+            validationWarnings.push(widget.component + ' widget ' + label + ', invalid inputHint configured: ' + widget.config.inputHint)
           }
         })
         widgetList.forEach(widget => {


### PR DESCRIPTION
This adds support for configuring the inputHint parameter of the Input sitemap element in the sitemap editor of MainUI.
See https://github.com/openhab/openhab-core/pull/3418 and the BasicUI implementation #1787.