### PR TITLE
Sitemap editor: fix staticIcon parameter

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -113,7 +113,7 @@ WidgetAttr -> %widgetswitchattr                                                 
   | %widgetboolattr _ WidgetBooleanAttrValue                                      {% (d) => [d[0].value, d[2]] %}
   | %widgetfreqattr _ WidgetAttrValue                                             {% (d) => ['frequency', d[2]] %}
   | %icon _ WidgetIconAttrValue                                                   {% (d) => [d[0].value, d[2].join("")] %}
-  | %staticIcon_ WidgetIconAttrValue                                              {% (d) => [d[0].value, d[2].join("")] %}
+  | %staticIcon _ WidgetIconAttrValue                                             {% (d) => [d[0].value, d[2].join("")] %}
   | WidgetAttrName _ WidgetAttrValue                                              {% (d) => [d[0][0].value, d[2]] %}
   | WidgetMappingsAttrName WidgetMappingsAttrValue                                {% (d) => [d[0][0].value, d[1]] %}
   | WidgetVisibilityAttrName WidgetVisibilityAttrValue                            {% (d) => [d[0][0].value, d[1]] %}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -11,13 +11,13 @@ function writeWidget (widget, indent) {
         dsl += ' sendFrequency=' + widget.config[key]
       } else if (key === 'forceAsItem') {
         dsl += ' forceasitem=' + widget.config[key]
-      } else if (['icon', 'staticIcon'].includes(key)) {
+      } else if (key === 'icon') {
         if (widget.config.staticIcon) {
           dsl += ' staticIcon=' + widget.config[key]
         } else {
           dsl += ' icon=' + widget.config[key]
         }
-      } else {
+      } else if (key !== 'staticIcon') {
         dsl += ` ${key}=`
         if (key === 'item' || key === 'period' || key === 'legend' || Number.isFinite(widget.config[key])) {
           dsl += widget.config[key]


### PR DESCRIPTION
One missing blank in the lexer made the functionality fail, but the test still succeed.
Corrected the blank, and then also had to correct the DSL generator.