### PR TITLE
Developer sidebar: Support search for rule tags

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -442,7 +442,7 @@ export default {
      * Checks:
      *  - name
      *  - label
-     *  - metadata namespaces (requires exact match)
+     *  - metadata
      *  - tags (requires exact match)
      *
      * @param i Item
@@ -465,6 +465,7 @@ export default {
      *  - name
      *  - label
      *  - description
+     *  - tags (requires exact match)
      *  - itemName & thingUID of triggers, actions & conditions
      *  - script content (e.g. JavaScript or Rule DSL)
      *  - script MIME types (requires exact match)
@@ -479,6 +480,7 @@ export default {
       if (r.uid.toLowerCase().indexOf(query) >= 0) return true
       if (r.name.toLowerCase().indexOf(query) >= 0) return true
       if (r.description && r.description.toLowerCase().indexOf(query) >= 0) return true
+      if (r.tags && r.tags.map(t => t.toLowerCase()).includes(query)) return true
       const searchItemOrThing = (m) => {
         // Match Item names non case-intensive
         if (m.configuration.itemName && m.configuration.itemName.toLowerCase().indexOf(query) >= 0) {


### PR DESCRIPTION
It is possible to filter the rules on tags in the search bar of the rule list, as they are visible on screen. As items can be searched by tag in the developer toolbar search, I think it is still useful to extend the rule search in the developer toolbar to tags as well. I tend to give my rules tags, often corresponding to tags on items as well. This allows finding all of these in one place.