### PR TITLE
[blockly] Add pattern to text of date block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
@@ -611,13 +611,27 @@ export default function (f7, isGraalJs) {
       this.appendValueInput('date')
         .appendField('text of')
         .setCheck('ZonedDateTime')
+
+      let thisBlock = this
+      let dropDown = new Blockly.FieldDropdown(
+        [['without time', 'without'], ['with time', 'with'], ['as OH-Time', 'asOHTime'], ['with pattern', 'withPattern']],
+        function (newMode) {
+          thisBlock.updateType_(newMode)
+        })
       this.appendDummyInput()
-        .appendField(new Blockly.FieldDropdown([['without time', 'without'], ['with time', 'with'], ['as OH-Time', 'asOHTime']]), 'withtime')
+        .appendField(dropDown, 'withtime')
 
       this.setOutput(true, 'String')
       this.setColour(160)
       this.setTooltip('converts an ZonedDateTime into a date string')
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-string-representation-of-date')
+    },
+    updateType_: function (type) {
+      if (type === 'withPattern') {
+        this.appendValueInput('pattern')
+      } else if (this.getInput('pattern')) {
+        this.removeInput('pattern')
+      }
     }
   }
 
@@ -635,6 +649,9 @@ export default function (f7, isGraalJs) {
       code = `${date}.format(${dtf}.ofPattern('yyyy-MM-dd HH:mm:ss'))`
     } else if (withtime === 'without') {
       code = `${date}.format(${dtf}.ofPattern('yyyy-MM-dd'))`
+    } else if (withtime === 'withPattern') {
+      const pattern = javascriptGenerator.valueToCode(block, 'pattern', javascriptGenerator.ORDER_ATOMIC)
+      code = `${date}.format(${dtf}.ofPattern(${pattern}))`
     } else {
       code = `${date}.format(${dtf}.ofPattern('yyyy-MM-dd\\'T\\'HH:mm:ss.SSSZ'))`
     }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dateoffsets.js
@@ -608,15 +608,15 @@ export default function (f7, isGraalJs) {
   */
   Blockly.Blocks['oh_zdt_toText'] = {
     init: function () {
+      const block = this
       this.appendValueInput('date')
         .appendField('text of')
         .setCheck('ZonedDateTime')
 
-      let thisBlock = this
-      let dropDown = new Blockly.FieldDropdown(
+      const dropDown = new Blockly.FieldDropdown(
         [['without time', 'without'], ['with time', 'with'], ['as OH-Time', 'asOHTime'], ['with pattern', 'withPattern']],
         function (newMode) {
-          thisBlock.updateType_(newMode)
+          block._updateType(newMode)
         })
       this.appendDummyInput()
         .appendField(dropDown, 'withtime')
@@ -626,9 +626,12 @@ export default function (f7, isGraalJs) {
       this.setTooltip('converts an ZonedDateTime into a date string')
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-date-handling.html#get-string-representation-of-date')
     },
-    updateType_: function (type) {
+    _updateType: function (type) {
       if (type === 'withPattern') {
+        if (this.getInput('pattern')) return
         this.appendValueInput('pattern')
+          .setCheck('String')
+          .setShadowDom(Blockly.Xml.textToDom('<shadow type="text"><field name="TEXT">yyyy-MM-dd</field></shadow>'))
       } else if (this.getInput('pattern')) {
         this.removeInput('pattern')
       }


### PR DESCRIPTION
fixes #1636

mutating text to data block that allows providing a date pattern:

<img width="536" alt="image" src="https://user-images.githubusercontent.com/5937600/235496162-634874a9-e2e8-4b91-8dbf-a580471a9f3e.png">

vs

<img width="342" alt="image" src="https://user-images.githubusercontent.com/5937600/235496215-5004d211-9007-49be-bd8b-6f56c6917bec.png">
