### PR TITLE
Transformation edit: Remove i18n string from Item state transform hint

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-edit.vue
@@ -119,7 +119,7 @@ export default {
       return false
     },
     itemStateTransformationCode () {
-      return `${this.transformation.type.toUpperCase()}(${this.transformationId})`
+      return `${this.transformation.type.toUpperCase()}(${this.transformationId.replace(/:([A-Z][a-z]{1,2}-)?([a-z]{2,3})(-[A-Z]{2,3})?$/, '')})`
     }
   },
   methods: {


### PR DESCRIPTION
Follow-up for #1845.

The i18n identifier should not be part of the hint "How to use this transformation for Item states".