### PR TITLE
[blockly] Add new `math_round` block with round up, down and by decimals

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -82,10 +82,10 @@ export default function (f7, isGraalJs) {
 
   Blockly.Blocks['math_round'] = {
     init: function () {
-      let thisBlock = this
-      let dropDown = new Blockly.FieldDropdown([['round', 'ROUND'], ['round up', 'ROUNDUP'], ['round down', 'ROUNDDOWN'], ['round →', 'toFixed']],
+      const block = this
+      const dropDown = new Blockly.FieldDropdown([['round', 'ROUND'], ['round up', 'ROUNDUP'], ['round down', 'ROUNDDOWN'], ['round →', 'toFixed']],
         function (operation) {
-          thisBlock.updateType_(operation)
+          block.updateType(operation)
         })
       this.appendValueInput('NUM')
         .setCheck('Number')
@@ -96,16 +96,18 @@ export default function (f7, isGraalJs) {
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#round')
       this.setOutput(true, 'Number')
     },
-    updateType_: function (type) {
+    updateType: function (type) {
       if (type === 'toFixed') {
-        this.appendValueInput('decimals')
+        if (this.getInput('DECIMALS')) return
+        this.appendValueInput('DECIMALS')
           .setCheck('Number')
           .appendField('by')
+          .setShadowDom(Blockly.Xml.textToDom('<shadow type="math_number"><field name="NUM">2</field></shadow>'))
         this.appendDummyInput('declabel')
           .appendField('decimals')
         this.setInputsInline(true)
-      } else if (this.getInput('decimals')) {
-        this.removeInput('decimals')
+      } else if (this.getInput('DECIMALS')) {
+        this.removeInput('DECIMALS')
         this.removeInput('declabel')
         this.setInputsInline(false)
       }
@@ -114,7 +116,7 @@ export default function (f7, isGraalJs) {
 
   javascriptGenerator['math_round'] = function (block) {
     const math_number = javascriptGenerator.valueToCode(block, 'NUM', javascriptGenerator.ORDER_FUNCTION_CALL)
-    const decimals = javascriptGenerator.valueToCode(block, 'decimals', javascriptGenerator.ORDER_NONE)
+    const decimals = javascriptGenerator.valueToCode(block, 'DECIMALS', javascriptGenerator.ORDER_NONE)
     const operand = block.getFieldValue('op')
     let code = ''
     if (operand !== 'toFixed') {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -83,7 +83,7 @@ export default function (f7, isGraalJs) {
   Blockly.Blocks['math_round'] = {
     init: function () {
       const block = this
-      const dropDown = new Blockly.FieldDropdown([['round', 'ROUND'], ['round up', 'ROUNDUP'], ['round down', 'ROUNDDOWN'], ['round →', 'toFixed']],
+      const dropDown = new Blockly.FieldDropdown([['round', 'ROUND'], ['round up', 'ROUNDUP'], ['round down', 'ROUNDDOWN'], ['round (by decimals)', 'toFixed']],
         function (operation) {
           block.updateType(operation)
         })

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -79,4 +79,61 @@ export default function (f7, isGraalJs) {
     }
     return [`${first} ${operand} ${second}`, parentheses]
   }
+
+  Blockly.Blocks['math_round'] = {
+    init: function () {
+      let thisBlock = this
+      let dropDown = new Blockly.FieldDropdown([['round', 'ROUND'], ['round up', 'ROUNDUP'], ['round down', 'ROUNDDOWN'], ['round →', 'toFixed']],
+        function (operation) {
+          thisBlock.updateType_(operation)
+        })
+      this.appendValueInput('NUM')
+        .setCheck('Number')
+        .appendField(dropDown, 'op')
+      this.setColour('%{BKY_MATH_HUE}')
+      this.setInputsInline(false)
+      this.setTooltip('Round a number up or down')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#round')
+      this.setOutput(true, 'Number')
+    },
+    updateType_: function (type) {
+      if (type === 'toFixed') {
+        this.appendValueInput('decimals')
+          .setCheck('Number')
+          .appendField('by')
+        this.appendDummyInput('declabel')
+          .appendField('decimals')
+        this.setInputsInline(true)
+      } else if (this.getInput('decimals')) {
+        this.removeInput('decimals')
+        this.removeInput('declabel')
+        this.setInputsInline(false)
+      }
+    }
+  }
+
+  javascriptGenerator['math_round'] = function (block) {
+    const math_number = javascriptGenerator.valueToCode(block, 'NUM', javascriptGenerator.ORDER_FUNCTION_CALL)
+    const decimals = javascriptGenerator.valueToCode(block, 'decimals', javascriptGenerator.ORDER_NONE)
+    const operand = block.getFieldValue('op')
+    let code = ''
+    if (operand !== 'toFixed') {
+      let method = ''
+      switch (operand) {
+        case 'ROUND':
+          method = 'Math.round'
+          break
+        case 'ROUNDUP':
+          method = 'Math.ceil'
+          break
+        case 'ROUNDDOWN':
+          method = 'Math.floor'
+          break
+      }
+      code = `${method}(${math_number})`
+    } else {
+      code = `(${math_number}).toFixed(${decimals})`
+    }
+    return [code, 0]
+  }
 }


### PR DESCRIPTION
Fixes #1303.

Replaces the original Math-Round block with a new one that adds rounding by given decimals. 
Block adds an additional field to enter the decimals for the fourth mode

<img width="442" alt="image" src="https://user-images.githubusercontent.com/5937600/235518474-1ae4b8ed-a94a-4810-805f-1e0817a00c78.png">
