### PR TITLE
Set unit metadata & state description pattern when creating UoM Item

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -17,7 +17,7 @@
         </select>
       </f7-list-item>
       <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
-                     info="Used internally and for persistence & API(s). It is independent from the state description, which is used for display purposes only."
+                     info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
                      @input="item.unit = $event.target.value" clear-button />
       <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes."

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -9,11 +9,11 @@
         </select>
       </f7-list-item>
       <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
-        <select name="select-dimension" @change="setGroupType($event.target.value)">
+        <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'">
             &nbsp;
           </option>
-          <option v-for="d in dimensions" :key="d.name" :value="'Number:' + d.name" :selected="'Number:' + d.name === item.groupType">
+          <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
             {{ d.label }}
           </option>
         </select>
@@ -87,6 +87,11 @@ export default {
       this.$nextTick(() => {
         if (type !== 'None') this.$set(this.item, 'groupType', type)
       })
+    },
+    setDimension (index) {
+      const dimension = this.dimensions[index]
+      this.setGroupType('Number:' + dimension.name)
+      this.$set(this.item, 'unit', dimension.systemUnit)
     },
     setFunction (key) {
       if (!key) {

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -3,7 +3,7 @@
     <f7-list inline-labels no-hairlines-md>
       <f7-list-item v-if="item.type === 'Group'" title="Members Base Type" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-basetype" @change="setGroupType($event.target.value)">
-          <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="type === item.groupType.split(':')[0]">
+          <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
             {{ type }}
           </option>
         </select>
@@ -89,6 +89,10 @@ export default {
       })
     },
     setDimension (index) {
+      if (index === 'Number') {
+        this.setGroupType('Number')
+        return
+      }
       const dimension = this.dimensions[index]
       this.setGroupType('Number:' + dimension.name)
       this.$set(this.item, 'unit', dimension.systemUnit)

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -16,6 +16,9 @@
           </option>
         </select>
       </f7-list-item>
+      <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
+                     info="All processed values are internally normalized to the specified unit. The normalized value is used to propagate the value to external integrations (e.g. persistence, REST API, WebSocket) so these values will always have the specified unit and scale."
+                     @input="item.unit = $event.target.value" clear-button />
       <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.ArithmeticFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
@@ -62,7 +65,7 @@ import uomMixin from '@/components/item/uom-mixin'
 
 export default {
   mixins: [uomMixin],
-  props: ['item'],
+  props: ['item', 'createMode'],
   data () {
     return {
       types

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -10,9 +10,7 @@
       </f7-list-item>
       <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
-          <option key="Number" value="Number" :selected="item.type === 'Number'">
-            &nbsp;
-          </option>
+          <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
             {{ d.label }}
           </option>

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -17,8 +17,11 @@
         </select>
       </f7-list-item>
       <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
-                     info="All processed values are internally normalized to the specified unit. The normalized value is used to propagate the value to external integrations (e.g. persistence, REST API, WebSocket) so these values will always have the specified unit and scale."
+                     info="Used internally and for persistence & API(s). It is independent from the state description, which is used for display purposes only."
                      @input="item.unit = $event.target.value" clear-button />
+      <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
+                     info="Pattern or transformation applied to the state for display purposes."
+                     @input="item.stateDescriptionPattern = $event.target.value" clear-button />
       <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.ArithmeticFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
@@ -97,6 +100,7 @@ export default {
       const dimension = this.dimensions[index]
       this.setGroupType('Number:' + dimension.name)
       this.$set(this.item, 'unit', dimension.systemUnit)
+      this.$set(this.item, 'stateDescriptionPattern', `%.0f ${dimension.systemUnit}`)
     },
     setFunction (key) {
       if (!key) {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -22,6 +22,9 @@
           </option>
         </select>
       </f7-list-item>
+      <f7-list-input v-if="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
+                     info="All processed values are internally normalized to the specified unit. The normalized value is used to propagate the value to external integrations (e.g. persistence, REST API, WebSocket) so these values will always have the specified unit and scale."
+                     @input="item.unit = $event.target.value" clear-button />
       <f7-list-input v-if="!hideCategory" ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
                      @input="item.category = $event.target.value" clear-button>
         <div slot="root-end" style="margin-left: calc(35% + 8px)">

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -24,7 +24,7 @@
       </f7-list-item>
       <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
-                     info="Used internally and for persistence & API(s). It is independent from the state description, which is used for display purposes only."
+                     info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
                      @input="item.unit = $event.target.value" clear-button />
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes."

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -22,9 +22,13 @@
           </option>
         </select>
       </f7-list-item>
-      <f7-list-input v-if="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
-                     info="All processed values are internally normalized to the specified unit. The normalized value is used to propagate the value to external integrations (e.g. persistence, REST API, WebSocket) so these values will always have the specified unit and scale."
+      <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
+      <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
+                     info="Used internally and for persistence & API(s). It is independent from the state description, which is used for display purposes only."
                      @input="item.unit = $event.target.value" clear-button />
+      <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
+                     info="Pattern or transformation applied to the state for display purposes."
+                     @input="item.stateDescriptionPattern = $event.target.value" clear-button />
       <f7-list-input v-if="!hideCategory" ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
                      @input="item.category = $event.target.value" clear-button>
         <div slot="root-end" style="margin-left: calc(35% + 8px)">
@@ -89,6 +93,7 @@ export default {
       const dimension = this.dimensions[index]
       this.$set(this.item, 'type', 'Number:' + dimension.name)
       this.$set(this.item, 'unit', dimension.systemUnit)
+      this.$set(this.item, 'stateDescriptionPattern', `%.0f ${dimension.systemUnit}`)
     },
     initializeAutocomplete (inputElement) {
       this.categoryAutocomplete = this.$f7.autocomplete.create({

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -16,9 +16,7 @@
       </f7-list-item>
       <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
-          <option key="Number" value="Number" :selected="item.type === 'Number'">
-            &nbsp;
-          </option>
+          <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.type">
             {{ d.label }}
           </option>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -81,6 +81,10 @@ export default {
   },
   methods: {
     setDimension (index) {
+      if (index === 'Number') {
+        this.$set(this.item, 'type', 'Number')
+        return
+      }
       const dimension = this.dimensions[index]
       this.$set(this.item, 'type', 'Number:' + dimension.name)
       this.$set(this.item, 'unit', dimension.systemUnit)

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -15,11 +15,11 @@
         </select>
       </f7-list-item>
       <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
-        <select name="select-dimension" @change="item.type = $event.target.value">
+        <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'">
             &nbsp;
           </option>
-          <option v-for="d in dimensions" :key="d.name" :value="'Number:' + d.name" :selected="'Number:' + d.name === item.type">
+          <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.type">
             {{ d.label }}
           </option>
         </select>
@@ -80,6 +80,11 @@ export default {
     }
   },
   methods: {
+    setDimension (index) {
+      const dimension = this.dimensions[index]
+      this.$set(this.item, 'type', 'Number:' + dimension.name)
+      this.$set(this.item, 'unit', dimension.systemUnit)
+    },
     initializeAutocomplete (inputElement) {
       this.categoryAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -84,6 +84,14 @@ export default {
       return this.getNonSemanticTags(this.item).length
     }
   },
+  watch: {
+    // Required for pre-filling unit and state description pattern fields in "Add Items from Thing" functionality
+    dimensions () {
+      if (this.createMode && this.item.type && this.item.type.startsWith('Number:')) {
+        this.setDimension(this.dimensions.findIndex((d) => d.name === this.item.type.split(':')[1]))
+      }
+    }
+  },
   methods: {
     setDimension (index) {
       if (index === 'Number') {

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -27,6 +27,48 @@ export default {
     getNonSemanticTags (item) {
       if (!item.tags) return []
       return item.tags.filter((t) => !this.isSemanticTag(t))
+    },
+    doSave (item) {
+      console.log(item)
+
+      if (item.groupType === 'None') delete item.groupType
+      if (item.function === 'None') delete item.groupType
+
+      const unit = item.unit
+      delete item.unit
+      const stateDescriptionPattern = item.stateDescriptionPattern
+      delete item.stateDescriptionPattern
+
+      // TODO: Add support for saving metadata
+      return this.$oh.api.put('/rest/items/' + item.name, item).then(() => {
+        let unitPromise = Promise.resolve()
+        if (this.createMode && (item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && unit) {
+          const metadata = {
+            value: unit,
+            config: {}
+          }
+          unitPromise = this.$oh.api.put('/rest/items/' + item.name + '/metadata/unit', metadata)
+        }
+        return unitPromise
+      }).then(() => {
+        let stateDescriptionPromise = Promise.resolve()
+        if (this.createMode && (item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && stateDescriptionPattern) {
+          if (stateDescriptionPattern !== `%.0f ${unit}`) {
+            const metadata = {
+              value: ' ',
+              config: {
+                pattern: stateDescriptionPattern
+              }
+            }
+            stateDescriptionPromise = this.$oh.api.put('/rest/items/' + item.name + '/metadata/stateDescription', metadata)
+          }
+        }
+        return stateDescriptionPromise
+      }).then(() => {
+        return Promise.resolve()
+      }).catch((err) => {
+        return Promise.reject(err)
+      })
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -5,6 +5,9 @@ export default {
   methods: {
     getItemTypeAndMetaLabel (item) {
       let ret = item.type
+      if (item.type === 'Group') {
+        ret += ` (${item.groupType})`
+      }
       if (item.metadata && item.metadata.semantics) {
         ret += ' · '
         const classParts = item.metadata.semantics.value.split('_')

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -9,7 +9,8 @@ export default {
       data.uomInfo.dimensions.forEach((d) => {
         this.dimensions.push({
           name: d.dimension,
-          label: d.dimension + ' (' + d.systemUnit + ')'
+          label: d.dimension + ' (' + d.systemUnit + ')',
+          systemUnit: d.systemUnit
         })
       })
     })

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -16,7 +16,7 @@
         <h2>{{ item.label }}</h2>
         <!-- <h4 v-show="item.label">{{item.name}}</h4> -->
         <h5 v-show="item.type">
-          <small>{{ item.type }}</small>
+          <small>{{ item.type === 'Group' ? `${item.type} (${item.groupType})` : item.type }}</small>
         </h5>
       </f7-subnavbar>
     </f7-navbar>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -163,17 +163,36 @@ export default {
       if (this.item.groupType === 'None') delete this.item.groupType
       if (this.item.function === 'None') delete this.item.groupType
 
+      const unit = this.item.unit
+      delete this.item.unit
+      const stateDescriptionPattern = this.item.stateDescriptionPattern
+      delete this.item.stateDescriptionPattern
+
       // TODO: Add support for saving metadata
       this.$oh.api.put('/rest/items/' + this.item.name, this.item).then(() => {
         let unitPromise = Promise.resolve()
-        if (this.createMode && (this.item.type.startsWith('Number:') || this.item.groupType?.startsWith('Number:')) && this.item.unit) {
+        if (this.createMode && (this.item.type.startsWith('Number:') || this.item.groupType?.startsWith('Number:')) && unit) {
           const metadata = {
-            value: this.item.unit,
+            value: unit,
             config: {}
           }
           unitPromise = this.$oh.api.put('/rest/items/' + this.item.name + '/metadata/unit', metadata)
         }
         return unitPromise
+      }).then(() => {
+        let stateDescriptionPromise = Promise.resolve()
+        if (this.createMode && (this.item.type.startsWith('Number:') || this.item.groupType?.startsWith('Number:')) && stateDescriptionPattern) {
+          if (stateDescriptionPattern !== `%.0f ${unit}`) {
+            const metadata = {
+              value: ' ',
+              config: {
+                pattern: stateDescriptionPattern
+              }
+            }
+            stateDescriptionPromise = this.$oh.api.put('/rest/items/' + this.item.name + '/metadata/stateDescription', metadata)
+          }
+        }
+        return stateDescriptionPromise
       }).then(() => {
         if (this.createMode) {
           this.$f7.toast.create({

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -35,7 +35,7 @@
           </f7-col>
           <f7-col v-if="item && item.type === 'Group'">
             <f7-block-title>Group Settings</f7-block-title>
-            <group-form :item="item" />
+            <group-form :item="item" :createMode="createMode" />
           </f7-col>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -164,7 +164,17 @@ export default {
       if (this.item.groupType === 'None') delete this.item.groupType
 
       // TODO: Add support for saving metadata
-      this.$oh.api.put('/rest/items/' + this.item.name, this.item).then((data) => {
+      this.$oh.api.put('/rest/items/' + this.item.name, this.item).then(() => {
+        let unitPromise = Promise.resolve()
+        if (this.createMode && this.item.unit) {
+          const metadata = {
+            value: this.item.unit,
+            config: {}
+          }
+          unitPromise = this.$oh.api.put('/rest/items/' + this.item.name + '/metadata/unit', metadata)
+        }
+        return unitPromise
+      }).then(() => {
         if (this.createMode) {
           this.$f7.toast.create({
             text: 'Item created',


### PR DESCRIPTION
Related to https://github.com/openhab/openhab-core/pull/3481.
Closes #2108.

- Ensures that the internal unit is set when an Item is created, so that in case the system unit changes (i.e. measurement system changes) persisted data does not get corrupted.
By default, the unit metadata is set to the system default unit, however the user can easily change that on Item creation.
  
  The unit can also be changed later as it is just normal metadata, however this can corrupt persisted data.
- Adds the ability to set state description pattern when creating a UoM Item.
- Shows the group type for groups, e.g. `Group (Number:Temperature)` instead of just the Item type.

This applies to both the Items and the model page.