### PR TITLE
[BasicUI] Prefer sitemap label to name in sitemap selection

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
@@ -217,13 +217,16 @@ public class PageRenderer extends AbstractWidgetRenderer {
     }
 
     public CharSequence renderSitemapList(Set<SitemapProvider> sitemapProviders) throws RenderException {
-        List<String> sitemapList = new LinkedList<String>();
+        List<Sitemap> sitemapList = new LinkedList<>();
 
         for (SitemapProvider sitemapProvider : sitemapProviders) {
             Set<String> sitemaps = sitemapProvider.getSitemapNames();
-            for (String sitemap : sitemaps) {
-                if (!"_default".equals(sitemap)) {
-                    sitemapList.add(sitemap);
+            for (String sitemapName : sitemaps) {
+                if (!"_default".equals(sitemapName)) {
+                    Sitemap sitemap = sitemapProvider.getSitemap(sitemapName);
+                    if (sitemap != null) {
+                        sitemapList.add(sitemap);
+                    }
                 }
             }
         }
@@ -241,8 +244,31 @@ public class PageRenderer extends AbstractWidgetRenderer {
             }
             sb.append(listEmptySnippet);
         } else {
-            for (String sitemap : sitemapList) {
-                sb.append(sitemapSnippet.replace("%sitemap%", sitemap));
+            sitemapList.sort((s1, s2) -> {
+                String s1Label = s1.getLabel();
+                String s2Label = s2.getLabel();
+                s1Label = s1Label != null ? s1Label : s1.getName();
+                s2Label = s2Label != null ? s2Label : s2.getName();
+                int result = s1Label.compareTo(s2Label);
+                if (result == 0) {
+                    result = s1.getName().compareTo(s2.getName());
+                }
+                return result;
+            });
+
+            for (Sitemap sitemap : sitemapList) {
+                String label = sitemap.getLabel();
+                final String name = sitemap.getName();
+                if (label != null) {
+                    if (sitemapList.stream()
+                            .filter(s -> sitemap.getLabel().equals(s.getLabel() != null ? s.getLabel() : s.getName()))
+                            .count() > 1) {
+                        label = label + " (" + name + ")";
+                    }
+                } else {
+                    label = name;
+                }
+                sb.append(sitemapSnippet.replace("%label%", label).replace("%name%", name));
             }
         }
 

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/main_static.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/main_static.html
@@ -37,7 +37,7 @@
 			</div>
 		</header>
 		<main class="mdl-layout__content">
-			<div class="page-content page-static__content mdl-color--white mdl-shadow--2dp mdl-grid">
+			<div class="page-content page-static__content mdl-shadow--2dp mdl-grid">
 				%content%
 			</div>
 		</main>

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/sitemaps_list_item.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/sitemaps_list_item.html
@@ -1,4 +1,4 @@
 <div class="welcome-sitemaps__sitemap">
 <i class='material-icons'>&#xe85a;</i>
-<a href='/basicui/app?sitemap=%sitemap%'>%sitemap%</a>
+<a href='/basicui/app?sitemap=%name%'>%label%</a>
 </div>

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -679,7 +679,7 @@ $colorpicker-mobile-size: 270px;
 			padding-right: 6px;
 		}
 		a {
-			text-transform: capitalize;
+			// text-transform: capitalize;
 		}
 	}
 	&__empty {


### PR DESCRIPTION
Sitemaps are now also sorted by label/name.
Dark theme is now properly handled.

In case several sitemaps have the same label, the sitemap name is concatenated in parenthesis.

Fix #2101

Signed-off-by: Laurent Garnier <lg.hc@free.fr>