### PR TITLE
Remove "Other Services" section from main settings page

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
@@ -134,14 +134,6 @@
               :link="'services/' + service.id"
               :title="service.label" />
           </f7-list>
-          <f7-block-title>Other Services</f7-block-title>
-          <f7-list class="search-list">
-            <f7-list-item
-              v-for="service in otherServices"
-              :key="service.id"
-              :link="'services/' + service.id"
-              :title="service.label" />
-          </f7-list>
         </f7-col>
       </f7-row>
       <f7-block-footer v-if="$t('home.overview.title') !== 'Overview'" class="margin text-align-center">
@@ -161,7 +153,6 @@ export default {
       servicesLoaded: false,
       addonStoreTabShortcuts: AddonStoreTabShortcuts,
       systemServices: [],
-      otherServices: [],
       objectsSubtitles: {
         things: 'Manage the physical layer',
         model: 'The semantic model of your home',
@@ -201,7 +192,6 @@ export default {
       // can be done in parallel!
       servicesPromise.then((data) => {
         this.systemServices = data.filter(s => s.category === 'system')
-        this.otherServices = data.filter(s => s.category !== 'system' && s.category !== 'persistence')
         this.servicesLoaded = true
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/settings-menu.vue
@@ -201,7 +201,7 @@ export default {
       // can be done in parallel!
       servicesPromise.then((data) => {
         this.systemServices = data.filter(s => s.category === 'system')
-        this.otherServices = data.filter(s => s.category !== 'system')
+        this.otherServices = data.filter(s => s.category !== 'system' && s.category !== 'persistence')
         this.servicesLoaded = true
       })
     },


### PR DESCRIPTION
Add-on service settings are configurable from the respective add-on's page and therefore the "Other Services" section of the main settings page is not needed anymore.
Services provided by openHAB core that were previously listed unter "Other Services" were moved to "System Services".