### PR TITLE
[blockly] Add Quantity support to round block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
@@ -230,8 +230,7 @@ export function blockGetCheckedInputType (block, inputName) {
   // Get the input type checks for this block
   const thisBlock = block.getInput(inputName).connection.getCheck()
   // Get the output type checks for the connected block
-  if (!block.getInput(inputName).connection.targetBlock()) return ''
-  const connectedBlock = block.getInput(inputName).connection.targetBlock().outputConnection.getCheck()
+  const connectedBlock = block.getInput(inputName).connection.targetBlock()?.outputConnection.getCheck()
   // Skip if no checks are available
   if (!thisBlock || !connectedBlock) return ''
   // Find any intersection in the checklist

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/utils.js
@@ -230,6 +230,7 @@ export function blockGetCheckedInputType (block, inputName) {
   // Get the input type checks for this block
   const thisBlock = block.getInput(inputName).connection.getCheck()
   // Get the output type checks for the connected block
+  if (!block.getInput(inputName).connection.targetBlock()) return ''
   const connectedBlock = block.getInput(inputName).connection.targetBlock().outputConnection.getCheck()
   // Skip if no checks are available
   if (!thisBlock || !connectedBlock) return ''


### PR DESCRIPTION
Round block now also takes a Qty block as input.
Output type changes according to input.

<img width="841" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/2b215802-fecf-4f74-abeb-089f5e0e3d47">
