### PR TITLE
Developer sidebar: Support search in metadata value and config

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -453,10 +453,7 @@ export default {
       query = query.toLowerCase()
       if (i.name.toLowerCase().indexOf(query) >= 0) return true
       if (i.label && i.label.toLowerCase().indexOf(query) >= 0) return true
-      if (i.metadata) {
-        const namespaces = Object.keys(i.metadata).map(n => n.toLowerCase())
-        if (namespaces.includes(query)) return true
-      }
+      if (i.metadata && JSON.stringify(i.metadata).toLowerCase().indexOf(query) >= 0) return true
       if (i.tags && i.tags.map(t => t.toLowerCase()).includes(query)) return true
       return false
     },


### PR DESCRIPTION
Improves developer sidebar search to even search within the metadata values and config object. 

This e.g. allows you to search for all pattern settings in the `stateDescription` metadata.

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/5937600/236666202-d3916cf6-0c3d-4d39-91d6-159723b4e2d2.png">
