### PR TITLE
Fix Things by binding & pages by type not in alphabetical order

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -181,7 +181,7 @@ export default {
           return prev
         }, {})
       } else {
-        return this.pages.reduce((prev, page, i, things) => {
+        const typeGroups = this.pages.reduce((prev, page, i, things) => {
           const type = this.getPageType(page).label
           if (!prev[type]) {
             prev[type] = []
@@ -189,6 +189,10 @@ export default {
           prev[type].push(page)
 
           return prev
+        }, {})
+        return Object.keys(typeGroups).sort().reduce((objEntries, key) => {
+          objEntries[key] = typeGroups[key]
+          return objEntries
         }, {})
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -190,7 +190,7 @@ export default {
 
           return prev
         }, {})
-        return Object.keys(typeGroups).sort().reduce((objEntries, key) => {
+        return Object.keys(typeGroups).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
           objEntries[key] = typeGroups[key]
           return objEntries
         }, {})

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -153,7 +153,7 @@ export default {
           return prev
         }, {})
       } else {
-        return filteredInbox.reduce((prev, entry, i, inbox) => {
+        const bindingGroups = filteredInbox.reduce((prev, entry, i, inbox) => {
           const binding = entry.thingUID.split(':')[0]
           if (!prev[binding]) {
             prev[binding] = []
@@ -161,6 +161,10 @@ export default {
           prev[binding].push(entry)
 
           return prev
+        }, {})
+        return Object.keys(bindingGroups).sort().reduce((objEntries, key) => {
+          objEntries[key] = bindingGroups[key]
+          return objEntries
         }, {})
       }
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -162,7 +162,7 @@ export default {
 
           return prev
         }, {})
-        return Object.keys(bindingGroups).sort().reduce((objEntries, key) => {
+        return Object.keys(bindingGroups).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
           objEntries[key] = bindingGroups[key]
           return objEntries
         }, {})

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -163,7 +163,7 @@ export default {
           return prev
         }, {})
       } else {
-        return this.things.reduce((prev, thing, i, things) => {
+        const bindingGroups = this.things.reduce((prev, thing, i, things) => {
           const binding = thing.thingTypeUID.split(':')[0]
           if (!prev[binding]) {
             prev[binding] = []
@@ -171,6 +171,10 @@ export default {
           prev[binding].push(thing)
 
           return prev
+        }, {})
+        return Object.keys(bindingGroups).sort().reduce((objEntries, key) => {
+          objEntries[key] = bindingGroups[key]
+          return objEntries
         }, {})
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -172,7 +172,7 @@ export default {
 
           return prev
         }, {})
-        return Object.keys(bindingGroups).sort().reduce((objEntries, key) => {
+        return Object.keys(bindingGroups).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
           objEntries[key] = bindingGroups[key]
           return objEntries
         }, {})

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -151,7 +151,7 @@ export default {
 
           return prev
         }, {})
-        return Object.keys(typeGroups).sort().reduce((objEntries, key) => {
+        return Object.keys(typeGroups).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
           objEntries[key] = typeGroups[key]
           return objEntries
         }, {})


### PR DESCRIPTION
Fixes #792.
Fixes #1673.

This fixes the `Things by binding` and `pages by type` order to always be alphentically.
These views only seemed to be alphabetically ordered in edge cases.