### PR TITLE
[blockly] Cosmetic changes on cancel and reschedule timer

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-timers.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-timers.js
@@ -336,7 +336,7 @@ export default function defineOHBlocks_Timers (f7, isGraalJs) {
   }
 
   /*
-  * Allows cancelation of a named timer
+  * Cancels a named timer
   *
   * Block type definition
   */
@@ -348,6 +348,7 @@ export default function defineOHBlocks_Timers (f7, isGraalJs) {
       if (isGraalJs) {
         tn.appendField(new Blockly.FieldDropdown([['private', 'private'], ['shared', 'shared']]), 'cache')
       }
+      tn.appendField('timer')
 
       this.setPreviousStatement(true, null)
       this.setNextStatement(true, null)
@@ -358,7 +359,7 @@ export default function defineOHBlocks_Timers (f7, isGraalJs) {
   }
 
   /*
-  * Allows cancelation of a named timer
+  * Cancels a named timer
   *
   * Code generation
   */
@@ -395,6 +396,7 @@ export default function defineOHBlocks_Timers (f7, isGraalJs) {
       if (isGraalJs) {
         tn.appendField(new Blockly.FieldDropdown([['private', 'private'], ['shared', 'shared']]), 'cache')
       }
+      tn.appendField('timer')
 
       this.setInputsInline(true)
       this.setPreviousStatement(true, null)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -526,6 +526,18 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_timer_reschedule">
+            <value name="timerName">
+              <shadow type="text">
+                <field name="TEXT">MyTimer</field>
+              </shadow>
+            </value>
+            <value name="delay">
+              <shadow type="math_number">
+                <field name="NUM">10</field>
+              </shadow>
+            </value>
+          </block>
           <block type="oh_timer_isActive">
             <value name="timerName">
               <shadow type="text">
@@ -544,18 +556,6 @@
             <value name="timerName">
               <shadow type="text">
                 <field name="TEXT">MyTimer</field>
-              </shadow>
-            </value>
-          </block>
-          <block type="oh_timer_reschedule">
-            <value name="timerName">
-              <shadow type="text">
-                <field name="TEXT">MyTimer</field>
-              </shadow>
-            </value>
-            <value name="delay">
-              <shadow type="math_number">
-                <field name="NUM">10</field>
               </shadow>
             </value>
           </block>


### PR DESCRIPTION
Make the blocks say "Cancel [private|shared] timer XXX" and "after xx reschedule [private|shared] timer XXXX"

Also put the reschedule block right after cancel.