### PR TITLE
Fix navigation issues with model cards

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
@@ -78,7 +78,6 @@ export default {
       setTimeout(() => { this.$f7.card.close(this.$refs.card.$el) }, 100)
     },
     back (evt) {
-      console.debug(evt.state)
       if (!evt.state || evt.state.cardId === this.cardId) return
       if (this.opened) this.closeCard()
     }

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -92,45 +92,7 @@ export default [
     // keepAlive: true,
     options: {
       transition: 'f7-dive'
-    },
-    routes: [
-      {
-        path: 'overview',
-        component: HomePage,
-        options: {
-          props: {
-            initialTab: 'overview'
-          }
-        }
-      },
-      {
-        path: 'locations',
-        component: HomePage,
-        options: {
-          props: {
-            initialTab: 'locations'
-          }
-        }
-      },
-      {
-        path: 'equipment',
-        component: HomePage,
-        options: {
-          props: {
-            initialTab: 'equipment'
-          }
-        }
-      },
-      {
-        path: 'properties',
-        component: HomePage,
-        options: {
-          props: {
-            initialTab: 'properties'
-          }
-        }
-      }
-    ]
+    }
   },
   {
     path: '/page/:uid',

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -88,7 +88,6 @@ import ModelTab from './home/model-tab.vue'
 import HomeCards from './home/homecards-mixin'
 
 export default {
-  props: ['initialTab'],
   mixins: [HomeCards],
   components: {
     OverviewTab,
@@ -101,7 +100,7 @@ export default {
       showCards: false,
       showPinToHome: false,
       showExitToApp: false,
-      currentTab: this.initialTab || 'overview',
+      currentTab: this.$f7.data.currentHomeTab || 'overview',
       overviewPageKey: this.$utils.id(),
       items: []
     }
@@ -165,7 +164,7 @@ export default {
   },
   methods: {
     onPageBeforeIn () {
-      this.$f7router.updateCurrentUrl('/' + this.currentTab)
+      this.$f7.data.currentHomeTab = this.currentTab
       this.overviewPageKey = this.$utils.id()
     },
     onPageAfterIn () {
@@ -176,6 +175,7 @@ export default {
     },
     onPageBeforeOut () {
       this.$store.dispatch('stopTrackingStates')
+      this.$f7.data.currentHomeTab = this.currentTab
     },
     onPageInit () {
       this.$store.subscribe((mutation, state) => {
@@ -197,7 +197,6 @@ export default {
     },
     switchTab (tab) {
       this.currentTab = tab
-      this.$f7router.updateCurrentUrl('/' + this.currentTab)
     },
     tabVisible (tab) {
       if (!this.tabsVisible) return false


### PR DESCRIPTION
Fixes #2196.
Reverts #2074.

I have tried messing around with the browser history manually to fix that issue, however trying several approaches, none worked perfect. This is the best solution I could come up with, and it at least remembers which tab you had opened when you navigate back to the home page from any other page.