### PR TITLE
Add a new settings menu for persistence

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
@@ -45,5 +45,8 @@
   "addons.text": "Add-ons add functionality to your openHAB system.<br><br>Install them with the button below.",
 
   "page.unavailable.title": "Page Unavailable",
-  "page.unavailable.text": "You are not allowed to view this page because of visibility restrictions."
+  "page.unavailable.text": "You are not allowed to view this page because of visibility restrictions.",
+
+  "persistence.title": "No persistence add-on installed",
+  "persistence.text": "With a persistence configuration you can automatically store item states for the future. To configure persistence, you need at least one persistence add-on to be installed.<br><br>Install one from the Add-On store following the button below."
 }

--- a/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
@@ -48,5 +48,5 @@
   "page.unavailable.text": "You are not allowed to view this page because of visibility restrictions.",
 
   "persistence.title": "No persistence add-on installed",
-  "persistence.text": "With a persistence configuration you can automatically store item states for the future. To configure persistence, you need at least one persistence add-on to be installed.<br><br>Install one from the Add-On store following the button below."
+  "persistence.text": "With persistence you can store Item states over time, no matter they are historic or future values. To configure persistence, you need at least one persistence add-on to be installed."
 }

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -34,6 +34,7 @@ const InboxListPage = () => import(/* webpackChunkName: "admin-config" */ '../pa
 const TransformationsListPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/transformations/transformations-list.vue')
 const TransformationsEditPage = () => import(/* webpackChunkName: "admin-rules" */ '../pages/settings/transformations/transformation-edit.vue')
 
+const PersistenceSettingsPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/persistence/persistence-settings.vue')
 const PersistenceEditPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/persistence/persistence-edit.vue')
 
 const SemanticModelPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/model/model.vue')
@@ -279,6 +280,8 @@ export default [
       },
       {
         path: 'persistence/',
+        beforeEnter: [enforceAdminForRoute],
+        async: loadAsync(PersistenceSettingsPage),
         routes: [
           {
             path: ':serviceId',

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -281,6 +281,7 @@ export default [
       {
         path: 'persistence/',
         beforeEnter: [enforceAdminForRoute],
+        beforeLeave: [checkDirtyBeforeLeave],
         async: loadAsync(PersistenceSettingsPage),
         routes: [
           {

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-config.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-config.vue
@@ -10,11 +10,9 @@
     </f7-navbar>
     <f7-block v-if="type === 'persistence'" class="service-config block-narrow">
       <f7-col>
-        <f7-block-title medium>
-          <f7-link color="blue" :href="'/settings/persistence/' + name">
-            Persistence configuration
-          </f7-link>
-        </f7-block-title>
+        <f7-button large fill color="blue" :href="'/settings/persistence/' + name">
+          Configure Persistence Policies
+        </f7-button>
       </f7-col>
     </f7-block>
     <f7-block form v-if="configDescription && config" class="service-config block-narrow">

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -72,8 +72,6 @@
               :footer="objectsSubtitles.transform">
               <f7-icon slot="media" f7="function" color="gray" />
             </f7-list-item>
-          </f7-list>
-          <f7-list media-list class="search-list">
             <f7-list-item
               media-item
               link="persistence/"

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -219,8 +219,8 @@ export default {
 
       // can be done in parallel!
       servicesPromise.then((data) => {
-        this.systemServices = data.filter(s => s.category === 'system')
-        this.addonsServices = data.filter(s => s.category !== 'system')
+        this.systemServices = data.filter(s => s.category === 'system').sort((s1, s2) => s1.label.toLowerCase() > s2.label.toLowerCase() ? 1 : -1)
+        this.addonsServices = data.filter(s => s.category !== 'system').sort((s1, s2) => s1.label.toLowerCase() > s2.label.toLowerCase() ? 1 : -1)
         this.servicesLoaded = true
       })
       addonsPromise.then((data) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -73,6 +73,16 @@
               <f7-icon slot="media" f7="function" color="gray" />
             </f7-list-item>
           </f7-list>
+          <f7-list media-list class="search-list">
+            <f7-list-item
+              media-item
+              link="persistence/"
+              title="Persistence"
+              badge-color="blue"
+              :footer="objectsSubtitles.persistence">
+              <f7-icon slot="media" f7="tray-arrow-down" color="gray" />
+            </f7-list-item>
+          </f7-list>
           <f7-block-title v-if="$store.getters.apiEndpoint('rules')">
             Automation
           </f7-block-title>
@@ -157,6 +167,7 @@ export default {
       addonsLoaded: false,
       servicesLoaded: false,
       addonsInstalled: [],
+      persistenceAddonsInstalled: [],
       addonsServices: [],
       systemServices: [],
       objectsSubtitles: {
@@ -165,6 +176,7 @@ export default {
         items: 'Manage the functional layer',
         pages: 'Design displays for user control & monitoring',
         transform: 'Make raw data human-readable',
+        persistence: 'Persist data for future use',
         rules: 'Automate with triggers and actions',
         scenes: 'Store a set of desired states as a scene',
         scripts: 'Rules dedicated to running code',
@@ -219,14 +231,20 @@ export default {
 
       // can be done in parallel!
       servicesPromise.then((data) => {
-        this.systemServices = data.filter(s => s.category === 'system').sort((s1, s2) => s1.label.toLowerCase() > s2.label.toLowerCase() ? 1 : -1)
-        this.addonsServices = data.filter(s => s.category !== 'system').sort((s1, s2) => s1.label.toLowerCase() > s2.label.toLowerCase() ? 1 : -1)
+        this.systemServices = data.filter(s => s.category === 'system').sort((s1, s2) => this.sortByLabel(s1, s2))
+        this.addonsServices = data.filter(s => s.category !== 'system').sort((s1, s2) => this.sortByLabel(s1, s2))
         this.servicesLoaded = true
       })
       addonsPromise.then((data) => {
-        this.addonsInstalled = data.filter(a => a.installed && !['application/vnd.openhab.ruletemplate', 'application/vnd.openhab.uicomponent;type=widget', 'application/vnd.openhab.uicomponent;type=blocks'].includes(a.contentType))
+        this.addonsInstalled = data
+          .filter(a => a.installed && !['application/vnd.openhab.ruletemplate', 'application/vnd.openhab.uicomponent;type=widget', 'application/vnd.openhab.uicomponent;type=blocks'].includes(a.contentType))
+          .sort((s1, s2) => this.sortByLabel(s1, s2))
+        this.persistenceAddonsInstalled = this.addonsInstalled.filter(a => a.installed && a.type === 'persistence')
         this.addonsLoaded = true
       })
+    },
+    sortByLabel (s1, s2) {
+      return s1.label.toLowerCase() > s2.label.toLowerCase() ? 1 : -1
     },
     loadCounters () {
       if (!this.apiEndpoints) return

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -231,7 +231,9 @@ export default {
 
       // can be done in parallel!
       servicesPromise.then((data) => {
-        this.systemServices = data.filter(s => s.category === 'system').sort((s1, s2) => this.sortByLabel(s1, s2))
+        this.systemServices = data
+          .filter(s => (s.category === 'system') && (s.id !== 'org.openhab.persistence'))
+          .sort((s1, s2) => this.sortByLabel(s1, s2))
         this.addonsServices = data.filter(s => s.category !== 'system').sort((s1, s2) => this.sortByLabel(s1, s2))
         this.servicesLoaded = true
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -69,7 +69,7 @@ export default {
   },
   computed: {
     documentationLink () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/docs/configuration/persistence.html`
+      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/persistence`
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -9,40 +9,48 @@
       </f7-nav-right>
     </f7-navbar>
 
-    <f7-block form v-if="persistenceList.length > 0">
-      <f7-row>
-        <f7-col>
-          <f7-block-title>General Settings</f7-block-title>
-          <config-sheet
-            :parameter-groups="configDescriptions.parameterGroups"
-            :parameters="configDescriptions.parameters"
-            :configuration="config"
-            :set-empty-config-as-null="true" />
-          <f7-block-title>Configure Persistence Policies</f7-block-title>
-          <f7-list>
-            <f7-list-item
-              v-for="persistence in persistenceList"
-              media-item
-              :key="persistence.id"
-              :link="persistence.id"
-              :title="persistence.label"
-              :footer="persistence.id" />
-          </f7-list>
-        </f7-col>
-      </f7-row>
+    <f7-block form v-if="ready && persistenceList.length" class="block-narrow">
+      <f7-col>
+        <f7-block-title medium>
+          General Settings
+        </f7-block-title>
+        <config-sheet
+          :parameter-groups="configDescriptions.parameterGroups"
+          :parameters="configDescriptions.parameters"
+          :configuration="config"
+          :set-empty-config-as-null="true" />
+      </f7-col>
+    </f7-block>
+    <f7-block v-if="ready && persistenceList.length" class="block-narrow">
+      <f7-col>
+        <f7-block-title medium>
+          Configure Persistence Policies
+        </f7-block-title>
+        <f7-list style="margin-top: 15px">
+          <f7-list-item
+            v-for="persistence in persistenceList"
+            media-item
+            :key="persistence.id"
+            :link="persistence.id"
+            :title="persistence.label"
+            :footer="persistence.id" />
+          <f7-list-item link="/addons/other/" no-chevron media-item :color="($theme.dark) ? 'black' : 'white'" subtitle="Install more persistence add-ons">
+            <f7-icon slot="media" color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+          </f7-list-item>
+        </f7-list>
+      </f7-col>
     </f7-block>
 
     <f7-block v-if="ready && !persistenceList.length" class="service-config block-narrow">
       <empty-state-placeholder icon="tray-arrow-down" title="persistence.title" text="persistence.text" />
-      <f7-row v-if="$f7.width < 1280" class="display-flex justify-content-center">
+      <f7-row class="display-flex justify-content-center">
         <f7-button large fill color="blue" external :href="documentationLink" target="_blank" v-t="'home.overview.button.documentation'" />
+        <span style="width: 8px" />
+        <f7-button large fill color="blue" href="/addons/other/">
+          Install a persistence add-on
+        </f7-button>
       </f7-row>
     </f7-block>
-
-    <f7-fab v-show="ready" position="right-bottom" slot="fixed" color="blue" href="/addons/other/">
-      <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
-      <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
-    </f7-fab>
   </f7-page>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -62,7 +62,6 @@ export default {
       ready: false,
       serviceId: 'org.openhab.persistence',
       persistenceList: [],
-      service: {},
       configDescriptions: null,
       config: null
     }
@@ -102,24 +101,17 @@ export default {
         this.$set(this, 'persistenceList', data)
       })
       this.$oh.api.get('/rest/services/' + this.serviceId).then(data => {
-        this.service = data
-        if (this.service.configDescriptionURI) {
-          this.$oh.api.get('/rest/config-descriptions/' + this.service.configDescriptionURI).then(data2 => {
-            this.configDescriptions = data2
+        if (data.configDescriptionURI) {
+          this.$oh.api.get('/rest/config-descriptions/' + data.configDescriptionURI).then(data2 => {
+            this.$set(this, 'configDescriptions', data2)
             this.$oh.api.get('/rest/services/' + this.serviceId + '/config').then(data3 => {
-              this.config = data3
+              this.$set(this, 'config', data3)
               this.$nextTick(() => {
                 this.loading = false
                 this.ready = true
               })
             })
           })
-        }
-      }).catch((e) => {
-        if (e === 404 || e === 'Not Found') {
-          this.loading = false
-        } else {
-          Promise.reject(e)
         }
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -78,7 +78,8 @@ export default {
         if (!this.loading) {
           this.dirty = true
         }
-      }
+      },
+      deep: true
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -12,10 +12,10 @@
     <f7-block form v-if="persistenceList.length > 0">
       <f7-row>
         <f7-col>
-          <f7-block-title>Default Persistence</f7-block-title>
+          <f7-block-title>General Settings</f7-block-title>
           <config-sheet
-            :parameter-groups="[]"
-            :parameters="params"
+            :parameter-groups="configDescriptions.parameterGroups"
+            :parameters="configDescriptions.parameters"
             :configuration="config"
             :set-empty-config-as-null="true" />
           <f7-block-title>Configure Persistence Policies</f7-block-title>
@@ -63,7 +63,7 @@ export default {
       serviceId: 'org.openhab.persistence',
       persistenceList: [],
       service: {},
-      params: null,
+      configDescriptions: null,
       config: null
     }
   },
@@ -104,7 +104,7 @@ export default {
         this.service = data
         if (this.service.configDescriptionURI) {
           this.$oh.api.get('/rest/config-descriptions/' + this.service.configDescriptionURI).then(data2 => {
-            this.params = data2.parameters ? data2.parameters : []
+            this.configDescriptions = data2
             this.$oh.api.get('/rest/services/' + this.serviceId + '/config').then(data3 => {
               this.config = data3
               this.$nextTick(() => {


### PR DESCRIPTION
Persistence policies can be configured from the UI. However, it is difficult to find, and one needs to know where to look. Apart from a documentation issue, I think persistence is core enough to merrit its own entry in the settings, so it becomes more prominent.

See for example here: https://community.openhab.org/t/after-reboot-string-values-are-empty/152064/16

This adds a persistence entry below transformations to the settings menu.

The new persistence config page allows to set the default persistence, and links to defining the policies for each installed persistence add-on.
There also is a "add" list entry to install more persistence add-ons.
If none is installed, it will explain persistence and link to the docs and the add-on store.

The default persistence settings has been removed from the system settings, and the link to the persistence policy config from the add-on settings page has been converted to a button.