### PR TITLE
Re-Apply Fix SSE failure toast container not removed

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/connection-health-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/connection-health-mixin.js
@@ -24,7 +24,7 @@ export default {
         text: message,
         closeButton: reloadButton,
         closeButtonText: this.$t('dialogs.reload'),
-        destroyOnClose: autoClose,
+        destroyOnClose: true,
         closeTimeout: (autoClose) ? 5000 : undefined,
         cssClass: 'failure-toast button-outline',
         position: 'bottom',
@@ -51,7 +51,6 @@ export default {
                   this.communicationFailureTimeoutId = setTimeout(() => {
                     if (this.communicationFailureToast !== null) return
                     this.communicationFailureToast = this.displayFailureToast(this.$t('error.communicationFailure'), true, false)
-                    this.communicationFailureToast.open()
                     this.communicationFailureTimeoutId = null
                   }, 1000)
                 }
@@ -59,7 +58,6 @@ export default {
                 if (this.communicationFailureTimeoutId !== null) clearTimeout(this.communicationFailureTimeoutId)
                 if (this.communicationFailureToast !== null) {
                   this.communicationFailureToast.close()
-                  this.communicationFailureToast.destroy()
                   this.communicationFailureToast = null
                 }
               }


### PR DESCRIPTION
This re-applies the fix from #2075, which must have been lost while rebasing #1987.