### PR TITLE
Fix auto-opening developer dock

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/de.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/de.json
@@ -19,6 +19,7 @@
   "home.overview.tab": "Übersicht",
   "home.overview.button.documentation": "Dokumentation",
   "home.overview.button.tutorial": "Tutorial",
+  "home.overview.button.quickstart": "Schnellstartanleitung",
   "home.locations.title": "Standorte",
   "home.locations.tab": "Standorte",
   "home.equipment.title": "Geräte",

--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/de.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/de.json
@@ -19,7 +19,7 @@
   "home.overview.tab": "Übersicht",
   "home.overview.button.documentation": "Dokumentation",
   "home.overview.button.tutorial": "Tutorial",
-  "home.overview.button.quickstart": "Schnellstartanleitung",
+  "home.overview.button.quickstart": "Öffne Schnellstart-Assistent",
   "home.locations.title": "Standorte",
   "home.locations.tab": "Standorte",
   "home.equipment.title": "Geräte",

--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -19,7 +19,7 @@
   "home.overview.tab": "Overview",
   "home.overview.button.documentation": "Documentation",
   "home.overview.button.tutorial": "Tutorial",
-  "home.overview.button.quickstart": "Quick Start Guide",
+  "home.overview.button.quickstart": "Open Quick Start Assistant",
   "home.locations.title": "Locations",
   "home.locations.tab": "Locations",
   "home.equipment.title": "Equipment",

--- a/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/common/en.json
@@ -19,6 +19,7 @@
   "home.overview.tab": "Overview",
   "home.overview.button.documentation": "Documentation",
   "home.overview.button.tutorial": "Tutorial",
+  "home.overview.button.quickstart": "Quick Start Guide",
   "home.locations.title": "Locations",
   "home.locations.tab": "Locations",
   "home.equipment.title": "Equipment",

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -374,7 +374,6 @@ export default {
       activeDock: 'tools',
       activeToolTab: 'pin',
       activeHelpTab: 'current',
-      quickStartShow: true,
       currentUrl: ''
     }
   },
@@ -504,12 +503,6 @@ export default {
             })
 
           if (data[2]) dayjs.locale(data[2].key)
-
-          const page = data[0].find((p) => p.uid === 'overview')
-          if ((!page) || (page.component !== 'oh-layout-page') || (!page.slots || (!page.slots.default.length && !page.slots.masonry && !page.slots.canvas && !page.slots.grid))) {
-            if (this.quickStartShow) this.selectDeveloperDock({ 'dock': 'help', 'helpTab': 'quick' })
-            this.quickStartShow = false
-          }
 
           // finished with loading
           this.ready = true

--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -20,6 +20,9 @@
         <span style="width: 8px" />
         <f7-button large color="blue" external :href="`${documentationLinkPrefix}link/tutorial`" target="_blank" v-t="'home.overview.button.tutorial'" />
       </f7-row>
+      <f7-row v-else class="display-flex justify-content-center">
+        <f7-button large fill color="blue" @click="$f7.emit('selectDeveloperDock',{'dock':'help','helpTab':'quick'})" v-t="'home.overview.button.quickstart'" />
+      </f7-row>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Closes #2206 

This will replace the auto-opening developer dock with a button on the empty overview page to open the in-app quick start tutorial.  Button will only appear on pages wide enough to support the open developer dock.