### PR TITLE
Model Item picker: Add button to expand or collapse model

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -21,6 +21,8 @@
           search-item=".treeview-item"
           search-in=".treeview-item-label"
           :disable-button="!$theme.aurora" />
+        <f7-button v-if="!expanded" style="text-overflow:unset; bottom: 2px" icon-size="24" :tooltip="Expand" icon-f7="rectangle_expand_vertical" @click="toggleExpanded()" />
+        <f7-button v-else style="text-overflow:unset; bottom: 2px" color="gray" icon-size="24" :tooltip="Collapse" icon-f7="rectangle_compress_vertical" @click="toggleExpanded()" />
       </f7-subnavbar>
       <f7-toolbar bottom class="toolbar-details">
         <f7-link v-if="!multiple" :disabled="selectedItem != null" class="left" @click="selectedItem = null">
@@ -66,6 +68,7 @@ export default {
       loading: false,
       initSearchbar: false,
       includeNonSemantic: false,
+      expanded: false,
       items: [],
       links: [],
       locations: [],
@@ -267,6 +270,22 @@ export default {
       this.rootGroups = []
       this.rootItems = []
       this.includeNonSemantic = !this.includeNonSemantic
+      this.load()
+    },
+    toggleExpanded () {
+      this.expanded = !this.expanded
+
+      const treeviewItems = document.querySelectorAll('.treeview-item')
+
+      treeviewItems.forEach(item => {
+        if (item.classList.contains('treeview-item')) {
+          if (this.expanded) {
+            item.classList.add('treeview-item-opened')
+          } else {
+            item.classList.remove('treeview-item-opened')
+          }
+        }
+      })
       this.load()
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -286,7 +286,6 @@ export default {
           }
         }
       })
-      this.load()
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -21,8 +21,8 @@
           search-item=".treeview-item"
           search-in=".treeview-item-label"
           :disable-button="!$theme.aurora" />
-        <f7-button v-if="!expanded" style="text-overflow:unset; bottom: 2px" icon-size="24" :tooltip="Expand" icon-f7="rectangle_expand_vertical" @click="toggleExpanded()" />
-        <f7-button v-else style="text-overflow:unset; bottom: 2px" color="gray" icon-size="24" :tooltip="Collapse" icon-f7="rectangle_compress_vertical" @click="toggleExpanded()" />
+        <f7-button v-if="!expanded" style="text-overflow:unset; bottom: 2px" icon-size="24" tooltip="Expand" icon-f7="rectangle_expand_vertical" @click="toggleExpanded()" />
+        <f7-button v-else style="text-overflow:unset; bottom: 2px" color="gray" icon-size="24" tooltip="Collapse" icon-f7="rectangle_compress_vertical" @click="toggleExpanded()" />
       </f7-subnavbar>
       <f7-toolbar bottom class="toolbar-details">
         <f7-link v-if="!multiple" :disabled="selectedItem != null" class="left" @click="selectedItem = null">


### PR DESCRIPTION
fixes #665

Provides a button to expand or collapse the model tree while searching.

<img width="632" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/a8a30672-ce26-4012-bfdd-183b5dd6a2c5">

<img width="630" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/d47249b9-baf4-481c-b63b-024252791d42">

Note: I didn't implement an auto-open because I felt it would be rather disturbing.
