### PR TITLE
Create aux badge for humidity setpoints similar to temperature badge

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/location/measurement-badge.vue
@@ -79,6 +79,10 @@ export default {
           direct = findPoints(this.element.properties, 'Point_Setpoint', true, 'Property_Temperature')
           if (direct.length) return direct
           return findPoints(allEquipmentPoints(this.element.equipment), 'Point_Setpoint', true, 'Property_Temperature')
+        case 'humidity':
+          direct = findPoints(this.element.properties, 'Point_Setpoint', true, 'Property_Humidity')
+          if (direct.length) return direct
+          return findPoints(allEquipmentPoints(this.element.equipment), 'Point_Setpoint', true, 'Property_Humidity')
         default:
           return []
       }
@@ -101,7 +105,7 @@ export default {
       return (this.type === 'temperature') ? Math.round(ret * 10) / 10 : Math.round(ret)
     },
     reduceAux () {
-      if (this.type !== 'temperature') return undefined
+      if (this.type !== 'temperature' && this.type !== 'humidity') return undefined
       const ret = this.mapAux.reduce((avg, state, arr, { length }) => {
         const value = Number.parseFloat(state)
         if (Number.isFinite(value)) {


### PR DESCRIPTION
Now the temperature badge shows both the measured temperature and the temperature setpoint in the form "measurement_value (setpoint_value)", e.g. 20° (21°). The proposed change introduces the same format for humidity badge by showing humidity setpoint in addition to humidity measurement.

Signed-off-by:  Alexander Antonov <alexxys@gmail.com>