### PR TITLE
Profile page: Only show latest 10 sessions

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -8,6 +8,7 @@
   "dialogs.copy": "Copy",
   "dialogs.delete": "Delete",
   "dialogs.reload": "Reload",
+  "dialogs.showAll": "Show All",
   "dialogs.search": "Search",
   "dialogs.search.items": "Search items",
   "dialogs.search.things": "Search things",

--- a/bundles/org.openhab.ui/web/src/pages/profile.vue
+++ b/bundles/org.openhab.ui/web/src/pages/profile.vue
@@ -36,7 +36,7 @@
             <f7-list media-list swipeout>
               <f7-list-item
                 media-item swipeout
-                v-for="session in sessions"
+                v-for="session in filteredSessions"
                 :key="session.sessionId"
                 :title="session.clientId"
                 :subtitle="$t('profile.sessions.created') + new Date(session.createdTime).toLocaleString($store.getters.locale)"
@@ -48,6 +48,9 @@
                   </f7-swipeout-button>
                 </f7-swipeout-actions>
               </f7-list-item>
+              <f7-list-button v-if="!expandedTypes.sessions && sessions.length > 10" color="blue" @click="$set(expandedTypes, 'sessions', true)">
+                {{ $t('dialogs.showAll') }}
+              </f7-list-button>
               <f7-list-button color="red" @click="logout()">
                 {{ $t('profile.sessions.signOut') }}
               </f7-list-button>
@@ -140,11 +143,20 @@ export default {
     return {
       user: this.$store.getters.user,
       sessions: [],
-      apiTokens: []
+      apiTokens: [],
+
+      expandedTypes: {
+        sessions: false
+      }
     }
   },
   i18n: {
     messages: loadLocaleMessages(require.context('@/assets/i18n/profile'))
+  },
+  computed: {
+    filteredSessions () {
+      return (this.expandedTypes.sessions) ? this.sessions : (this.sessions ? this.sessions.slice(this.sessions.length - 10, this.sessions.length) : [])
+    }
   },
   methods: {
     onPageBeforeIn () {


### PR DESCRIPTION
The openHAB demo's profile page takes ages to render because of the huge sessions list. This should fix that problem.