### PR TITLE
[BasicUI] Set color-scheme for OH icon

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/AbstractWidgetRenderer.java
@@ -387,6 +387,18 @@ public abstract class AbstractWidgetRenderer implements WidgetRenderer {
 
         if (color != null) {
             style = "style=\"color:" + color + "\"";
+        } else {
+            switch (config.getTheme()) {
+                case WebAppConfig.THEME_NAME_BRIGHT:
+                    style = "style=\"color-scheme: light\"";
+                    break;
+                case WebAppConfig.THEME_NAME_DARK:
+                    style = "style=\"color-scheme: dark\"";
+                    break;
+                default:
+                    break;
+            }
+
         }
         snippet = snippet.replace("%iconstyle%", style);
 


### PR DESCRIPTION
to have icon color depending on selected theme

Fix #1861

Will work only with SVG custom OH icons containing style="color-scheme: light dark" and currentColor as fill color.

Signed-off-by : Laurent Garnier <lg.hc@free.fr>