### PR TITLE
Persistence page: Fix config update on filter removal

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -25,7 +25,7 @@
           <f7-col>
             <f7-block-footer>
               Persistence stores data over time, which can be retrieved at a later time, e.g. to restore Item states after startup, or to display graphs in the UI.
-              <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo && $store.state.runtimeInfo.buildString !== 'Release Build' ? 'next' : 'www'}.openhab.org/link/persistence`">
+              <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/persistence`">
                 Learn more about persistence.
               </f7-link>
             </f7-block-footer>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -642,7 +642,7 @@ export default {
       const filterName = this.persistence[module][index].name
       this.persistence.configs.forEach((cfg) => {
         const i = cfg.filters.findIndex((f) => f === filterName)
-        cfg.filters.splice(i, 1)
+        if (i > -1) cfg.filters.splice(i, 1)
       })
       this.deleteModule(ev, module, index)
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -25,7 +25,7 @@
           <f7-col>
             <f7-block-footer>
               Persistence stores data over time, which can be retrieved at a later time, e.g. to restore Item states after startup, or to display graphs in the UI.
-              <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/persistence`">
+              <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo && $store.state.runtimeInfo.buildString !== 'Release Build' ? 'next' : 'www'}.openhab.org/link/persistence`">
                 Learn more about persistence.
               </f7-link>
             </f7-block-footer>


### PR DESCRIPTION
When removing a filter, the persistence editor checks which configs use that filter and removes the filter from those configs, otherwise the save request fails with an HTTP error.

However, the implementation was buggy and also removed other filters from configs because of a missing check.