### PR TITLE
fix blockly uom var support

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
@@ -195,6 +195,7 @@ function generateQuantityCode (block, inputName) {
       code = `Quantity(${input})`
       break
     case 'oh_itemtype':
+    case '': // vars are expected to contain an item object
       code = `${input}.quantityState`
       break
     case 'oh_item':


### PR DESCRIPTION
fixes variable support for the blockly unit of measurement blocks which did not work at all -> var defaults to item object 

Blockly cannot detect the type that is contained in a variable so it expects an item object.
This allows to iterate over a group of item members which returns a list of item objects


