### PR TITLE
Model page: Add expand/collapse model button

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -21,8 +21,10 @@
           search-item=".treeview-item"
           search-in=".treeview-item-label"
           :disable-button="!$theme.aurora" />
-        <f7-button v-if="!expanded" style="text-overflow:unset; bottom: 2px" icon-size="24" tooltip="Expand" icon-f7="rectangle_expand_vertical" @click="toggleExpanded()" />
-        <f7-button v-else style="text-overflow:unset; bottom: 2px" color="gray" icon-size="24" tooltip="Collapse" icon-f7="rectangle_compress_vertical" @click="toggleExpanded()" />
+        <div class="expand-button">
+          <f7-button v-if="!expanded" icon-size="24" tooltip="Expand" icon-f7="rectangle_expand_vertical" @click="toggleExpanded()" />
+          <f7-button v-else color="gray" icon-size="24" tooltip="Collapse" icon-f7="rectangle_compress_vertical" @click="toggleExpanded()" />
+        </div>
       </f7-subnavbar>
       <f7-toolbar bottom class="toolbar-details">
         <f7-link v-if="!multiple" :disabled="selectedItem != null" class="left" @click="selectedItem = null">
@@ -47,6 +49,15 @@
     </f7-page>
   </f7-popup>
 </template>
+
+<style lang="stylus">
+.expand-button
+  margin-right 8px
+  text-overflow: unset
+  align-self: center
+  .icon
+    margin-bottom: 2.75px !important
+</style>
 
 <script>
 import ModelTreeview from '@/components/model/model-treeview.vue'

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -14,6 +14,10 @@
           search-in=".treeview-item-label"
           :placeholder="searchPlaceholder"
           :disable-button="!$theme.aurora" />
+        <div class="expand-button">
+          <f7-button v-if="!expanded" icon-size="24" tooltip="Expand" icon-f7="rectangle_expand_vertical" @click="toggleExpanded()" />
+          <f7-button v-else color="gray" icon-size="24" tooltip="Collapse" icon-f7="rectangle_compress_vertical" @click="toggleExpanded()" />
+        </div>
       </f7-subnavbar>
     </f7-navbar>
 
@@ -212,6 +216,13 @@
     margin-bottom var(--f7-sheet-height)
   .details-sheet
     height calc(1.4*var(--f7-sheet-height))
+
+.expand-button
+  margin-right 8px
+  text-overflow unset
+  align-self center
+  .icon
+    margin-bottom 2.75px !important
 </style>
 
 <script>
@@ -245,6 +256,7 @@ export default {
       includeNonSemantic: false,
       includeItemName: false,
       includeItemTags: false,
+      expanded: false,
       items: [],
       links: [],
       locations: [],
@@ -474,6 +486,21 @@ export default {
     toggleItemTags () {
       this.includeItemTags = !this.includeItemTags
       this.load()
+    },
+    toggleExpanded () {
+      this.expanded = !this.expanded
+
+      const treeviewItems = document.querySelectorAll('.treeview-item')
+
+      treeviewItems.forEach(item => {
+        if (item.classList.contains('treeview-item')) {
+          if (this.expanded) {
+            item.classList.add('treeview-item-opened')
+          } else {
+            item.classList.remove('treeview-item-opened')
+          }
+        }
+      })
     },
     addSemanticItem (semanticType) {
       this.newItem = {


### PR DESCRIPTION
Brings #2191 to the model page:
Provides a button to expand or collapse the model tree.