### PR TITLE
[blockly] Automatic shadow block conversion into real block

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -12,6 +12,7 @@
         "@blockly/field-slider": "^4.0.3",
         "@blockly/plugin-cross-tab-copy-paste": "^2.0.4",
         "@blockly/plugin-workspace-search": "^6.0.7",
+        "@blockly/shadow-block-converter": "^2.0.13",
         "@blockly/theme-dark": "^4.0.1",
         "@blockly/zoom-to-fit": "^3.0.3",
         "@jsep-plugin/arrow": "^1.0.5",
@@ -2787,6 +2788,17 @@
       "integrity": "sha512-MXMR5pgbFCm47QZ5cyFVyF4TwP6bIP0Po59/Sp3QzlutD+OTiecLolXivBYXGriQfBYpNzlD5BQvWD0UtoDDXA==",
       "engines": {
         "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^9.0.0"
+      }
+    },
+    "node_modules/@blockly/shadow-block-converter": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@blockly/shadow-block-converter/-/shadow-block-converter-2.0.13.tgz",
+      "integrity": "sha512-EQWO6GLAEPw+hh4bTrpEPPD/Zar+fQ7u4a4loSwBYHvzApDoOS5uAMeuFzeuWOV5RoucHmBtnQtw8LvpKGK5Xw==",
+      "engines": {
+        "node": ">=8.0.0"
       },
       "peerDependencies": {
         "blockly": "^9.0.0"
@@ -26583,6 +26595,12 @@
       "version": "6.0.7",
       "resolved": "https://registry.npmjs.org/@blockly/plugin-workspace-search/-/plugin-workspace-search-6.0.7.tgz",
       "integrity": "sha512-MXMR5pgbFCm47QZ5cyFVyF4TwP6bIP0Po59/Sp3QzlutD+OTiecLolXivBYXGriQfBYpNzlD5BQvWD0UtoDDXA==",
+      "requires": {}
+    },
+    "@blockly/shadow-block-converter": {
+      "version": "2.0.13",
+      "resolved": "https://registry.npmjs.org/@blockly/shadow-block-converter/-/shadow-block-converter-2.0.13.tgz",
+      "integrity": "sha512-EQWO6GLAEPw+hh4bTrpEPPD/Zar+fQ7u4a4loSwBYHvzApDoOS5uAMeuFzeuWOV5RoucHmBtnQtw8LvpKGK5Xw==",
       "requires": {}
     },
     "@blockly/theme-dark": {

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -64,6 +64,7 @@
     "@blockly/field-slider": "^4.0.3",
     "@blockly/plugin-cross-tab-copy-paste": "^2.0.4",
     "@blockly/plugin-workspace-search": "^6.0.7",
+    "@blockly/shadow-block-converter": "^2.0.13",
     "@blockly/theme-dark": "^4.0.1",
     "@blockly/zoom-to-fit": "^3.0.3",
     "@jsep-plugin/arrow": "^1.0.5",

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1033,6 +1033,8 @@ import { javascriptGenerator } from 'blockly/javascript'
 import DarkTheme from '@blockly/theme-dark'
 import { CrossTabCopyPaste } from '@blockly/plugin-cross-tab-copy-paste'
 import { ZoomToFitControl } from '@blockly/zoom-to-fit'
+import { shadowBlockConversionChangeListener } from '@blockly/shadow-block-converter';
+
 import Vue from 'vue'
 
 import defineOHBlocks from '@/assets/definitions/blockly'
@@ -1145,6 +1147,7 @@ export default {
           },
         trashcan: false
       })
+      this.workspace.addChangeListener(shadowBlockConversionChangeListener);
       const workspaceSearch = new WorkspaceSearch(this.workspace)
       workspaceSearch.init()
 

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1033,7 +1033,7 @@ import { javascriptGenerator } from 'blockly/javascript'
 import DarkTheme from '@blockly/theme-dark'
 import { CrossTabCopyPaste } from '@blockly/plugin-cross-tab-copy-paste'
 import { ZoomToFitControl } from '@blockly/zoom-to-fit'
-import { shadowBlockConversionChangeListener } from '@blockly/shadow-block-converter';
+import { shadowBlockConversionChangeListener } from '@blockly/shadow-block-converter'
 
 import Vue from 'vue'
 
@@ -1147,7 +1147,7 @@ export default {
           },
         trashcan: false
       })
-      this.workspace.addChangeListener(shadowBlockConversionChangeListener);
+      this.workspace.addChangeListener(shadowBlockConversionChangeListener)
       const workspaceSearch = new WorkspaceSearch(this.workspace)
       workspaceSearch.init()
 


### PR DESCRIPTION
This blockly plugin automatically converts a shadow block into a real block as soon as it is being edited. This is very helpful in case the same block needs to be reused again and can therefore be copied:

Before editing:
<img width="236" alt="image" src="https://user-images.githubusercontent.com/5937600/236669226-dc0db90b-c6b9-478c-9e30-219c24945644.png">
After:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/5937600/236669242-783755e0-9017-479b-a378-59742427c770.png">



Known issues: 
- this sometimes only works if the whole block is selected with the option "external inputs":
<img width="130" alt="image" src="https://user-images.githubusercontent.com/5937600/236668352-63198e33-a254-493e-9deb-ede6f4d9d385.png">

- unfortunately it also doesn't work with item and thing picker. The root cause remains to be seen and is currently being investigated with the blockly community.
