### PR TITLE
Reverts v-if/v-show change from #2029.

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -141,7 +141,7 @@
       <developer-sidebar />
     </f7-panel>
 
-    <f7-view main v-if="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
+    <f7-view main v-show="ready" class="safe-areas" url="/" :master-detail-breakpoint="960" :animate="themeOptions.pageTransitionAnimation !== 'disabled'" />
 
   <!-- <f7-login-screen id="my-login-screen" :opened="loginScreenOpened">
     <f7-view name="login" v-if="$device.cordova">


### PR DESCRIPTION
Regression from #2029.

@florian-h05 i noticed when upgrading my system this AM that a few of my UI pages stopped loading properly.  Specifically there seemed to be a condition where when the page would draw its widgets before other parts of the page were loaded ( or something similar, some race conditional).  This would result in widgets loading with the wrong state, colors, icons, etc that are dependent on item state.  I tracked it down to this one very small change,  reverting back to a `v-show` from `v-if` for the main view ready state fixes this. 