### PR TITLE
Extend chart periods to 3Y, 5Y and 10Y

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/chart.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/chart.js
@@ -23,7 +23,10 @@ export default () => [
     { value: '2M', label: '2M' },
     { value: '4M', label: '4M' },
     { value: '6M', label: '6M' },
-    { value: 'Y', label: 'Y' }
+    { value: 'Y', label: 'Y' },
+    { value: '3Y', label: '3Y' },
+    { value: '5Y', label: '5Y' },
+    { value: '10Y', label: '10Y' }
   ]).v((value, configuration, configDescription, parameters) => {
     return !configuration.chartType
   })

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue
@@ -15,7 +15,7 @@
       </f7-menu-item>
       <f7-menu-item v-else dropdown :text="period">
         <f7-menu-dropdown right>
-          <f7-menu-dropdown-item v-for="p in ['h', '2h', '4h', '12h', 'D', '2D', '3D', 'W', '2W', 'M', '2M', '4M', '6M', 'Y']"
+          <f7-menu-dropdown-item v-for="p in ['h', '2h', '4h', '12h', 'D', '2D', '3D', 'W', '2W', 'M', '2M', '4M', '6M', 'Y', '3Y', '5Y', '10Y']"
                                  :key="p" @click="setPeriod(p)" href="#" :text="p" />
         </f7-menu-dropdown>
       </f7-menu-item>


### PR DESCRIPTION
Allow further settings 3Y, 5Y, 10Y for dynamic period of chart.

![image](https://github.com/openhab/openhab-webui/assets/5937600/7050f0e8-3fe3-4a50-9f91-eadc43857093)
