### PR TITLE
Sitemap editor: Trim spaces from color value

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -41,7 +41,7 @@ function writeWidget (widget, indent) {
           dsl += '['
           dsl += widget.config[key].filter(Boolean).map(color => {
             let index = color.lastIndexOf('=') + 1
-            let colorvalue = color.substring(index)
+            let colorvalue = color.substring(index).trim()
             if (!/^(".*")|('.*')$/.test(colorvalue)) {
               colorvalue = '"' + colorvalue + '"'
             }


### PR DESCRIPTION
When generating the sitemap DSL from a UI configured sitemap with color conditions, if the color in the condition has a leading space, it will be included in the color string.
While this does not have an impact on the sitemap functionality (it works), it is an issue if one would copy this sitemap to a sitemap file.
This PR strips the blanks from the color.

See https://github.com/openhab/openhab-webui/issues/2082 and the example provided there:
```
sitemap page_c6c037636f label="New Sitemap" {
    Text item=KitchenLights labelcolor=[KitchenLights == ON =" red"] label="Lights are: [%s]"
}
```