### PR TITLE
context block typing, extended Qty block var type support

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -173,6 +173,7 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
           ['triggered event', 'event']
         ]),
         'contextInfo')
+      this.contextInfo = this.getFieldValue('contextInfo')
       this.setInputsInline(true)
       this.setOutput(true, null)
       this.setColour(0)
@@ -192,6 +193,19 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
         return TIP[contextData]
       })
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#retrieve-rule-context-information')
+    },
+    onchange: function (event) {
+      let contextInfo = this.getFieldValue('contextInfo')
+      if (this.contextInfo !== contextInfo) {
+        this.contextInfo = contextInfo
+        if (contextInfo === 'itemName') {
+          this.setOutput(true, 'oh_item')
+          console.log('type = oh_item')
+        } else {
+          this.setOutput(true, 'String')
+          console.log('type = State String')
+        }
+      }
     }
   }
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-uom.js
@@ -195,8 +195,8 @@ function generateQuantityCode (block, inputName) {
       code = `Quantity(${input})`
       break
     case 'oh_itemtype':
-    case '': // vars are expected to contain an item object
-      code = `${input}.quantityState`
+    case '': // vars are expected to contain an item object or the state itself
+      code = `Quantity(${input})`
       break
     case 'oh_item':
       code = `items.getItem(${input}).quantityState`


### PR DESCRIPTION
Fixes #1942.
Requires version 4.5.0 of openhab-js, therefore awaiting https://github.com/openhab/openhab-addons/pull/15219.

- Adds context block typings.
- Adds supports for Item state input in addition to Item object only in case Qty Block has a var as input.