### PR TITLE
[bloxkly] Fix picker update detection to allow shadow block conversion

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/date-field.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/date-field.js
@@ -38,8 +38,7 @@ export class FieldDatePicker extends Blockly.FieldTextInput {
             change (calendar, value) {
               if (value.length < 1) return
               if (!value[0].toISOString) return
-              self.value_ = dayjs(value[0]).format('YYYY-MM-DD')
-              self.setEditorValue_(self.value)
+              self.setEditorValue_(dayjs(value[0]).format('YYYY-MM-DD'))
             }
           }
         })

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/item-field.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/item-field.js
@@ -18,8 +18,7 @@ export class FieldItemModelPicker extends Blockly.FieldTextInput {
   showEditor_ (options) {
     if (this.f7) {
       const itemsPicked = (value) => {
-        this.value_ = value.name
-        this.setEditorValue_(this.value)
+        this.setEditorValue_(value.name)
       }
       const popup = {
         component: ModelPickerPopup

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/thing-field.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/fields/thing-field.js
@@ -18,8 +18,7 @@ export class FieldThingPicker extends Blockly.FieldTextInput {
   showEditor_ (options) {
     if (this.f7) {
       const itemsPicked = (value) => {
-        this.value_ = value
-        this.setEditorValue_(this.value)
+        this.setEditorValue_(value)
       }
       const popup = {
         component: ThingPicker


### PR DESCRIPTION
Follow-up for #1877.

This improves the above PR which didn't capture the openHAB blocks for shadow block conversion due to a small implementation issue in the Item, Thing and date pickers. 
Now all these three work fine as well.