### PR TITLE
[blockly] Show toast instead of error when saving / running from code preview

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -298,7 +298,7 @@ export default {
         if (!this.eventSource) this.startEventSource()
       })
     },
-    save (noToast) {
+    saveRule (noToast) {
       if (!this.isEditable) return
       if (this.rule.status.status === 'RUNNING') {
         this.$f7.toast.create({
@@ -321,7 +321,7 @@ export default {
               destroyOnClose: true,
               closeTimeout: 3000
             }).open()
-            return Promise.reject()
+            return Promise.reject('saveOnCodePreviewRejected')
           }
         } catch (e) {
           this.$f7.dialog.alert(e)
@@ -346,6 +346,9 @@ export default {
           closeTimeout: 2000
         }).open()
       })
+    },
+    save () {
+      this.saveRule().catch((e) => { if (e !== 'saveOnCodePreviewRejected') { throw (e) } })
     },
     changeLanguage (contentType) {
       if (this.createMode) return
@@ -383,7 +386,7 @@ export default {
         closeTimeout: 2000
       }).open()
 
-      const savePromise = (this.isEditable && (this.dirty || this.isBlockly)) ? this.save(true) : Promise.resolve()
+      const savePromise = (this.isEditable && (this.dirty || this.isBlockly)) ? this.saveRule(true) : Promise.resolve()
 
       savePromise.then(() => {
         this.$oh.api.postPlain('/rest/rules/' + this.rule.uid + '/runnow', '').catch((err) => {
@@ -394,7 +397,7 @@ export default {
           }).open()
         })
       })
-        .catch(() => {})
+        .catch((e) => { if (e !== 'saveOnCodePreviewRejected') { throw (e) } })
     },
     deleteRule () {
       this.$f7.dialog.confirm(

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -310,8 +310,19 @@ export default {
       }
       if (this.isBlockly) {
         try {
-          this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
-          this.script = this.$refs.blocklyEditor.getCode()
+          if (!this.blocklyCodePreview) {
+            this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
+            this.script = this.$refs.blocklyEditor.getCode()
+          } else {
+            this.$f7.toast.create({
+              text: 'Running / saving is only supported in block mode - <br>please switch back from code preview to block editor',
+              position: 'center',
+              icon: '<i class="f7-icons">exclamationmark_bubble</i>',
+              destroyOnClose: true,
+              closeTimeout: 3000
+            }).open()
+            return Promise.reject()
+          }
         } catch (e) {
           this.$f7.dialog.alert(e)
           return Promise.reject(e)
@@ -383,6 +394,7 @@ export default {
           }).open()
         })
       })
+        .catch(() => {})
     },
     deleteRule () {
       this.$f7.dialog.confirm(


### PR DESCRIPTION
Since the very beginning the following error dialog always annoyed me...

<img width="636" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/cdbeaeaf-276e-4b26-ab6c-327caf4ead89">

which happens when you try to save in the blocky code review.

Instead we can detect that situation and show a nice hint that saving (and running) is not supported when in the code review page:

<img width="377" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/fa6b41a8-e526-4e97-9a5e-03ab9a269eea">
