### PR TITLE
Limit add-on settings menu list to bundles

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -224,7 +224,7 @@ export default {
         this.servicesLoaded = true
       })
       addonsPromise.then((data) => {
-        this.addonsInstalled = data.filter(a => { return a.installed && ['application/vnd.openhab.bundle', 'application/vnd.openhab.feature;type=karfile'].includes(a.contentType) })
+        this.addonsInstalled = data.filter(a => a.installed && !['application/vnd.openhab.ruletemplate', 'application/vnd.openhab.uicomponent;type=widget', 'application/vnd.openhab.uicomponent;type=blocks'].includes(a.contentType))
         this.addonsLoaded = true
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -224,7 +224,7 @@ export default {
         this.servicesLoaded = true
       })
       addonsPromise.then((data) => {
-        this.addonsInstalled = data.filter(a => a.installed === true)
+        this.addonsInstalled = data.filter(a => { return a.installed && ['application/vnd.openhab.bundle', 'application/vnd.openhab.feature;type=karfile'].includes(a.contentType) })
         this.addonsLoaded = true
       })
     },


### PR DESCRIPTION
When installing rule templates or UI components or blockly libraries from the marketplace, they get an entry in the add-on settings menu. There is nothing that can be configured in these types of add-ons. Therefore limit the list to bundles and features.