### PR TITLE
Semantic model: Add options to display and search Item names and tags

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -16,14 +16,16 @@
                          @checked="(item, check) => $emit('checked', item, check)" />
     <div slot="label" class="semantic-class">
       {{ className() }}
-      <div class="semantic-class chip" v-if="includeItemTags" v-for="tag in getNonSemanticTags(model.item)" :key="tag" style="height: 16px; margin-left: 4px">
+      <template v-if="includeItemTags">
+        <div class="semantic-class chip" v-for="tag in getNonSemanticTags(model.item)" :key="tag" style="height: 16px; margin-left: 4px">
           <div class="chip-media bg-color-blue" style="height: 16px; width: 16px">
             <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" style="font-size: 8px; height: 16px; line-height: 16px" />
           </div>
           <div class="chip-label" style="height: 16px; line-height: 16px">
             {{ tag }}
           </div>
-      </div>
+        </div>
+      </template>
     </div>
     <f7-checkbox slot="content-start" v-if="model.checkable"
                  :checked="model.checked === true" :disabled="model.disabled" @change="check" />
@@ -86,7 +88,7 @@ export default {
           tagsNonS = item.tags.filter((t) =>
             t !== item.metadata.semantics.value.split('_').pop() &&
             t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-            )
+          )
         }
       }
       return tagsNonS

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-treeview-item selectable :label="(model.item.created === false) ? '(New Item)' : ((model.item.label) ? ((includeItemName) ? model.item.label + ' (' + model.item.name + ')' : model.item.label) : model.item.name)"
+  <f7-treeview-item selectable :label="(model.item.created === false) ? '(New Item)' : (model.item.label ? (includeItemName ? model.item.label + ' (' + model.item.name + ')' : model.item.label) : model.item.name)"
                     :icon-ios="icon('ios')" :icon-aurora="icon('aurora')" :icon-md="icon('md')"
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
@@ -33,7 +33,10 @@
 </template>
 
 <script>
+import ItemMixin from '@/components/item/item-mixin'
+
 export default {
+  mixins: [ItemMixin],
   props: ['model', 'selected', 'includeItemName', 'includeItemTags'],
   computed: {
     children () {
@@ -79,19 +82,6 @@ export default {
       if (this.model.disabled) return
       this.model.checked = event.target.checked
       this.$emit('checked', this.model, event.target.checked)
-    },
-    getNonSemanticTags (item) {
-      let tagsNonS = []
-      if (item.tags) {
-        tagsNonS = item.tags
-        if (item.metadata && item.metadata.semantics) {
-          tagsNonS = item.tags.filter((t) =>
-            t !== item.metadata.semantics.value.split('_').pop() &&
-            t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
-          )
-        }
-      }
-      return tagsNonS
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-treeview-item selectable :label="(model.item.created === false) ? '(New Item)' : (model.item.label || model.item.name)"
+  <f7-treeview-item selectable :label="(model.item.created === false) ? '(New Item)' : ((model.item.label) ? ((includeItemName) ? model.item.label + ' (' + model.item.name + ')' : model.item.label) : model.item.name)"
                     :icon-ios="icon('ios')" :icon-aurora="icon('aurora')" :icon-md="icon('md')"
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
@@ -12,9 +12,18 @@
                          :model="node"
                          @selected="(event) => $emit('selected', event)"
                          :selected="selected"
+                         :includeItemName="includeItemName" :includeItemTags="includeItemTags"
                          @checked="(item, check) => $emit('checked', item, check)" />
     <div slot="label" class="semantic-class">
       {{ className() }}
+      <div class="semantic-class chip" v-if="includeItemTags" v-for="tag in getNonSemanticTags(model.item)" :key="tag" style="height: 16px; margin-left: 4px">
+          <div class="chip-media bg-color-blue" style="height: 16px; width: 16px">
+            <f7-icon slot="media" ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" style="font-size: 8px; height: 16px; line-height: 16px" />
+          </div>
+          <div class="chip-label" style="height: 16px; line-height: 16px">
+            {{ tag }}
+          </div>
+      </div>
     </div>
     <f7-checkbox slot="content-start" v-if="model.checkable"
                  :checked="model.checked === true" :disabled="model.disabled" @change="check" />
@@ -23,7 +32,7 @@
 
 <script>
 export default {
-  props: ['model', 'selected'],
+  props: ['model', 'selected', 'includeItemName', 'includeItemTags'],
   computed: {
     children () {
       return [this.model.children.locations,
@@ -68,6 +77,19 @@ export default {
       if (this.model.disabled) return
       this.model.checked = event.target.checked
       this.$emit('checked', this.model, event.target.checked)
+    },
+    getNonSemanticTags (item) {
+      let tagsNonS = []
+      if (item.tags) {
+        tagsNonS = item.tags
+        if (item.metadata && item.metadata.semantics) {
+          tagsNonS = item.tags.filter((t) =>
+            t !== item.metadata.semantics.value.split('_').pop() &&
+            t !== ((item.metadata.semantics.config && item.metadata.semantics.config.relatesTo) ? item.metadata.semantics.config.relatesTo.split('_').pop() : '')
+            )
+        }
+      }
+      return tagsNonS
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -58,7 +58,7 @@
               <model-treeview-item v-for="node in [rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
                                    :key="node.item.name" :model="node"
                                    @selected="selectItem" :selected="selectedItem"
-                                   :includeItemName="includeItemName" :includeItemTags="includeItemTags"/>
+                                   :includeItemName="includeItemName" :includeItemTags="includeItemTags" />
             </f7-treeview>
           </f7-block>
         </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -12,7 +12,9 @@
           :disable-button="!$theme.aurora" />
       </f7-subnavbar>
     </f7-navbar>
-    <f7-toolbar bottom class="toolbar-details" v-if="!(this.$theme.ios || this.$theme.md)">
+
+    <!-- Toolbar -->
+    <f7-toolbar bottom class="toolbar-details" v-if="$f7.width >= 500">
       <f7-link :disabled="selectedItem != null" class="left" @click="selectedItem = null">
         Clear
       </f7-link>
@@ -26,11 +28,11 @@
       </div>
       <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
     </f7-toolbar>
-    <f7-toolbar bottom class="toolbar-details" v-if="this.$theme.ios || this.$theme.md" style="height: 50px">
+    <f7-toolbar bottom class="toolbar-details" v-else style="height: 50px">
       <f7-link :disabled="selectedItem != null" class="left" @click="selectedItem = null">
         Clear
       </f7-link>
-      <div class="padding-right text-align-center" style="font-size: 12px">
+      <div class="padding-left padding-right text-align-center" style="font-size: 12px">
         <div>
           <f7-checkbox :checked="includeNonSemantic" @change="toggleNonSemantic" />
           <label @click="toggleNonSemantic" class="advanced-label">Show non-semantic</label>
@@ -44,6 +46,7 @@
       </div>
       <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
     </f7-toolbar>
+
     <f7-block v-if="!ready" class="text-align-center">
       <f7-preloader />
       <div>Loading...</div>
@@ -57,8 +60,8 @@
             <f7-treeview>
               <model-treeview-item v-for="node in [rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
                                    :key="node.item.name" :model="node"
-                                   @selected="selectItem" :selected="selectedItem"
-                                   :includeItemName="includeItemName" :includeItemTags="includeItemTags" />
+                                   :includeItemName="includeItemName" :includeItemTags="includeItemTags"
+                                   @selected="selectItem" :selected="selectedItem" />
             </f7-treeview>
           </f7-block>
         </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -12,13 +12,35 @@
           :disable-button="!$theme.aurora" />
       </f7-subnavbar>
     </f7-navbar>
-    <f7-toolbar bottom class="toolbar-details">
+    <f7-toolbar bottom class="toolbar-details" v-if="!(this.$theme.ios || this.$theme.md)">
       <f7-link :disabled="selectedItem != null" class="left" @click="selectedItem = null">
         Clear
       </f7-link>
       <div class="padding-right text-align-right">
         <f7-checkbox :checked="includeNonSemantic" @change="toggleNonSemantic" />
         <label @click="toggleNonSemantic" class="advanced-label">Show non-semantic</label>
+        <f7-checkbox style="margin-left: 5px" :checked="includeItemName" @change="toggleItemName" />
+        <label @click="toggleItemName" class="advanced-label">Show name</label>
+        <f7-checkbox style="margin-left: 5px" :checked="includeItemTags" @change="toggleItemTags" />
+        <label @click="toggleItemTags" class="advanced-label">Show tags</label>
+      </div>
+      <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
+    </f7-toolbar>
+    <f7-toolbar bottom class="toolbar-details" v-if="this.$theme.ios || this.$theme.md" style="height: 50px">
+      <f7-link :disabled="selectedItem != null" class="left" @click="selectedItem = null">
+        Clear
+      </f7-link>
+      <div class="padding-right text-align-center" style="font-size: 12px">
+        <div>
+          <f7-checkbox :checked="includeNonSemantic" @change="toggleNonSemantic" />
+          <label @click="toggleNonSemantic" class="advanced-label">Show non-semantic</label>
+        </div>
+        <div>
+          <f7-checkbox :checked="includeItemName" @change="toggleItemName" />
+          <label @click="toggleItemName" class="advanced-label">Show name</label>
+          <f7-checkbox style="margin-left: 5px" :checked="includeItemTags" @change="toggleItemTags" />
+          <label @click="toggleItemTags" class="advanced-label">Show tags</label>
+        </div>
       </div>
       <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
     </f7-toolbar>
@@ -35,7 +57,8 @@
             <f7-treeview>
               <model-treeview-item v-for="node in [rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
                                    :key="node.item.name" :model="node"
-                                   @selected="selectItem" :selected="selectedItem" />
+                                   @selected="selectItem" :selected="selectedItem"
+                                   :includeItemName="includeItemName" :includeItemTags="includeItemTags"/>
             </f7-treeview>
           </f7-block>
         </f7-col>
@@ -213,6 +236,8 @@ export default {
       ready: false,
       loading: false,
       includeNonSemantic: false,
+      includeItemName: false,
+      includeItemTags: false,
       items: [],
       links: [],
       locations: [],
@@ -433,6 +458,14 @@ export default {
       this.rootGroups = []
       this.rootItems = []
       this.includeNonSemantic = !this.includeNonSemantic
+      this.load()
+    },
+    toggleItemName () {
+      this.includeItemName = !this.includeItemName
+      this.load()
+    },
+    toggleItemTags () {
+      this.includeItemTags = !this.includeItemTags
       this.load()
     },
     addSemanticItem (semanticType) {


### PR DESCRIPTION
Closes #2092

- Adds possibility to display Item name and Non-semantic tags in Semantic model tree view
- Adds search for items also based on Item name and tags depending on selected view options

Tested extended model tree view and toolbar for all combinations of most common browsers and devices.
Windows - Chrome, Edge, Firefox
Mac - Safari, Chrome, Firefox
Linux - Chrome, Firefox
Android - Chrome (phone/tablet)
iOS - Safari, Chrome (iPhone/iPad)