### PR TITLE
oh-colorpicker: Replace defaultColor option with an actual default color

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-card.md
@@ -83,11 +83,6 @@ Display a color picker in a card
     <PropOption value="initial-current-colors" label="Initial current colors" />
   </PropOptions>
 </PropBlock>
-<PropBlock type="TEXT" name="defaultColor" label="Default Color">
-  <PropDescription>
-    Color (e.g. <code>[0,0,0]</code> for black) to use for the color picker if state does not contain a color (e.g. because it is <code>NULL</code>)
-  </PropDescription>
-</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -93,11 +93,6 @@ A cell expanding to a color picker
     <PropOption value="initial-current-colors" label="Initial current colors" />
   </PropOptions>
 </PropBlock>
-<PropBlock type="TEXT" name="defaultColor" label="Default Color">
-  <PropDescription>
-    Color (e.g. <code>[0,0,0]</code> for black) to use for the color picker if state does not contain a color (e.g. because it is <code>NULL</code>)
-  </PropDescription>
-</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-item.md
@@ -88,11 +88,6 @@ Display a color picker in a list
     <PropOption value="initial-current-colors" label="Initial current colors" />
   </PropOptions>
 </PropBlock>
-<PropBlock type="TEXT" name="defaultColor" label="Default Color">
-  <PropDescription>
-    Color (e.g. <code>[0,0,0]</code> for black) to use for the color picker if state does not contain a color (e.g. because it is <code>NULL</code>)
-  </PropDescription>
-</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker.md
@@ -51,11 +51,6 @@ Control to pick a color
     <PropOption value="initial-current-colors" label="Initial current colors" />
   </PropOptions>
 </PropBlock>
-<PropBlock type="TEXT" name="defaultColor" label="Default Color">
-  <PropDescription>
-    Color (e.g. <code>[0,0,0]</code> for black) to use for the color picker if state does not contain a color (e.g. because it is <code>NULL</code>)
-  </PropDescription>
-</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/colorpicker.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/colorpicker.js
@@ -14,6 +14,5 @@ export default () => [
     { value: 'palette', label: 'Palette' },
     { value: 'current-color', label: 'Current color' },
     { value: 'initial-current-colors', label: 'Initial current colors' }
-  ], true, true),
-  pt('defaultColor', 'Default Color', 'Color (e.g. <code>[0,0,0]</code> for black) to use for the color picker if state does not contain a color (e.g. because it is <code>NULL</code>)')
+  ], true, true)
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-colorpicker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-colorpicker.vue
@@ -51,14 +51,7 @@ export default {
         color[2] = color[2] / 100
         return color
       }
-      if (this.config.defaultColor) {
-        try {
-          return JSON.parse(this.config.defaultColor)
-        } catch {
-          return null
-        }
-      }
-      return null
+      return [0, 0, 0]
     }
   },
   watch: {


### PR DESCRIPTION
Remove the defaultColor option.
Instead use RGB(0,0,0) black as default color if the Item state holds no valid color, so that the color picker is accessible.