### PR TITLE
Add panel for voiceSystem metadata

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -11,5 +11,6 @@ export default [
   { name: 'expire', label: 'Expiration Timer' },
   { name: 'alexa', label: 'Amazon Alexa' },
   { name: 'homekit', label: 'Apple HomeKit' },
-  { name: 'ga', label: 'Google Assistant' }
+  { name: 'ga', label: 'Google Assistant' },
+  { name: 'voiceSystem', label: 'Voice System' }
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -9,8 +9,8 @@ export default [
   { name: 'widgetOrder', label: 'Default Widget Order Index' },
   { name: 'autoupdate', label: 'Auto-update' },
   { name: 'expire', label: 'Expiration Timer' },
+  { name: 'voiceSystem', label: 'Voice System' },
   { name: 'alexa', label: 'Amazon Alexa' },
   { name: 'homekit', label: 'Apple HomeKit' },
-  { name: 'ga', label: 'Google Assistant' },
-  { name: 'voiceSystem', label: 'Voice System' }
+  { name: 'ga', label: 'Google Assistant' }
 ]

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -21,9 +21,9 @@ export default {
   data: () => {
     return {
       ruleOptionParameters: [
-        { type: 'BOOLEAN', name: 'isForced', label: 'Is Forced', description: 'Send command without check current item state' },
+        { type: 'BOOLEAN', name: 'isForced', label: 'Is Forced', description: 'Send command without check current Item state' },
         { type: 'BOOLEAN', name: 'isSilent', label: 'Is Silent', description: 'Disable success confirmation message' },
-        { type: 'BOOLEAN', name: 'isTemplate', label: 'Is Template', description: 'Target similar items instead of the current one' }
+        { type: 'BOOLEAN', name: 'isTemplate', label: 'Is Template', description: 'Target similar Items instead of the current one' }
       ]
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -1,0 +1,63 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-input ref="input" type="textarea" :floating-label="$theme.md" :label="'Custom Rules'" name="custom-rules"
+                     :value="customRules" @input="updateValue" />
+      <f7-block-footer class="param-description" slot="after-list">
+        <small>Enter each rule on a separate line. Available placeholders: $name$, $cmd$ and $*$.</small>
+      </f7-block-footer>
+    </f7-list>
+    <f7-list>
+      <f7-list-item checkbox :checked="isForced" @change="updateForcedConfig" title="Is Forced">
+        <small>Force send command without check current item state.</small>
+      </f7-list-item>
+      <f7-list-item checkbox :checked="isSilent" @change="updateSilentConfig" title="Is Silent">
+        <small>Disable success confirmation message.</small>
+      </f7-list-item>
+      <f7-list-item checkbox :checked="isTemplate" @change="updateTemplateConfig" title="Is Template">
+        <small>Target similar items instead of the current one.</small>
+      </f7-list-item>
+      <f7-block-footer class="param-description" slot="after-list">
+        <small>Flags for modifying rule behavior.</small>
+      </f7-block-footer>
+    </f7-list>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  computed: {
+    customRules () {
+      if (!this.metadata.value) return []
+      return this.metadata.value.split('\n').map((s) => s.trim()).join('\n')
+    },
+    isSilent () {
+      return this.metadata.config?.['isSilent'] ?? false
+    },
+    isForced () {
+      return this.metadata.config?.['isForced'] ?? false
+    },
+    isTemplate () {
+      return this.metadata.config?.['isTemplate'] ?? false
+    }
+  },
+  methods: {
+    updateValue (ev) {
+      this.metadata.value = ev.target.value.split('\n').map((s) => s.trim()).join('\n')
+    },
+    updateSilentConfig (ev) {
+      const config = this.metadata.config ?? (this.metadata.config = {})
+      config.isSilent = ev.target.checked
+    },
+    updateForcedConfig (ev) {
+      const config = this.metadata.config ?? (this.metadata.config = {})
+      config.isForced = ev.target.checked
+    },
+    updateTemplateConfig (ev) {
+      const config = this.metadata.config ?? (this.metadata.config = {})
+      config.isTemplate = ev.target.checked
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -4,7 +4,7 @@
       <f7-list-input ref="input" type="textarea" :floating-label="$theme.md" :label="'Custom Rules'" name="custom-rules"
                      :value="customRules" @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
-        <small>Enter each rule on a separate line. Available placeholders: $name$, $cmd$ and $*$.</small>
+        <small>Enter each rule on a separate line. Available placeholders: $name$, $cmd$ and $*$</small>
       </f7-block-footer>
     </f7-list>
     <config-sheet :parameterGroups="[]" :parameters="ruleOptionParameters" :configuration="metadata.config" />

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -7,56 +7,35 @@
         <small>Enter each rule on a separate line. Available placeholders: $name$, $cmd$ and $*$.</small>
       </f7-block-footer>
     </f7-list>
-    <f7-list>
-      <f7-list-item checkbox :checked="isForced" @change="updateForcedConfig" title="Is Forced">
-        <small>Force send command without check current item state.</small>
-      </f7-list-item>
-      <f7-list-item checkbox :checked="isSilent" @change="updateSilentConfig" title="Is Silent">
-        <small>Disable success confirmation message.</small>
-      </f7-list-item>
-      <f7-list-item checkbox :checked="isTemplate" @change="updateTemplateConfig" title="Is Template">
-        <small>Target similar items instead of the current one.</small>
-      </f7-list-item>
-      <f7-block-footer class="param-description" slot="after-list">
-        <small>Flags for modifying rule behavior.</small>
-      </f7-block-footer>
-    </f7-list>
+    <config-sheet :parameterGroups="[]" :parameters="ruleOptionParameters" :configuration="metadata.config" />
   </div>
 </template>
 
 <script>
+import ConfigSheet from '@/components/config/config-sheet.vue'
 export default {
   props: ['itemName', 'metadata', 'namespace'],
+  components: {
+    ConfigSheet
+  },
+  data: () => {
+    return {
+      ruleOptionParameters: [
+        { type: 'BOOLEAN', name: 'isForced', label: 'Is Forced', description: 'Send command without check current item state' },
+        { type: 'BOOLEAN', name: 'isSilent', label: 'Is Silent', description: 'Disable success confirmation message' },
+        { type: 'BOOLEAN', name: 'isTemplate', label: 'Is Template', description: 'Target similar items instead of the current one' }
+      ]
+    }
+  },
   computed: {
     customRules () {
       if (!this.metadata.value) return []
       return this.metadata.value.split('\n').map((s) => s.trim()).join('\n')
-    },
-    isSilent () {
-      return this.metadata.config?.['isSilent'] ?? false
-    },
-    isForced () {
-      return this.metadata.config?.['isForced'] ?? false
-    },
-    isTemplate () {
-      return this.metadata.config?.['isTemplate'] ?? false
     }
   },
   methods: {
     updateValue (ev) {
       this.metadata.value = ev.target.value.split('\n').map((s) => s.trim()).join('\n')
-    },
-    updateSilentConfig (ev) {
-      const config = this.metadata.config ?? (this.metadata.config = {})
-      config.isSilent = ev.target.checked
-    },
-    updateForcedConfig (ev) {
-      const config = this.metadata.config ?? (this.metadata.config = {})
-      config.isForced = ev.target.checked
-    },
-    updateTemplateConfig (ev) {
-      const config = this.metadata.config ?? (this.metadata.config = {})
-      config.isTemplate = ev.target.checked
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -75,6 +75,7 @@ import ItemMetadataExpire from '@/components/item/metadata/item-metadata-expire.
 import ItemMetadataAlexa from '@/components/item/metadata/item-metadata-alexa.vue'
 import ItemMetadataHomeKit from '@/components/item/metadata/item-metadata-homekit.vue'
 import ItemMetadataGa from '@/components/item/metadata/item-metadata-ga.vue'
+import ItemMetadataVoiceSystem from '@/components/item/metadata/item-metadata-voicesystem.vue'
 import DirtyMixin from '../../dirty-mixin'
 
 export default {
@@ -128,6 +129,8 @@ export default {
           return ItemMetadataAlexa
         case 'homekit':
           return ItemMetadataHomeKit
+        case 'voiceSystem':
+          return ItemMetadataVoiceSystem
         case 'ga':
           return ItemMetadataGa
         default:


### PR DESCRIPTION
Hello, I would like to add these panel for editing the item voiceSystem namespace.

It needs to wait for the review of these core PR https://github.com/openhab/openhab-core/pull/3925 , hope it's fine to open the PR anyway.

Screenshots:

<img width="1065" alt="Screenshot 2023-12-15 at 22 23 46" src="https://github.com/openhab/openhab-webui/assets/9007708/e165bcb9-3424-49cd-a1c4-8c843ad9b7c2">

<img width="508" alt="Screenshot 2023-12-15 at 20 16 22" src="https://github.com/openhab/openhab-webui/assets/9007708/03683561-c4c9-4520-bcd1-f4d0c6d9a822">


<img width="457" alt="Screenshot 2023-12-15 at 22 20 30" src="https://github.com/openhab/openhab-webui/assets/9007708/7fb5ac51-9d75-4d77-b5dc-a204f54777e6">
