### PR TITLE
Sitemap code generation in mainUI, quote colors

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
@@ -162,7 +162,7 @@ describe('dslUtil', () => {
       ]
     })
     const sitemap = dslUtil.toDsl(component).split('\n')
-    expect(sitemap[1]).toEqual('    Text item=Temperature valuecolor=[Last_Update==Uninitialized=gray,>=25=orange,==15=green,0=white,blue]')
+    expect(sitemap[1]).toEqual('    Text item=Temperature valuecolor=[Last_Update==Uninitialized="gray",>=25="orange",==15="green",0="white","blue"]')
   })
 
   it('renders widget with valuecolor and text condition correctly', () => {
@@ -176,6 +176,6 @@ describe('dslUtil', () => {
       ]
     })
     const sitemap = dslUtil.toDsl(component).split('\n')
-    expect(sitemap[1]).toEqual('    Text item=Temperature valuecolor=[Heat_Warning=="It is hot"=gray]')
+    expect(sitemap[1]).toEqual('    Text item=Temperature valuecolor=[Heat_Warning=="It is hot"="gray"]')
   })
 })

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -42,7 +42,7 @@ function writeWidget (widget, indent) {
           dsl += widget.config[key].filter(Boolean).map(color => {
             let index = color.lastIndexOf('=') + 1
             let colorvalue = color.substring(index)
-            if (/^[^"'].*\W.*[^"']$/.test(colorvalue)) {
+            if (!/^(".*")|('.*')$/.test(colorvalue)) {
               colorvalue = '"' + colorvalue + '"'
             }
             colorvalue = (index > 0 ? '=' + colorvalue : colorvalue)


### PR DESCRIPTION
The sitemap syntax requires colors in icon, label and valuecolors to be strings and have quotes around the values.
This is currently not respected, therefore the generated code could not be used without correction when copied into a sitemap file.

This PR fixes that bug.