### PR TITLE
Rule edit: Only save rule if it has changed when opening script editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -674,7 +674,7 @@ export default {
       this.currentModuleType = mod.type
       this.scriptCode = mod.configuration.script
 
-      const updatePromise = (this.rule.editable || this.isNewRule) ? this.save() : Promise.resolve()
+      const updatePromise = (this.rule.editable || this.isNewRule) && this.dirty ? this.save() : Promise.resolve()
       updatePromise.then(() => {
         this.$f7router.navigate('/settings/rules/' + this.rule.uid + '/script/' + mod.id, { transition: this.$theme.aurora ? 'f7-cover-v' : '' })
       })


### PR DESCRIPTION
Fixes #2027.

When a script inside a rule was opened, the UI always saved the rule before navigating to the script editor. With this fix, the rule is only saved if there is a change to save. If the rule hasn't been changed, no save request is performed.