### PR TITLE
Items list: Fix searchbar broken after Items list update & Fix search query not stored

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -28,7 +28,7 @@ const store = new Vuex.Store({
   },
   getters: {
     apiEndpoint: (state) => (type) => (!state.apiEndpoints) ? null : state.apiEndpoints.find((e) => e.type === type),
-    locale: (state) => state.locale ?? 'default'
+    locale: (state, getters) => state.locale ?? 'default'
   },
   mutations: {
     setRootResource (state, { rootResponse }) {

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -24,7 +24,8 @@ const store = new Vuex.Store({
     locale: null,
     runtimeInfo: null,
     developerDock: false,
-    pagePath: null
+    pagePath: null,
+    searchQuery: null
   },
   getters: {
     apiEndpoint: (state) => (type) => (!state.apiEndpoints) ? null : state.apiEndpoints.find((e) => e.type === type),
@@ -45,6 +46,9 @@ const store = new Vuex.Store({
     },
     setPagePath (state, value) {
       state.pagePath = value
+    },
+    setSearchQuery (state, value) {
+      state.searchQuery = value
     }
   },
   actions: {

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -24,12 +24,11 @@ const store = new Vuex.Store({
     locale: null,
     runtimeInfo: null,
     developerDock: false,
-    pagePath: null,
-    searchQuery: null
+    pagePath: null
   },
   getters: {
     apiEndpoint: (state) => (type) => (!state.apiEndpoints) ? null : state.apiEndpoints.find((e) => e.type === type),
-    locale: (state, getters) => state.locale ?? 'default'
+    locale: (state) => state.locale ?? 'default'
   },
   mutations: {
     setRootResource (state, { rootResponse }) {
@@ -46,9 +45,6 @@ const store = new Vuex.Store({
     },
     setPagePath (state, value) {
       state.pagePath = value
-    },
-    setSearchQuery (state, value) {
-      state.searchQuery = value
     }
   },
   actions: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -166,9 +166,12 @@ export default {
     },
     onPageBeforeOut (event) {
       this.stopEventSource()
+      this.$store.commit('setSearchQuery', this.$refs.searchbar?.f7Searchbar.query)
     },
     load () {
       this.ready = false
+      this.$store.commit('setSearchQuery', this.$refs.searchbar?.f7Searchbar.query)
+
       this.$oh.api.get('/rest/items?metadata=semantics').then(data => {
         this.items = data.sort((a, b) => {
           const labelA = a.label || a.name
@@ -178,14 +181,10 @@ export default {
         this.$refs.itemsList.f7VirtualList.replaceAllItems(this.items)
         if (!this.eventSource) this.startEventSource()
 
-        // replaceAllItems() overrides search, run again
-        let searchbarQuery = this.$refs.searchbar.f7Searchbar.query
-        this.$refs.searchbar.clear() // same search doesn't get re-executed, reset first
-        this.$refs.searchbar.search(searchbarQuery)
-
         this.$nextTick(() => {
           if (this.$device.desktop) {
-            this.$refs.searchbar.f7Searchbar.$inputEl[0].focus()
+            this.$refs.searchbar?.f7Searchbar.$inputEl[0].focus()
+            this.$refs.searchbar?.f7Searchbar.search(this.$store.state.searchQuery || '')
           }
         })
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -8,7 +8,9 @@
                  :text="(!$theme.md) ? ((showCheckboxes) ? 'Done' : 'Select') : ''" />
       </f7-nav-right>
       <f7-subnavbar :inner="false" v-show="ready">
+        <!-- Only render searchbar, if page is ready. Otherwise searchbar is broken after changes to the Items list. -->
         <f7-searchbar
+          v-if="ready"
           ref="searchbar"
           class="searchbar-items"
           search-container=".virtual-list"

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -66,7 +66,7 @@
           ref="itemsList"
           media-list
           virtual-list
-          :virtual-list-params="{ items, searchAll, renderExternal, height }">
+          :virtual-list-params="vlParams">
           <ul>
             <f7-list-item
               v-for="(item, index) in vlData.items"
@@ -146,9 +146,14 @@ export default {
     return {
       ready: false,
       items: [], // [{ label: 'Staircase', name: 'Staircase'}],
-      indexedItems: {},
       vlData: {
         items: []
+      },
+      vlParams: {
+        items: [],
+        searchAll: this.searchAll,
+        renderExternal: this.renderExternal,
+        height: this.height
       },
       selectedItems: [],
       showCheckboxes: false,

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -166,11 +166,11 @@ export default {
     },
     onPageBeforeOut (event) {
       this.stopEventSource()
-      this.$store.commit('setSearchQuery', this.$refs.searchbar?.f7Searchbar.query)
+      this.$f7.data.lastItemSearchQuery = this.$refs.searchbar?.f7Searchbar.query
     },
     load () {
+      if (this.ready) this.$f7.data.lastItemSearchQuery = this.$refs.searchbar?.f7Searchbar.query
       this.ready = false
-      this.$store.commit('setSearchQuery', this.$refs.searchbar?.f7Searchbar.query)
 
       this.$oh.api.get('/rest/items?metadata=semantics').then(data => {
         this.items = data.sort((a, b) => {
@@ -184,8 +184,8 @@ export default {
         this.$nextTick(() => {
           if (this.$device.desktop) {
             this.$refs.searchbar?.f7Searchbar.$inputEl[0].focus()
-            this.$refs.searchbar?.f7Searchbar.search(this.$store.state.searchQuery || '')
           }
+          this.$refs.searchbar?.f7Searchbar.search(this.$f7.data.lastItemSearchQuery || '')
         })
 
         this.ready = true


### PR DESCRIPTION
Fixes #1334.
Fixes #1702.

- After editing or removing an Item, the searchbar of the Items list was sometimes not working anymore. Console then showed this error: 
  ```
  TypeError: undefined is not an object (evaluating 'n.virtualList.params')
  ```
  
  It seems that this was caused because the replaceAllItems operation was applied on the virtual list without re-rendering the searchbar afterward.

- The search query was forgotten when the Items list reloaded or the Items list page was re-entered from an Item detail page.
  This is also fixed by using `$f7.data` to store the query.