### PR TITLE
`foreground-service`: Listen to tab visibility change event

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-foreground-service.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-foreground-service.js
@@ -21,6 +21,14 @@ export default {
 
     this.$f7.on('pageAfterIn', this.onPageAfterIn)
     this.$f7.on('pageBeforeOut', this.onPageBeforeOut)
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState === 'visible') {
+        this.startForegroundActivity()
+      } else if (document.visibilityState === 'hidden') {
+        this.stopForegroundActivity()
+      }
+    })
   },
   beforeDestroy () {
     this.$f7.off('pageAfterIn', this.onPageAfterIn)


### PR DESCRIPTION
Fixes #1872.

This makes the foreground service also listen to the `visibilitychange` event to stop and resume foreground activity when the tab is changed or the browser is closed.

See https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilitychange_event.