### PR TITLE
Items tag: added tags to list, unification of items tag edit

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -43,7 +43,7 @@
           </f7-block-title>
           <f7-list>
             <ul>
-              <item v-for="item in pinnedObjects.items" :key="item.name" link="" :item="item" :context="context" :no-icon="true" :no-type="true" @click="(evt) => showItem(evt, item)">
+              <item v-for="item in pinnedObjects.items" :key="item.name" link="" :item="item" :context="context" :no-icon="true" :no-type="true" :no-tags="true" @click="(evt) => showItem(evt, item)">
                 <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px" slot="footer">
                   <f7-link class="margin-right itemlist-actions" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/items/' + item.name" :animate="false" />
                   <f7-link class="itemlist-actions" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" @click="unpin('items', item, 'name')" />

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -75,7 +75,7 @@ export default {
         tagsNonS = this.item.tags.filter((t) =>
           t !== this.item.metadata.semantics.value.split('_').pop() &&
           t !== ((this.item.metadata.semantics.config && this.item.metadata.semantics.config.relatesTo) ? this.item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-          )
+        )
       }
       return tagsNonS.length
     }

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -30,7 +30,7 @@
     </f7-list>
     <semantics-picker v-if="!hideSemantics" :item="item" :same-class-only="true" :hide-type="true" :hide-none="forceSemantics" />
     <f7-list inline-labels accordion-list no-hairline-md>
-      <f7-list-item accordion-item title="Tags" :after="numberOfTags">
+      <f7-list-item accordion-item title="Non-Semantic Tags" :after="numberOfTags">
         <f7-accordion-content>
           <tag-input :item="item" />
         </f7-accordion-content>
@@ -53,7 +53,10 @@ import TagInput from '@/components/tags/tag-input.vue'
 import * as Types from '@/assets/item-types.js'
 import { Categories } from '@/assets/categories.js'
 
+import ItemMixin from '@/components/item/item-mixin'
+
 export default {
+  mixins: [ItemMixin],
   props: ['item', 'items', 'createMode', 'hideCategory', 'hideType', 'hideSemantics', 'forceSemantics'],
   components: {
     SemanticsPicker,
@@ -69,15 +72,7 @@ export default {
   },
   computed: {
     numberOfTags () {
-      if (!this.item.tags) return 0
-      let tagsNonS = this.item.tags
-      if (this.item.metadata && this.item.metadata.semantics) {
-        tagsNonS = this.item.tags.filter((t) =>
-          t !== this.item.metadata.semantics.value.split('_').pop() &&
-          t !== ((this.item.metadata.semantics.config && this.item.metadata.semantics.config.relatesTo) ? this.item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-        )
-      }
-      return tagsNonS.length
+      return this.getNonSemanticTags(this.item).length
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -29,6 +29,13 @@
       </f7-list-input>
     </f7-list>
     <semantics-picker v-if="!hideSemantics" :item="item" :same-class-only="true" :hide-type="true" :hide-none="forceSemantics" />
+    <f7-list inline-labels accordion-list no-hairline-md>
+      <f7-list-item accordion-item title="Tags" :after="numberOfTags">
+        <f7-accordion-content>
+          <tag-input :item="item" />
+        </f7-accordion-content>
+      </f7-list-item>
+    </f7-list>
   </div>
 </template>
 
@@ -42,13 +49,15 @@
 
 <script>
 import SemanticsPicker from '@/components/tags/semantics-picker.vue'
+import TagInput from '@/components/tags/tag-input.vue'
 import * as Types from '@/assets/item-types.js'
 import { Categories } from '@/assets/categories.js'
 
 export default {
   props: ['item', 'items', 'createMode', 'hideCategory', 'hideType', 'hideSemantics', 'forceSemantics'],
   components: {
-    SemanticsPicker
+    SemanticsPicker,
+    TagInput
   },
   data () {
     return {
@@ -56,6 +65,19 @@ export default {
       categoryInputId: '',
       categoryAutocomplete: null,
       nameErrorMessage: ''
+    }
+  },
+  computed: {
+    numberOfTags () {
+      if (!this.item.tags) return 0
+      let tagsNonS = this.item.tags
+      if (this.item.metadata && this.item.metadata.semantics) {
+        tagsNonS = this.item.tags.filter((t) =>
+          t !== this.item.metadata.semantics.value.split('_').pop() &&
+          t !== ((this.item.metadata.semantics.config && this.item.metadata.semantics.config.relatesTo) ? this.item.metadata.semantics.config.relatesTo.split('_').pop() : '')
+          )
+      }
+      return tagsNonS.length
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -1,4 +1,7 @@
+import TagMixin from '@/components/tags/tag-mixin'
+
 export default {
+  mixins: [TagMixin],
   methods: {
     getItemTypeAndMetaLabel (item) {
       let ret = item.type
@@ -17,6 +20,10 @@ export default {
         }
       }
       return ret
+    },
+    getNonSemanticTags (item) {
+      if (!item.tags) return []
+      return item.tags.filter((t) => !this.isSemanticTag(t))
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -1,0 +1,22 @@
+export default {
+  methods: {
+    getItemTypeAndMetaLabel (item) {
+      let ret = item.type
+      if (item.metadata && item.metadata.semantics) {
+        ret += ' · '
+        const classParts = item.metadata.semantics.value.split('_')
+        ret += classParts[0]
+        if (classParts.length > 1) {
+          ret += ' > ' + classParts.pop()
+          if (item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) {
+            const relatesToParts = item.metadata.semantics.config.relatesTo.split('_')
+            if (relatesToParts.length > 1) {
+              ret += ' > ' + relatesToParts.pop()
+            }
+          }
+        }
+      }
+      return ret
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -11,7 +11,11 @@
     <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" :state="(noState) ? null : (context && context.store) ? context.store[item.name].state : item.state" height="32" width="32" />
     <span v-else-if="!noIcon" slot="media" class="item-initial">{{ item.name[0] }}</span>
     <f7-icon v-if="!item.editable && !ignoreEditable" slot="after-title" f7="lock_fill" size="1rem" color="gray" />
-    <slot name="footer" #footer />
+    <div v-if="!noTags" slot="subtitle">
+      <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+        <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+      </f7-chip>
+    </div>
   </f7-list-item>
 </template>
 
@@ -20,7 +24,7 @@ import ItemMixin from '@/components/item/item-mixin'
 
 export default {
   mixins: [ItemMixin],
-  props: ['item', 'context', 'ignoreEditable', 'noState', 'noType', 'noIcon', 'link'],
+  props: ['item', 'context', 'ignoreEditable', 'noState', 'noType', 'noIcon', 'noTags', 'link'],
   computed: {
     state () {
       if (this.noState) return

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -5,7 +5,7 @@
     :link="link"
     :title="(item.label) ? item.label :item.name"
     :footer="(item.label) ? item.name : '\xa0'"
-    :subtitle="getItemTypeAndMetaLabel(item)"
+    :subtitle="noType ? '' : getItemTypeAndMetaLabel(item)"
     :after="state"
     v-on="$listeners">
     <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" :state="(noState) ? null : (context && context.store) ? context.store[item.name].state : item.state" height="32" width="32" />
@@ -16,34 +16,16 @@
 </template>
 
 <script>
+import ItemMixin from '@/components/item/item-mixin'
+
 export default {
+  mixins: [ItemMixin],
   props: ['item', 'context', 'ignoreEditable', 'noState', 'noType', 'noIcon', 'link'],
   computed: {
     state () {
       if (this.noState) return
       if (!this.context || !this.context.store) return this.item.state
       return this.context.store[this.item.name].displayState || this.context.store[this.item.name].state
-    }
-  },
-  methods: {
-    getItemTypeAndMetaLabel () {
-      if (this.noType) return
-      let ret = this.item.type
-      if (this.item.metadata && this.item.metadata.semantics) {
-        ret += ' · '
-        const classParts = this.item.metadata.semantics.value.split('_')
-        ret += classParts[0]
-        if (classParts.length > 1) {
-          ret += ' > ' + classParts.pop()
-          if (this.item.metadata.semantics.config && this.item.metadata.semantics.config.relatesTo) {
-            const relatesToParts = this.item.metadata.semantics.config.relatesTo.split('_')
-            if (relatesToParts.length > 1) {
-              ret += ' · ' + relatesToParts.pop()
-            }
-          }
-        }
-      }
-      return ret
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -36,7 +36,7 @@ export default {
         if (classParts.length > 1) {
           ret += ' > ' + classParts.pop()
           if (this.item.metadata.semantics.config && this.item.metadata.semantics.config.relatesTo) {
-            const relatesToParts  = this.item.metadata.semantics.config.relatesTo.split('_')
+            const relatesToParts = this.item.metadata.semantics.config.relatesTo.split('_')
             if (relatesToParts.length > 1) {
               ret += ' · ' + relatesToParts.pop()
             }

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -34,7 +34,13 @@ export default {
         const classParts = this.item.metadata.semantics.value.split('_')
         ret += classParts[0]
         if (classParts.length > 1) {
-          ret += '>' + classParts.pop()
+          ret += ' > ' + classParts.pop()
+          if (this.item.metadata.semantics.config && this.item.metadata.semantics.config.relatesTo) {
+            const relatesToParts  = this.item.metadata.semantics.config.relatesTo.split('_')
+            if (relatesToParts.length > 1) {
+              ret += ' · ' + relatesToParts.pop()
+            }
+          }
         }
       }
       return ret

--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -25,21 +25,17 @@
 </template>
 
 <script>
+import TagMixin from '@/components/tags/tag-mixin'
+
 export default {
+  mixins: [TagMixin],
   props: ['item', 'disabled', 'inScriptEditor'],
   data () {
     return {
-      pendingTag: '',
-      semanticClasses: this.$store.getters.semanticClasses
+      pendingTag: ''
     }
   },
   methods: {
-    isSemanticTag (tag) {
-      return [this.semanticClasses.Locations,
-        this.semanticClasses.Equipment,
-        this.semanticClasses.Points,
-        this.semanticClasses.Properties].some((t) => t.indexOf(tag) >= 0)
-    },
     isScriptTag (tag) {
       if (this.inScriptEditor !== true) return false
       if (tag === 'Script') return true

--- a/bundles/org.openhab.ui/web/src/components/tags/tag-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-mixin.js
@@ -1,0 +1,15 @@
+export default {
+  data () {
+    return {
+      semanticClasses: this.$store.getters.semanticClasses
+    }
+  },
+  methods: {
+    isSemanticTag (tag) {
+      return [this.semanticClasses.Locations,
+        this.semanticClasses.Equipment,
+        this.semanticClasses.Points,
+        this.semanticClasses.Properties].some((t) => t.indexOf(tag) >= 0)
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -62,7 +62,10 @@ import AddLinkPage from '@/pages/settings/things/link/link-add.vue'
 import ConfigureLinkPage from '@/pages/settings/things/link/link-edit.vue'
 import ConfigureChannelPage from '@/pages/settings/things/channel/channel-edit.vue'
 
+import ItemMixin from '@/components/item/item-mixin'
+
 export default {
+  mixins: [ItemMixin],
   props: ['channelType', 'channelId', 'channel', 'thing', 'opened', 'extensible', 'context'],
   data () {
     return {
@@ -203,18 +206,6 @@ export default {
           self.thing.channels.splice(idx, 1)
           self.$emit('channel-updated', true)
         })
-    },
-    getItemTypeAndMetaLabel (item) {
-      let ret = item.type
-      if (item.metadata && item.metadata.semantics) {
-        ret += ' · '
-        const classParts = item.metadata.semantics.value.split('_')
-        ret += classParts[0]
-        if (classParts.length > 1) {
-          ret += '>' + classParts.pop()
-        }
-      }
-      return ret
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -37,10 +37,6 @@
             <f7-block-title>Group Settings</f7-block-title>
             <group-form :item="item" />
           </f7-col>
-          <f7-col class="tags-editor">
-            <f7-block-title>Non-Semantic Tags</f7-block-title>
-            <tag-input :item="item" />
-          </f7-col>
         </f7-block>
       </f7-tab>
 
@@ -79,7 +75,6 @@ import YAML from 'yaml'
 
 import ItemForm from '@/components/item/item-form.vue'
 import GroupForm from '@/components/item/group-form.vue'
-import TagInput from '@/components/tags/tag-input.vue'
 import ItemPicker from '@/components/config/controls/item-picker.vue'
 import DirtyMixin from '../dirty-mixin'
 
@@ -90,7 +85,6 @@ export default {
     ItemPicker,
     ItemForm,
     GroupForm,
-    TagInput,
     'editor': () => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue')
   },
   data () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -219,7 +219,9 @@ export default {
       if (this.$theme.ios) vlHeight = 78
       if (this.$theme.aurora) vlHeight = 60.77
       if (this.$theme.md) vlHeight = 87.4
-      if (this.$device.macos) vlHeight -= 0.77
+      if (this.$device.macos) {
+        if (window.navigator.userAgent.includes('Safari') && !window.navigator.userAgent.includes('Chrome')) vlHeight -= 0.77
+      }
       if (item.tags) {
         let tagsNonS = item.tags
         if (item.metadata && item.metadata.semantics) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -241,19 +241,6 @@ export default {
       }
       return vlHeight
     },
-    getNonSemanticTags (item) {
-      let tagsNonS = []
-      if (item.tags) {
-        tagsNonS = item.tags
-        if (item.metadata && item.metadata.semantics) {
-          tagsNonS = item.tags.filter((t) =>
-            t !== item.metadata.semantics.value.split('_').pop() &&
-            t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-          )
-        }
-      }
-      return tagsNonS
-    },
     toggleCheck () {
       this.showCheckboxes = !this.showCheckboxes
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -132,7 +132,10 @@
 </style>
 
 <script>
+import ItemMixin from '@/components/item/item-mixin'
+
 export default {
+  mixins: [ItemMixin],
   components: {
     'empty-state-placeholder': () => import('@/components/empty-state-placeholder.vue')
   },
@@ -250,24 +253,6 @@ export default {
         }
       }
       return tagsNonS
-    },
-    getItemTypeAndMetaLabel (item) {
-      let ret = item.type
-      if (item.metadata && item.metadata.semantics) {
-        ret += ' · '
-        const classParts = item.metadata.semantics.value.split('_')
-        ret += classParts[0]
-        if (classParts.length > 1) {
-          ret += ' > ' + classParts.pop()
-          if (item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) {
-            const relatesToParts = item.metadata.semantics.config.relatesTo.split('_')
-            if (relatesToParts.length > 1) {
-              ret += ' · ' + relatesToParts.pop()
-            }
-          }
-        }
-      }
-      return ret
     },
     toggleCheck () {
       this.showCheckboxes = !this.showCheckboxes

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -225,19 +225,12 @@ export default {
       if (this.$device.macos) {
         if (window.navigator.userAgent.includes('Safari') && !window.navigator.userAgent.includes('Chrome')) vlHeight -= 0.77
       }
-      if (item.tags) {
-        let tagsNonS = item.tags
-        if (item.metadata && item.metadata.semantics) {
-          tagsNonS = item.tags.filter((t) =>
-            t !== item.metadata.semantics.value.split('_').pop() &&
-            t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-          )
-        }
-        if (tagsNonS.length) {
-          vlHeight += 24
-          if (this.$theme.ios) vlHeight += 4
-          if (this.$theme.md) vlHeight += 12
-        }
+
+      const nonSemanticTags = this.getNonSemanticTags(item)
+      if (nonSemanticTags.length > 0) {
+        vlHeight += 24
+        if (this.$theme.ios) vlHeight += 4
+        if (this.$theme.md) vlHeight += 12
       }
       return vlHeight
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -226,9 +226,9 @@ export default {
           tagsNonS = item.tags.filter((t) =>
             t !== item.metadata.semantics.value.split('_').pop() &&
             t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-            )
+          )
         }
-        if (tagsNonS.length ) {
+        if (tagsNonS.length) {
           vlHeight += 24
           if (this.$theme.ios) vlHeight += 4
           if (this.$theme.md) vlHeight += 12
@@ -244,7 +244,7 @@ export default {
           tagsNonS = item.tags.filter((t) =>
             t !== item.metadata.semantics.value.split('_').pop() &&
             t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-            )
+          )
         }
       }
       return tagsNonS
@@ -258,7 +258,7 @@ export default {
         if (classParts.length > 1) {
           ret += ' > ' + classParts.pop()
           if (item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) {
-            const relatesToParts  = item.metadata.semantics.config.relatesTo.split('_')
+            const relatesToParts = item.metadata.semantics.config.relatesTo.split('_')
             if (relatesToParts.length > 1) {
               ret += ' · ' + relatesToParts.pop()
             }

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -218,8 +218,8 @@ export default {
       let vlHeight
       if (this.$theme.ios) vlHeight = 78
       if (this.$theme.aurora) vlHeight = 60.77
-      if (this.$theme.md) vlHeight = 87
-      if (this.$device.firefox) vlHeight += 0.23
+      if (this.$theme.md) vlHeight = 87.4
+      if (this.$device.macos) vlHeight -= 0.77
       if (item.tags) {
         let tagsNonS = item.tags
         if (item.metadata && item.metadata.semantics) {
@@ -228,7 +228,11 @@ export default {
             t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
             )
         }
-        if (tagsNonS.length ) vlHeight += 24
+        if (tagsNonS.length ) {
+          vlHeight += 24
+          if (this.$theme.ios) vlHeight += 4
+          if (this.$theme.md) vlHeight += 12
+        }
       }
       return vlHeight
     },


### PR DESCRIPTION
Closes #2086

- Adds Non-semantic tags to Items list (e.g. /settings/items/) consistently with similar list of Rules / Scripts / Pages.
- Extends `getItemTypeAndMetaLabel` with relatesTo part of Semantic classification.
- Fixes incorrect calculation of vue virtual box height on Items list.
- Replaces custom tag input with accordion tag input (inspired by https://github.com/openhab/openhab-webui/pull/2078) and show number of tags (inspired by https://github.com/openhab/openhab-webui/pull/2083).
- Moves the custom tag input to `item-form.vue`, so it is available also in Model view, when creating Item from Thing etc.

At minimum for the calculation of vue virtual box height it would be great to fully test this PR for variety of browsers. Currently I do not have complete BrowserStack access avaible, but anyway I have tried to test and adjust height calculation for following browsers using trial and my own devices (This PR is tested with BrowserStack):
Windows – Chrome, Edge, Firefox
MacOS – Chrome
Linux – Chrome, Firefox
iOS – Safari, Chrome
Android - Chrome
I kindly ask maintainers to test this PR using BrowserStack for other browsers. If I get full access from BrowserStack in the meantime, I will complete the testing with other browsers as well.
