### PR TITLE
Items: Fix `unit` metadata not available for UoM groups

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -38,7 +38,7 @@ export default {
     }
   },
   beforeMount () {
-    if (this.item.type.indexOf('Number:') < 0) this.metadataNamespaces = this.metadataNamespaces.filter(n => n.name !== 'unit')
+    if (this.item.type === 'Group' ? this.item.groupType.indexOf('Number:') < 0 : this.item.type.indexOf('Number:') < 0) this.metadataNamespaces = this.metadataNamespaces.filter(n => n.name !== 'unit')
   },
   computed: {
     editableNamespaces () {


### PR DESCRIPTION
Fixes #1933.
Follow-up for #1901.

This enables the unit metadata for UoM groups (i.e. groups with a groupType of `Number:`).