### PR TITLE
Rules list: Add filtering by (multiple) tags

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -417,7 +417,7 @@ export default {
           searchbar.clear()
           searchbar.search(filterQuery)
         }
-        /*if (groupBy === 'alphabetical')*/ this.$refs.listIndex.update()
+        this.$refs.listIndex.update()
       })
     },
     toggleSearchTag (e, item) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -79,7 +79,7 @@
           {{ rules.length }} {{ type.toLowerCase() }}
         </f7-block-title>
 
-        <div v-if="uniqueTags.length" class="block block-strong-ios block-outline-ios" ref="filterTags">
+        <div v-if="uniqueTags.length > 0" class="block block-strong-ios block-outline-ios" ref="filterTags">
           <f7-chip v-for="tag in uniqueTags" :key="tag" :text="tag" media-bg-color="blue"
                    :color="isTagSelected(tag) ? 'blue' : ''"
                    style="margin-right: 6px; cursor: pointer;"
@@ -156,7 +156,7 @@ export default {
       noRuleEngine: false,
       rules: [],
       uniqueTags: [],
-      checkedTags: [],
+      selectedTags: [],
       initSearchbar: false,
       selectedItems: [],
       showCheckboxes: false,
@@ -170,9 +170,17 @@ export default {
     documentationLink () {
       return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/${this.type.toLowerCase()}`
     },
+    filteredRules () {
+      if (this.selectedTags.length === 0) return this.rules
+      return this.rules.filter((r) => {
+        for (const t of this.selectedTags) {
+          if (r.tags.includes(t)) return true
+        }
+        return false
+      })
+    },
     indexedRules () {
-      const filteredRules = this.filterRules()
-      const initialGroup = filteredRules.reduce((prev, rule, i, rules) => {
+      return this.filteredRules.reduce((prev, rule, i, rules) => {
         const initial = rule.name.substring(0, 1).toUpperCase()
         if (!prev[initial]) {
           prev[initial] = []
@@ -181,7 +189,6 @@ export default {
 
         return prev
       }, {})
-      return initialGroup
     },
     searchPlaceholder () {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
@@ -349,34 +356,17 @@ export default {
       })
     },
     toggleSearchTag (e, item) {
-      const target = e.target
-
-      const idx = this.checkedTags.indexOf(item)
+      const idx = this.selectedTags.indexOf(item)
       if (idx !== -1) {
-        this.checkedTags.splice(idx, 1)
+        this.selectedTags.splice(idx, 1)
       } else {
-        this.checkedTags.push(item)
+        this.selectedTags.push(item)
       }
       // update rules list
       this.$refs.listIndex.update()
     },
     isTagSelected (tag) {
-      return this.checkedTags.includes(tag)
-    },
-    filterRules () {
-      return this.rules.filter((r) => {
-        if (this.checkedTags.length === 0) return true
-        let found = false
-        for (let i = 0; i < this.checkedTags.length; i++) {
-          for (let j = 0; j < r.tags.length; j++) {
-            if (r.tags[j].toLowerCase().indexOf(this.checkedTags[i].toLowerCase()) !== -1) {
-              found = true
-              break
-            }
-          }
-        }
-        return found
-      })
+      return this.selectedTags.includes(tag)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -188,7 +188,6 @@ export default {
     },
     indexedRules () {
       const filteredRules = this.filterRules()
-      // console.warn('filteredRules:', filteredRules)
       if (this.groupBy === 'alphabetical') {
         const initialGroup = filteredRules.reduce((prev, rule, i, rules) => {
           const initial = rule.name.substring(0, 1).toUpperCase()
@@ -438,7 +437,6 @@ export default {
     },
     filterRules () {
       return this.rules.filter((r) => {
-        console.warn('checkedTags', this.checkedTags)
         if (this.checkedTags.length === 0) return true
         let found = false
         for (let i = 0; i < this.checkedTags.length; i++) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -86,6 +86,9 @@
             <f7-button v-if="type === 'Rules'" :active="groupBy === 'semantic'" @click="switchGroupOrder('semantic')">
               By Semantic
             </f7-button>
+            <f7-button :active="groupBy === 'tags'" @click="switchGroupOrder('tags')">
+              By Tags
+            </f7-button>
           </f7-segmented>
         </div>
         <f7-list
@@ -196,6 +199,32 @@ export default {
         }, {})
         return Object.keys(semanticGroup).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
           objEntries[key] = semanticGroup[key]
+          return objEntries
+        }, {})
+      } else if (this.groupBy === 'tags') {
+        const tagsMap = new Map()
+        this.rules.forEach((rule, i, rules) => {
+          if (rule.tags.length > 0) {
+            rule.tags.filter((t) => t !== 'Scratchpad')
+              .forEach(t => {
+                let tag = t.substring(0, 1).toUpperCase() + t.slice(1)
+                if (tag.includes('Marketplace:')) tag = '- Marketplace -'
+                let tags = []
+                if (tagsMap.has(tag)) tags = tagsMap.get(tag)
+                if (!tags.includes(rule)) tags.push(rule)
+                tagsMap.set(tag, tags)
+              })
+          } else {
+            let tags = []
+            if (tagsMap.has('- No Tags -')) tags = tagsMap.get('- No Tags -')
+            tags.push(rule)
+            tagsMap.set('- No Tags -', tags)
+          }
+        })
+
+        let tagsRules = Object.fromEntries(tagsMap)
+        return Object.keys(tagsRules).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
+          objEntries[key] = tagsRules[key]
           return objEntries
         }, {})
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -242,6 +242,8 @@ export default {
           objEntries[key] = tagsRules[key]
           return objEntries
         }, {})
+      } else {
+        return this.rules
       }
     },
     searchPlaceholder () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -106,7 +106,7 @@
           v-show="rules.length"
           class="searchbar-found col rules-list"
           ref="rulesList"
-          media-list contacts-list>
+          media-list :contacts-list="groupBy === 'alphabetical'">
           <f7-list-group v-for="(rulesWithInitial, initial) in indexedRules" :key="initial">
             <f7-list-item v-if="rulesWithInitial.length" :title="initial" group-title />
             <f7-list-item

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -83,8 +83,8 @@
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical
             </f7-button>
-            <f7-button :active="groupBy === 'semantic'" @click="switchGroupOrder('semantic')">
-              By Semantic Tag
+            <f7-button v-if="type === 'Rules'" :active="groupBy === 'semantic'" @click="switchGroupOrder('semantic')">
+              By Semantic
             </f7-button>
           </f7-segmented>
         </div>
@@ -184,7 +184,7 @@ export default {
       } else if (this.groupBy === 'semantic') {
         const semanticGroup = this.rules.reduce((prev, rule, i, rules) => {
           let initial = rule.tags.filter((t) => t !== 'Script' && t !== 'Scene' &&
-            t !== 'Schedule' && this.isSemanticTag(t))
+            this.isSemanticTag(t))
           if (initial.length === 0) initial = '- No Semantic Tags -'
 
           if (!prev[initial]) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -76,7 +76,10 @@
 
       <f7-col v-else-if="rules.length > 0">
         <f7-block-title class="searchbar-hide-on-search">
-          {{ rules.length }} {{ type.toLowerCase() }}
+          {{ filteredRules.length }} {{ type.toLowerCase() }} {{ selectedTags.length > 0 ? ' - ' : '' }}
+          <f7-link v-if="selectedTags.length > 0" @click="selectedTags = []">
+            Reset filter
+          </f7-link>
         </f7-block-title>
 
         <div v-if="uniqueTags.length > 0" class="block block-strong-ios block-outline-ios" ref="filterTags">

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -78,18 +78,24 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ filteredRules.length }} {{ type.toLowerCase() }} {{ selectedTags.length > 0 ? ' - ' : '' }}
           <f7-link v-if="selectedTags.length > 0" @click="selectedTags = []">
-            Reset filter
+            Reset filter(s)
           </f7-link>
         </f7-block-title>
 
-        <div v-if="uniqueTags.length > 0" class="block block-strong-ios block-outline-ios" ref="filterTags">
-          <f7-chip v-for="tag in uniqueTags" :key="tag" :text="tag" media-bg-color="blue"
-                   :color="isTagSelected(tag) ? 'blue' : ''"
-                   style="margin-right: 6px; cursor: pointer;"
-                   @click="(e) => toggleSearchTag(e, tag)">
-            <f7-icon v-if="isTagSelected(tag)" slot="media" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
-          </f7-chip>
-        </div>
+        <f7-list v-if="uniqueTags.length > 0">
+          <f7-list-item accordion-item title="Filter by tags">
+            <f7-accordion-content>
+              <div class="block block-strong-ios block-outline-ios padding-bottom" ref="filterTags">
+                <f7-chip v-for="tag in uniqueTags" :key="tag" :text="tag" media-bg-color="blue"
+                         :color="isTagSelected(tag) ? 'blue' : ''"
+                         style="margin-right: 6px; cursor: pointer;"
+                         @click="(e) => toggleSearchTag(e, tag)">
+                  <f7-icon v-if="isTagSelected(tag)" slot="media" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
+                </f7-chip>
+              </div>
+            </f7-accordion-content>
+          </f7-list-item>
+        </f7-list>
         <f7-list
           v-show="rules.length > 0"
           class="searchbar-found col rules-list"

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -91,19 +91,19 @@
             </f7-button>
           </f7-segmented>
         </div>
-        <div class="block-title">
+        <div v-if="uniqueTags.length" class="block-title">
           Tags:
         </div>
-        <div class="block block-strong-ios block-outline-ios" ref="filterTags">
+        <div v-if="uniqueTags.length" class="block block-strong-ios block-outline-ios" ref="filterTags">
           <f7-chip v-for="tag in uniqueTags" :key="tag" :text="tag" media-bg-color="blue"
                    :color="isTagSelected(tag) ? 'blue' : ''"
                    style="margin-right: 6px"
                    @click="(e) => toggleSearchTag(e, tag)">
-            <f7-icon v-if="isTagSelected(tag)" slot="media" ios="f7:checkmark_circle_fill" md="material:check-circle" aurora="f7:checkmark_circle_fill" />
+            <f7-icon v-if="isTagSelected(tag)" slot="media" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
           </f7-chip>
         </div>
         <f7-list
-          v-show="rules.length > 0"
+          v-show="rules.length"
           class="searchbar-found col rules-list"
           ref="rulesList"
           media-list contacts-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -218,9 +218,8 @@ export default {
 
         this.rules.forEach(rule => {
           rule.tags.forEach(t => {
-            let tag = t.substring(0, 1).toUpperCase() + t.slice(1)
-            if (tag.includes('Marketplace:')) tag = 'Marketplace'
-            if (!this.uniqueTags.includes(tag)) this.uniqueTags.push(tag)
+            if (t.startsWith('marketplace:')) t = 'Marketplace'
+            if (!this.uniqueTags.includes(t)) this.uniqueTags.push(t)
           })
         })
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -150,10 +150,9 @@
 
 <script>
 import RuleStatus from '@/components/rule/rule-status-mixin'
-import TagMixin from '@/components/tags/tag-mixin'
 
 export default {
-  mixins: [RuleStatus, TagMixin],
+  mixins: [RuleStatus],
   props: ['showScripts', 'showScenes'],
   components: {
     'empty-state-placeholder': () => import('@/components/empty-state-placeholder.vue')

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -91,9 +91,7 @@
             </f7-button>
           </f7-segmented>
         </div>
-        <div v-if="uniqueTags.length" class="block-title">
-          Tags:
-        </div>
+
         <div v-if="uniqueTags.length" class="block block-strong-ios block-outline-ios" ref="filterTags">
           <f7-chip v-for="tag in uniqueTags" :key="tag" :text="tag" media-bg-color="blue"
                    :color="isTagSelected(tag) ? 'blue' : ''"
@@ -286,6 +284,8 @@ export default {
             if (!this.uniqueTags.includes(tag)) this.uniqueTags.push(tag)
           })
         })
+
+        this.uniqueTags.sort()
 
         this.loading = false
         this.ready = true

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -97,7 +97,7 @@
         <div v-if="uniqueTags.length" class="block block-strong-ios block-outline-ios" ref="filterTags">
           <f7-chip v-for="tag in uniqueTags" :key="tag" :text="tag" media-bg-color="blue"
                    :color="isTagSelected(tag) ? 'blue' : ''"
-                   style="margin-right: 6px"
+                   style="margin-right: 6px; cursor: pointer;"
                    @click="(e) => toggleSearchTag(e, tag)">
             <f7-icon v-if="isTagSelected(tag)" slot="media" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
           </f7-chip>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -78,7 +78,16 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ rules.length }} {{ type.toLowerCase() }}
         </f7-block-title>
-
+        <div class="searchbar-found padding-left padding-right">
+          <f7-segmented strong tag="p">
+            <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
+              Alphabetical
+            </f7-button>
+            <f7-button :active="groupBy === 'semantic'" @click="switchGroupOrder('semantic')">
+              By Semantic Tag
+            </f7-button>
+          </f7-segmented>
+        </div>
         <f7-list
           v-show="rules.length > 0"
           class="searchbar-found col rules-list"
@@ -133,9 +142,10 @@
 
 <script>
 import RuleStatus from '@/components/rule/rule-status-mixin'
+import TagMixin from '@/components/tags/tag-mixin'
 
 export default {
-  mixins: [RuleStatus],
+  mixins: [RuleStatus, TagMixin],
   props: ['showScripts', 'showScenes'],
   components: {
     'empty-state-placeholder': () => import('@/components/empty-state-placeholder.vue')
@@ -149,6 +159,7 @@ export default {
       initSearchbar: false,
       selectedItems: [],
       showCheckboxes: false,
+      groupBy: 'alphabetical',
       eventSource: null
     }
   },
@@ -160,15 +171,34 @@ export default {
       return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/${this.type.toLowerCase()}`
     },
     indexedRules () {
-      return this.rules.reduce((prev, rule, i, rules) => {
-        const initial = rule.name.substring(0, 1).toUpperCase()
-        if (!prev[initial]) {
-          prev[initial] = []
-        }
-        prev[initial].push(rule)
+      if (this.groupBy === 'alphabetical') {
+        return this.rules.reduce((prev, rule, i, rules) => {
+          const initial = rule.name.substring(0, 1).toUpperCase()
+          if (!prev[initial]) {
+            prev[initial] = []
+          }
+          prev[initial].push(rule)
 
-        return prev
-      }, {})
+          return prev
+        }, {})
+      } else if (this.groupBy === 'semantic') {
+        const semanticGroup = this.rules.reduce((prev, rule, i, rules) => {
+          let initial = rule.tags.filter((t) => t !== 'Script' && t !== 'Scene' &&
+            t !== 'Schedule' && this.isSemanticTag(t))
+          if (initial.length === 0) initial = '- No Semantic Tags -'
+
+          if (!prev[initial]) {
+            prev[initial] = []
+          }
+          prev[initial].push(rule)
+
+          return prev
+        }, {})
+        return Object.keys(semanticGroup).sort((a, b) => a.localeCompare(b)).reduce((objEntries, key) => {
+          objEntries[key] = semanticGroup[key]
+          return objEntries
+        }, {})
+      }
     },
     searchPlaceholder () {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
@@ -324,6 +354,18 @@ export default {
         this.load()
         console.error(err)
         this.$f7.dialog.alert('An error occurred while enabling/disabling: ' + err)
+      })
+    },
+    switchGroupOrder (groupBy) {
+      this.groupBy = groupBy
+      const searchbar = this.$refs.searchbar.$el.f7Searchbar
+      const filterQuery = searchbar.query
+      this.$nextTick(() => {
+        if (filterQuery) {
+          searchbar.clear()
+          searchbar.search(filterQuery)
+        }
+        if (groupBy === 'alphabetical') this.$refs.listIndex.update()
       })
     }
   }


### PR DESCRIPTION
Closes #2123.

This adds filtering by tags to the rules list, the filter is inside an accordion.
In case you select multiple tags, the filter behaves like OR, which means all rules which have at least one of the selected tags are displayed.
In case you use the searchbar, the rules list will be narrowed down to the rules which match the search query and have the selected tags.