### PR TITLE
Addon suggestions

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
@@ -12,7 +12,10 @@
     <div class="addons-cards">
       <addon-card v-for="addon in featuredAddons" :key="addon.uid" :addon="addon" :install-action-text="installActionText" :headline="'Featured'" @addonButtonClick="addonButtonClick" />
     </div>
-    <div v-if="showAsCards" class="addons-cards">
+    <div v-if="suggested" class="addons-cards">
+      <addon-card v-for="addon in addonsList" :key="addon.uid" :addon="addon" :install-action-text="installActionText" :headline="'Suggested'" @addonButtonClick="addonButtonClick" />
+    </div>
+    <div v-else-if="showAsCards" class="addons-cards">
       <addon-card v-for="addon in addonsList" :key="addon.uid" :addon="addon" :install-action-text="installActionText" @addonButtonClick="addonButtonClick" />
     </div>
     <f7-list v-else media-list ref="addonlist" class="addons-table-list" no-chevron no-hairlines>
@@ -95,7 +98,7 @@ import AddonCard from './addon-card.vue'
 import { compareAddons } from '@/assets/addon-store'
 
 export default {
-  props: ['addons', 'title', 'subtitle', 'showAll', 'featured', 'showAsCards', 'installActionText'],
+  props: ['addons', 'title', 'subtitle', 'showAll', 'featured', 'showAsCards', 'suggested', 'installActionText'],
   components: {
     AddonListItem,
     AddonCard

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -53,7 +53,7 @@
           v-if="suggestedAddons" :show-all="true"
           @addonButtonClick="addonButtonClick"
           :addons="suggestedAddons.filter((a) => a.type === 'binding')"
-          :show-as-cards="true"
+          :suggested="true"
           :title="'Binding Suggestions'"
           :subtitle="'Suggested bindings from network scan'" />
         <addons-section
@@ -117,7 +117,7 @@
         <addons-section
           v-if="suggestedAddons" :show-all="true"
           @addonButtonClick="addonButtonClick"
-          :show-as-cards="true"
+          :suggested="true"
           :addons="suggestedAddons.filter((a) => a.type === 'misc')"
           :title="'System Integrations Suggestions'"
           :subtitle="'Suggested system integrations from network scan'" />

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -205,7 +205,7 @@ export default {
       return Object.keys(this.addons).flatMap((k) => this.addons[k])
     },
     suggestedAddons () {
-      return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => this.suggestions.some((s) => s.uid === a.uid))
+      return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => this.suggestions.some((s) => s.id === a.id))
     },
     unsuggestedAddons () {
       return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => !this.suggestedAddons.includes(a))

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -415,31 +415,33 @@ export default {
         this.i18nReady = true
       }
     })
-    this.$oh.api.get('/rest/addons').then((data) => {
-      this.addons = data.sort((a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
-      this.selectedAddons = this.addons.filter((a) => this.recommendedAddons.includes(a.uid) && !a.installed)
-      const self = this
-      this.autocompleteAddons = this.$f7.autocomplete.create({
-        openIn: 'popup',
-        pageTitle: this.$t('setupwizard.addons.selectAddons'),
-        searchbarPlaceholder: this.$t('setupwizard.addons.selectAddons.placeholder'),
-        openerEl: this.$refs.selectAddons,
-        multiple: true,
-        requestSourceOnOpen: true,
-        source: (query, render) => {
-          if (query.length === 0) {
-            render(self.addons.filter((a) => !a.installed).map((a) => a.label))
-          } else {
-            render(self.addons.filter((a) => !a.installed && (a.label.toLowerCase().indexOf(query.toLowerCase()) >= 0 || a.uid.toLowerCase().indexOf(query.toLowerCase()) >= 0)).map((a) => a.label))
-          }
-        },
-        on: {
-          change (value) {
-            const selected = value.map((label) => self.addons.find((a) => a.label === label))
-            self.$set(self, 'selectedAddons', selected)
-          }
-        },
-        value: this.addons.filter((a) => this.recommendedAddons.includes(a.uid)).map((a) => a.label)
+    this.$oh.api.get('/rest/addons/suggestions').then((suggestedAddons) => {
+      this.$oh.api.get('/rest/addons').then((data) => {
+        this.addons = data.sort((a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
+        this.selectedAddons = this.addons.filter((a) => (this.recommendedAddons.includes(a.uid) || suggestedAddons.includes(a.uid)) && !a.installed)
+        const self = this
+        this.autocompleteAddons = this.$f7.autocomplete.create({
+          openIn: 'popup',
+          pageTitle: this.$t('setupwizard.addons.selectAddons'),
+          searchbarPlaceholder: this.$t('setupwizard.addons.selectAddons.placeholder'),
+          openerEl: this.$refs.selectAddons,
+          multiple: true,
+          requestSourceOnOpen: true,
+          source: (query, render) => {
+            if (query.length === 0) {
+              render(self.addons.filter((a) => !a.installed).map((a) => a.label))
+            } else {
+              render(self.addons.filter((a) => !a.installed && (a.label.toLowerCase().indexOf(query.toLowerCase()) >= 0 || a.uid.toLowerCase().indexOf(query.toLowerCase()) >= 0)).map((a) => a.label))
+            }
+          },
+          on: {
+            change (value) {
+              const selected = value.map((label) => self.addons.find((a) => a.label === label))
+              self.$set(self, 'selectedAddons', selected)
+            }
+          },
+          value: this.addons.filter((a) => this.recommendedAddons.includes(a.uid) || suggestedAddons.includes(a.uid)).map((a) => a.label)
+        })
       })
     })
   }

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -416,10 +416,11 @@ export default {
       }
     })
     this.$oh.api.get('/rest/addons/suggestions').then((suggestedAddons) => {
-      let suggestions = suggestedAddons.flatMap((s) => s.uid)
+      let suggestions = suggestedAddons.flatMap((s) => s.id)
       this.$oh.api.get('/rest/addons').then((data) => {
         this.addons = data.sort((a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
-        this.selectedAddons = this.addons.filter((a) => (this.recommendedAddons.includes(a.uid) || suggestions.includes(a.uid)) && !a.installed)
+        this.selectedAddons = this.addons.filter((a) => (this.recommendedAddons.includes(a.uid) || suggestions.includes(a.id)) && !a.installed).sort((a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
+        const sortedAddons = this.selectedAddons.concat(this.addons.filter((a) => (!this.selectedAddons.includes(a))))
         const self = this
         this.autocompleteAddons = this.$f7.autocomplete.create({
           openIn: 'popup',
@@ -430,9 +431,9 @@ export default {
           requestSourceOnOpen: true,
           source: (query, render) => {
             if (query.length === 0) {
-              render(self.addons.filter((a) => !a.installed).map((a) => a.label))
+              render(sortedAddons.filter((a) => !a.installed).map((a) => a.label))
             } else {
-              render(self.addons.filter((a) => !a.installed && (a.label.toLowerCase().indexOf(query.toLowerCase()) >= 0 || a.uid.toLowerCase().indexOf(query.toLowerCase()) >= 0)).map((a) => a.label))
+              render(sortedAddons.filter((a) => !a.installed && (a.label.toLowerCase().indexOf(query.toLowerCase()) >= 0 || a.uid.toLowerCase().indexOf(query.toLowerCase()) >= 0)).map((a) => a.label))
             }
           },
           on: {
@@ -441,7 +442,7 @@ export default {
               self.$set(self, 'selectedAddons', selected)
             }
           },
-          value: this.addons.filter((a) => this.recommendedAddons.includes(a.uid) || suggestions.includes(a.uid)).map((a) => a.label)
+          value: this.addons.filter((a) => this.recommendedAddons.includes(a.uid) || suggestions.includes(a.id)).map((a) => a.label)
         })
       })
     })

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -416,9 +416,10 @@ export default {
       }
     })
     this.$oh.api.get('/rest/addons/suggestions').then((suggestedAddons) => {
+      let suggestions = suggestedAddons.flatMap((s) => s.uid)
       this.$oh.api.get('/rest/addons').then((data) => {
         this.addons = data.sort((a, b) => a.label.toUpperCase().localeCompare(b.label.toUpperCase()))
-        this.selectedAddons = this.addons.filter((a) => (this.recommendedAddons.includes(a.uid) || suggestedAddons.includes(a.uid)) && !a.installed)
+        this.selectedAddons = this.addons.filter((a) => (this.recommendedAddons.includes(a.uid) || suggestions.includes(a.uid)) && !a.installed)
         const self = this
         this.autocompleteAddons = this.$f7.autocomplete.create({
           openIn: 'popup',
@@ -440,7 +441,7 @@ export default {
               self.$set(self, 'selectedAddons', selected)
             }
           },
-          value: this.addons.filter((a) => this.recommendedAddons.includes(a.uid) || suggestedAddons.includes(a.uid)).map((a) => a.label)
+          value: this.addons.filter((a) => this.recommendedAddons.includes(a.uid) || suggestions.includes(a.uid)).map((a) => a.label)
         })
       })
     })


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/3806.

Work is underway in the core and addon repositories to automatically generate addon suggestions by scanning the network for mDNS and uPnP devices and suggesting relevant addons based in criteria in the addon.xml resource file.

In this PR, the UI is enhanced in 2 places:

1. Have the setup wizard propose these addon suggestions (as a complement to the hardcoded recommended addons).
2. List the addon suggestions on top in the addon store page.

@andrewfg: FYI