### PR TITLE
Developer sidebar: Add search for persistence configs & Style enhancements

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -322,7 +322,7 @@
     <f7-popover ref="itemPopover" class="item-popover">
       <item-standalone-control v-if="openedItem" :item="openedItem" :context="context" :no-border="true" />
     </f7-popover>
-    <search-results v-if="searching" :searchResults="searchResults" :pinnedObjects="pinnedObjects" @pin="pin" @unpin="unpin" :cachedObjects="cachedObjects" :loading="searchResultsLoading" />
+    <search-results v-if="searching" class="margin-top" :searchResults="searchResults" :pinnedObjects="pinnedObjects" @pin="pin" @unpin="unpin" :cachedObjects="cachedObjects" :loading="searchResultsLoading" />
   </f7-block>
 </template>
 
@@ -336,7 +336,7 @@
   width 100%
 
   .developer-sidebar-content
-    padding-top 0.3rem
+    margin-top 1rem
 
   &.page
     background #e7e7e7 !important

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="after-big-title">
+  <div>
     <f7-block v-if="loading" class="text-align-center">
       <f7-preloader />
       <div>Loading...</div>

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -126,6 +126,23 @@
         </f7-list-button>
       </f7-list>
     </f7-block>
+    <!-- Persistence configs -->
+    <f7-block class="no-margin no-padding" v-if="searchResults.persistenceConfigs.length">
+      <f7-block-title class="padding-left">
+        <f7-icon class="margin-right" f7="download_circle" />Persistence Configs ({{ searchResults.persistenceConfigs.length }})
+      </f7-block-title>
+      <f7-list media-list>
+        <f7-list-item media-item v-for="persistenceConfig in filteredSearchResults.persistenceConfigs" :key="persistenceConfig.serviceId"
+                      :title="persistenceConfig.label" :footer="persistenceConfig.serviceId" link="" no-chevron @click="(evt) => togglePin(evt, 'persistenceConfigs', persistenceConfig, 'serviceId')">
+          <f7-link slot="after" color="gray" icon-f7="pencil" icon-size="18" tooltip="Edit" :href="'/settings/persistence/' + persistenceConfig.serviceId" :animate="false" />
+          <f7-link slot="after" v-if="isPinned('persistenceConfigs', persistenceConfig, 'serviceId')" @click="$emit('unpin', 'persistenceConfigs', persistenceConfig, 'serviceId')" color="red" icon-f7="pin_slash_fill" icon-size="18" tooltip="Unpin" />
+          <f7-link slot="after" v-else @click="$emit('pin', 'persistenceConfigs', persistenceConfig, 'serviceId')" color="blue" icon-f7="unpin" icon-size="18" tooltip="Pin" />
+        </f7-list-item>
+        <f7-list-button v-if="!showingAll('persistenceConfigs')" color="blue" @click="$set(expandedTypes, 'persistenceConfigs', true)">
+          Show All
+        </f7-list-button>
+      </f7-list>
+    </f7-block>
   </div>
 </template>
 
@@ -161,7 +178,8 @@ export default {
       const scripts = (this.expandedTypes.scripts) ? this.searchResults.scripts : (this.searchResults.scripts ? this.searchResults.scripts.slice(0, 5) : [])
       const pages = (this.expandedTypes.pages) ? this.searchResults.pages : (this.searchResults.pages ? this.searchResults.pages.slice(0, 5) : [])
       const transformations = (this.expandedTypes.transformations) ? this.searchResults.transformations : (this.searchResults.transformations ? this.searchResults.transformations.slice(0, 5) : [])
-      return { items, things, rules, scenes, scripts, pages, transformations }
+      const persistenceConfigs = (this.expandedTypes.persistenceConfigs) ? this.searchResults.persistenceConfigs : (this.searchResults.persistenceConfigs ? this.searchResults.persistenceConfigs.slice(0, 5) : [])
+      return { items, things, rules, scenes, scripts, pages, transformations, persistenceConfigs }
     }
   },
   watch: {


### PR DESCRIPTION
This adds support to the developer sidebar search to search persistence configs by:
- serviceId
- label
- Items included in them

It also fixes a styling issue, where tools where to close to the search bar and search results were far away from the search bar.