### PR TITLE
Fix invalid chart period "3M" of sitemaps

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -109,7 +109,7 @@ export default {
         { key: '2W', value: '2 Weeks' },
         { key: 'M', value: 'Month' },
         { key: '2M', value: '2 Months' },
-        { key: '3M', value: '3 Months' },
+        { key: '4M', value: '4 Months' },
         { key: 'Y', value: 'Year' }
       ],
       inputHintDefs: [

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -427,7 +427,7 @@ export default {
           }
         })
         widgetList.filter(widget => widget.component === 'Chart').forEach(widget => {
-          if (!(widget.config && widget.config.period && ['h', '4h', '8h', '12h', 'D', '2D', '3D', 'W', '2W', 'M', '2M', '3M', 'Y'].includes(widget.config.period))) {
+          if (!(widget.config && widget.config.period && ['h', '4h', '8h', '12h', 'D', '2D', '3D', 'W', '2W', 'M', '2M', '4M', 'Y'].includes(widget.config.period))) {
             let label = widget.config && widget.config.label ? widget.config.label : 'without label'
             validationWarnings.push(widget.component + ' widget ' + label + ', invalid period configured: ' + widget.config.period)
           }


### PR DESCRIPTION
"3M" for three months is an invalid chart period for a sitemap. Replace it with "4M" for four months, which is missing.

See https://next.openhab.org/docs/ui/sitemaps.html#element-type-chart