### PR TITLE
`oh-knob` & `oh-stepper`: Add offset functionality

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-knob-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-card.md
@@ -81,6 +81,11 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
     Minimum interval between values (default 1)
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="offset" label="Offset">
+  <PropDescription>
+    Offset to be applied to the Item's state (e.g. Item state = 2; offset = 20; knob/rounded slider behaves as Item state would be 22)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
     If enabled, no commands are sent during sliding

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -90,6 +90,11 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
     Minimum interval between values (default 1)
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="offset" label="Offset">
+  <PropDescription>
+    Offset to be applied to the Item's state (e.g. Item state = 2; offset = 20; knob/rounded slider behaves as Item state would be 22)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
     If enabled, no commands are sent during sliding

--- a/bundles/org.openhab.ui/doc/components/oh-knob.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob.md
@@ -48,6 +48,11 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
     Minimum interval between values (default 1)
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="offset" label="Offset">
+  <PropDescription>
+    Offset to be applied to the Item's state (e.g. Item state = 2; offset = 20; knob/rounded slider behaves as Item state would be 22)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">
   <PropDescription>
     If enabled, no commands are sent during sliding

--- a/bundles/org.openhab.ui/doc/components/oh-stepper-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper-card.md
@@ -90,6 +90,11 @@ Display a stepper in a card to control an item
     Display the buttons without the value in the middle
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="enableInput" label="Enable Input Field">
+  <PropDescription>
+    Enables the input field between the buttons. Note that this might not work when min/max is set.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="small" label="Small">
   <PropDescription>
     Smaller size

--- a/bundles/org.openhab.ui/doc/components/oh-stepper-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper-card.md
@@ -80,6 +80,11 @@ Display a stepper in a card to control an item
     Minimum interval between values
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="offset" label="Offset">
+  <PropDescription>
+    Offset to be applied to the Item's state (e.g. Item state = 2; offset = 20; stepper behaves as Item state would be 22)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="buttonsOnly" label="Buttons Only">
   <PropDescription>
     Display the buttons without the value in the middle

--- a/bundles/org.openhab.ui/doc/components/oh-stepper-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper-item.md
@@ -85,6 +85,11 @@ Display a stepper control in a list
     Minimum interval between values
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="offset" label="Offset">
+  <PropDescription>
+    Offset to be applied to the Item's state (e.g. Item state = 2; offset = 20; stepper behaves as Item state would be 22)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="buttonsOnly" label="Buttons Only">
   <PropDescription>
     Display the buttons without the value in the middle

--- a/bundles/org.openhab.ui/doc/components/oh-stepper-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper-item.md
@@ -95,6 +95,11 @@ Display a stepper control in a list
     Display the buttons without the value in the middle
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="enableInput" label="Enable Input Field">
+  <PropDescription>
+    Enables the input field between the buttons. Note that this might not work when min/max is set.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="small" label="Small">
   <PropDescription>
     Smaller size

--- a/bundles/org.openhab.ui/doc/components/oh-stepper.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper.md
@@ -58,6 +58,11 @@ Stepper control, allows to input a number or decrement/increment it using button
     Display the buttons without the value in the middle
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="enableInput" label="Enable Input Field">
+  <PropDescription>
+    Enables the input field between the buttons. Note that this might not work when min/max is set.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="small" label="Small">
   <PropDescription>
     Smaller size

--- a/bundles/org.openhab.ui/doc/components/oh-stepper.md
+++ b/bundles/org.openhab.ui/doc/components/oh-stepper.md
@@ -48,6 +48,11 @@ Stepper control, allows to input a number or decrement/increment it using button
     Minimum interval between values
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="offset" label="Offset">
+  <PropDescription>
+    Offset to be applied to the Item's state (e.g. Item state = 2; offset = 20; stepper behaves as Item state would be 22)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="buttonsOnly" label="Buttons Only">
   <PropDescription>
     Display the buttons without the value in the middle

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/knob.js
@@ -6,6 +6,7 @@ export default () => [
   pn('min', 'Min', 'Minimum value (default 0)'),
   pn('max', 'Max', 'Maximum value (default 100)'),
   pd('step', 'Step', 'Minimum interval between values (default 1)'),
+  pd('offset', 'Offset', 'Offset to be applied to the Item\'s state (e.g. Item state = 2; offset = 20; knob/rounded slider behaves as Item state would be 22)'),
   pb('releaseOnly', 'Send command only on release', 'If enabled, no commands are sent during sliding'),
   pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)').a(),
   pn('delayStateDisplay', 'Delay State Display', 'Time to wait before switching from displaying user input to displaying Item state in ms (default 2000)').a(),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/stepper.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/stepper.js
@@ -7,6 +7,7 @@ export default () => [
   pd('step', 'Step', 'Minimum interval between values'),
   pd('offset', 'Offset', 'Offset to be applied to the Item\'s state (e.g. Item state = 2; offset = 20; stepper behaves as Item state would be 22)'),
   pb('buttonsOnly', 'Buttons Only', 'Display the buttons without the value in the middle'),
+  pb('enableInput', 'Enable Input Field', 'Enables the input field between the buttons. Note that this might not work when min/max is set.'),
   pb('small', 'Small', 'Smaller size'),
   pb('large', 'Large', 'Larger size'),
   pb('fill', 'Fill', 'Fill the buttons with the primary color'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/stepper.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/stepper.js
@@ -1,10 +1,11 @@
-import { pi, pb, pn, pd } from '../helpers.js'
+import { pi, pb, pd } from '../helpers.js'
 
 export default () => [
   pi('item', 'Item', 'Item to control'),
   pd('min', 'Min', 'Minimum value'),
   pd('max', 'Max', 'Maximum value'),
   pd('step', 'Step', 'Minimum interval between values'),
+  pd('offset', 'Offset', 'Offset to be applied to the Item\'s state (e.g. Item state = 2; offset = 20; stepper behaves as Item state would be 22)'),
   pb('buttonsOnly', 'Buttons Only', 'Display the buttons without the value in the middle'),
   pb('small', 'Small', 'Smaller size'),
   pb('large', 'Large', 'Larger size'),

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
@@ -1,6 +1,5 @@
 <template>
-  <round-slider v-bind="resolvedConfig" :value="value" :style="`stroke-dasharray: ${(config.dottedPath) ? config.dottedPath : 0}`" mouseScrollAction="true"
-                @input="sendCommandDebounced($event)" @click.native.stop="sendCommandDebounced(value, true)" @touchend.native.stop="sendCommandDebounced(value, true)" />
+  <round-slider v-bind="resolvedConfig" :value="computedValue" :style="`stroke-dasharray: ${(config.dottedPath) ? config.dottedPath : 0}`" mouseScrollAction="true" @input="onChange" />
 </template>
 
 <script>
@@ -16,6 +15,9 @@ export default {
   },
   widget: OhKnobDefinition,
   computed: {
+    computedValue () {
+      return (typeof this.config.offset === 'number') ? (this.value + this.config.offset) : this.value
+    },
     resolvedConfig () {
       const cfg = this.config
       return {
@@ -29,6 +31,12 @@ export default {
         startAngle: !cfg.circleShape !== undefined ? (cfg.startAngle !== undefined ? cfg.startAngle : -50) : null,
         endAngle: !cfg.circleShape !== undefined ? (cfg.endAngle !== undefined ? cfg.endAngle : -130) : null
       }
+    }
+  },
+  methods: {
+    onChange (newValue) {
+      if (typeof this.config.offset === 'number') newValue -= this.config.offset
+      this.sendCommandDebounced(newValue)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -1,7 +1,12 @@
 <template>
   <f7-stepper ref="stepper" v-bind="config" :value="value" @stepper:change="onChange" @click.native.stop
-              :manual-input-mode="false" :format-value="formatValue" />
+              :input="false" :manual-input-mode="false" :format-value="formatValue" />
 </template>
+
+<style lang="stylus">
+.stepper-value
+  margin-top: 0px
+</style>
 
 <script>
 import mixin from '../widget-mixin'

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-stepper ref="stepper" v-bind="config" :value="value" @stepper:change="onChange" @click.native.stop
-              :input="false" :manual-input-mode="false" :format-value="formatValue" />
+              :input="config.enableInput === true" :manual-input-mode="false" :format-value="formatValue" />
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -21,13 +21,14 @@ export default {
   },
   computed: {
     value () {
+      const applyOffset = (value) => (typeof this.config.offset === 'number') ? value + this.config.offset : value
       if (this.config.variable) {
         if (this.config.variableKey) {
-          return this.getLastVariableKeyValue(this.context.vars[this.config.variable], this.config.variableKey)
+          return applyOffset(this.getLastVariableKeyValue(this.context.vars[this.config.variable], this.config.variableKey))
         }
-        return this.context.vars[this.config.variable]
+        return applyOffset(this.context.vars[this.config.variable])
       }
-      let value = this.toStepFixed(parseFloat(this.context.store[this.config.item].state))
+      let value = applyOffset(this.toStepFixed(parseFloat(this.context.store[this.config.item].state)))
       if (this.config.min !== undefined) value = Math.max(value, this.config.min)
       if (this.config.max !== undefined) value = Math.min(value, this.config.max)
       return value
@@ -50,11 +51,12 @@ export default {
       return parseFloat(Number(value).toFixed(nbDecimals))
     },
     onChange (value) {
-      let newValue = this.toStepFixed(value)
+      const applyOffset = (value) => (typeof this.config.offset === 'number') ? value - this.config.offset : value
+      let newValue = applyOffset(this.toStepFixed(value))
       if (newValue === this.value) return
       if (this.config.variable) {
         if (this.config.variableKey) {
-          newValue = this.setVariableKeyValues(this.context.vars[this.config.variable], this.config.variableKey, value)
+          newValue = applyOffset(this.setVariableKeyValues(this.context.vars[this.config.variable], this.config.variableKey, value))
         }
         this.$set(this.context.vars, this.config.variable, newValue)
       } else if (this.config.item) {


### PR DESCRIPTION
Supersedes #1565.

This adds an offset parameter to the knob and stepper components, that allows to add or subtract a number value to the displayed state of the component. 

This is useful for thermostats which have a fixed temperature of n and are controlled with an offset to that temperature n, e.g. you have a KNX HVAC system which has a fixed temperature of 20 °C: -2 would mean the target temperature is 18 °C, +2 would mean that the target temperature is 22 °C. By setting the offset parameter to 20, the UI will display the real target temperature instead of the -2 or 2.