### PR TITLE
[BaiscUI] Adjust the SVG icon in buttons to the current theme

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -262,7 +262,8 @@
 		}
 		.mdl-button-icon {
 			min-width: 0;
-			img {
+			img,
+			svg {
 				width: 24px;
 				height: 24px;
 				object-fit: contain;


### PR DESCRIPTION
Only concerns SVG icons delivered by the openHAB icon servlet and having "currentColor" as fill color.

Convertion to inline SVG is applied only if the "inline SVG" setting is enabled.

Fix #2249

Signed-off-by: Laurent Garnier <lg.hc@free.fr>