### PR TITLE
Add a "Add from template" page for the semantic model

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -488,7 +488,7 @@ export default {
         .filter((i) => (!i.metadata.semantics.config || !i.metadata.semantics.config.isPartOf) && (i.templates & (1 << this.selectedTemplate)))
         .map(this.modelItem).sort(compareModelItems)
       newModel.forEach(this.getChildren)
-      this.currentModel = newModel
+      this.currentModel = newModel // eslint-disable-line vue/no-side-effects-in-computed-properties
 
       return newModel
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -488,7 +488,7 @@ export default {
         .filter((i) => (!i.metadata.semantics.config || !i.metadata.semantics.config.isPartOf) && (i.templates & (1 << this.selectedTemplate)))
         .map(this.modelItem).sort(compareModelItems)
       newModel.forEach(this.getChildren)
-      this.setCurrentTemplate(newModel)
+      this.setCurrentModel(newModel)
 
       return newModel
     }
@@ -518,8 +518,8 @@ export default {
 
       return modelItem
     },
-    setCurrentTemplate (model) {
-
+    setCurrentModel (model) {
+      this.currentModel = model
     },
     getChildren (parent) {
       // restore previous selection
@@ -568,8 +568,10 @@ export default {
       } else {
         this.checkedItems.splice(this.checkedItems.indexOf(item), 1)
         item.children.locations.forEach((i) => {
-          i.checked = false
-          this.checkItem(i, false)
+          if (i.checked) {
+            i.checked = false
+            this.checkItem(i, false)
+          }
         })
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -34,7 +34,7 @@
                            :error-message-force="!!prefixErrorMessage" />
           </f7-list>
           <f7-block-footer class="padding-horizontal">
-            Add a prefix to each created item's name (optional: default is 'l')
+            Add a prefix to each created item's name (optional, default is 'l')
           </f7-block-footer>
         </f7-block>
         <f7-block v-if="selectedTemplate !== null" class="semantic-tree-wrapper">
@@ -138,7 +138,7 @@ export default {
           'type': 'Group',
           'name': 'lBathroom2',
           'label': 'Bathroom',
-          'category': '',
+          'category': 'bath',
           'tags': [
             'Bathroom'
           ],
@@ -159,7 +159,7 @@ export default {
           'type': 'Group',
           'name': 'lApartment',
           'label': 'Apartment',
-          'category': '',
+          'category': 'corridor',
           'tags': [
             'Building'
           ],
@@ -180,7 +180,7 @@ export default {
           'type': 'Group',
           'name': 'lHouse',
           'label': 'House',
-          'category': '',
+          'category': 'house',
           'tags': [
             'Building'
           ],
@@ -198,7 +198,7 @@ export default {
           'type': 'Group',
           'name': 'lProperty',
           'label': 'Property',
-          'category': '',
+          'category': 'none',
           'tags': [
             'Location'
           ],
@@ -217,7 +217,7 @@ export default {
           'type': 'Group',
           'name': 'lKitchen',
           'label': 'Kitchen',
-          'category': '',
+          'category': 'kitchen',
           'tags': [
             'Kitchen'
           ],
@@ -238,7 +238,7 @@ export default {
           'type': 'Group',
           'name': 'lGarage',
           'label': 'Garage',
-          'category': '',
+          'category': 'garage',
           'tags': [
             'Garage'
           ],
@@ -259,7 +259,7 @@ export default {
           'type': 'Group',
           'name': 'lBackYard',
           'label': 'Back Yard',
-          'category': '',
+          'category': 'garden',
           'tags': [
             'Location'
           ],
@@ -280,7 +280,7 @@ export default {
           'type': 'Group',
           'name': 'lEntry',
           'label': 'Entry',
-          'category': '',
+          'category': 'corridor',
           'tags': [
             'Entry'
           ],
@@ -301,7 +301,7 @@ export default {
           'type': 'Group',
           'name': 'lLivingRoom',
           'label': 'Living Room',
-          'category': '',
+          'category': 'sofa',
           'tags': [
             'LivingRoom'
           ],
@@ -322,7 +322,7 @@ export default {
           'type': 'Group',
           'name': 'lFloor_Ground',
           'label': 'Ground Floor',
-          'category': '',
+          'category': 'groundfloor',
           'tags': [
             'Floor'
           ],
@@ -343,7 +343,7 @@ export default {
           'type': 'Group',
           'name': 'lDiningRoom',
           'label': 'Dining Room',
-          'category': '',
+          'category': 'none',
           'tags': [
             'DiningRoom'
           ],
@@ -364,7 +364,7 @@ export default {
           'type': 'Group',
           'name': 'lOffice',
           'label': 'Office',
-          'category': '',
+          'category': 'office',
           'tags': [
             'Office'
           ],
@@ -385,7 +385,7 @@ export default {
           'type': 'Group',
           'name': 'lFrontYard',
           'label': 'Front Yard',
-          'category': '',
+          'category': 'lawnmower',
           'tags': [
             'Location'
           ],
@@ -406,7 +406,7 @@ export default {
           'type': 'Group',
           'name': 'lBedroom1',
           'label': 'Main Bedroom',
-          'category': '',
+          'category': 'bedroom_blue',
           'tags': [
             'Bedroom'
           ],
@@ -427,7 +427,7 @@ export default {
           'type': 'Group',
           'name': 'lBedroom2',
           'label': 'Second Bedroom',
-          'category': '',
+          'category': 'bedroom_red',
           'tags': [
             'Bedroom'
           ],
@@ -448,7 +448,7 @@ export default {
           'type': 'Group',
           'name': 'lBathroom1',
           'label': 'Bathroom',
-          'category': '',
+          'category': 'bath',
           'tags': [
             'Bathroom'
           ],
@@ -469,7 +469,7 @@ export default {
           'type': 'Group',
           'name': 'lFloor_Second',
           'label': 'Upstairs',
-          'category': '',
+          'category': 'firstfloor',
           'tags': [
             'Floor'
           ],

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -484,12 +484,13 @@ export default {
       if (this.currentModel) {
         return this.currentModel
       }
-      this.currentModel = this.locations
+      let newModel = this.locations
         .filter((i) => (!i.metadata.semantics.config || !i.metadata.semantics.config.isPartOf) && (i.templates & (1 << this.selectedTemplate)))
         .map(this.modelItem).sort(compareModelItems)
-      this.currentModel.forEach(this.getChildren)
+      newModel.forEach(this.getChildren)
+      this.setCurrentTemplate(newModel)
 
-      return this.currentModel
+      return newModel
     }
   },
   methods: {
@@ -516,6 +517,9 @@ export default {
       this.checkedItems.push(modelItem)
 
       return modelItem
+    },
+    setCurrentTemplate (model) {
+
     },
     getChildren (parent) {
       // restore previous selection
@@ -591,7 +595,8 @@ export default {
       if (this.checkedItems.length === 0) {
         this.$f7.dialog.alert('Please select some locations')
       } else if (this.checkedItems.some((i) => existingNames.includes(i.item.name))) {
-        this.$f7.dialog.confirm('Some Item names already exist. Continuing will overwrite those Items. Continue?','Warning',
+        this.$f7.dialog.confirm('Some Item names already exist. Continuing will overwrite those Items. Continue?',
+          'Warning',
           () => { this.doAdd() }
         )
       } else {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -30,16 +30,16 @@
           </f7-block-title>
           <f7-list>
             <f7-list-input label="Prefix" type="text" placeholder="item prefix"
-                            @input="onPrefixInput" clear-button  :error-message="prefixErrorMessage"
-                            :error-message-force="!!prefixErrorMessage"/>
+                           @input="onPrefixInput" clear-button :error-message="prefixErrorMessage"
+                           :error-message-force="!!prefixErrorMessage" />
           </f7-list>
           <f7-block-footer class="padding-left padding-right">
-              Add a prefix to each created item's name (optional: default is 'l')
+            Add a prefix to each created item's name (optional: default is 'l')
           </f7-block-footer>
         </f7-block>
         <f7-block v-if="selectedTemplate !== null" class="semantic-tree-wrapper">
           <f7-block-footer class="padding-left padding-right">
-              Select the locations to add to your model (you may add others from the model page at a later time).
+            Select the locations to add to your model (you may add others from the model page at a later time).
           </f7-block-footer>
           <f7-block class="semantic-tree">
             <model-treeview class="model-picker-treeview" :rootNodes="rootLocations"
@@ -122,361 +122,361 @@ export default {
   },
   computed: {
     locations () {
-      let floor1 = (this.selectedTemplate == 0) ? 'lAppartment' : (this.selectedTemplate == 1) ? 'lHouse' : 'lFloor_Ground'
-      let floor2 = (this.selectedTemplate == 0) ? 'lAppartment' : (this.selectedTemplate == 1) ? 'lHouse' : 'lFloor_Second'
+      let floor1 = (this.selectedTemplate === 0) ? 'lApartment' : (this.selectedTemplate === 1) ? 'lHouse' : 'lFloor_Ground'
+      let floor2 = (this.selectedTemplate === 0) ? 'lApartment' : (this.selectedTemplate === 1) ? 'lHouse' : 'lFloor_Second'
 
       return [
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Bathroom",
-              "config": {
-                "isPartOf": floor2
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Bathroom',
+              'config': {
+                'isPartOf': floor2
               }
             }
           },
-          "type": "Group",
-          "name": "lBathroom2",
-          "label": "Bathroom",
-          "category": "",
-          "tags": [
-            "Bathroom"
+          'type': 'Group',
+          'name': 'lBathroom2',
+          'label': 'Bathroom',
+          'category': '',
+          'tags': [
+            'Bathroom'
           ],
-          "groupNames": [
+          'groupNames': [
             floor2
           ],
-          "templates": 4
+          'templates': 4
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Building",
-              "config": {
-                "isPartOf": "lProperty"
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Building',
+              'config': {
+                'isPartOf': 'lProperty'
               }
             }
           },
-          "type": "Group",
-          "name": "lAppartment",
-          "label": "Appartment",
-          "category": "",
-          "tags": [
-            "Building"
+          'type': 'Group',
+          'name': 'lApartment',
+          'label': 'Apartment',
+          'category': '',
+          'tags': [
+            'Building'
           ],
-          "groupNames": [
-            "lProperty"
+          'groupNames': [
+            'lProperty'
           ],
-          "templates": 1
+          'templates': 1
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Building",
-              "config": {
-                "isPartOf": "lProperty"
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Building',
+              'config': {
+                'isPartOf': 'lProperty'
               }
             }
           },
-          "type": "Group",
-          "name": "lHouse",
-          "label": "House",
-          "category": "",
-          "tags": [
-            "Building"
+          'type': 'Group',
+          'name': 'lHouse',
+          'label': 'House',
+          'category': '',
+          'tags': [
+            'Building'
           ],
-          "groupNames": [
-            "lProperty"
+          'groupNames': [
+            'lProperty'
           ],
-          "templates": 6
+          'templates': 6
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location"
+          'metadata': {
+            'semantics': {
+              'value': 'Location'
             }
           },
-          "type": "Group",
-          "name": "lProperty",
-          "label": "Property",
-          "category": "",
-          "tags": [
-            "Location"
+          'type': 'Group',
+          'name': 'lProperty',
+          'label': 'Property',
+          'category': '',
+          'tags': [
+            'Location'
           ],
-          "groupNames": [],
-          "templates": 7
+          'groupNames': [],
+          'templates': 7
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Kitchen",
-              "config": {
-                "isPartOf": floor1
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Kitchen',
+              'config': {
+                'isPartOf': floor1
               }
             }
           },
-          "type": "Group",
-          "name": "lKitchen",
-          "label": "Kitchen",
-          "category": "",
-          "tags": [
-            "Kitchen"
+          'type': 'Group',
+          'name': 'lKitchen',
+          'label': 'Kitchen',
+          'category': '',
+          'tags': [
+            'Kitchen'
           ],
-          "groupNames": [
+          'groupNames': [
             floor1
           ],
-          "templates": 7
+          'templates': 7
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Building_Garage",
-              "config": {
-                "isPartOf": floor1
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Building_Garage',
+              'config': {
+                'isPartOf': floor1
               }
             }
           },
-          "type": "Group",
-          "name": "lGarage",
-          "label": "Garage",
-          "category": "",
-          "tags": [
-            "Garage"
+          'type': 'Group',
+          'name': 'lGarage',
+          'label': 'Garage',
+          'category': '',
+          'tags': [
+            'Garage'
           ],
-          "groupNames": [
+          'groupNames': [
             floor1
           ],
-          "templates": 6
+          'templates': 6
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location",
-              "config": {
-                "isPartOf": "lProperty"
+          'metadata': {
+            'semantics': {
+              'value': 'Location',
+              'config': {
+                'isPartOf': 'lProperty'
               }
             }
           },
-          "type": "Group",
-          "name": "lBackYard",
-          "label": "Back Yard",
-          "category": "",
-          "tags": [
-            "Location"
+          'type': 'Group',
+          'name': 'lBackYard',
+          'label': 'Back Yard',
+          'category': '',
+          'tags': [
+            'Location'
           ],
-          "groupNames": [
-            "lProperty"
+          'groupNames': [
+            'lProperty'
           ],
-          "templates": 6
+          'templates': 6
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Entry",
-              "config": {
-                "isPartOf": floor1
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Entry',
+              'config': {
+                'isPartOf': floor1
               }
             }
           },
-          "type": "Group",
-          "name": "lEntry",
-          "label": "Entry",
-          "category": "",
-          "tags": [
-            "Entry"
+          'type': 'Group',
+          'name': 'lEntry',
+          'label': 'Entry',
+          'category': '',
+          'tags': [
+            'Entry'
           ],
-          "groupNames": [
+          'groupNames': [
             floor1
           ],
-          "templates": 7
+          'templates': 7
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_LivingRoom",
-              "config": {
-                "isPartOf": floor1
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_LivingRoom',
+              'config': {
+                'isPartOf': floor1
               }
             }
           },
-          "type": "Group",
-          "name": "lLivingRoom",
-          "label": "Living Room",
-          "category": "",
-          "tags": [
-            "LivingRoom"
+          'type': 'Group',
+          'name': 'lLivingRoom',
+          'label': 'Living Room',
+          'category': '',
+          'tags': [
+            'LivingRoom'
           ],
-          "groupNames": [
+          'groupNames': [
             floor1
           ],
-          "templates": 7
+          'templates': 7
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Floor",
-              "config": {
-                "isPartOf": "lHouse"
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Floor',
+              'config': {
+                'isPartOf': 'lHouse'
               }
             }
           },
-          "type": "Group",
-          "name": "lFloor_Ground",
-          "label": "Ground Floor",
-          "category": "",
-          "tags": [
-            "Floor"
+          'type': 'Group',
+          'name': 'lFloor_Ground',
+          'label': 'Ground Floor',
+          'category': '',
+          'tags': [
+            'Floor'
           ],
-          "groupNames": [
-            "lHouse"
+          'groupNames': [
+            'lHouse'
           ],
-          "templates": 4
+          'templates': 4
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_DiningRoom",
-              "config": {
-                "isPartOf": floor1
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_DiningRoom',
+              'config': {
+                'isPartOf': floor1
               }
             }
           },
-          "type": "Group",
-          "name": "lDiningRoom",
-          "label": "Dining Room",
-          "category": "",
-          "tags": [
-            "DiningRoom"
+          'type': 'Group',
+          'name': 'lDiningRoom',
+          'label': 'Dining Room',
+          'category': '',
+          'tags': [
+            'DiningRoom'
           ],
-          "groupNames": [
+          'groupNames': [
             floor1
           ],
-          "templates": 6
+          'templates': 6
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Office",
-              "config": {
-                "isPartOf": floor2
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Office',
+              'config': {
+                'isPartOf': floor2
               }
             }
           },
-          "type": "Group",
-          "name": "lOffice",
-          "label": "Office",
-          "category": "",
-          "tags": [
-            "Office"
+          'type': 'Group',
+          'name': 'lOffice',
+          'label': 'Office',
+          'category': '',
+          'tags': [
+            'Office'
           ],
-          "groupNames": [
+          'groupNames': [
             floor2
           ],
-          "templates": 4
+          'templates': 4
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location",
-              "config": {
-                "isPartOf": "lProperty"
+          'metadata': {
+            'semantics': {
+              'value': 'Location',
+              'config': {
+                'isPartOf': 'lProperty'
               }
             }
           },
-          "type": "Group",
-          "name": "lFrontYard",
-          "label": "Front Yard",
-          "category": "",
-          "tags": [
-            "Location"
+          'type': 'Group',
+          'name': 'lFrontYard',
+          'label': 'Front Yard',
+          'category': '',
+          'tags': [
+            'Location'
           ],
-          "groupNames": [
-            "lProperty"
+          'groupNames': [
+            'lProperty'
           ],
-          "templates": 6
+          'templates': 6
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Bedroom",
-              "config": {
-                "isPartOf": floor2
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Bedroom',
+              'config': {
+                'isPartOf': floor2
               }
             }
           },
-          "type": "Group",
-          "name": "lBedroom1",
-          "label": "Main Bedroom",
-          "category": "",
-          "tags": [
-            "Bedroom"
+          'type': 'Group',
+          'name': 'lBedroom1',
+          'label': 'Main Bedroom',
+          'category': '',
+          'tags': [
+            'Bedroom'
           ],
-          "groupNames": [
+          'groupNames': [
             floor2
           ],
-          "templates": 7
+          'templates': 7
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Bedroom",
-              "config": {
-                "isPartOf": floor2
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Bedroom',
+              'config': {
+                'isPartOf': floor2
               }
             }
           },
-          "type": "Group",
-          "name": "lBedroom2",
-          "label": "Second Bedroom",
-          "category": "",
-          "tags": [
-            "Bedroom"
+          'type': 'Group',
+          'name': 'lBedroom2',
+          'label': 'Second Bedroom',
+          'category': '',
+          'tags': [
+            'Bedroom'
           ],
-          "groupNames": [
+          'groupNames': [
             floor2
           ],
-          "templates": 6
+          'templates': 6
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Room_Bathroom",
-              "config": {
-                "isPartOf": floor1
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Room_Bathroom',
+              'config': {
+                'isPartOf': floor1
               }
             }
           },
-          "type": "Group",
-          "name": "lBathroom1",
-          "label": "Bathroom",
-          "category": "",
-          "tags": [
-            "Bathroom"
+          'type': 'Group',
+          'name': 'lBathroom1',
+          'label': 'Bathroom',
+          'category': '',
+          'tags': [
+            'Bathroom'
           ],
-          "groupNames": [
+          'groupNames': [
             floor1
           ],
-          "templates": 7
+          'templates': 7
         },
         {
-          "metadata": {
-            "semantics": {
-              "value": "Location_Indoor_Floor",
-              "config": {
-                "isPartOf": "lHouse"
+          'metadata': {
+            'semantics': {
+              'value': 'Location_Indoor_Floor',
+              'config': {
+                'isPartOf': 'lHouse'
               }
             }
           },
-          "type": "Group",
-          "name": "lFloor_Second",
-          "label": "Upstairs",
-          "category": "",
-          "tags": [
-            "Floor"
+          'type': 'Group',
+          'name': 'lFloor_Second',
+          'label': 'Upstairs',
+          'category': '',
+          'tags': [
+            'Floor'
           ],
-          "groupNames": [
-            "lHouse"
+          'groupNames': [
+            'lHouse'
           ],
-          "templates": 4
+          'templates': 4
         }
       ]
     },
@@ -536,7 +536,7 @@ export default {
       }
     },
     findLocation (searchNode, name) {
-      if (searchNode.item.name == name) {
+      if (searchNode.item.name === name) {
         return searchNode
       } else if (searchNode.children.locations != null) {
         let foundNode = null
@@ -557,15 +557,15 @@ export default {
         if (item.item.groupNames.length > 0) {
           let parentNode = this.findLocation(this.rootLocations[0], item.item.groupNames[0])
           if (parentNode && !parentNode.checked) {
-            parentNode.checked=true
+            parentNode.checked = true
             this.checkItem(parentNode, true)
           }
         }
       } else {
         this.checkedItems.splice(this.checkedItems.indexOf(item), 1)
         item.children.locations.forEach((i) => {
-          i.checked=false
-          this.checkItem(i,false)
+          i.checked = false
+          this.checkItem(i, false)
         })
       }
     },
@@ -590,12 +590,10 @@ export default {
       let existingNames = this.itemList.map((i) => i.name)
       if (this.checkedItems.length === 0) {
         this.$f7.dialog.alert('Please select some locations')
-        return
       } else if (this.checkedItems.some((i) => existingNames.includes(i.item.name))) {
-      this.$f7.dialog.confirm('Some Item names already exist. Continuing will overwrite those Items. Continue?','Warning',
-        () => { this.doAdd() },
-        () => { return }
-      )
+        this.$f7.dialog.confirm('Some Item names already exist. Continuing will overwrite those Items. Continue?','Warning',
+          () => { this.doAdd() }
+        )
       } else {
         this.doAdd()
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -1,0 +1,640 @@
+<template>
+  <f7-page>
+    <f7-navbar title="Add Locations from Template" back-link="Back">
+      <f7-nav-right class="if-not-aurora">
+        <f7-link @click="add()" v-if="$theme.md" icon-md="material:save" icon-only />
+        <f7-link @click="add()" v-if="!$theme.md">
+          Add
+        </f7-link>
+      </f7-nav-right>
+    </f7-navbar>
+
+    <f7-block class="block-narrow">
+      <f7-col>
+        <f7-block>
+          <f7-block-title>
+            Location Template
+          </f7-block-title>
+          <f7-list>
+            <f7-list-item radio value="0" @change="onSelectTemplate(0)" title="One Bedroom Apartment" name="select-template" />
+            <f7-list-item radio value="1" @change="onSelectTemplate(1)" title="One Story House" name="select-template" />
+            <f7-list-item radio value="2" @change="onSelectTemplate(2)" title="Two Story House" name="select-template" />
+          </f7-list>
+          <f7-block-footer class="padding-left padding-right">
+            Select the template that best matches the description of your property.
+          </f7-block-footer>
+        </f7-block>
+        <f7-block>
+          <f7-block-title>
+            Item Name Prefix
+          </f7-block-title>
+          <f7-list>
+            <f7-list-input label="Prefix" type="text" placeholder="item prefix"
+                            @input="onPrefixInput" clear-button  :error-message="prefixErrorMessage"
+                            :error-message-force="!!prefixErrorMessage"/>
+          </f7-list>
+          <f7-block-footer class="padding-left padding-right">
+              Add a prefix to each created item's name (optional: default is 'l')
+          </f7-block-footer>
+        </f7-block>
+        <f7-block v-if="selectedTemplate !== null" class="semantic-tree-wrapper">
+          <f7-block-footer class="padding-left padding-right">
+              Select the locations to add to your model (you may add others from the model page at a later time).
+          </f7-block-footer>
+          <f7-block class="semantic-tree">
+            <model-treeview class="model-picker-treeview" :rootNodes="rootLocations"
+                            :selected-item="selectedItem" @selected="selectItem" @checked="checkItem" />
+          </f7-block>
+        </f7-block>
+      </f7-col>
+    </f7-block>
+
+    <div v-if="selectedTemplate !== null && (checkedItems.length > 0)" class="if-aurora display-flex justify-content-center margin padding">
+      <div class="flex-shrink-0">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="add">
+          Add to Model
+        </f7-button>
+      </div>
+    </div>
+  </f7-page>
+</template>
+
+<style lang="stylus">
+.semantic-tree-wrapper
+  padding 0
+  margin-bottom 0
+.semantic-tree
+  padding 0
+  border-top 1px solid var(--f7-block-strong-border-color)
+  border-bottom 1px solid var(--f7-block-strong-border-color)
+  background: var(--f7-list-bg-color)
+  .treeview
+    --f7-treeview-item-height 40px
+    .treeview-item-label
+      font-size 10pt
+      white-space nowrap
+      overflow-x hidden
+    .semantic-class
+      font-size 8pt
+      color var(--f7-list-item-footer-text-color)
+@media (min-width: 768px)
+  .semantic-tree-wrapper
+    height calc(100% - var(--f7-navbar-height))
+    .row
+      height 100%
+      .col-100
+        height 100%
+        overflow auto
+        .semantic-tree
+          min-height 100%
+          margin 0
+          height auto
+
+@media (max-width: 767px)
+  .semantic-tree-wrapper.sheet-opened
+    margin-bottom var(--f7-sheet-height)
+</style>
+
+<script>
+import ModelTreeview from '@/components/model/model-treeview.vue'
+
+import { compareItems } from '@/components/widgets/widget-order'
+
+function compareModelItems (o1, o2) {
+  return compareItems(o1.item || o1, o2.item || o2)
+}
+
+export default {
+  data () {
+    return {
+      selectedItem: null,
+      previousSelection: null,
+      checkedItems: [],
+      selectedTemplate: null,
+      currentModel: null,
+      prefix: null,
+      prefixErrorMessage: null
+    }
+  },
+  props: ['itemList'],
+  components: {
+    ModelTreeview
+  },
+  computed: {
+    locations () {
+      let floor1 = (this.selectedTemplate == 0) ? 'lAppartment' : (this.selectedTemplate == 1) ? 'lHouse' : 'lFloor_Ground'
+      let floor2 = (this.selectedTemplate == 0) ? 'lAppartment' : (this.selectedTemplate == 1) ? 'lHouse' : 'lFloor_Second'
+
+      return [
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Bathroom",
+              "config": {
+                "isPartOf": floor2
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lBathroom2",
+          "label": "Bathroom",
+          "category": "",
+          "tags": [
+            "Bathroom"
+          ],
+          "groupNames": [
+            floor2
+          ],
+          "templates": 4
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Building",
+              "config": {
+                "isPartOf": "lProperty"
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lAppartment",
+          "label": "Appartment",
+          "category": "",
+          "tags": [
+            "Building"
+          ],
+          "groupNames": [
+            "lProperty"
+          ],
+          "templates": 1
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Building",
+              "config": {
+                "isPartOf": "lProperty"
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lHouse",
+          "label": "House",
+          "category": "",
+          "tags": [
+            "Building"
+          ],
+          "groupNames": [
+            "lProperty"
+          ],
+          "templates": 6
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location"
+            }
+          },
+          "type": "Group",
+          "name": "lProperty",
+          "label": "Property",
+          "category": "",
+          "tags": [
+            "Location"
+          ],
+          "groupNames": [],
+          "templates": 7
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Kitchen",
+              "config": {
+                "isPartOf": floor1
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lKitchen",
+          "label": "Kitchen",
+          "category": "",
+          "tags": [
+            "Kitchen"
+          ],
+          "groupNames": [
+            floor1
+          ],
+          "templates": 7
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Building_Garage",
+              "config": {
+                "isPartOf": floor1
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lGarage",
+          "label": "Garage",
+          "category": "",
+          "tags": [
+            "Garage"
+          ],
+          "groupNames": [
+            floor1
+          ],
+          "templates": 6
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location",
+              "config": {
+                "isPartOf": "lProperty"
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lBackYard",
+          "label": "Back Yard",
+          "category": "",
+          "tags": [
+            "Location"
+          ],
+          "groupNames": [
+            "lProperty"
+          ],
+          "templates": 6
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Entry",
+              "config": {
+                "isPartOf": floor1
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lEntry",
+          "label": "Entry",
+          "category": "",
+          "tags": [
+            "Entry"
+          ],
+          "groupNames": [
+            floor1
+          ],
+          "templates": 7
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_LivingRoom",
+              "config": {
+                "isPartOf": floor1
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lLivingRoom",
+          "label": "Living Room",
+          "category": "",
+          "tags": [
+            "LivingRoom"
+          ],
+          "groupNames": [
+            floor1
+          ],
+          "templates": 7
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Floor",
+              "config": {
+                "isPartOf": "lHouse"
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lFloor_Ground",
+          "label": "Ground Floor",
+          "category": "",
+          "tags": [
+            "Floor"
+          ],
+          "groupNames": [
+            "lHouse"
+          ],
+          "templates": 4
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_DiningRoom",
+              "config": {
+                "isPartOf": floor1
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lDiningRoom",
+          "label": "Dining Room",
+          "category": "",
+          "tags": [
+            "DiningRoom"
+          ],
+          "groupNames": [
+            floor1
+          ],
+          "templates": 6
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Office",
+              "config": {
+                "isPartOf": floor2
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lOffice",
+          "label": "Office",
+          "category": "",
+          "tags": [
+            "Office"
+          ],
+          "groupNames": [
+            floor2
+          ],
+          "templates": 4
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location",
+              "config": {
+                "isPartOf": "lProperty"
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lFrontYard",
+          "label": "Front Yard",
+          "category": "",
+          "tags": [
+            "Location"
+          ],
+          "groupNames": [
+            "lProperty"
+          ],
+          "templates": 6
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Bedroom",
+              "config": {
+                "isPartOf": floor2
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lBedroom1",
+          "label": "Main Bedroom",
+          "category": "",
+          "tags": [
+            "Bedroom"
+          ],
+          "groupNames": [
+            floor2
+          ],
+          "templates": 7
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Bedroom",
+              "config": {
+                "isPartOf": floor2
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lBedroom2",
+          "label": "Second Bedroom",
+          "category": "",
+          "tags": [
+            "Bedroom"
+          ],
+          "groupNames": [
+            floor2
+          ],
+          "templates": 6
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Room_Bathroom",
+              "config": {
+                "isPartOf": floor1
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lBathroom1",
+          "label": "Bathroom",
+          "category": "",
+          "tags": [
+            "Bathroom"
+          ],
+          "groupNames": [
+            floor1
+          ],
+          "templates": 7
+        },
+        {
+          "metadata": {
+            "semantics": {
+              "value": "Location_Indoor_Floor",
+              "config": {
+                "isPartOf": "lHouse"
+              }
+            }
+          },
+          "type": "Group",
+          "name": "lFloor_Second",
+          "label": "Upstairs",
+          "category": "",
+          "tags": [
+            "Floor"
+          ],
+          "groupNames": [
+            "lHouse"
+          ],
+          "templates": 4
+        }
+      ]
+    },
+    rootLocations () {
+      if (this.currentModel) {
+        return this.currentModel
+      }
+      this.currentModel = this.locations
+        .filter((i) => (!i.metadata.semantics.config || !i.metadata.semantics.config.isPartOf) && (i.templates & (1 << this.selectedTemplate)))
+        .map(this.modelItem).sort(compareModelItems)
+      this.currentModel.forEach(this.getChildren)
+
+      return this.currentModel
+    }
+  },
+  methods: {
+    modelItem (item) {
+      const modelItem = {
+        item: item,
+        opened: true,
+        checked: true,
+        checkable: true,
+        class: (item.metadata && item.metadata.semantics) ? item.metadata.semantics.value : '',
+        children: {
+          locations: [],
+          equipment: [],
+          points: [],
+          groups: [],
+          items: []
+        }
+      }
+      if (this.previousSelection && item.name === this.previousSelection.item.name) {
+        this.selectedItem = parent
+        this.previousSelection = null
+        this.selectItem(modelItem)
+      }
+      this.checkedItems.push(modelItem)
+
+      return modelItem
+    },
+    getChildren (parent) {
+      // restore previous selection
+      if (this.previousSelection && parent.item.name === this.previousSelection.item.name) {
+        this.selectedItem = parent
+        this.previousSelection = null
+        this.selectItem(parent)
+      }
+
+      parent.children.locations = this.locations
+        .filter((i) => i.metadata.semantics.config && i.metadata.semantics.config.isPartOf === parent.item.name && (i.templates & (1 << this.selectedTemplate)))
+        .map(this.modelItem).sort(compareModelItems)
+      parent.children.locations.forEach(this.getChildren)
+    },
+    selectItem (item) {
+      if (item.children && item.opened !== undefined) {
+        item.opened = !item.opened
+      }
+    },
+    findLocation (searchNode, name) {
+      if (searchNode.item.name == name) {
+        return searchNode
+      } else if (searchNode.children.locations != null) {
+        let foundNode = null
+        let childList = searchNode.children.locations
+        for (let i = 0; i < childList.length; i++) {
+          foundNode = this.findLocation(childList[i], name)
+          if (foundNode) {
+            return foundNode
+          }
+        }
+        return null
+      }
+      return null
+    },
+    checkItem (item, check) {
+      if (check) {
+        this.checkedItems.push(item)
+        if (item.item.groupNames.length > 0) {
+          let parentNode = this.findLocation(this.rootLocations[0], item.item.groupNames[0])
+          if (parentNode && !parentNode.checked) {
+            parentNode.checked=true
+            this.checkItem(parentNode, true)
+          }
+        }
+      } else {
+        this.checkedItems.splice(this.checkedItems.indexOf(item), 1)
+        item.children.locations.forEach((i) => {
+          i.checked=false
+          this.checkItem(i,false)
+        })
+      }
+    },
+    onSelectTemplate (template) {
+      this.$set(this, 'checkedItems', [])
+      this.currentModel = null
+      this.selectedTemplate = template
+    },
+    add () {
+      if (this.prefixErrorMessage) {
+        this.$f7.dialog.alert('Invalid prefix for item names')
+        return
+      }
+      if (this.prefix) {
+        this.checkedItems.forEach((i) => {
+          i.item.name = this.prefix + i.item.name.substr(1)
+          if (i.item.groupNames.length > 0) {
+            i.item.groupNames[0] = this.prefix + i.item.groupNames[0].substr(1)
+          }
+        })
+      }
+      let existingNames = this.itemList.map((i) => i.name)
+      if (this.checkedItems.length === 0) {
+        this.$f7.dialog.alert('Please select some locations')
+        return
+      } else if (this.checkedItems.some((i) => existingNames.includes(i.item.name))) {
+      this.$f7.dialog.confirm('Some Item names already exist. Continuing will overwrite those Items. Continue?','Warning',
+        () => { this.doAdd() },
+        () => { return }
+      )
+      } else {
+        this.doAdd()
+      }
+    },
+    doAdd () {
+      let dialog = this.$f7.dialog.progress('Creating template...')
+      const payload = this.checkedItems.map((i) => i.item)
+
+      this.$oh.api.put('/rest/items/', payload).then((data) => {
+        dialog.setText('Creating Items...')
+        dialog.setProgress(50)
+      }).catch((err) => {
+        dialog.close()
+        console.error(err)
+        this.$f7.dialog.alert('An error occurred while creating the model items: ' + err)
+      }).then((data) => {
+        dialog.setProgress(100)
+        this.$f7.toast.create({
+          text: 'Model created',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        dialog.close()
+        this.$f7router.back()
+      })
+    },
+    onPrefixInput (event) {
+      this.prefix = event.target.value
+      this.validatePrefix(this.prefix)
+    },
+    validatePrefix (prefix) {
+      let oldError = this.prefixErrorMessage
+      if (prefix && (!/^[A-Za-z0-9_]+$/.test(prefix))) {
+        this.prefixErrorMessage = 'A-Z,a-z,0-9,_ only'
+      } else {
+        this.prefixErrorMessage = ''
+      }
+      if (oldError !== this.prefixErrorMessage) this.$emit('valid', !this.prefixErrorMessage)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -61,7 +61,15 @@
     <f7-block v-else class="semantic-tree-wrapper" :class="{ 'sheet-opened' : detailsOpened }">
       <f7-row>
         <f7-col width="100" medium="50">
-          <empty-state-placeholder v-if="empty" icon="list_bullet_indent" title="model.title" text="model.text" />
+          <f7-block v-if="empty">
+            <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
+            <f7-row class="display-flex justify-content-center">
+              <f7-button color="blue" large raised fill @click="addLocationTemplate()">
+                Create Locations From Templates
+              </f7-button>
+            </f7-row>
+          </f7-block>
+
           <f7-block v-show="!empty" strong class="semantic-tree" no-gap @click.native="clearSelection">
             <!-- <empty-state-placeholder v-if="empty" icon="list_bullet_indent" title="model.title" text="model.text" /> -->
             <f7-treeview>
@@ -92,14 +100,6 @@
                   <f7-list-button color="blue" title="Add Equipment" @click="addSemanticItem('Equipment')" />
                   <f7-list-button color="blue" title="Add Point" @click="addSemanticItem('Point')" />
                   <f7-list-button color="blue" v-if="includeNonSemantic" title="Add Item" @click="addNonSemanticItem(false)" />
-                </f7-list>
-              </f7-card-content>
-            </f7-card>
-            <div><f7-block-title>Model Templates</f7-block-title></div>
-            <f7-card>
-              <f7-card-content>
-                <f7-list>
-                  <f7-list-button color="blue" title="Location Templates" @click="addLocationTemplate()" />
                 </f7-list>
               </f7-card-content>
             </f7-card>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -65,7 +65,7 @@
             <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
             <f7-row class="display-flex justify-content-center">
               <f7-button color="blue" large raised fill @click="addLocationTemplate()">
-                Create Locations From Templates
+                Get Started
               </f7-button>
             </f7-row>
           </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -95,6 +95,14 @@
                 </f7-list>
               </f7-card-content>
             </f7-card>
+            <div><f7-block-title>Model Templates</f7-block-title></div>
+            <f7-card>
+              <f7-card-content>
+                <f7-list>
+                  <f7-list-button color="blue" title="Location Templates" @click="addLocationTemplate()" />
+                </f7-list>
+              </f7-card-content>
+            </f7-card>
           </f7-block>
         </f7-col>
       </f7-row>
@@ -227,6 +235,7 @@
 <script>
 import ModelDetailsPane from '@/components/model/details-pane.vue'
 import AddFromThing from './add-from-thing.vue'
+import AddFromTemplate from './add-from-template.vue'
 
 import ItemStatePreview from '@/components/item/item-state-preview.vue'
 import ItemDetails from '@/components/model/item-details.vue'
@@ -379,6 +388,20 @@ export default {
           this.applyExpandedOption()
         })
         if (!this.eventSource) this.startEventSource()
+      
+        if (this.empty) {
+          let dialog = this.$f7.dialog.confirm('There is no semantic model. Create model locations from template?', () => {
+            this.$f7router.navigate({
+              url: 'add-template',
+              route: {
+                component: AddFromTemplate,
+                path: 'add-template',
+                props: {
+                }
+              }
+            })
+          })
+        }
       })
     },
     update () {
@@ -584,6 +607,22 @@ export default {
         props: {
           parent: this.selectedItem,
           createEquipment
+        }
+      })
+    },
+    addLocationTemplate () {
+      const self = this
+      this.$f7router.navigate({
+        url: 'add-template',
+        route: {
+          component: AddFromTemplate,
+          path: 'add-template',
+          props: {
+          }
+        }
+      }, {
+        props: {
+          itemList: this.items
         }
       })
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -388,20 +388,6 @@ export default {
           this.applyExpandedOption()
         })
         if (!this.eventSource) this.startEventSource()
-
-        if (this.empty) {
-          let dialog = this.$f7.dialog.confirm('There is no semantic model. Create model locations from template?', () => {
-            this.$f7router.navigate({
-              url: 'add-template',
-              route: {
-                component: AddFromTemplate,
-                path: 'add-template',
-                props: {
-                }
-              }
-            })
-          })
-        }
       })
     },
     update () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -64,8 +64,8 @@
           <f7-block v-if="empty">
             <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
             <f7-row class="display-flex justify-content-center">
-              <f7-button color="blue" large raised fill @click="addLocationTemplate()">
                 Get Started
+              <f7-button color="blue" large raised fill @click="addFromLocationTemplate()">
               </f7-button>
             </f7-row>
           </f7-block>
@@ -576,7 +576,6 @@ export default {
       this.load()
     },
     addFromThing (createEquipment) {
-      const self = this
       this.$f7router.navigate({
         url: 'add-thing',
         route: {
@@ -596,8 +595,7 @@ export default {
         }
       })
     },
-    addLocationTemplate () {
-      const self = this
+    addFromLocationTemplate () {
       this.$f7router.navigate({
         url: 'add-template',
         route: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -388,7 +388,7 @@ export default {
           this.applyExpandedOption()
         })
         if (!this.eventSource) this.startEventSource()
-      
+
         if (this.empty) {
           let dialog = this.$f7.dialog.confirm('There is no semantic model. Create model locations from template?', () => {
             this.$f7router.navigate({

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -65,7 +65,7 @@
             <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
             <f7-row class="display-flex justify-content-center">
               <f7-button color="blue" large raised fill @click="addFromLocationTemplate()">
-                Create Model from Template
+                Add Locations from Template
               </f7-button>
             </f7-row>
           </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -64,8 +64,8 @@
           <f7-block v-if="empty">
             <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
             <f7-row class="display-flex justify-content-center">
-                Get Started
               <f7-button color="blue" large raised fill @click="addFromLocationTemplate()">
+                Create Model from Template
               </f7-button>
             </f7-row>
           </f7-block>


### PR DESCRIPTION
This is the second of [my suggested additions](https://community.openhab.org/t/first-time-user-wizard-for-oh4/149670/36) for helping new users.

This adds a button and new sub page to the semantic model.  On that sub-page the user can select from a  few different basic templates for semantic locations which can then be automatically created and added to the model.

There are a few options for customization:
1) The user can select a custom prefix that will be applied to all the items to fit or establish a desired naming scheme (or just differentiate between two different semantic dwellings if this is a multi dwelling OH instance)
2) The user can optionally deselect extra pieces of the model that are not appropriate to their needs.

![image](https://github.com/openhab/openhab-webui/assets/77952587/c62e5019-2336-4f4e-8252-7253c9996e3b)

![image](https://github.com/openhab/openhab-webui/assets/77952587/12603bff-3044-4c52-afe6-a6a6c5a5c3a8)
