### PR TITLE
[blockly] Add block to get hue, saturation and brightness from Color Item

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-color.js
@@ -5,7 +5,7 @@
 
 import Blockly from 'blockly'
 import { javascriptGenerator } from 'blockly/javascript'
-import { blockGetCheckedInputType } from '@/assets/definitions/blockly/utils.js';
+import { blockGetCheckedInputType } from '@/assets/definitions/blockly/utils.js'
 
 export default function (f7, isGraalJs) {
   /*
@@ -69,17 +69,13 @@ export default function (f7, isGraalJs) {
     const inputType = blockGetCheckedInputType(block, 'item')
     let attributeName = block.getFieldValue('attributeName')
 
-    if (!isGraalJs) {
-      attributeName = attributeName.charAt(0).toLowerCase() + attributeName.slice(1)
-      let code = (inputType === 'oh_item') ? `items.getItem(${theItem}).rawState.${attributeName}` : `${theItem}.rawState.${attributeName}`
-      return [code, 0]
+    let code = ''
+    if (isGraalJs) {
+      code = (inputType === 'oh_item') ? `items.getItem(${theItem}).rawState.get${attributeName}()` : `${theItem}.rawState.get${attributeName}()`
     } else {
-      if (attributeName === 'Tags' || attributeName === 'GroupNames') {
-        return [`Java.from(${theItem}.getRawState().get${attributeName}())`, 0]
-      } else {
-        return [`${theItem}.getRawState().get${attributeName}()`, 0]
-      }
+      code = (inputType === 'oh_item') ? `itemRegistry.getItem(${theItem}).getRawState().get${attributeName}()` : `${theItem}.getRawState().get${attributeName}()`
     }
+    return [code, 0]
   }
 
   /*

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -394,6 +394,15 @@
             </shadow>
           </value>
         </block>
+        <block type="oh_color_item">
+          <value name="item">
+            <shadow type="oh_getitem">
+              <value name="itemName">
+                <shadow type="oh_item" />
+              </value>
+            </shadow>
+          </value>
+        </block>
       </category>
 
       <category name="openHAB" colour="0" :expanded="$f7.device.desktop">


### PR DESCRIPTION
Small extension to retrieve Hue, Saturation or Brightness from a color item

<img width="315" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/309030a7-5ba7-435d-9139-09aa3c35a492">
