### PR TITLE
Fix missing labels for semantic cards

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -136,7 +136,7 @@
       <developer-sidebar />
     </f7-panel>
 
-    <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
+    <f7-view main v-if="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
 
   <!-- <f7-login-screen id="my-login-screen" :opened="loginScreenOpened">
     <f7-view name="login" v-if="$device.cordova">

--- a/bundles/org.openhab.ui/web/src/js/store/modules/semantics.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/semantics.js
@@ -25,15 +25,12 @@ const actions = {
           state.Points = tags.filter(t => t.uid.startsWith('Point_')).map(t => t.name)
           state.Properties = tags.filter(t => t.uid.startsWith('Property_')).map(t => t.name)
           // Store i18n labels
-          Object.values(tags).forEach(t => {
-            if (t.label) {
-              state.Labels[t.name] = t.label
-            } else {
-              state.Labels[t.name] = t.name
-            }
-          })
+          for (const i in tags) {
+            const t = tags[i]
+            state.Labels[t.name] = t.label || t.name
+          }
           // Save as i18n messages
-          i18n.mergeLocaleMessage(this.getters.locale, state.Labels)
+          i18n.mergeLocaleMessage(i18n.locale, state.Labels)
 
           return Promise.resolve()
         })

--- a/bundles/org.openhab.ui/web/src/js/store/modules/semantics.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/semantics.js
@@ -18,7 +18,7 @@ const getters = {
 const actions = {
   loadSemantics () {
     if (this.getters.apiEndpoint('tags')) {
-      api.get('/rest/tags')
+      return api.get('/rest/tags')
         .then((tags) => {
           state.Locations = tags.filter(t => t.uid.startsWith('Location_')).map(t => t.name)
           state.Equipment = tags.filter(t => t.uid.startsWith('Equipment_')).map(t => t.name)


### PR DESCRIPTION
Fixes #2006.
Probably fixes the issue described in https://github.com/openhab/openhab-webui/pull/1986#issuecomment-1656746939.

Reported on the community: https://community.openhab.org/t/openhab-4-0-release-discussion/147957/86.

Sometimes, the equipment and property cards did not use the translations.
I found out, that in some cases the equipment and property pages (Main UI in general) initialized before the translations loaded, this hopefully solves it.