### PR TITLE
Item details: Fix metadata error thrown when opened

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -38,7 +38,7 @@ export default {
     }
   },
   beforeMount () {
-    if (this.item.type === 'Group' ? this.item.groupType.indexOf('Number:') < 0 : this.item.type.indexOf('Number:') < 0) this.metadataNamespaces = this.metadataNamespaces.filter(n => n.name !== 'unit')
+    if (this.item.type === 'Group' ? (this.item.groupType && this.item.groupType.indexOf('Number:') < 0) : this.item.type.indexOf('Number:') < 0) this.metadataNamespaces = this.metadataNamespaces.filter(n => n.name !== 'unit')
   },
   computed: {
     editableNamespaces () {


### PR DESCRIPTION
When the Item was a group Item and groupType was not defined, an error was thrown. This fixes it.