### PR TITLE
Items: Add `unit` metadata for UoM (`Number:`) Items

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -1,5 +1,6 @@
 export default [
   { name: 'stateDescription', label: 'State Description' },
+  { name: 'unit', label: 'Internal Unit' },
   { name: 'commandDescription', label: 'Command Options' },
   { name: 'synonyms', label: 'Synonyms' },
   { name: 'widget', label: 'Default Standalone Widget' },

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -1,6 +1,6 @@
 export default [
+  { name: 'unit', label: 'Unit' },
   { name: 'stateDescription', label: 'State Description' },
-  { name: 'unit', label: 'Internal Unit' },
   { name: 'commandDescription', label: 'Command Options' },
   { name: 'synonyms', label: 'Synonyms' },
   { name: 'widget', label: 'Default Standalone Widget' },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -37,6 +37,9 @@ export default {
       metadataNamespaces: MetadataNamespaces
     }
   },
+  beforeMount () {
+    if (this.item.type.indexOf('Number:') < 0) this.metadataNamespaces = this.metadataNamespaces.filter(n => n.name !== 'unit')
+  },
   computed: {
     editableNamespaces () {
       if (!this.item.metadata) return []
@@ -54,9 +57,9 @@ export default {
     },
     wellKnownNamespaces () {
       return this.editableNamespaces
-        .filter((n) => MetadataNamespaces.some((wk) => wk.name === n.name))
+        .filter((n) => this.metadataNamespaces.some((wk) => wk.name === n.name))
         .map((n) => {
-          const wellKnown = MetadataNamespaces.find((wk) => wk.name === n.name)
+          const wellKnown = this.metadataNamespaces.find((wk) => wk.name === n.name)
           return {
             ...n,
             label: wellKnown.label
@@ -65,7 +68,7 @@ export default {
     },
     customNamespaces () {
       return this.editableNamespaces
-        .filter((n) => !MetadataNamespaces.some((wk) => wk.name === n.name))
+        .filter((n) => !this.metadataNamespaces.some((wk) => wk.name === n.name))
         .map((n) => {
           return {
             ...n,
@@ -87,7 +90,7 @@ export default {
         buttons: [
           [
             { label: true, text: 'Well-known namespaces' },
-            ...MetadataNamespaces.map((n) => {
+            ...this.metadataNamespaces.map((n) => {
               return {
                 text: n.label,
                 color: 'blue',

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -4,7 +4,7 @@
       <f7-list>
         <ul>
           <f7-list-item
-            v-for="namespace in wellKnownNamespaces" :key="namespace"
+            v-for="namespace in wellKnownNamespaces" :key="namespace.name"
             :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
             :title="namespace.label"
             :after="namespace.value || 'Not Set'" />
@@ -12,7 +12,7 @@
         <ul v-if="customNamespaces.length > 0">
           <f7-list-item divider />
           <f7-list-item
-            v-for="namespace in customNamespaces" :key="namespace"
+            v-for="namespace in customNamespaces" :key="namespace.name"
             :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
             :title="namespace.label"
             :after="namespace.value || 'Not Set'" />

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
@@ -5,7 +5,7 @@
     </f7-block-header>
     <f7-list>
       <f7-list-input
-        label="Internal Unit"
+        label="Unit"
         name="value"
         ref="value"
         type="text"
@@ -14,7 +14,13 @@
         @blur="(evt) => metadata.value = evt.target.value" />
     </f7-list>
     <f7-block-footer class="param-description">
-      <small>Unit used internally, e.g. in events and for persistence.<br>The unit of the item is independent of the state description. The state description is used for display purposes only, it can contain any compatible unit and will not affect the internal unit.</small>
+      <small>All processed values are internally normalized to the specified <code>unit</code>. The normalized value is used to propagate the value to external integrations (e.g. persistence, REST API, WebSocket) so these values will always have the specified unit and scale.
+        <br>
+        Changing the <code>unit</code> will change the values that these systems receive.
+        <br>
+        <br>
+        Additionally the <code>unit</code> will be used in UIs if no unit is specified for the state description. The state description is used for display purpose only, it can contain any compatible unit and will not affect the internal <code>unit</code>.
+      </small>
     </f7-block-footer>
   </div>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
@@ -1,0 +1,26 @@
+<template>
+  <div>
+    <f7-block-header>
+      <b style="color: var(--f7-theme-color) !important;">WARNING: Changing the internal unit can corrupt your persisted data!</b>
+    </f7-block-header>
+    <f7-list>
+      <f7-list-input
+        label="Internal Unit"
+        name="value"
+        ref="value"
+        type="text"
+        placeholder="leave empty to use system default"
+        :value="metadata.value"
+        @blur="(evt) => metadata.value = evt.target.value" />
+    </f7-list>
+    <f7-block-footer class="param-description">
+      <small>Unit used internally, e.g. in events and for persistence.<br>The unit of the item is independent of the state description. The state description is used for display purposes only, it can contain any compatible unit and will not affect the internal unit.</small>
+    </f7-block-footer>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['itemName', 'metadata', 'namespace']
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -66,6 +66,7 @@ import YAML from 'yaml'
 import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'
 
 import ItemMetadataItemDescription from '@/components/item/metadata/item-metadata-itemdescription.vue'
+import ItemMetadataUnit from '@/components/item/metadata/item-metadata-unit.vue'
 import ItemMetadataSynonyms from '@/components/item/metadata/item-metadata-synonyms.vue'
 import ItemMetadataWidget from '@/components/item/metadata/item-metadata-widget.vue'
 import ItemMetadataWidgetOrder from '@/components/item/metadata/item-metadata-widgetorder.vue'
@@ -109,6 +110,8 @@ export default {
         case 'stateDescription':
         case 'commandDescription':
           return ItemMetadataItemDescription
+        case 'unit':
+          return ItemMetadataUnit
         case 'synonyms':
           return ItemMetadataSynonyms
         case 'widget':


### PR DESCRIPTION
Fixes #1890.

This adds the `unit` metadata from https://github.com/openhab/openhab-core/pull/3481 to the pre-defined metadata namespaces for UoM Items (Item type `Number:`) and provides a metadata edit page for it.

Once https://github.com/openhab/openhab-core/pull/3611 is merged, the Item create page will be adjusted to set the `unit` metadata to the system default on Item creation.