### PR TITLE
Fix unwanted model card back navigation

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -166,6 +166,7 @@ export default {
   methods: {
     onPageBeforeIn () {
       this.$f7router.updateCurrentUrl('/' + this.currentTab)
+      this.$f7router.url = '/' + this.currentTab
       this.overviewPageKey = this.$utils.id()
     },
     onPageAfterIn () {
@@ -198,6 +199,7 @@ export default {
     switchTab (tab) {
       this.currentTab = tab
       this.$f7router.updateCurrentUrl('/' + this.currentTab)
+      this.$f7router.url = '/' + this.currentTab
     },
     tabVisible (tab) {
       if (!this.tabsVisible) return false


### PR DESCRIPTION
Fixes #2196.
Replaces #2211.

The double back navigation was caused by:
https://github.com/framework7io/framework7/blob/31f4c7065e8abe9b8b27f354de4e390a8cd584c0/src/core/utils/history.js#L56-L61

and `router.updateCurrentUrl()`, unlike the name implies, doesn't update `router.url` for some reason (maybe a bug?).

Signed-off-by: Yannick Schaus <github@schaus.net>