### PR TITLE
`oh-stepper`: Fix NaN shown for Item state with unit & Fix unable to control Item with NaN state

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -53,6 +53,7 @@ export default {
     onChange (value) {
       const applyOffset = (value) => (typeof this.config.offset === 'number') ? Number(this.toStepFixed(value - this.config.offset)) : value
       let newValue = applyOffset(Number(this.toStepFixed(value)))
+      if (isNaN(newValue)) newValue = this.config.min || this.config.max || 0
       if (newValue === this.value) return
       if (this.config.variable) {
         if (this.config.variableKey) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -28,7 +28,7 @@ export default {
         }
         return applyOffset(this.context.vars[this.config.variable])
       }
-      let value = applyOffset(Number(this.context.store[this.config.item].state))
+      let value = applyOffset(parseFloat(this.context.store[this.config.item].state))
       if (this.config.min !== undefined) value = Math.max(value, this.config.min)
       if (this.config.max !== undefined) value = Math.min(value, this.config.max)
       return value

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -21,7 +21,7 @@ export default {
   },
   computed: {
     value () {
-      const applyOffset = (value) => (typeof this.config.offset === 'number') ? Number(this.toStepFixed(value + this.config.offset)) : value
+      const applyOffset = (num) => (!isNaN(this.config.offset)) ? Number(this.toStepFixed(num + Number(this.config.offset))) : num
       if (this.config.variable) {
         if (this.config.variableKey) {
           return applyOffset(this.getLastVariableKeyValue(this.context.vars[this.config.variable], this.config.variableKey))
@@ -48,10 +48,11 @@ export default {
       // uses the number of decimals in the step config to round the provided number
       if (!this.config.step) return value
       const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]
-      return parseFloat(Number(value)).toFixed(nbDecimals ? nbDecimals.length : 0)
+      // do NOT convert to number, instead return string, otherwise formatting wouldn't work
+      return parseFloat(value).toFixed(nbDecimals ? nbDecimals.length : 0)
     },
     onChange (value) {
-      const applyOffset = (value) => (typeof this.config.offset === 'number') ? Number(this.toStepFixed(value - this.config.offset)) : value
+      const applyOffset = (num) => (!isNaN(this.config.offset)) ? Number(this.toStepFixed(num - Number(this.config.offset))) : num
       let newValue = applyOffset(Number(this.toStepFixed(value)))
       if (isNaN(newValue)) newValue = this.config.min || this.config.max || 0
       if (newValue === this.value) return


### PR DESCRIPTION
Regression from #2090.

Reported on the community, see https://community.openhab.org/t/openhab-4-1-0-m2-oh-stepper-not-working-properly/150372?u=florian-h05.