### PR TITLE
Add cacheSource repeater property

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-repeater.md
+++ b/bundles/org.openhab.ui/doc/components/oh-repeater.md
@@ -124,7 +124,7 @@ Iterate over an array and repeat the children components in the default slot
 </PropBlock>
 <PropBlock type="BOOLEAN" name="cacheSource" label="Suppress source refresh">
   <PropDescription>
-    The source array will be cached and not refreshed on page updates
+    For loaded sources (e.g. with Items or rules), the source array will be cached and not refreshed on page updates
   </PropDescription>
 </PropBlock>
 </PropGroup>

--- a/bundles/org.openhab.ui/doc/components/oh-repeater.md
+++ b/bundles/org.openhab.ui/doc/components/oh-repeater.md
@@ -122,6 +122,11 @@ Iterate over an array and repeat the children components in the default slot
     Render all children directly under the repeater's parent, without any container
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="cacheSource" label="Suppress source refresh">
+  <PropDescription>
+    The source array will be cached and not refreshed on page updates
+  </PropDescription>
+</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/repeater.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/repeater.js
@@ -28,5 +28,5 @@ export default () => [
   pt('containerClasses', 'Classes of the container', 'Add these CSS classes to the container'),
   pt('containerStyle', 'Styles of the container', 'Add these CSS styles to the container'),
   pb('fragment', 'No container (fragment)', 'Render all children directly under the repeater\'s parent, without any container'),
-  pb('cacheSource', 'Suppress source refresh', 'The source array will be cached and not refreshed on page updates')
+  pb('cacheSource', 'Suppress source refresh', 'For loaded sources (e.g. with Items or rules), the source array will be cached and not refreshed on page updates')
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/repeater.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/repeater.js
@@ -27,5 +27,6 @@ export default () => [
   pb('listContainer', 'List container', 'The child components will be wrapped in a <code>ul</code> HTML elements instead of a <code>div</code>'),
   pt('containerClasses', 'Classes of the container', 'Add these CSS classes to the container'),
   pt('containerStyle', 'Styles of the container', 'Add these CSS styles to the container'),
-  pb('fragment', 'No container (fragment)', 'Render all children directly under the repeater\'s parent, without any container')
+  pb('fragment', 'No container (fragment)', 'Render all children directly under the repeater\'s parent, without any container'),
+  pb('cacheSource', 'Suppress source refresh', 'The source array will be cached and not refreshed on page updates')
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
@@ -75,6 +75,7 @@ export default {
   },
   asyncComputed: {
     source () {
+      if (this.config.cacheSource && this.sourceCache) return this.sourceCache
       let sourceResult
       if (this.config.sourceType === 'range') {
         const start = this.config.rangeStart || 0
@@ -82,24 +83,23 @@ export default {
         const step = this.config.rangeStep || 1
         sourceResult = Promise.resolve(Array(Math.ceil((stop + 1 - start) / step)).fill(start).map((x, y) => x + y * step))
       } else if (this.config.sourceType === 'itemsWithTags' && this.config.itemTags) {
-        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((d) => Promise.resolve(d.sort(compareItems)))
+        this.sourceCache = (this.config.cacheSource) ? sourceResult : null
       } else if (this.config.sourceType === 'itemsInGroup') {
-        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items/' + this.config.groupItem + '?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((i) => Promise.resolve(i.members.sort(compareItems)))
+        this.sourceCache = (this.config.cacheSource) ? sourceResult : null
       } else if (this.config.sourceType === 'itemStateOptions') {
-        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.stateDescription) ? i.stateDescription.options : []))
+        this.sourceCache = (this.config.cacheSource) ? sourceResult : null
       } else if (this.config.sourceType === 'itemCommandOptions') {
-        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.commandDescription) ? i.commandDescription.commandOptions : []))
+        this.sourceCache = (this.config.cacheSource) ? sourceResult : null
       } else if (this.config.sourceType === 'rulesWithTags' && this.config.ruleTags) {
-        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/rules?summary=true' + '&tags=' + this.config.ruleTags).then((r) => Promise.resolve(r.sort(compareRules)))
+        this.sourceCache = (this.config.cacheSource) ? sourceResult : null
       } else {
         sourceResult = Promise.resolve(this.config.in)
       }
-      this.sourceCache = (this.config.cacheSource) ? sourceResult : null
       return sourceResult
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
@@ -22,6 +22,11 @@ export default {
     Fragment
   },
   widget: OhRepeaterDefinition,
+  data () {
+    return {
+      sourceCache: null
+    }
+  },
   computed: {
     childrenContexts () {
       const iterationContext = (ctx, el, idx, source) => {
@@ -70,7 +75,6 @@ export default {
   },
   asyncComputed: {
     source () {
-      if (this.config.cacheSource && this.sourceCache) return this.sourceCache
       let sourceResult
       if (this.config.sourceType === 'range') {
         const start = this.config.rangeStart || 0
@@ -78,14 +82,19 @@ export default {
         const step = this.config.rangeStep || 1
         sourceResult = Promise.resolve(Array(Math.ceil((stop + 1 - start) / step)).fill(start).map((x, y) => x + y * step))
       } else if (this.config.sourceType === 'itemsWithTags' && this.config.itemTags) {
+        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((d) => Promise.resolve(d.sort(compareItems)))
       } else if (this.config.sourceType === 'itemsInGroup') {
+        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items/' + this.config.groupItem + '?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((i) => Promise.resolve(i.members.sort(compareItems)))
       } else if (this.config.sourceType === 'itemStateOptions') {
+        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.stateDescription) ? i.stateDescription.options : []))
       } else if (this.config.sourceType === 'itemCommandOptions') {
+        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.commandDescription) ? i.commandDescription.commandOptions : []))
       } else if (this.config.sourceType === 'rulesWithTags' && this.config.ruleTags) {
+        if (this.config.cacheSource && this.sourceCache) return this.sourceCache
         sourceResult = this.$oh.api.get('/rest/rules?summary=true' + '&tags=' + this.config.ruleTags).then((r) => Promise.resolve(r.sort(compareRules)))
       } else {
         sourceResult = Promise.resolve(this.config.in)

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
@@ -1,4 +1,4 @@
-<template v-if="ready">
+<template>
   <ul v-if="config.listContainer" :class="config.containerClasses" :style="config.containerStyle">
     <generic-widget-component :context="ctx" v-for="(ctx, idx) in childrenContexts" :key="'repeater-' + idx" @command="onCommand" />
   </ul>
@@ -22,15 +22,6 @@ export default {
     Fragment
   },
   widget: OhRepeaterDefinition,
-  data () {
-    return {
-      ready: false,
-      loadedSource: null
-    }
-  },
-  created () {
-    this.load()
-  },
   computed: {
     childrenContexts () {
       const iterationContext = (ctx, el, idx, source) => {
@@ -75,41 +66,32 @@ export default {
       }
 
       return contexts
-    },
-    source () {
-      if (this.loadedSource !== null) return this.loadedSource
-      switch (this.config.sourceType) {
-        case 'range':
-          const start = this.config.rangeStart || 0
-          const stop = this.config.rangeStop || 10
-          const step = this.config.rangeStep || 1
-          return Array(Math.ceil((stop + 1 - start) / step)).fill(start).map((x, y) => x + y * step)
-        default:
-          return this.config.in
-      }
     }
   },
-  methods: {
-    load () {
-      let loadPromise
-      if (this.config.sourceType === 'itemsWithTags' && this.config.itemTags) {
-        loadPromise = this.$oh.api.get('/rest/items?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((d) => Promise.resolve(d.sort(compareItems)))
+  asyncComputed: {
+    source () {
+      if (this.config.cacheSource && this.sourceCache) return this.sourceCache
+      let sourceResult
+      if (this.config.sourceType === 'range') {
+        const start = this.config.rangeStart || 0
+        const stop = this.config.rangeStop || 10
+        const step = this.config.rangeStep || 1
+        sourceResult = Promise.resolve(Array(Math.ceil((stop + 1 - start) / step)).fill(start).map((x, y) => x + y * step))
+      } else if (this.config.sourceType === 'itemsWithTags' && this.config.itemTags) {
+        sourceResult = this.$oh.api.get('/rest/items?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((d) => Promise.resolve(d.sort(compareItems)))
       } else if (this.config.sourceType === 'itemsInGroup') {
-        loadPromise = this.$oh.api.get('/rest/items/' + this.config.groupItem + '?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((i) => Promise.resolve(i.members.sort(compareItems)))
+        sourceResult = this.$oh.api.get('/rest/items/' + this.config.groupItem + '?metadata=' + this.config.fetchMetadata + '&tags=' + this.config.itemTags).then((i) => Promise.resolve(i.members.sort(compareItems)))
       } else if (this.config.sourceType === 'itemStateOptions') {
-        loadPromise = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.stateDescription) ? i.stateDescription.options : []))
+        sourceResult = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.stateDescription) ? i.stateDescription.options : []))
       } else if (this.config.sourceType === 'itemCommandOptions') {
-        loadPromise = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.commandDescription) ? i.commandDescription.commandOptions : []))
+        sourceResult = this.$oh.api.get('/rest/items/' + this.config.itemOptions).then((i) => Promise.resolve((i.commandDescription) ? i.commandDescription.commandOptions : []))
       } else if (this.config.sourceType === 'rulesWithTags' && this.config.ruleTags) {
-        loadPromise = this.$oh.api.get('/rest/rules?summary=true' + '&tags=' + this.config.ruleTags).then((r) => Promise.resolve(r.sort(compareRules)))
+        sourceResult = this.$oh.api.get('/rest/rules?summary=true' + '&tags=' + this.config.ruleTags).then((r) => Promise.resolve(r.sort(compareRules)))
       } else {
-        this.ready = true
-        return
+        sourceResult = Promise.resolve(this.config.in)
       }
-      loadPromise.then((d) => {
-        this.loadedSource = d
-        this.ready = true
-      })
+      this.sourceCache = (this.config.cacheSource) ? sourceResult : null
+      return sourceResult
     }
   }
 }


### PR DESCRIPTION
fixes #1956 

Adds a boolean property to the repeater (and relevant docs), `cacheSource` which allows the user to determine whether the repeater should refresh the source array with css and object changes or cache the source array for performance improvements.

Signed-off-by : Justin Georgi justin.georgi@gmail.com