### PR TITLE
[blockly] Add parse number block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-math.js
@@ -7,6 +7,24 @@ import { javascriptGenerator } from 'blockly/javascript'
 import { blockGetCheckedInputType } from './utils'
 
 export default function (f7, isGraalJs) {
+  Blockly.Blocks['oh_toNumber'] = {
+    init: function () {
+      this.appendValueInput('valueAsText')
+        .setCheck('String')
+        .appendField('Number')
+      this.setColour('%{BKY_MATH_HUE}')
+      this.setInputsInline(true)
+      this.setTooltip('convert text to number')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-math.html#toNumber')
+      this.setOutput(true, 'Number')
+    }
+  }
+
+  javascriptGenerator['oh_toNumber'] = function (block) {
+    const value = javascriptGenerator.valueToCode(block, 'valueAsText', javascriptGenerator.ORDER_FUNCTION_CALL)
+    return [`parseFloat(${value})`, 0]
+  }
+
   Blockly.Blocks['oh_bit_not'] = {
     init: function () {
       this.appendValueInput('value')

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -56,6 +56,13 @@
         <block type="math_number">
           <field name="NUM">123</field>
         </block>
+        <block type="oh_toNumber">
+          <value name="valueAsText">
+            <shadow type="text">
+              <field name="TEXT">123</field>
+            </shadow>
+          </value>
+        </block>
         <block type="math_arithmetic">
           <value name="A">
             <shadow type="math_number">


### PR DESCRIPTION
fixes #2139

I added a new toNumber block in the Math section that parses to float (I think we don't need both parseFloat and parseInt).

<img width="429" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/443c107b-d5ee-4c67-98e8-649ce49c3673">

generates

````
console.info(parseFloat('3.14159'));
console.info((1 + parseFloat('2.14159')));
````