### PR TITLE
Navigation to `/pages/:type/:uid` does not work

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -170,9 +170,9 @@ export default [
             path: ':type/:uid',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
-            async: [(routeTo, routeFrom, resolve, reject) => {
+            async: (routeTo, routeFrom, resolve, reject) => {
               PageEditors[routeTo.params.type]().then((c) => { resolve({ component: c.default }, (routeTo.params.uid === 'add') ? { props: { createMode: true } } : {}) })
-            }]
+            }
           }
         ]
       },


### PR DESCRIPTION
When navigating from "Pages" to a page, navigation does not work and the following is logged

```
app.3f791c6744592694cdec.js:7 TypeError: s.route.async.call is not a function
    at b (app.3f791c6744592694cdec.js:7:912111)
    at app.3f791c6744592694cdec.js:7:913375
    at app.3f791c6744592694cdec.js:7:875547
    at t (app.3f791c6744592694cdec.js:7:875320)
    at app.3f791c6744592694cdec.js:7:875295
    at l.b (app.3f791c6744592694cdec.js:7:98909)
    at t (app.3f791c6744592694cdec.js:7:875272)
    at w (app.3f791c6744592694cdec.js:7:875324)
    at r (app.3f791c6744592694cdec.js:7:875459)
    at l.k (app.3f791c6744592694cdec.js:7:875775)
```
Probably regression of https://github.com/openhab/openhab-webui/pull/1815