### PR TITLE
Un-expand system & addon settings when re-entering settings page

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
@@ -9,7 +9,7 @@
         :key="a.uid"
         :link="'addons/' + a.uid"
         :title="a.label" />
-      <f7-list-button v-if="!expanded && addonsInstalled.length > addonsSettings.length" color="blue" @click="expanded = true">
+      <f7-list-button v-if="!expanded && addonsInstalled.length > addonsSettings.length" color="blue" @click="$emit('expanded', true)">
         {{ $t('dialogs.showAll') }}
       </f7-list-button>
     </f7-list>
@@ -18,16 +18,16 @@
 
 <script>
 export default {
-  props: ['addonsInstalled', 'addonsServices'],
+  props: ['addonsInstalled', 'addonsServices', 'expanded'],
+  emits: ['expanded'],
   data () {
     return {
-      ready: false,
-      expanded: false
+      ready: false
     }
   },
   computed: {
     addonsSettings () {
-      if (this.expanded) return this.addonsInstalled
+      if (this.expanded !== false) return this.addonsInstalled
       return this.addonsInstalled.filter((a) =>
         a.type === 'persistence' ||
         this.addonsServices.findIndex((as) => as.configDescriptionURI.split(':')[1] === a.id) > -1

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -129,12 +129,12 @@
             </f7-list>
           </div>
           <div v-if="$store.getters.apiEndpoint('addons') && addonsLoaded && $f7.width < 1450">
-            <addon-section class="add-on-section" :addonsInstalled="addonsInstalled" :addonsServices="addonsServices" />
+            <addon-section class="add-on-section" :addonsInstalled="addonsInstalled" :addonsServices="addonsServices" :expanded="expandedTypes.addonSettings" @expanded="expandedTypes.addonSettings = true" />
           </div>
         </f7-col>
         <f7-col width="33" class="add-on-col">
           <div v-if="$store.getters.apiEndpoint('addons') && addonsLoaded && $f7.width >= 1450">
-            <addon-section :addonsInstalled="addonsInstalled" :addonsServices="addonsServices" />
+            <addon-section :addonsInstalled="addonsInstalled" :addonsServices="addonsServices" :expanded="expandedTypes.addonSettings" @expanded="expandedTypes.addonSettings = true" />
           </div>
         </f7-col>
       </f7-row>
@@ -191,7 +191,8 @@ export default {
       ],
 
       expandedTypes: {
-        systemSettings: this.$f7.width >= 1450
+        systemSettings: this.$f7.width >= 1450,
+        addonSettings: false
       }
     }
   },
@@ -250,6 +251,8 @@ export default {
       this.loadMenu()
     },
     onPageAfterIn () {
+      this.$set(this.expandedTypes, 'systemSettings', this.$f7.width >= 1450)
+      this.$set(this.expandedTypes, 'addonSettings', false)
       // this.loadMenu()
       this.loadCounters()
     }


### PR DESCRIPTION
@ghys When re-designing the settings page, our idea was that the expanded stuff is automatically de-expanded once you re-enter the page. That's however not always the case. This should fix this, however it would be better to de-expand `onPageAfterOut` or on `pageBeforeIn`. Unfortunately I wasn't able to get that working.