### PR TITLE
Use right UID attribute in Thing picker

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/thing-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/thing-picker.vue
@@ -36,8 +36,8 @@ export default {
     // TODO use a Vuex store
     this.$oh.api.get('/rest/things?summary=true').then((data) => {
       this.things = data.sort((a, b) => {
-        const labelA = a.label || a.uid
-        const labelB = b.label || b.uid
+        const labelA = a.label || a.UID
+        const labelB = b.label || b.UID
         return labelA.localeCompare(labelB)
       })
       if (this.filterType) {


### PR DESCRIPTION
Thing picker sort uses wrong UID attribute as fallback during sort of thing list.

Follow-up for #1837.