### PR TITLE
Sitemap editor: Support AND conditions and icon rules

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -31,6 +31,7 @@
     gteq:             '>=',
     lt:               '<',
     gt:               '>',
+    and:              'AND',
     equals:           '=',
     NL:               { match: /\n/, lineBreaks: true },
     SL_COMMENT:       /\/\/.*$/,
@@ -112,6 +113,7 @@ WidgetAttr -> %widgetswitchattr                                                 
   | %widgetfrcitmattr _ WidgetBooleanAttrValue                                    {% (d) => ['forceAsItem', d[2]] %}
   | %widgetboolattr _ WidgetBooleanAttrValue                                      {% (d) => [d[0].value, d[2]] %}
   | %widgetfreqattr _ WidgetAttrValue                                             {% (d) => ['frequency', d[2]] %}
+  | %icon _ WidgetIconRulesAttrValue                                              {% (d) => ['iconrules', d[2]] %}
   | %icon _ WidgetIconAttrValue                                                   {% (d) => [d[0].value, d[2].join("")] %}
   | %staticIcon _ WidgetIconAttrValue                                             {% (d) => [d[0].value, d[2].join("")] %}
   | WidgetAttrName _ WidgetAttrValue                                              {% (d) => [d[0][0].value, d[2]] %}
@@ -125,8 +127,9 @@ WidgetIconAttrValue -> %string
   | WidgetIconName
   | %identifier %colon WidgetIconName
   | %identifier %colon %identifier %colon WidgetIconName
+WidgetIconRulesAttrValue -> %lbracket _ IconRules _ %rbracket                     {% (d) => d[2] %}
 WidgetIconName -> %identifier
-  | %identifier %hyphen WidgetIconName                                            {% (d) => d[0].value + "-" + d[2] %}
+  | WidgetIconName %hyphen %identifier                                            {% (d) => d[0] + "-" + d[2].value %}
 WidgetAttrValue -> %number                                                        {% (d) => { return parseFloat(d[0].value) } %}
   | %identifier                                                                   {% (d) => d[0].value %}
   | %string                                                                       {% (d) => d[0].value %}
@@ -143,23 +146,28 @@ Mapping -> MappingCommand _ %equals _ MappingLabel                              
 MappingCommand -> %number | %identifier | %string
 MappingLabel -> %number | %identifier | %string
 
-Visibilities -> Visibility                                                        {% (d) => [d[0]] %}
-  | Visibilities _ %comma _ Visibility                                            {% (d) => d[0].concat([d[4]]) %}
-Visibility -> VisibilityCommand _ VisibilityComparator _ VisibilityValue          {% (d) => d[0][0].value + d[2][0].value + d[4][0].value %}
-VisibilityCommand -> %identifier
-VisibilityComparator -> %eq | %noteq | %lteq | %gteq | %lt | %gt
-VisibilityValue -> %number | %identifier | %string
+Visibilities -> Conditions                                                        {% (d) => d[0] %}
+  | Visibilities _ %comma _ Conditions                                            {% (d) => d[0].concat(d[4]) %}
 
 Colors -> Color                                                                   {% (d) => [d[0]] %}
   | Colors _ %comma _ Color                                                       {% (d) => d[0].concat([d[4]]) %}
-Color -> ColorCommand _ ColorComparator _ ColorValue _ %equals _ ColorName        {% (d) => d[0][0].value + d[2][0].value + d[4][0].value + '=' + d[8][0].value %}
-  | ColorComparator _ ColorValue _ %equals _ ColorName                            {% (d) => d[0][0].value + d[2][0].value + '=' + d[6][0].value %}
-  | ColorValue _ %equals _ ColorName                                              {% (d) => d[0][0].value + '=' + d[4][0].value %}
+Color -> Conditions _ %equals _ ColorName                                         {% (d) => d[0] + '=' + d[4][0].value %}
   | ColorName                                                                     {% (d) => d[0][0].value %}
-ColorCommand -> %identifier
-ColorComparator -> %eq | %noteq | %lteq | %gteq | %lt | %gt
-ColorValue ->  %number | %identifier | %string
 ColorName ->  %identifier | %string
+
+IconRules -> IconRule                                                             {% (d) => [d[0]] %}
+  | IconRules _ %comma _ IconRule                                                 {% (d) => d[0].concat([d[4]]) %}
+IconRule -> Conditions _ %equals _ WidgetIconAttrValue                            {% (d) => d[0] + '=' + d[4].join("") %}
+  | WidgetIconAttrValue                                                           {% (d) => d[0].join("") %}
+
+Conditions -> Condition
+  | Conditions _ %and _ Condition                                                 {% (d) => d[0] + ' AND ' + d[4] %}
+Condition -> ConditionCommand _ ConditionComparator _ ConditionValue              {% (d) => d[0][0].value + d[2][0].value + d[4][0].value %}
+  | ConditionComparator _ ConditionValue                                          {% (d) => d[0][0].value + d[2][0].value %}
+  | ConditionValue                                                                {% (d) => d[0][0].value %}
+ConditionCommand -> %identifier
+ConditionComparator -> %eq | %noteq | %lteq | %gteq | %lt | %gt
+ConditionValue -> %number | %identifier | %string
 
 _ -> null               {% () => null %}
 	| __                  {% () => null %}

--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -143,6 +143,7 @@ WidgetColorAttrValue -> %lbracket _ Colors _ %rbracket                          
 Mappings -> Mapping                                                               {% (d) => [d[0]] %}
   | Mappings _ %comma _ Mapping                                                   {% (d) => d[0].concat([d[4]]) %}
 Mapping -> MappingCommand _ %equals _ MappingLabel                                {% (d) => d[0][0].value + '=' + d[4][0].value %}
+  |  MappingCommand _ %equals _ MappingLabel _ %equals _ WidgetIconAttrValue      {% (d) => d[0][0].value + '=' + d[4][0].value + '=' + d[8].join("") %}
 MappingCommand -> %number | %identifier | %string
 MappingLabel -> %number | %identifier | %string
 

--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -113,7 +113,7 @@ WidgetAttr -> %widgetswitchattr                                                 
   | %widgetboolattr _ WidgetBooleanAttrValue                                      {% (d) => [d[0].value, d[2]] %}
   | %widgetfreqattr _ WidgetAttrValue                                             {% (d) => ['frequency', d[2]] %}
   | %icon _ WidgetIconAttrValue                                                   {% (d) => [d[0].value, d[2].join("")] %}
-  | %staticIcon_ WidgetIconAttrValue                                              {% (d) => [d[0].value, d[2].join("")] %}
+  | %staticIcon _ WidgetIconAttrValue                                             {% (d) => [d[0].value, d[2].join("")] %}
   | WidgetAttrName _ WidgetAttrValue                                              {% (d) => [d[0][0].value, d[2]] %}
   | WidgetMappingsAttrName WidgetMappingsAttrValue                                {% (d) => [d[0][0].value, d[1]] %}
   | WidgetVisibilityAttrName WidgetVisibilityAttrValue                            {% (d) => [d[0][0].value, d[1]] %}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
@@ -116,11 +116,11 @@ describe('dslUtil', () => {
         '10=Cinéma',
         '11=TV',
         '3=Bed time',
-        '4=Night'
+        '4=Night=moon'
       ]
     })
     const sitemap = dslUtil.toDsl(component).split('\n')
-    expect(sitemap[1]).toEqual('    Selection item=Scene_General mappings=[1=Morning,2=Evening,10="Cinéma",11=TV,3="Bed time",4=Night]')
+    expect(sitemap[1]).toEqual('    Selection item=Scene_General mappings=[1=Morning,2=Evening,10="Cinéma",11=TV,3="Bed time",4=Night=moon]')
   })
 
   it('renders a widget with mappings and string keys correctly', () => {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
@@ -215,4 +215,18 @@ describe('dslUtil', () => {
     const sitemap = dslUtil.toDsl(component).split('\n')
     expect(sitemap[1]).toEqual('    Text item=Temperature valuecolor=[Heat_Warning=="It is hot"="gray"]')
   })
+
+  it('renders widget with valuecolor and AND condition correctly', () => {
+    const component = createSitemapComponent('test', 'Test')
+    const widget = {
+    }
+    addWidget(component, 'Text', {
+      item: 'Temperature',
+      valuecolor: [
+        'Heat_Warning==It is hot AND >=25=gray'
+      ]
+    })
+    const sitemap = dslUtil.toDsl(component).split('\n')
+    expect(sitemap[1]).toEqual('    Text item=Temperature valuecolor=[Heat_Warning=="It is hot" AND >=25="gray"]')
+  })
 })

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
@@ -152,13 +152,12 @@ describe('SitemapCode', () => {
     })
   })
 
-  it('parses a segmented icon name with hyphens', async () => {
+  it('parses an icon rule correctly', async () => {
     expect(wrapper.vm.sitemapDsl).toBeDefined()
     // simulate updating the sitemap in code
     const sitemap = [
       'sitemap test label="Test" {',
-      '    Default item=Item_Icon icon=iconify:wi:day-sunny-overcast',
-      '    Default item=Item_Icon_String icon="iconify:wi:day-sunny-overcast"',
+      '    Default item=Item_Icon icon=[>5=iconify:wi:day-sunny-overcast,<=5 AND Test_Item=="check error"=error]',
       '}',
       ''
     ].join('\n')
@@ -176,19 +175,15 @@ describe('SitemapCode', () => {
     const payload = events[0][0]
     expect(payload.slots).toBeDefined()
     expect(payload.slots.widgets).toBeDefined()
-    expect(payload.slots.widgets.length).toBe(2)
+    expect(payload.slots.widgets.length).toBe(1)
     expect(payload.slots.widgets[0]).toEqual({
       component: 'Default',
       config: {
         item: 'Item_Icon',
-        icon: 'iconify:wi:day-sunny-overcast'
-      }
-    })
-    expect(payload.slots.widgets[1]).toEqual({
-      component: 'Default',
-      config: {
-        item: 'Item_Icon_String',
-        icon: 'iconify:wi:day-sunny-overcast'
+        iconrules: [
+          '>5=iconify:wi:day-sunny-overcast',
+          '<=5 AND Test_Item==check error=error'
+        ]
       }
     })
   })

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
@@ -193,7 +193,7 @@ describe('SitemapCode', () => {
     // simulate updating the sitemap in code
     const sitemap = [
       'sitemap test label="Test" {',
-      '    Selection item=Scene_General mappings=[1=Morning,2="Evening",10="Cinéma",11=TV,3="Bed time",4=Night]',
+      '    Selection item=Scene_General mappings=[1=Morning,2="Evening",10="Cinéma",11=TV,3="Bed time",4=Night=moon]',
       '}',
       ''
     ].join('\n')
@@ -222,7 +222,7 @@ describe('SitemapCode', () => {
           '10=Cinéma',
           '11=TV',
           '3=Bed time',
-          '4=Night'
+          '4=Night=moon'
         ]
       }
     })

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -29,7 +29,7 @@ function writeWidget (widget, indent) {
           dsl += '['
           dsl += widget.config[key].filter(Boolean).map(mapping => {
             return mapping.split('=').map(value => {
-              if (/^[^"'].*\W.*[^"']$/.test(value)) {
+              if (/^.*\W.*$/.test(value) && /^[^"'].*[^"']$/.test(value)) {
                 return '"' + value + '"'
               }
               return value
@@ -74,7 +74,7 @@ function writeConditions (value, hasArgument = false) {
     return conditions.split(' AND ').map(condition => {
       let index = Math.max(condition.lastIndexOf('='), condition.lastIndexOf('>'), condition.lastIndexOf('<')) + 1
       let conditionValue = condition.substring(index).trim()
-      if (/^[^"'].*\W.*[^"']$/.test(conditionValue)) {
+      if (/^.*\W.*$/.test(conditionValue) && /^[^"'].*[^"']$/.test(conditionValue)) {
         conditionValue = '"' + conditionValue + '"'
       }
       return condition.substring(0, index) + conditionValue

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -11,13 +11,13 @@ function writeWidget (widget, indent) {
         dsl += ' sendFrequency=' + widget.config[key]
       } else if (key === 'forceAsItem') {
         dsl += ' forceasitem=' + widget.config[key]
-      } else if (['icon', 'staticIcon'].includes(key)) {
+      } else if (key === 'icon') {
         if (widget.config.staticIcon) {
           dsl += ' staticIcon=' + widget.config[key]
         } else {
           dsl += ' icon=' + widget.config[key]
         }
-      } else {
+      } else if (key !== 'staticIcon') {
         dsl += ` ${key}=`
         if (key === 'item' || key === 'period' || key === 'legend' || Number.isFinite(widget.config[key])) {
           dsl += widget.config[key]

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -14,11 +14,15 @@ function writeWidget (widget, indent) {
       } else if (key === 'icon') {
         if (widget.config.staticIcon) {
           dsl += ' staticIcon=' + widget.config[key]
-        } else {
+        } else if (!widget.config['iconrules'] || widget.config['iconrules'].length === 0) {
           dsl += ' icon=' + widget.config[key]
         }
       } else if (key !== 'staticIcon') {
-        dsl += ` ${key}=`
+        if (key === 'iconrules') {
+          dsl += ' icon='
+        } else {
+          dsl += ` ${key}=`
+        }
         if (key === 'item' || key === 'period' || key === 'legend' || Number.isFinite(widget.config[key])) {
           dsl += widget.config[key]
         } else if (key === 'mappings') {
@@ -33,34 +37,9 @@ function writeWidget (widget, indent) {
           }).join(',')
           dsl += ']'
         } else if (key === 'visibility') {
-          dsl += '['
-          dsl += widget.config[key].filter(Boolean).map(visibility => {
-            let index = Math.max(visibility.lastIndexOf('='), visibility.lastIndexOf('>'), visibility.lastIndexOf('<')) + 1
-            let value = visibility.substring(index)
-            if (/^[^"'].*\W.*[^"']$/.test(value)) {
-              value = '"' + value + '"'
-            }
-            return visibility.substring(0, index) + value
-          }).join(',')
-          dsl += ']'
-        } else if (['valuecolor', 'labelcolor', 'iconcolor'].includes(key)) {
-          dsl += '['
-          dsl += widget.config[key].filter(Boolean).map(color => {
-            let index = color.lastIndexOf('=') + 1
-            let colorvalue = color.substring(index).trim()
-            if (!/^(".*")|('.*')$/.test(colorvalue)) {
-              colorvalue = '"' + colorvalue + '"'
-            }
-            colorvalue = (index > 0 ? '=' + colorvalue : colorvalue)
-            let value = color.substring(0, index - 1)
-            index = Math.max(value.lastIndexOf('='), value.lastIndexOf('>'), value.lastIndexOf('<')) + 1
-            let condition = value.substring(index)
-            if (/^[^"'].*\W.*[^"']$/.test(condition)) {
-              condition = '"' + condition + '"'
-            }
-            return color.substring(0, index) + condition + colorvalue
-          }).join(',')
-          dsl += ']'
+          dsl += '[' + writeConditions(widget.config[key]) + ']'
+        } else if (['valuecolor', 'labelcolor', 'iconcolor', 'iconrules'].includes(key)) {
+          dsl += '[' + writeConditions(widget.config[key], true) + ']'
         } else {
           dsl += '"' + widget.config[key] + '"'
         }
@@ -77,6 +56,30 @@ function writeWidget (widget, indent) {
   dsl += '\n'
 
   return dsl
+}
+
+function writeConditions (value, hasArgument = false) {
+  return value.filter(Boolean).map(rule => {
+    let argument = ''
+    let conditions = rule
+    if (hasArgument) {
+      let index = rule.lastIndexOf('=') + 1
+      argument = rule.substring(index).trim()
+      if (!/^(".*")|('.*')$/.test(argument)) {
+        argument = '"' + argument + '"'
+      }
+      argument = (index > 0 ? '=' + argument : argument)
+      conditions = rule.substring(0, index - 1)
+    }
+    return conditions.split(' AND ').map(condition => {
+      let index = Math.max(condition.lastIndexOf('='), condition.lastIndexOf('>'), condition.lastIndexOf('<')) + 1
+      let conditionValue = condition.substring(index).trim()
+      if (/^[^"'].*\W.*[^"']$/.test(conditionValue)) {
+        conditionValue = '"' + conditionValue + '"'
+      }
+      return condition.substring(0, index) + conditionValue
+    }).join(' AND ') + argument
+  }).join(',')
 }
 
 export default {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/__tests__/sitemap-edit_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/__tests__/sitemap-edit_jest.spec.js
@@ -328,7 +328,7 @@ describe('SitemapEdit', () => {
     localVue.set(wrapper.vm.selectedWidget.config, 'item', 'Item1')
     localVue.set(wrapper.vm.selectedWidget.config, 'label', 'Text Test')
     localVue.set(wrapper.vm.selectedWidget.config, 'visibility', [
-      true
+      'true>"="test'
     ])
 
     // should not validate as the visibility has a syntax error
@@ -378,7 +378,7 @@ describe('SitemapEdit', () => {
       'Heat_Warning==It is hot=gray',
       'Last_Update==Uninitialized=gray',
       '>=25=orange',
-      '==15=green',
+      '==15 AND Heat_Warning==It is a nice temperature=green',
       '0=white',
       'blue'
     ])

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/__tests__/sitemap-edit_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/__tests__/sitemap-edit_jest.spec.js
@@ -312,7 +312,7 @@ describe('SitemapEdit', () => {
       '10=Cinéma',
       '11=TV',
       '3=Bed time',
-      '4=Night'
+      '4=Night=moon'
     ])
     wrapper.vm.validateWidgets()
     expect(lastDialogConfig).toBeFalsy()

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -68,7 +68,7 @@
               </f7-block>
               <f7-block v-if="selectedWidget && ['Switch', 'Selection'].indexOf(selectedWidget.component) >= 0">
                 <div><f7-block-title>Mappings</f7-block-title></div>
-                <attribute-details :widget="selectedWidget" attribute="mappings" placeholder="command = label" />
+                <attribute-details :widget="selectedWidget" attribute="mappings" placeholder="command = label = icon" />
               </f7-block>
               <f7-block v-if="selectedWidget && canAddChildren">
                 <div><f7-block-title>Add Child Widget</f7-block-title></div>
@@ -452,7 +452,7 @@ export default {
           if (widget.config) {
             Object.keys(widget.config).filter(attr => ['mappings', 'visibility', 'valuecolor', 'labelcolor', 'iconcolor', 'iconrules'].includes(attr)).forEach(attr => {
               widget.config[attr].forEach(param => {
-                if (((attr === 'mappings') && !(/^\s*("[^\n"]*"|[^\n"]+)\s*=\s*("[^\n"]*"|[^\n"]+)\s*$/u.test(param))) ||
+                if (((attr === 'mappings') && !(/^\s*("[^\n"]*"|[^\n="]+)\s*=\s*("[^\n"]*"|[^\n="]+)\s*(=\s*("[^\n"]*"|[^\n="]+))?$/u.test(param))) ||
                     ((attr === 'visibility') && !this.validateRule(param)) ||
                     ((['valuecolor', 'labelcolor', 'iconcolor', 'iconrules'].includes(attr)) && !this.validateRule(param, true))) {
                   let label = widget.config && widget.config.label ? widget.config.label : 'without label'

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -62,6 +62,10 @@
                 <div><f7-block-title>Icon Color</f7-block-title></div>
                 <attribute-details :widget="selectedWidget" attribute="iconcolor" placeholder="item_name operator value = color" />
               </f7-block>
+              <f7-block v-if="selectedWidget && selectedWidget.component !== 'Sitemap'">
+                <div><f7-block-title>Icon Rules</f7-block-title></div>
+                <attribute-details :widget="selectedWidget" attribute="iconrules" placeholder="item_name operator value = icon" />
+              </f7-block>
               <f7-block v-if="selectedWidget && ['Switch', 'Selection'].indexOf(selectedWidget.component) >= 0">
                 <div><f7-block-title>Mappings</f7-block-title></div>
                 <attribute-details :widget="selectedWidget" attribute="mappings" placeholder="command = label" />
@@ -446,11 +450,11 @@ export default {
         })
         widgetList.forEach(widget => {
           if (widget.config) {
-            Object.keys(widget.config).filter(attr => ['mappings', 'visibility', 'valuecolor', 'labelcolor', 'iconcolor'].includes(attr)).forEach(attr => {
+            Object.keys(widget.config).filter(attr => ['mappings', 'visibility', 'valuecolor', 'labelcolor', 'iconcolor', 'iconrules'].includes(attr)).forEach(attr => {
               widget.config[attr].forEach(param => {
                 if (((attr === 'mappings') && !(/^\s*("[^\n"]*"|[^\n"]+)\s*=\s*("[^\n"]*"|[^\n"]+)\s*$/u.test(param))) ||
-                    ((attr === 'visibility') && !(/^\s*\S+\s*(==|>=|<=|!=|>|<)\s*("[^\n"]*"|[^\n"]+)\s*$/u.test(param))) ||
-                    ((attr.includes('color')) && !(/^\s*(((\S+\s*)?(==|>=|<=|!=|>|<)\s*)?(("[^\n"]*"|[^\n"]+)\s*=\s*))?("#?\w+"|'#?\w+'|#?\w+)\s*$/u.test(param)))) {
+                    ((attr === 'visibility') && !this.validateRule(param)) ||
+                    ((['valuecolor', 'labelcolor', 'iconcolor', 'iconrules'].includes(attr)) && !this.validateRule(param, true))) {
                   let label = widget.config && widget.config.label ? widget.config.label : 'without label'
                   validationWarnings.push(widget.component + ' widget ' + label + ', syntax error in ' + attr + ': ' + param)
                 }
@@ -474,6 +478,16 @@ export default {
         }
         return true
       }
+    },
+    validateRule (rule, hasArgument = false) {
+      let conditions = rule
+      if (hasArgument) {
+        let index = rule.lastIndexOf('=') + 1
+        if (!/^("#?(\w|:|-)+"|'#?(\w|:|-)+'|#?(\w|:|-)+)$/.test(rule.substring(index).trim())) return false
+        conditions = rule.substring(0, index - 1)
+        if (conditions === '') return true
+      }
+      return conditions.split(' AND ').every(p => /^\s*((\S+\s*)?(==|>=|<=|!=|>|<)\s*)?("[^\n"]*"|[^\n"]+)\s*$/u.test(p))
     },
     cleanConfig (widget) {
       if (widget.config) {


### PR DESCRIPTION
Fixes #2149.

Sitemaps now support icon rules and AND conditions in icon, color and visibility rules.
Mappings now also support an icon.

This PR introduces support to configure this in the sitemap editor.
It also contains a fix for staticIcon support.

Depends on https://github.com/openhab/openhab-core/pull/3850