### PR TITLE
Sitemap parser: Fix negative numbers not allowed for visibility

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -20,7 +20,6 @@
     lwidget:          ['Text ', 'Group ', 'Image ', 'Frame '],
     lparen:           '(',
     rparen:           ')',
-    colon:            ':',
     lbrace:           '{',
     rbrace:           '}',
     lbracket:         '[',

--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -32,13 +32,13 @@
     lt:               '<',
     gt:               '>',
     equals:           '=',
-    comma:            ',',
-    colon:            ':',
-    hyphen:           '-',
     NL:               { match: /\n/, lineBreaks: true },
     boolean:          /(?:true)|(?:false)/,
     identifier:       /(?:[A-Za-z_][A-Za-z0-9_]*)|(?:[0-9]+[A-Za-z_][A-Za-z0-9_]*)/,
-    number:           /\-?[0-9]+(?:\.[0-9]*)?/,
+    number:           /-?[0-9]+(?:\.[0-9]*)?/,
+    comma:            ',',
+    colon:            ':',
+    hyphen:           '-',
     string:           { match: /"(?:\\["\\]|[^\n"\\])*"/, value: x => x.slice(1, -1) }
   })
   const requiresItem = ['Group', 'Chart', 'Switch', 'Mapview', 'Slider', 'Selection', 'Setpoint', 'Input ', 'Colorpicker', 'Default']


### PR DESCRIPTION
The sitemap DSL parser was not able to correctly recognize negative numbers.
Something like

```
Text icon="error" item=Restafval label="Restafval [MAP(weekdag.map):%1$tA]" visibility=[Restafval>-172800]
```

fails on the hyphen in -172800.

This PR fixes this bug.

This is a regression from https://github.com/openhab/openhab-webui/pull/1843 where explicit recognition of hyphens was introduced for new icon syntax.