### PR TITLE
[blockly] Toggle between item name or label

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -21,10 +21,9 @@ export default function (f7, isGraalJs) {
       this.setColour(160)
       this.setInputsInline(true)
 
-      let thisFieldpicker = this.fieldPicker
       this.setTooltip(() => {
         let tooltip = 'Pick an Item from the Model'
-        const itemData = thisFieldpicker.data
+        const itemData = this.fieldPicker.data
         if (itemData[0] !== itemData[1]) {
           tooltip = itemData[0]
         }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -7,6 +7,7 @@ import Blockly from 'blockly'
 import { javascriptGenerator } from 'blockly/javascript'
 import { FieldItemModelPicker } from './fields/item-field'
 import { FieldThingPicker } from './fields/thing-field'
+import api from '@/js/openhab/api'
 
 export default function (f7, isGraalJs) {
   /* Helper block to allow selecting an item */
@@ -40,6 +41,11 @@ export default function (f7, isGraalJs) {
 
       if (!this.fieldPicker.data) { // "migrate" old storage
         this.fieldPicker.data = [this.fieldPicker.value_, this.fieldPicker.value_]
+        if (this.fieldPicker.value_ && this.fieldPicker.value_ != 'MyItem') {
+          api.get(`/rest/items/${this.fieldPicker.value_}?metadata=^$`).then((data) => {
+            this.fieldPicker.data = [this.fieldPicker.value_, data.label]
+          }).catch()
+        }
       }
       this.fieldPicker.value_ = (this.workspace.showLabels) ? this.fieldPicker.data[1] : this.fieldPicker.data[0]
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -41,7 +41,7 @@ export default function (f7, isGraalJs) {
 
       if (!this.fieldPicker.data) { // "migrate" old storage
         this.fieldPicker.data = [this.fieldPicker.value_, this.fieldPicker.value_]
-        if (this.fieldPicker.value_ && this.fieldPicker.value_ != 'MyItem') {
+        if (this.fieldPicker.value_ && this.fieldPicker.value_ !== 'MyItem') {
           api.get(`/rest/items/${this.fieldPicker.value_}?metadata=^$`).then((data) => {
             this.fieldPicker.data = [this.fieldPicker.value_, data.label]
           }).catch()

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -21,8 +21,8 @@ export default function (f7, isGraalJs) {
       this.setInputsInline(true)
 
       let thisFieldpicker = this.fieldPicker
-      this.setTooltip(function () {
-        let tooltip = 'Pick an item from the Model'
+      this.setTooltip(() => {
+        let tooltip = 'Pick an Item from the Model'
         const itemData = thisFieldpicker.data
         if (itemData[0] !== itemData[1]) {
           tooltip = itemData[0]
@@ -32,11 +32,11 @@ export default function (f7, isGraalJs) {
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#item')
       this.setOutput(true, 'oh_item')
     },
-    update_: function (name, label) {
+    _updateFieldPicker: function (name, label) {
       this.fieldPicker.data = [name, label]
     },
     mutationToDom: function () {
-      let container = Blockly.utils.xml.createElement('mutation')
+      const container = Blockly.utils.xml.createElement('mutation')
 
       if (!this.fieldPicker.data) { // "migrate" old storage
         this.fieldPicker.data = [this.fieldPicker.value_, this.fieldPicker.value_]
@@ -48,7 +48,7 @@ export default function (f7, isGraalJs) {
       return container
     },
     domToMutation: function (xmlElement) {
-      this.update_(xmlElement.getAttribute('itemName'), xmlElement.getAttribute('itemLabel'))
+      this._updateFieldPicker(xmlElement.getAttribute('itemName'), xmlElement.getAttribute('itemLabel'))
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/item-field.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/item-field.js
@@ -18,7 +18,8 @@ export class FieldItemModelPicker extends Blockly.FieldTextInput {
   showEditor_ (options) {
     if (this.f7) {
       const itemsPicked = (value) => {
-        this.setEditorValue_(value.name)
+        this.data = [value.name, value.label]
+        this.setEditorValue_(value.label)
       }
       const popup = {
         component: ModelPickerPopup

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/item-field.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/item-field.js
@@ -19,7 +19,7 @@ export class FieldItemModelPicker extends Blockly.FieldTextInput {
     if (this.f7) {
       const itemsPicked = (value) => {
         this.data = [value.name, value.label]
-        this.setEditorValue_(value.label)
+        this.setEditorValue_(value.name)
       }
       const popup = {
         component: ModelPickerPopup

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1193,7 +1193,7 @@ export default {
         window.open(button.info.helpurl, '_blank')
       })
       Blockly.Workspace.prototype.refresh = function () {
-        let xml = Blockly.Xml.workspaceToDom(this)
+        const xml = Blockly.Xml.workspaceToDom(this)
         this.clear()
         Blockly.Xml.domToWorkspace(xml, this)
         this.refreshToolboxSelection()
@@ -1217,7 +1217,6 @@ export default {
       this.workspace.showLabels = showLabels
       this.workspace.refresh()
       this.workspace.loadItem('test')
-      debugger
     },
     getBlocks () {
       const xml = Blockly.Xml.workspaceToDom(this.workspace)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1216,7 +1216,6 @@ export default {
     showHideLabels (showLabels) {
       this.workspace.showLabels = showLabels
       this.workspace.refresh()
-      this.workspace.loadItem('test')
     },
     getBlocks () {
       const xml = Blockly.Xml.workspaceToDom(this.workspace)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1157,7 +1157,8 @@ export default {
             scaleSpeed: 1.2,
             pinch: true
           },
-        trashcan: false
+        trashcan: false,
+        showLabels: false
       })
       this.workspace.addChangeListener(shadowBlockConversionChangeListener)
       const workspaceSearch = new WorkspaceSearch(this.workspace)
@@ -1191,6 +1192,12 @@ export default {
       this.workspace.registerButtonCallback('ohBlocklyHelp', function (button) {
         window.open(button.info.helpurl, '_blank')
       })
+      Blockly.Workspace.prototype.refresh = function () {
+        let xml = Blockly.Xml.workspaceToDom(this)
+        this.clear()
+        Blockly.Xml.domToWorkspace(xml, this)
+        this.refreshToolboxSelection()
+      }
     },
     addLibraryToToolbox (definitions) {
       const library = this.$refs.libraryCategory
@@ -1205,6 +1212,12 @@ export default {
       definitions.forEach((definition) => {
         this.workspace.registerToolboxCategoryCallback('LIBRARY_' + definition.uid, defineLibraryToolboxCategory(definition, this.$f7))
       })
+    },
+    showHideLabels (showLabels) {
+      this.workspace.showLabels = showLabels
+      this.workspace.refresh()
+      this.workspace.loadItem('test')
+      debugger
     },
     getBlocks () {
       const xml = Blockly.Xml.workspaceToDom(this.workspace)

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -26,7 +26,7 @@
       </span>
       <span class="display-flex flex-direction-row align-items-center">
         <f7-button v-if="!newScript && isBlockly && !blocklyCodePreview" outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" style="margin-right: 5px" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either Item labels or IDs'" />
-        <f7-segmented>
+        <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
           <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
           <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
         </f7-segmented>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -26,7 +26,7 @@
       </span>
       <span class="display-flex flex-direction-row align-items-center">
         <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
-          <f7-button outline small :active="showLabels" icon-f7="captions_bubble" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either item labels or IDs'" />
+          <f7-button outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either item labels or IDs'" />
         </f7-segmented>
         <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
           <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
@@ -148,7 +148,7 @@ export default {
       keyHandler: null,
       detailsOpened: false,
       blocklyCodePreview: false,
-      showLabels: true
+      blocklyShowLabels: false
     }
   },
   computed: {
@@ -398,9 +398,8 @@ export default {
       )
     },
     toggleBlocklyItemLabelId () {
-      let editor = this.$refs.blocklyEditor
-      this.showLabels = !this.showLabels
-      editor.showHideLabels(this.showLabels)
+      this.blocklyShowLabels = !this.blocklyShowLabels
+      this.$refs.blocklyEditor.showHideLabels(this.blocklyShowLabels)
     },
     showBlocklyCode () {
       try {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -26,8 +26,9 @@
       </span>
       <span class="display-flex flex-direction-row align-items-center">
         <f7-button v-if="!newScript && isBlockly && !blocklyCodePreview" outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" style="margin-right: 5px" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either Item labels or IDs'" />
-        <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
-        <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
+        <f7-segmented>
+          <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
+          <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
         </f7-segmented>
         <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
       </span>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -26,6 +26,9 @@
       </span>
       <span class="display-flex flex-direction-row align-items-center">
         <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
+          <f7-button outline small :active="showLabels" icon-f7="captions_bubble" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either item labels or IDs'" />
+        </f7-segmented>
+        <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
           <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
           <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
         </f7-segmented>
@@ -144,7 +147,8 @@ export default {
       eventSource: null,
       keyHandler: null,
       detailsOpened: false,
-      blocklyCodePreview: false
+      blocklyCodePreview: false,
+      showLabels: true
     }
   },
   computed: {
@@ -392,6 +396,11 @@ export default {
           })
         }
       )
+    },
+    toggleBlocklyItemLabelId () {
+      let editor = this.$refs.blocklyEditor
+      this.showLabels = !this.showLabels
+      editor.showHideLabels(this.showLabels)
     },
     showBlocklyCode () {
       try {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -25,12 +25,9 @@
                  :tooltip="rule.status.description" />
       </span>
       <span class="display-flex flex-direction-row align-items-center">
-        <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
-          <f7-button outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either item labels or IDs'" />
-        </f7-segmented>
-        <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
-          <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
-          <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
+        <f7-button v-if="!newScript && isBlockly && !blocklyCodePreview" outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" style="margin-right: 5px" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either Item labels or IDs'" />
+        <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
+        <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
         </f7-segmented>
         <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
       </span>


### PR DESCRIPTION
This PR allows to show either the name or the label of the item.

Since the beginning the item picker would show the label during selection but the item block itself then would show the name (hence the "id" that is used internally). This always confused me because I rather remember the labels rather the "internal" names of the item. From the implementation perspective it is now clear to me why this was done (it was much easier to generate the code) and also it is consistent with what is used for code generation. 

This new way allows the user of the blockly editor to switch between showing the label or the name while the code generation always uses the name.

Note that this requires both the name and the label stored in the blockly code. Because the current code does not store the label, it needs to repicked once, via the item picker, to retrieve that label and then store it. I may add automatic retrieval for the label in the future but due to some internal limitations it doesn't seem that easy to provide clear code separation for that.

The switch can be found on the lower bar of the editor

<img width="272" alt="image" src="https://user-images.githubusercontent.com/5937600/235449504-87b175b2-d874-4c20-8d08-b65acb8132ad.png">

The functionality behaves as follows

https://user-images.githubusercontent.com/5937600/235449639-8cbef4c5-5f19-4d33-a591-2791cfc6f52d.mov



