### PR TITLE
Fix oh-clock context in clock card

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-clock-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-clock-card.vue
@@ -6,17 +6,17 @@
     <f7-card-content @click.native="performAction" class="clock-card-content text-align-center">
       <f7-row v-if="config.showDate && config.datePos !== 'below'">
         <f7-col>
-          <oh-clock :context="{ component: 'oh-clock', config: {} }" :style="{ 'font-size': config.dateFontSize || '1vw', 'font-weight': config.dateFontWeight || 'normal' }" :format="config.dateFormat" />
+          <oh-clock :context="{ component: { component: 'oh-clock', config: {} }}" :style="{ 'font-size': config.dateFontSize || '1vw', 'font-weight': config.dateFontWeight || 'normal' }" :format="config.dateFormat" />
         </f7-col>
       </f7-row>
       <f7-row>
         <f7-col>
-          <oh-clock :context="{ component: 'oh-clock', config: {} }" :style="{ 'font-size': config.timeFontSize || '2vw', 'font-weight': config.timeFontWeight || 'normal' }" :format="config.timeFormat" />
+          <oh-clock :context="{ component: { component: 'oh-clock', config: {} }}" :style="{ 'font-size': config.timeFontSize || '2vw', 'font-weight': config.timeFontWeight || 'normal' }" :format="config.timeFormat" />
         </f7-col>
       </f7-row>
       <f7-row v-if="config.showDate && config.datePos === 'below'">
         <f7-col>
-          <oh-clock :context="{ component: 'oh-clock', config: {} }" :style="{ 'font-size': config.dateFontSize || '1vw', 'font-weight': config.dateFontWeight || 'normal' }" :format="config.dateFormat" />
+          <oh-clock :context="{ component: { component: 'oh-clock', config: {} }}" :style="{ 'font-size': config.dateFontSize || '1vw', 'font-weight': config.dateFontWeight || 'normal' }" :format="config.dateFormat" />
         </f7-col>
       </f7-row>
     </f7-card-content>


### PR DESCRIPTION
This PR fixes an error in the context definition of the `oh-clock` used  in the `oh-clock` card that was causing the clock cards to fail to render in the updated configuration definition.

See the forum discussion:

https://community.openhab.org/t/oh4-oh-clock-card-empty-since-oh4-1-m2/150518
