### PR TITLE
Add CO2 measurement badge to location card

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-location-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-location-card.md
@@ -100,6 +100,7 @@ A card showing model items in a certain location
     <PropOption value="speakers" label="Speakers/AV Receivers Powered On" />
     <PropOption value="temperature" label="Average Temperature (+ Setpoint)" />
     <PropOption value="humidity" label="Average Humidity" />
+    <PropOption value="co2" label="Average CO2" />
     <PropOption value="luminance" label="Average Luminance" />
   </PropOptions>
 </PropBlock>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/home/index.js
@@ -115,6 +115,7 @@ export const OhLocationCardParameters = () => new WidgetDefinition('oh-location-
         { value: 'speakers', label: 'Speakers/AV Receivers Powered On' },
         { value: 'temperature', label: 'Average Temperature (+ Setpoint)' },
         { value: 'humidity', label: 'Average Humidity' },
+        { value: 'co2', label: 'Average CO2' },
         { value: 'luminance', label: 'Average Luminance' }
       ], true, true)
   ])

--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
@@ -34,6 +34,7 @@ export default {
       badgeConfigs: {
         temperature: { icon: 'f7:thermometer', unit: '°' },
         humidity: { icon: 'f7:drop', unit: '%' },
+        co2: { icon: 'f7:wind', unit: 'ppm' },
         luminance: { icon: 'f7:sun_min', unit: 'lx' }
       }
     }
@@ -59,6 +60,10 @@ export default {
           direct = findPoints(this.element.properties, 'Point_Measurement', true, 'Property_Humidity')
           if (direct.length) return direct
           return findPoints(allEquipmentPoints(this.element.equipment), 'Point_Measurement', true, 'Property_Humidity')
+        case 'co2':
+          direct = findPoints(this.element.properties, 'Point_Measurement', true, 'Property_CO2')
+          if (direct.length) return direct
+          return findPoints(allEquipmentPoints(this.element.equipment), 'Point_Measurement', true, 'Property_CO2')  
         case 'luminance':
           direct = findPoints(this.element.properties, 'Point_Measurement', true, 'Property_Light')
           if (direct.length) return direct

--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
@@ -63,7 +63,7 @@ export default {
         case 'co2':
           direct = findPoints(this.element.properties, 'Point_Measurement', true, 'Property_CO2')
           if (direct.length) return direct
-          return findPoints(allEquipmentPoints(this.element.equipment), 'Point_Measurement', true, 'Property_CO2')  
+          return findPoints(allEquipmentPoints(this.element.equipment), 'Point_Measurement', true, 'Property_CO2')
         case 'luminance':
           direct = findPoints(this.element.properties, 'Point_Measurement', true, 'Property_Light')
           if (direct.length) return direct

--- a/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/location-card.vue
@@ -14,7 +14,7 @@
         </span>
       </div>
       <div class="location-stats margin-top-half" v-if="!config.disableBadges">
-        <span v-for="badgeType in ['temperature', 'humidity', 'luminance']" :key="badgeType">
+        <span v-for="badgeType in ['temperature', 'humidity', 'co2', 'luminance']" :key="badgeType">
           <measurement-badge v-if="!config.badges || !config.badges.length || config.badges.indexOf(badgeType) >= 0"
                              :store="context.store" :element="element" :type="badgeType" :invert-color="config.invertText" :badgeOverrides="badgeOverrides" />
         </span>


### PR DESCRIPTION
Closes #2067.

This PR introduces CO2 measument badge to the location card in MainUI.
It is same logic as other measuments badges, i.e. average from items with Measurement and CO2 Semantic tags.
