### PR TITLE
No suggestion for installed add-ons

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -226,7 +226,7 @@ export default {
       return Object.keys(this.addons).flatMap((k) => this.addons[k])
     },
     suggestedAddons () {
-      return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => this.suggestions.some((s) => s.id === a.id))
+      return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => !a.isInstalled && this.suggestions.some((s) => s.id === a.id))
     },
     unsuggestedAddons () {
       return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => !this.suggestedAddons.includes(a))

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -226,7 +226,7 @@ export default {
       return Object.keys(this.addons).flatMap((k) => this.addons[k])
     },
     suggestedAddons () {
-      return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => !a.isInstalled && this.suggestions.some((s) => s.id === a.id))
+      return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => !a.installed && this.suggestions.some((s) => s.id === a.id))
     },
     unsuggestedAddons () {
       return Object.keys(this.addons).flatMap((k) => this.addons[k]).filter((a) => !this.suggestedAddons.includes(a))


### PR DESCRIPTION
Suggestions are being shown in the add-on store for add-ons that are already installed.
This PR removes suggestions for installed add-ons.

See request here https://github.com/openhab/openhab-core/issues/3868#issuecomment-1859950504