### PR TITLE
Adds an UI command Item

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/theme-switcher/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/theme-switcher/en.json
@@ -12,5 +12,7 @@
   "about.miscellaneous.home.hideChatInput": "Hide chat input box on home page",
   "about.miscellaneous.home.disableCardExpansionAnimation": "Disable card expansion animations",
   "about.miscellaneous.theme.disablePageTransition": "Disable page transition animations",
-  "about.miscellaneous.webaudio.enable": "Enable Web Audio sink support"
+  "about.miscellaneous.webaudio.enable": "Enable Web Audio sink support",
+  "about.miscellaneous.commandItem.title": "Listen for UI commands",
+  "about.miscellaneous.commandItem.selectItem": "Item"
 }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -272,12 +272,13 @@ import DeveloperSidebar from './developer/developer-sidebar.vue'
 
 import auth from './auth-mixin.js'
 import i18n from './i18n-mixin.js'
+import sseEvents from './sse-events-mixin.js'
 
 import dayjs from 'dayjs'
 import dayjsLocales from 'dayjs/locale.json'
 
 export default {
-  mixins: [auth, i18n],
+  mixins: [auth, i18n, sseEvents],
   components: {
     PanelRight,
     DeveloperSidebar
@@ -622,52 +623,6 @@ export default {
         ev.preventDefault()
       }
     },
-    startEventSource () {
-      this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/webaudio/playurl', null, (event) => {
-        const topicParts = event.topic.split('/')
-        switch (topicParts[2]) {
-          case 'playurl':
-            this.playAudioUrl(JSON.parse(event.payload))
-            break
-        }
-      })
-    },
-    stopEventSource () {
-      this.$oh.sse.close(this.eventSource)
-      this.eventSource = null
-    },
-    playAudioUrl (audioUrl) {
-      try {
-        if (!this.audioContext) {
-          window.AudioContext = window.AudioContext || window.webkitAudioContext
-          if (typeof (window.AudioContext) !== 'undefined') {
-            this.audioContext = new AudioContext()
-            unlockAudioContext(this.audioContext)
-          }
-        }
-        console.log('Playing audio URL: ' + audioUrl)
-        this.$oh.api.getPlain(audioUrl, '', '*/*', 'arraybuffer').then((data) => {
-          this.audioContext.decodeAudioData(data, (buffer) => {
-            let source = this.audioContext.createBufferSource()
-            source.buffer = buffer
-            source.connect(this.audioContext.destination)
-            source.start(0)
-          })
-        })
-      } catch (e) {
-        console.warn('Error while playing audio URL: ' + e.toString())
-      }
-      // Safari requires a touch event after the stream has started, hence this workaround
-      // Credit: https://www.mattmontag.com/web/unlock-web-audio-in-safari-for-ios-and-macos
-      function unlockAudioContext (audioContext) {
-        if (audioContext.state !== 'suspended') return
-        const b = document.body
-        const events = ['touchstart', 'touchend', 'mousedown', 'keydown']
-        events.forEach(e => b.addEventListener(e, unlock, false))
-        function unlock () { audioContext.resume().then(clean) }
-        function clean () { events.forEach(e => b.removeEventListener(e, unlock)) }
-      }
-    },
     /**
      * Creates and opens a toast message that indicates a failure, e.g. of SSE connection
      * @param {string} message message to show
@@ -835,10 +790,8 @@ export default {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }
-
-      if (localStorage.getItem('openhab.ui:webaudio.enable') === 'enabled') {
-        this.startEventSource()
-      }
+      // sse-event mixin
+      this.startEventSource()
     })
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -703,6 +703,7 @@ export default {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }
+
       this.startEventSource()
     })
   }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -272,7 +272,7 @@ import DeveloperSidebar from './developer/developer-sidebar.vue'
 
 import auth from './auth-mixin.js'
 import i18n from './i18n-mixin.js'
-import sseEvents from './sse-events-mixin.js'
+import sseEvents from './sse-events-mixin'
 
 import dayjs from 'dayjs'
 import dayjsLocales from 'dayjs/locale.json'
@@ -298,8 +298,6 @@ export default {
     return {
       init: false,
       ready: false,
-      eventSource: null,
-      audioContext: null,
 
       // Framework7 Parameters
       f7params: {
@@ -790,7 +788,6 @@ export default {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }
-      // sse-event mixin
       this.startEventSource()
     })
   }

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -79,6 +79,8 @@ export default {
                 const payload = {
                   text: segments[0],
                   closeOnClick: true,
+                  closeButton: true,
+                  swipeToClose: true,
                   closeTimeout: 5000
                 }
                 if (segments.length > 1) {

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -78,7 +78,6 @@ export default {
               case 'notification':
                 const payload = {
                   text: segments[0],
-                  closeOnClick: true,
                   closeButton: true,
                   swipeToClose: true,
                   closeTimeout: 5000

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -1,0 +1,160 @@
+import OhPopup from './widgets/modals/oh-popup.vue'
+import OhSheet from './widgets/modals/oh-sheet.vue'
+import OhPopover from './widgets/modals/oh-popover.vue'
+
+export default {
+  data () {
+    return {
+      eventSource: null,
+      audioContext: null
+    }
+  },
+  methods: {
+    startEventSource () {
+      const topicAudio = 'openhab/webaudio/playurl'
+      const commandItem = localStorage.getItem('openhab.ui:commandItem')
+      const topicCommand = `openhab/items/${commandItem || ''}/command`
+      let topics = null
+      if (localStorage.getItem('openhab.ui:webaudio.enable') === 'enabled') {
+        topics = topicAudio
+      }
+      if (commandItem) {
+        topics = topics ? `${topics},${topicCommand}` : topicCommand
+      }
+      if (!topics) return
+      this.eventSource = this.$oh.sse.connect(`/rest/events?topics=${topics}`, null, (event) => {
+        console.debug('Received SSE event: ' + JSON.stringify(event))
+        function closePopup () {
+          const popupEl = this.$el.querySelector('.popup')
+          if (popupEl) {
+            this.$f7.popup.close(popupEl)
+          }
+        }
+        switch (event.topic) {
+          case topicAudio:
+            const topicParts = event.topic.split('/')
+            switch (topicParts[2]) {
+              case 'playurl':
+                this.playAudioUrl(JSON.parse(event.payload))
+                break
+            }
+            break
+          case topicCommand:
+            const payload = JSON.parse(event.payload)
+            const [command, ...segments] = payload.value.trim().split(/(?<!\\):/)
+            const combined = segments.join(':')
+            switch (command) {
+              case 'navigate':
+                this.$f7.views.main.router.navigate(combined)
+                break
+              case 'popup':
+              case 'popover':
+              case 'sheet':
+                if (combined.indexOf('page:') !== 0 && combined.indexOf('widget:') !== 0 && combined.indexOf('oh-') !== 0) {
+                  console.error('Action target is not of the format page:uid or widget:uid')
+                  return
+                }
+                console.debug(`Opening ${combined} in ${command} modal`)
+                let modalRoute = {
+                  url: combined + '/' + command,
+                  route: {
+                  }
+                }
+                if (command === 'popup') modalRoute.route.popup = { component: OhPopup }
+                if (command === 'popover') modalRoute.route.popup = { component: OhPopover }
+                if (command === 'sheet') modalRoute.route.popup = { component: OhSheet }
+                let modalProps = {
+                  props: {
+                    uid: combined,
+                    modalParams: {}
+                  }
+                }
+                this.closePopups()
+                this.$f7.views.main.router.navigate(modalRoute, modalProps)
+                break
+              case 'close':
+                this.closePopups()
+                break
+              case 'back':
+                this.$f7.views.main.router.back()
+                break
+              case 'reload':
+                window.location.reload()
+                break
+              case 'notification':
+                const payload = {
+                  text: segments[0],
+                  closeOnClick: true,
+                  closeTimeout: 5000
+                }
+                if (segments.length > 1) {
+                  payload.title = segments[1]
+                }
+                if (segments.length > 2) {
+                  payload.subtitle = segments[2]
+                }
+                if (segments.length > 3) {
+                  payload.titleRightText = segments[3]
+                }
+                if (segments.length > 4) {
+                  payload.closeTimeout = parseInt(segments[4])
+                }
+                this.$f7.notification.create(payload).open()
+                break
+            }
+            break
+        }
+      })
+    },
+    stopEventSource () {
+      this.$oh.sse.close(this.eventSource)
+      this.eventSource = null
+    },
+    playAudioUrl (audioUrl) {
+      try {
+        if (!this.audioContext) {
+          window.AudioContext = window.AudioContext || window.webkitAudioContext
+          if (typeof (window.AudioContext) !== 'undefined') {
+            this.audioContext = new AudioContext()
+            unlockAudioContext(this.audioContext)
+          }
+        }
+        console.log('Playing audio URL: ' + audioUrl)
+        this.$oh.api.getPlain(audioUrl, '', '*/*', 'arraybuffer').then((data) => {
+          this.audioContext.decodeAudioData(data, (buffer) => {
+            let source = this.audioContext.createBufferSource()
+            source.buffer = buffer
+            source.connect(this.audioContext.destination)
+            source.start(0)
+          })
+        })
+      } catch (e) {
+        console.warn('Error while playing audio URL: ' + e.toString())
+      }
+      // Safari requires a touch event after the stream has started, hence this workaround
+      // Credit: https://www.mattmontag.com/web/unlock-web-audio-in-safari-for-ios-and-macos
+      function unlockAudioContext (audioContext) {
+        if (audioContext.state !== 'suspended') return
+        const b = document.body
+        const events = ['touchstart', 'touchend', 'mousedown', 'keydown']
+        events.forEach(e => b.addEventListener(e, unlock, false))
+        function unlock () { audioContext.resume().then(clean) }
+        function clean () { events.forEach(e => b.removeEventListener(e, unlock)) }
+      }
+    },
+    closePopups () {
+      const popupEl = this.$el.querySelector('.popup')
+      if (popupEl) {
+        this.$f7.popup.close(popupEl)
+      }
+      const popoverEl = this.$el.querySelector('.popover')
+      if (popoverEl) {
+        this.$f7.popover.close(popoverEl)
+      }
+      const sheetEl = this.$el.querySelector('.sheet-modal')
+      if (sheetEl) {
+        this.$f7.sheet.close(sheetEl)
+      }
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -24,12 +24,6 @@ export default {
       if (!topics) return
       this.eventSource = this.$oh.sse.connect(`/rest/events?topics=${topics}`, null, (event) => {
         console.debug('Received SSE event: ' + JSON.stringify(event))
-        function closePopup () {
-          const popupEl = this.$el.querySelector('.popup')
-          if (popupEl) {
-            this.$f7.popup.close(popupEl)
-          }
-        }
         switch (event.topic) {
           case topicAudio:
             const topicParts = event.topic.split('/')

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -74,6 +74,10 @@
             <span v-t="'about.miscellaneous.webaudio.enable'" />
             <f7-toggle :checked="webAudio === 'enabled'" @toggle:change="setWebAudio" />
           </f7-list-item>
+          <f7-list-item>
+            <span v-t="'about.miscellaneous.commandItem.title'" />
+            <item-picker title="Item" :multiple="false" :value="commandItem" @input="setCommandItem" />
+          </f7-list-item>
         </f7-list>
       </f7-col>
     </f7-row>
@@ -81,7 +85,12 @@
 </template>
 <script>
 import { loadLocaleMessages } from '@/js/i18n'
+import ItemPicker from '@/components/config/controls/item-picker.vue'
+
 export default {
+  components: {
+    ItemPicker
+  },
   i18n: {
     messages: loadLocaleMessages(require.context('@/assets/i18n/theme-switcher'))
   },
@@ -127,6 +136,10 @@ export default {
     setWebAudio (value) {
       localStorage.setItem('openhab.ui:webaudio.enable', (value) ? 'enabled' : 'default')
       location.reload()
+    },
+    setCommandItem (value) {
+      localStorage.setItem('openhab.ui:commandItem', value)
+      location.reload()
     }
   },
   computed: {
@@ -156,6 +169,9 @@ export default {
     },
     webAudio () {
       return localStorage.getItem('openhab.ui:webaudio.enable') || 'default'
+    },
+    commandItem () {
+      return localStorage.getItem('openhab.ui:commandItem') || ''
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -139,7 +139,7 @@ export default {
     },
     setCommandItem (value) {
       localStorage.setItem('openhab.ui:commandItem', value)
-      location.reload()
+      setTimeout(() => { location.reload() }, 50) // Delay reload, otherwise it doesn't work
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -179,7 +179,7 @@ export const actionsMixin = {
           const actionModal = actionConfig[prefix + 'actionModal']
           const actionModalConfig = actionConfig[prefix + 'actionModalConfig']
           if (actionModal.indexOf('page:') !== 0 && actionModal.indexOf('widget:') !== 0 && actionModal.indexOf('oh-') !== 0) {
-            console.log('Action target is not of the format page:uid or widget:uid')
+            console.log('Action target is not of the format page:uid or widget:uid or oh-xxx')
             return
           }
 


### PR DESCRIPTION
This allows the local running instance of the UI to listen to an item for commands.  Specifically it will understand the following commands. 

- navigate
- popup
- popover
- sheet
- close (closes all popups/sheets/popover)
- back
- reload
- notification

Commands with arguments use a colon delimiter, mirroring widget actions in the UI, for example
`navigate:/pages/page`
`popup:widget:customWidget`
`notification:Text:Title:Sub Title:Title Right:5000`

~I have this as a WIP~ as i play with this some more, but its very handy for tablets i have mounted around the house, i can easily pop up a camera, or a SIP call when the doorbell rings, trigger a reload when i have made UI changes or after a system  update/restart,  etc.....  

users can select the item in the about menu,  since we have other local options set there its seemed to be the best place.

<img width="919" alt="image" src="https://github.com/openhab/openhab-webui/assets/1903737/2a223eec-815a-4c16-bf52-0b49499770e8">
