### PR TITLE
[BasicUI] Handle properly state updates to NULL or UNDEF

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/setpoint.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/setpoint.html
@@ -13,6 +13,7 @@
 		data-max="%maxValue%"
 		data-min="%minValue%"
 		data-step="%step%"
+		data-has-value="%has_value%"
 		data-value="%state%"
 		data-unit="%unit%"
 		data-widget-id="%widget_id%"


### PR DESCRIPTION
Live update to NULL state is no more ignored.
Live update to NULL or UNDEF is now properly handled by setpoint and slider widgets.

Fix #1886

Signed-off-by: Laurent Garnier <lg.hc@free.fr>