### PR TITLE
[BasicUI] Change assumption in case icon value contains only 2 segments

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
@@ -151,7 +151,6 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
                 iconName = segments[0];
             } else if (segments.length == 2) {
                 iconSource = segments[0];
-                iconSet = ICON_SOURCE_OH.equalsIgnoreCase(iconSource) ? ICON_SET_OH_CLASSIC : "";
                 iconName = segments[1];
             } else if (segments.length == 3) {
                 iconSource = segments[0];

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
@@ -61,8 +61,9 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
     private static final String ICON_SOURCE_IF = "if";
     private static final String ICON_SOURCE_ICONIFY = "iconify";
     private static final String ICON_SOURCE_MATERIAL = "material";
+    private static final String ICON_SET_OH_CLASSIC = "classic";
     private static final String DEFAULT_ICON_SOURCE = ICON_SOURCE_OH;
-    private static final String DEFAULT_ICON_SET = "classic";
+    private static final String DEFAULT_ICON_SET = ICON_SET_OH_CLASSIC;
     private static final String DEFAULT_ICON_NAME = "none";
 
     public static final String ICON_TYPE = "svg";
@@ -149,7 +150,8 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
             if (segments.length == 1) {
                 iconName = segments[0];
             } else if (segments.length == 2) {
-                iconSet = segments[0];
+                iconSource = segments[0];
+                iconSet = ICON_SOURCE_OH.equalsIgnoreCase(iconSource) ? ICON_SET_OH_CLASSIC : "";
                 iconName = segments[1];
             } else if (segments.length == 3) {
                 iconSource = segments[0];


### PR DESCRIPTION
The first segment is now expected to be the icon source.
The icon set is determined: "classic" if source is "oh" or "" in other cases.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>