### PR TITLE
Fix channel for Thing trigger cannot be chosen

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/triggerchannel-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/triggerchannel-picker.vue
@@ -33,7 +33,7 @@ export default {
   },
   created () {
     this.smartSelectParams.closeOnSelect = !(this.multiple)
-    this.$oh.api.get('/rest/things?staticDataOnly=true').then((data) => {
+    this.$oh.api.get('/rest/things').then((data) => {
       this.things = data.sort((a, b) => {
         const labelA = a.label
         const labelB = b.label


### PR DESCRIPTION
Fixes #1996.
Regression from #1661.

Better solution IMO than https://github.com/openhab/openhab-core/pull/3761.