### PR TITLE
`oh-knob`: Update docs for dotted path and line cap parameters

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-knob-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-card.md
@@ -145,7 +145,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
 </PropBlock>
 <PropBlock type="TEXT" name="lineCap" label="Line Cap">
   <PropDescription>
-    Sets the shape of the end of the path
+    Sets the shape of the end of the path; dotted path and line cap cannot be used together.
   </PropDescription>
   <PropOptions>
     <PropOption value="square" label="square" />
@@ -154,7 +154,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
 </PropBlock>
 <PropBlock type="TEXT" name="dottedPath" label="Dotted Path">
   <PropDescription>
-    Length of dotted path segments (using css stroke-dasharray)
+    Length of dotted path segments (using css stroke-dasharray); dotted path and line cap cannot be used together.
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="borderWidth" label="Border Width">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -154,7 +154,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
 </PropBlock>
 <PropBlock type="TEXT" name="lineCap" label="Line Cap">
   <PropDescription>
-    Sets the shape of the end of the path
+    Sets the shape of the end of the path; dotted path and line cap cannot be used together.
   </PropDescription>
   <PropOptions>
     <PropOption value="square" label="square" />
@@ -163,7 +163,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
 </PropBlock>
 <PropBlock type="TEXT" name="dottedPath" label="Dotted Path">
   <PropDescription>
-    Length of dotted path segments (using css stroke-dasharray)
+    Length of dotted path segments (using css stroke-dasharray); dotted path and line cap cannot be used together.
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="borderWidth" label="Border Width">

--- a/bundles/org.openhab.ui/doc/components/oh-knob.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob.md
@@ -112,7 +112,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
 </PropBlock>
 <PropBlock type="TEXT" name="lineCap" label="Line Cap">
   <PropDescription>
-    Sets the shape of the end of the path
+    Sets the shape of the end of the path; dotted path and line cap cannot be used together.
   </PropDescription>
   <PropOptions>
     <PropOption value="square" label="square" />
@@ -121,7 +121,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
 </PropBlock>
 <PropBlock type="TEXT" name="dottedPath" label="Dotted Path">
   <PropDescription>
-    Length of dotted path segments (using css stroke-dasharray)
+    Length of dotted path segments (using css stroke-dasharray); dotted path and line cap cannot be used together.
   </PropDescription>
 </PropBlock>
 <PropBlock type="INTEGER" name="borderWidth" label="Border Width">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
@@ -29,11 +29,11 @@ export default () => [
     { value: 'quarter-bottom-right', label: 'quarter bottom right' },
     { value: 'pie', label: 'pie' }
   ]),
-  po('lineCap', 'Line Cap', 'Sets the shape of the end of the path', [
+  po('lineCap', 'Line Cap', 'Sets the shape of the end of the path; dotted path and line cap cannot be used together.', [
     { value: 'square', label: 'square' },
     { value: 'round', label: 'round' }
   ]),
-  pt('dottedPath', 'Dotted Path', 'Length of dotted path segments (using css stroke-dasharray)'),
+  pt('dottedPath', 'Dotted Path', 'Length of dotted path segments (using css stroke-dasharray); dotted path and line cap cannot be used together.'),
   pn('borderWidth', 'Border Width', 'Sets the border width of the slider (px value)'),
   pt('handleSize', 'Handle Size', 'Sets the size of the slider handle (px value)'),
   po('handleShape', 'Handle Shape', 'Sets the shape of the slider handle', [


### PR DESCRIPTION
See https://github.com/openhab/openhab-webui/pull/1773#issuecomment-1481712236.

Document that dotted path and line cap cannot be used together.
