### PR TITLE
[BasicUI] Adjust slider unit handling

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1680,7 +1680,6 @@
 		}, 200);
 
 		_t.setValuePrivate = function(value, itemState) {
-			// itemState contains only value in the display unit (in case unit is set in label pattern)
 			if (_t.hasValue) {
 				_t.valueNode.innerHTML = value;
 			}
@@ -1695,7 +1694,7 @@
 			if (itemState === "NULL" || itemState === "UNDEF") {
 				_t.input.value = 0;
 			} else {
-				_t.input.value = itemState;
+				_t.input.value = itemState.split(" ")[0] * 1;
 			}
 			_t.input.MaterialSlider.change();
 		};


### PR DESCRIPTION
Adjust BasicUI slider unit handling.
So far, the unit was not passed on to the slider. With proposed changes in core https://github.com/openhab/openhab-core/pull/3644, unit would be passed and needs to stripped for the slider to work properly.