### PR TITLE
Add copy rule functionality

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -297,7 +297,10 @@ export default [
             path: ':ruleId',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
-            async: loadAsync(RuleEditPage, (routeTo) => (routeTo.params.ruleId === 'add') ? { createMode: true } : {}),
+            async: loadAsync(RuleEditPage, (routeTo) =>
+              (routeTo.params.ruleId === 'add')
+                ? { createMode: true } : (routeTo.params.ruleId === 'copy')
+                  ? { copyMode: true } : {}),
             routes: [
               {
                 path: 'script/:moduleId',

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -298,9 +298,9 @@ export default [
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
             async: loadAsync(RuleEditPage, (routeTo) =>
-              (routeTo.params.ruleId === 'add')
-                ? { createMode: true } : (routeTo.params.ruleId === 'copy')
-                  ? { copyMode: true } : {}),
+              routeTo.params.ruleId === 'add' ? { createMode: true }
+                : routeTo.params.ruleId === 'copy' ? { copyMode: true }
+                  : {}),
             routes: [
               {
                 path: 'script/:moduleId',

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -157,6 +157,9 @@
           </f7-col>
           <f7-col v-if="isEditable && !createMode">
             <f7-list>
+              <f7-list-button color="blue" @click="copyRule">
+                Copy Rule
+              </f7-list-button>
               <f7-list-button color="red" @click="deleteRule">
                 Remove Rule
               </f7-list-button>
@@ -402,6 +405,23 @@ export default {
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Error while disabling or enabling: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+      })
+    },
+    copyRule () {
+      let ruleClone = cloneDeep(this.rule)
+      ruleClone.uid = this.$f7.utils.id()
+      ruleClone.name = ruleClone.name + ' Copy'
+      const promise = this.$oh.api.postPlain('/rest/rules', JSON.stringify(ruleClone), 'text/plain', 'application/json')
+      promise.then((data) => {
+        this.$f7router.back()
+        this.$f7router.navigate((this.rule.editable) ? '/settings/rules/' + ruleClone.uid : '/settings/scripts/' + ruleClone.uid)
+        if (this.rule.status.statusDetail === 'DISABLED') this.$oh.api.postPlain('/rest/rules/' + ruleClone.uid + '/enable', 'false')
+      }).catch((err) => {
+        this.$f7.toast.create({
+          text: 'Error while copying rule: ' + err,
           destroyOnClose: true,
           closeTimeout: 2000
         }).open()

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -56,7 +56,7 @@
             <f7-list inline-labels no-hairlines-md>
               <f7-list-input label="Unique ID" type="text" placeholder="Required" value="_______" required validate
                              :disabled="true" :info="(isNewRule) ? 'Note: cannot be changed after the creation' : ''"
-                             @input="rule.uid = $event.target.value" :clear-button="createMode" />
+                             @input="rule.uid = $event.target.value" :clear-button="isNewRule" />
               <f7-list-input label="Name" type="text" placeholder="Required" required validate
                              :disabled="true" @input="rule.name = $event.target.value" :clear-button="isEditable" />
               <f7-list-input label="Description" type="text" value="__ _____ ___ __ ___"
@@ -71,7 +71,7 @@
               <f7-list-input label="Unique ID" type="text" placeholder="Required" :value="rule.uid" required validate
                              :disabled="!isNewRule" :info="(isNewRule) ? 'Note: cannot be changed after the creation' : ''"
                              pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
-                             @input="rule.uid = $event.target.value" :clear-button="createMode" />
+                             @input="rule.uid = $event.target.value" :clear-button="isNewRule" />
               <f7-list-input label="Name" type="text" placeholder="Required" :value="rule.name" required validate
                              :disabled="!isEditable" @input="rule.name = $event.target.value" :clear-button="isEditable" />
               <f7-list-input label="Description" type="text" :value="rule.description"
@@ -150,7 +150,7 @@
               </f7-list>
             </div>
           </f7-col>
-          <f7-col v-if="(isEditable || rule.tags.length > 0) && (!createMode || !hasTemplate)">
+          <f7-col v-if="(isEditable || rule.tags.length > 0) && !hasTemplate">
             <f7-block-title>Tags</f7-block-title>
             <semantics-picker v-if="isEditable" :item="rule" />
             <tag-input :item="rule" :disabled="!isEditable" />
@@ -352,6 +352,7 @@ export default {
             }
           })
           loadingFinished()
+          // no need for an event source, the rule doesn't exist yet
         } else {
           this.$oh.api.get('/rest/rules/' + this.ruleId).then((data2) => {
             this.$set(this, 'rule', data2)
@@ -412,7 +413,7 @@ export default {
       })
     },
     toggleDisabled () {
-      if (this.createMode) return
+      if (this.isNewRule) return
       const enable = (this.rule.status.statusDetail === 'DISABLED')
       this.$oh.api.postPlain('/rest/rules/' + this.rule.uid + '/enable', enable.toString()).then((data) => {
         this.$f7.toast.create({


### PR DESCRIPTION
Sometimes it is necessary to make copies of the rule for later editing.

Added ability to copy a rule.
After "copy rule" new rule is opened
~~If original rule is disabled, then copied rule also disabled~~

#### Original rule

![image](https://github.com/openhab/openhab-webui/assets/10882718/9f502336-48f7-4d07-b1a7-8bfbf50154d9)

#### Copied rule
Opened as New rule with pre-filled values

![image](https://github.com/openhab/openhab-webui/assets/10882718/b37ac97b-d523-491b-9515-10a374912e33)
