### PR TITLE
`oh-slider` & `oh-knob`: Fix user configured unit (state description) ignored

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-slider-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-card.md
@@ -107,7 +107,7 @@ Display a slider in a card to control an item
 </PropBlock>
 <PropBlock type="TEXT" name="unit" label="Unit">
   <PropDescription>
-    Text to append to the label while dragging the cursor
+    Unit for the command sent and also append to the label while dragging the cursor, leave empty to use Item's unit
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -117,7 +117,7 @@ A cell expanding to a big vertical slider
 </PropBlock>
 <PropBlock type="TEXT" name="unit" label="Unit">
   <PropDescription>
-    Text to append to the label while dragging the cursor
+    Unit for the command sent and also append to the label while dragging the cursor, leave empty to use Item's unit
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-item.md
@@ -112,7 +112,7 @@ Display a slider control in a list
 </PropBlock>
 <PropBlock type="TEXT" name="unit" label="Unit">
   <PropDescription>
-    Text to append to the label while dragging the cursor
+    Unit for the command sent and also append to the label while dragging the cursor, leave empty to use Item's unit
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">

--- a/bundles/org.openhab.ui/doc/components/oh-slider.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider.md
@@ -75,7 +75,7 @@ Slider control, allows to pick a number value on a scale
 </PropBlock>
 <PropBlock type="TEXT" name="unit" label="Unit">
   <PropDescription>
-    Text to append to the label while dragging the cursor
+    Unit for the command sent and also append to the label while dragging the cursor, leave empty to use Item's unit
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="releaseOnly" label="Send command only on release">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/slider.js
@@ -10,7 +10,7 @@ export default () => [
   pb('scale', 'Display Scale', 'Display a scale on the slider'),
   pn('scaleSteps', 'Scale steps', 'Number of (major) scale markers'),
   pn('scaleSubSteps', 'Scale sub-steps', 'Number of scale minor markers between each major marker'),
-  pt('unit', 'Unit', 'Text to append to the label while dragging the cursor'),
+  pt('unit', 'Unit', 'Unit for the command sent and also append to the label while dragging the cursor, leave empty to use Item\'s unit'),
   pb('releaseOnly', 'Send command only on release', 'If enabled, no commands are sent during sliding'),
   pn('commandInterval', 'Command Interval', 'Time to wait between subsequent commands in ms (default 200)'),
   pn('delayStateDisplay', 'Delay State Display', 'Time to wait before switching from displaying user input to displaying item state in ms (default 2000)').a()

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -29,6 +29,13 @@ export default {
       }
     }
   },
+  created () {
+    if (!isNaN(this.value)) {
+      this.sliderValue = this.value
+    } else {
+      this.sliderValue = this.config.min || this.config.max || 0
+    }
+  },
   mounted () {
     // f7-range inside of masonry can get rendered faulty, as the masonry changes its breakpoint layout after being rendered
     // re-calculate the range slider after masonry is updated
@@ -41,7 +48,7 @@ export default {
   },
   methods: {
     formatLabel (value) {
-      return this.toStepFixed(value) + (this.config.unit || '')
+      return this.toStepFixed(value) + (this.unit ? ' ' + this.unit : '')
     },
     formatScaleLabel (value) {
       return this.toStepFixed(value)

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/slide-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/slide-mixin.js
@@ -23,10 +23,15 @@ export default {
         }
       }
       if (this.pendingCommand !== null) return this.pendingCommand // to keep the control reactive when operating
-      const value = this.context.store[this.config.item].state
+      const value = this.context.store[this.config.item].displayState || this.context.store[this.config.item].state
       // use as a brightness control for HSB values
       if (value.split && value.split(',').length === 3) return parseFloat(value.split(',')[2])
       return parseFloat(value)
+    },
+    unit () {
+      if (this.config.unit) return this.config.unit
+      if (this.context.store[this.config.item].displayState && this.context.store[this.config.item].displayState.split(' ').length === 2) return this.context.store[this.config.item].displayState.split(' ')[1]
+      return undefined
     }
   },
   methods: {
@@ -56,8 +61,12 @@ export default {
       }
       if (!this.sendCommandTimer) {
         if (this.displayLockTimer) clearTimeout(this.displayLockTimer)
+        const stateType = this.context.store[this.config.item].type
         this.sendCommandTimer = setTimeout(() => {
-          this.$store.dispatch('sendCommand', { itemName: this.config.item, cmd: this.pendingCommand.toString() })
+          this.$store.dispatch('sendCommand', {
+            itemName: this.config.item,
+            cmd: (this.unit && stateType === 'Quantity') ? this.pendingCommand + ' ' + this.unit : this.pendingCommand.toString()
+          })
           this.lastValueSent = this.pendingCommand
           this.lastDateSent = Date.now()
           this.sendCommandTimer = null


### PR DESCRIPTION
Fixes #1913. Fixes https://github.com/openhab/openhab-core/issues/3643.
Depends on https://github.com/openhab/openhab-core/pull/3647.

While fixing this, I also noticed a minor regression from PR #1894, that I also fixed.