### PR TITLE
[BasicUI] Fix icon none

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ChartRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ChartRenderer.java
@@ -58,7 +58,7 @@ public class ChartRenderer extends AbstractWidgetRenderer {
 
     private final Logger logger = LoggerFactory.getLogger(ChartRenderer.class);
 
-    private static final String URL_NONE_ICON = "images/none.png";
+    private static final String URL_NONE_ICON = "/icon/none.svg";
 
     @Override
     public boolean canRender(Widget w) {

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ImageRenderer.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class ImageRenderer extends AbstractWidgetRenderer {
 
-    private static final String URL_NONE_ICON = "images/none.png";
+    private static final String URL_NONE_ICON = "/icon/none.svg";
 
     @Activate
     public ImageRenderer(final BundleContext bundleContext, final @Reference TranslationProvider i18nProvider,

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/VideoRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/VideoRenderer.java
@@ -41,7 +41,7 @@ import org.osgi.service.component.annotations.Reference;
 @NonNullByDefault
 public class VideoRenderer extends AbstractWidgetRenderer {
 
-    private static final String URL_NONE_ICON = "images/none.png";
+    private static final String URL_NONE_ICON = "/icon/none.svg";
 
     @Activate
     public VideoRenderer(final BundleContext bundleContext, final @Reference TranslationProvider i18nProvider,

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -349,7 +349,7 @@
 		var
 			_t = this,
 			suppress = false,
-			noneImageSrc = "/icon/none.png";
+			noneImageSrc = "/icon/none.svg";
 
 		_t.parentNode = parentNode;
 		if (_t.formRow === undefined) {
@@ -697,7 +697,7 @@
 		var
 			_t = this,
 			interval = null,
-			urlNoneIcon = "images/none.png";
+			urlNoneIcon = "/icon/none.svg";
 
 		_t.image = parentNode.querySelector("img");
 		_t.updateInterval = parseInt(parentNode.getAttribute("data-update-interval"), 10);
@@ -943,7 +943,7 @@
 		var
 			_t = this,
 			urlMarkerOffIcon = "images/map-marker-off.png",
-			urlNoneIcon = "images/none.png";
+			urlNoneIcon = "/icon/none.svg";
 
 		_t.iframe = parentNode.querySelector("iframe");
 		_t.url = parentNode.getAttribute("data-map-url");


### PR DESCRIPTION
As described in https://community.openhab.org/t/openhab-4-1-milestone-discussion/149502/222, none.png is not found for BasicUI.

This PR replaces it with non.svg, see discussion on forum.

@lolodomo @florian-h05 I was behind my screen when I saw the issue. I didn't test, but did the replacement based on info provided on the forum.