### PR TITLE
Fix `oh-stepper` not working if step is an integer

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -48,7 +48,7 @@ export default {
       // uses the number of decimals in the step config to round the provided number
       if (!this.config.step) return value
       const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]
-      return parseFloat(Number(value)).toFixed(nbDecimals.length)
+      return parseFloat(Number(value)).toFixed(nbDecimals ? nbDecimals.length : 0)
     },
     onChange (value) {
       const applyOffset = (value) => (typeof this.config.offset === 'number') ? Number(this.toStepFixed(value - this.config.offset)) : value


### PR DESCRIPTION
Regression from #2090.

Fixes `Uncaught TypeError: Cannot read properties of undefined (reading 'length')` being thrown if the step property is an integer value, e.g. 1 or 1.0.