### PR TITLE
Use EEAs with maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,10 @@ Import-Package: \\
           <configuration>
             <compilerId>eclipse</compilerId>
             <compilerArgs>
+              <arg>-annotationpath</arg>
+              <arg>CLASSPATH</arg>
+              <arg>-classpath</arg>
+              <arg>${project.build.directory}/dependency</arg>
               <arg>-err:+nullAnnot(org.eclipse.jdt.annotation.Nullable|org.eclipse.jdt.annotation.NonNull|org.eclipse.jdt.annotation.NonNullByDefault),+inheritNullAnnot,+nullAnnotConflict,-nullUncheckedConversion</arg>
               <arg>-warn:+null,+inheritNullAnnot,+nullAnnotConflict,-nullUncheckedConversion,+nullAnnotRedundant,+nullDereference</arg>
             </compilerArgs>


### PR DESCRIPTION
Using this configuration the maven-compiler-plugin will also use the Eclipse External Annotations. This results in more similar build results when not using Eclipse like CI, on the CLI and when using other IDEs.