### PR TITLE
[mainui] Increase list-item-min-height to avoid scrollbar

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -14,6 +14,7 @@ html
   --f7-list-item-header-line-height 1.3
   --f7-label-line-height 1.3
   --f7-list-item-after-line-height 1.3
+  --f7-list-item-min-height 36px
 
   // disable all searchbar backdrops on desktop devices
   .searchbar-backdrop


### PR DESCRIPTION
The default --f7-list-item-min-height was 32px
which caused a vertical scrollbar to appear on desktop

Resolve #2113 