### PR TITLE
Semantic model: Remove duplicate non-semantic tags in Item component

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -3,7 +3,7 @@
     <f7-card-content>
       <f7-list media-list accordion-list>
         <ul>
-          <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" :context="context" />
+          <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" :context="context" :no-tags="true" />
           <!-- <f7-list-button v-if="!editMode && !createMode" color="blue" title="Edit Item" @click="editMode = true">Edit Item</f7-list-button> -->
         </ul>
       </f7-list>

--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -3,7 +3,7 @@
     <f7-card-content>
       <f7-list media-list accordion-list>
         <ul>
-          <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" :context="context" :no-tags="true" />
+          <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" :context="context" :no-tags="editMode" />
           <!-- <f7-list-button v-if="!editMode && !createMode" color="blue" title="Edit Item" @click="editMode = true">Edit Item</f7-list-button> -->
         </ul>
       </f7-list>


### PR DESCRIPTION
Changes introduced into #2087 in combination with #2093 create duplicity in showing non-semantic tags in the model page (component/model/item-details.vue). 
Non-semantic tags are displayed both in the Item and when edit mode is enabled, in the accordion tag input in item-form.