### PR TITLE
[basic] Fix wrong addon id

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.ui.basic/src/main/resources/OH-INF/addon/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<addon:addon id="basicui" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<addon:addon id="basic" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:addon="https://openhab.org/schemas/addon/v1.0.0"
 	xsi:schemaLocation="https://openhab.org/schemas/addon/v1.0.0 https://openhab.org/schemas/addon-1.0.0.xsd">
 


### PR DESCRIPTION
The Basic UI uses `basic` as add-on id, not `basicui`.