### PR TITLE
[mainui] - evaluate service as part of series's chart config

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -155,8 +155,9 @@ export default {
           seriesStartTime = seriesStartTime.subtract(component.config.offsetAmount, component.config.offsetUnit)
           seriesEndTime = seriesEndTime.subtract(component.config.offsetAmount, component.config.offsetUnit)
         }
+        let serviceId = component.config.service ? this.evaluateExpression('.serviceId', component.config.service) : undefined
         let query = {
-          serviceId: component.config.service || undefined,
+          serviceId: serviceId,
           starttime: seriesStartTime.toISOString(),
           endtime: seriesEndTime.subtract(1, 'millisecond').toISOString(),
           boundary: boundary


### PR DESCRIPTION
As discussed https://community.openhab.org/t/widget-pass-persistence-service-as-property-to-custom-widget/146132 the `service` property of `series` is not evaluated:
```
- component: oh-chart
    config:
        ...
    slots:
      ...
      series:
        - component: oh-time-series
          config:
            service: =props.useInflux ? "influxdb":"rrd4j"
            ...
```