### PR TITLE
Developer sidebar: Fix Thing pinning fails

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -557,7 +557,7 @@ export default {
           Promise.resolve(this.cachedObjects[3])
         ] : [
           this.$oh.api.get('/rest/items?staticDataOnly=true&metadata=.*'),
-          this.$oh.api.get('/rest/things?staticDataOnly=true'),
+          this.$oh.api.get('/rest/things?summary=true'),
           this.$oh.api.get('/rest/rules?summary=false'),
           Promise.resolve(this.$store.getters.pages)
         ]


### PR DESCRIPTION
Regression from #1661.

Using the cacheable list for Things leads to a failure because the status field is not available then.
This reverts the change from #1661 to this single REST request.