### PR TITLE
[BasicUI] Use more contrasted color buttons in widgets when in dark mode

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/_theming.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_theming.scss
@@ -5,9 +5,11 @@ body[data-theme="default"] {
 	--body-bg: #f5f5f5;
 	--container-bg: #fff;
 	--container-text-color: #616161;
+	--switch-off-track-bg: rgba(0,0,0,.26);
 	--switch-on-track-bg: #9fa8da;
 	--border-color: #ccc;
 	--input-undef-color: rgba(0,0,0,.26);
+	--button-color: #000000;
 }
 
 body[data-theme="dark"] {
@@ -17,9 +19,11 @@ body[data-theme="dark"] {
 	--body-bg: #181818;
 	--container-bg: #232323;
 	--container-text-color: #c0c0c0;
+	--switch-off-track-bg: rgba(255,255,255,.26);
 	--switch-on-track-bg: #9fa8da;
 	--border-color: #343434;
 	--input-undef-color: rgba(158,158,158,.26);
+	--button-color: #e0e0e0;
 }
 
 .mdl-layout__header {
@@ -46,6 +50,11 @@ body {
 	border-bottom: 1px solid var(--border-color, #ccc);
 }
 
+.mdl-switch .mdl-switch__track {
+	background: rgba(0,0,0,.26);
+	background: var(--switch-off-track-bg, rgba(0,0,0,.26));
+}
+
 .mdl-switch.is-checked .mdl-switch__track {
 	background: #9fa8da;
 	background: var(--switch-on-track-bg, #9fa8da);
@@ -55,6 +64,11 @@ body {
 .mdl-switch__ripple-container .mdl-ripple {
 	background: #3f51b5;
 	background: var(--primary-color, #3f51b5);
+}
+
+.mdl-button {
+	color: #000000;
+	color: var(--button-color, #000000);
 }
 
 .mdl-textfield__input {


### PR DESCRIPTION
Applied to colopicker, setpoint, switch/rollerblind and switch/mappings widgets.

Also change the track color of the switch widget when state is OFF

Related to #1831

Signed-off-by: Laurent Garnier <lg.hc@free.fr>