### PR TITLE
[blockly] Support Quantity in more math blocks

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -270,29 +270,33 @@ export default function (f7, isGraalJs) {
   }
 
   javascriptGenerator['oh_math_minmax'] = function (block) {
+    const operand = block.getFieldValue('OP')
+
     const math_number_input1 = javascriptGenerator.valueToCode(block, 'NUM1', javascriptGenerator.ORDER_FUNCTION_CALL)
     const math_number_input2 = javascriptGenerator.valueToCode(block, 'NUM2', javascriptGenerator.ORDER_FUNCTION_CALL)
 
-    let inputType1 = blockGetCheckedInputType(block, 'NUM1')
-    let inputType2 = blockGetCheckedInputType(block, 'NUM2')
+    /*
+    When dealing with variables, Blockly does not provide type information (type is "").
+    In this case, we fall back to checking whether the actual input contains "Quantity" or is a number.
+     */
+    const inputType1 = blockGetCheckedInputType(block, 'NUM1') || getVariableType(math_number_input1)
+    const inputType2 = blockGetCheckedInputType(block, 'NUM2') || getVariableType(math_number_input2)
 
     /*
-     * When dealing with variables we need to find out best what we are dealing with to generate the right code
-     * if after detection still both types are different, we will throw an exception, but only of not a var is involved!
-     * if we don't know we will get back '' (=var) as the type and if both types are vars we need to assume the vars WILL contain a Number
-     * if only one of the types is a var, then we base the code generation on the other given input type
+    If exactly one of the two inputs is a variable, assume it has the same type as the other input.
+    In case both inputs are vars, assume they are numbers.
      */
-    inputType1 = detectVarQuantityNumberType(inputType1, math_number_input1)
-    inputType2 = detectVarQuantityNumberType(inputType2, math_number_input2)
-
-    const operand = block.getFieldValue('OP')
     const containsOneVar = (inputType1 === '' && inputType2 !== '') || (inputType1 !== '' && inputType2 === '')
 
+    /*
+    If both inputs are not the same type and none of them is a variable, throw an Error on code generation.
+     */
     if (inputType1 !== inputType2 && !containsOneVar) {
       throw new Error(`Both operand types need to be equal for ${operand.toUpperCase()}-block (${math_number_input1} -> ${inputType1}, ${math_number_input2} -> ${inputType2})`)
     }
 
-    const leadType = (!containsOneVar) ? inputType1 : ((inputType1 === '') ? inputType2 : inputType1)
+    const leadType = inputType1 || inputType1
+
     let code = ''
 
     switch (leadType) {
@@ -315,8 +319,7 @@ export default function (f7, isGraalJs) {
  *    if the content of the block contains the word "Quantity", then type is oh_quantity
  *    if the content of the block otherwise contains a number, then the type is Number
  */
-  function detectVarQuantityNumberType (inputType, math_number_input) {
-    if (inputType !== '') return inputType
+  function getVariableType (math_number_input) {
     if (math_number_input.includes('Quantity')) return 'oh_quantity'
     if (!isNaN(math_number_input)) return 'Number'
     return ''

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -138,7 +138,7 @@ export default function (f7, isGraalJs) {
     const decimals = javascriptGenerator.valueToCode(block, 'DECIMALS', javascriptGenerator.ORDER_NONE)
     const operand = block.getFieldValue('op')
 
-    let code = ''
+    let code
     if (operand !== 'toFixed') {
       let method = ''
       switch (operand) {
@@ -165,7 +165,6 @@ export default function (f7, isGraalJs) {
 
   Blockly.Blocks['math_single'] = {
     init: function () {
-      const block = this
       const dropDown = new Blockly.FieldDropdown([
         ['square root', 'ROOT'],
         ['absolute', 'ABS'],
@@ -208,8 +207,6 @@ export default function (f7, isGraalJs) {
     }
     const operand = block.getFieldValue('OP')
 
-    let code = ''
-
     let method = ''
     switch (operand) {
       case 'ROOT':
@@ -234,7 +231,8 @@ export default function (f7, isGraalJs) {
         method = `Math.pow(10,${math_number})`
         break
     }
-    code = `${method}`
+
+    let code = `${method}`
 
     if (inputType === 'oh_quantity') {
       code = `Quantity((${code}).toString() + ' ' + ${math_number_input}.symbol)`
@@ -244,7 +242,6 @@ export default function (f7, isGraalJs) {
 
   Blockly.Blocks['oh_math_minmax'] = {
     init: function () {
-      const block = this
       const dropDown = new Blockly.FieldDropdown([
         ['minimum of', 'min'],
         ['maximum of', 'max']
@@ -277,13 +274,12 @@ export default function (f7, isGraalJs) {
     const inputType2 = blockGetCheckedInputType(block, 'NUM2')
     let math_number_input1 = javascriptGenerator.valueToCode(block, 'NUM1', javascriptGenerator.ORDER_FUNCTION_CALL)
     let math_number_input2 = javascriptGenerator.valueToCode(block, 'NUM2', javascriptGenerator.ORDER_FUNCTION_CALL)
-    if (inputType1 !== 'oh_quantity' && inputType2 === 'oh_quantity') {
-      math_number_input2 = `${math_number_input2}.float`
-    }
-    if (inputType1 === 'oh_quantity' && inputType2 !== 'oh_quantity') {
-      math_number_input1 = `${math_number_input1}.float`
-    }
+
     const operand = block.getFieldValue('OP')
+
+    if (inputType1 !== inputType2) {
+      throw new Error(`both operand types need to be equal for  ${operand.toUpperCase()}-block (${math_number_input1} -> ${inputType1},${math_number_input2} -> ${inputType2})`)
+    }
 
     let code = ''
     switch (operand) {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -169,7 +169,7 @@ export default function (f7, isGraalJs) {
         ['square root', 'ROOT'],
         ['absolute', 'ABS'],
         ['-', 'NEG'],
-        ['n', 'LN'],
+        ['ln', 'LN'],
         ['log10', 'LOG10'],
         ['e^', 'EXP'],
         ['10^', 'POW10']
@@ -187,14 +187,14 @@ export default function (f7, isGraalJs) {
           case 'ROOT': return 'Return the square root of the input'
           case 'ABS': return 'Return the absolute value of the input'
           case 'NEG': return 'Return the negation of the input'
-          case 'LN': return 'Return the logarithm of the input'
-          case 'LOG10': return 'Return the 10 logarithm of the input'
+          case 'LN': return 'Return the natural (base e) logarithm of the input'
+          case 'LOG10': return 'Return the base 10 logarithm of the input'
           case 'EXP': return 'Return e to the power of the input'
           case 'POW10': return 'Return 10 to the power of the input'
         }
       })
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#functions')
-      this.setOutput(true, null)
+      this.setOutput(true, 'Number')
     }
   }
 
@@ -222,7 +222,7 @@ export default function (f7, isGraalJs) {
         method = `Math.log(${math_number})`
         break
       case 'LOG10':
-        method = `Math.log(${math_number}) / Math.log(10)`
+        method = `Math.log10(${math_number})`
         break
       case 'EXP':
         method = `Math.exp(${math_number})`
@@ -272,29 +272,24 @@ export default function (f7, isGraalJs) {
   javascriptGenerator['oh_math_minmax'] = function (block) {
     const inputType1 = blockGetCheckedInputType(block, 'NUM1')
     const inputType2 = blockGetCheckedInputType(block, 'NUM2')
-    let math_number_input1 = javascriptGenerator.valueToCode(block, 'NUM1', javascriptGenerator.ORDER_FUNCTION_CALL)
-    let math_number_input2 = javascriptGenerator.valueToCode(block, 'NUM2', javascriptGenerator.ORDER_FUNCTION_CALL)
+    const math_number_input1 = javascriptGenerator.valueToCode(block, 'NUM1', javascriptGenerator.ORDER_FUNCTION_CALL)
+    const math_number_input2 = javascriptGenerator.valueToCode(block, 'NUM2', javascriptGenerator.ORDER_FUNCTION_CALL)
 
     const operand = block.getFieldValue('OP')
 
     if (inputType1 !== inputType2) {
-      throw new Error(`both operand types need to be equal for  ${operand.toUpperCase()}-block (${math_number_input1} -> ${inputType1},${math_number_input2} -> ${inputType2})`)
+      throw new Error(`Both operand types need to be equal for ${operand.toUpperCase()}-block (${math_number_input1} -> ${inputType1}, ${math_number_input2} -> ${inputType2})`)
     }
 
     let code = ''
-    switch (operand) {
-      case 'min':
-        code = `Math.min(${math_number_input1},${math_number_input2})`
-        if (inputType1 === 'oh_quantity' && inputType2 === 'oh_quantity') {
-          code = `(${math_number_input1}.lessThan(${math_number_input2})) ? ${math_number_input1} : ${math_number_input2}`
-        }
-        break
 
-      case 'max':
-        code = `Math.max(${math_number_input1},${math_number_input2})`
-        if (inputType1 === 'oh_quantity' && inputType2 === 'oh_quantity') {
-          code = `(${math_number_input1}.greaterThan(${math_number_input2})) ? ${math_number_input1} : ${math_number_input2}`
-        }
+    switch (inputType1) {
+      case 'oh_quantity':
+        const op = (operand === 'min') ? 'lessThan' : 'greaterThan'
+        code = `(${math_number_input1}.${op}(${math_number_input2})) ? ${math_number_input1} : ${math_number_input2}`
+        break
+      default:
+        code = `Math.${operand}(${math_number_input1},${math_number_input2})`
         break
     }
 

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -116,6 +116,18 @@
             </shadow>
           </value>
         </block>
+        <block type="oh_math_minmax">
+          <value name="NUM1">
+            <shadow type="math_number">
+              <field name="NUM">3</field>
+            </shadow>
+          </value>
+          <value name="NUM2">
+            <shadow type="math_number">
+              <field name="NUM">4</field>
+            </shadow>
+          </value>
+        </block>
         <block type="math_on_list" />
         <block type="math_modulo">
           <value name="DIVIDEND">


### PR DESCRIPTION
fixes #2001

- Adds Quantity support for more math blocks.
- math_single had to be reimplemented
- math_minmax was added

<img width="396" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/21702807-ac63-49ac-8594-2ff22576cfe9">

Note that there is a special case on min/max if the inputs are not of equal type an error will be shown to user:

<img width="545" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/dd0da049-7b79-4d1c-9c22-6b5941a6b3cc">

In the special case of variables Blockly does its best to detect the right code to be generated for the min/max block:
- both are variables -> then numerical input is expected
- one of inputs is a variable: then blockly uses the type of the other non-var-block to base the generation on (either number or quantity comparison).
- note that no type conversion of the inputs is done

Here are working examples that depict what is possible:

<img width="583" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/a64b3d18-59f6-41dd-afbd-e4a8c55cbbb3">

