### PR TITLE
Rule/Script edit: Fix not editable not properly handled & Always show tags

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -8,12 +8,12 @@
                          pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
                          @input="rule.uid = $event.target.value" :clear-button="createMode" />
           <f7-list-input label="Name" type="text" placeholder="Required" :value="rule.name" required validate
-                         :disabled="!isEditable" @input="rule.name = $event.target.value" :clear-button="isEditable" />
+                         :disabled="!editable" @input="rule.name = $event.target.value" :clear-button="editable" />
           <f7-list-input label="Description" type="text" :value="rule.description"
-                         :disabled="!isEditable" @input="rule.description = $event.target.value" :clear-button="isEditable" />
-          <f7-list-item v-if="(isEditable || rule.tags.length > 0) && (!createMode || !hasRuleTemplate)" accordion-item title="Tags" :after="numberOfTags" :disabled="!isEditable">
+                         :disabled="!editable" @input="rule.description = $event.target.value" :clear-button="editable" />
+          <f7-list-item v-if="!createMode || !hasRuleTemplate" accordion-item title="Tags" :after="numberOfTags">
             <f7-accordion-content>
-              <tag-input :item="rule" :showSemanticTags="true" :inScriptEditor="inScriptEditor" :inSceneEditor="inSceneEditor" />
+              <tag-input :item="rule" :disabled="!editable" :showSemanticTags="true" :inScriptEditor="inScriptEditor" :inSceneEditor="inSceneEditor" />
             </f7-accordion-content>
           </f7-list-item>
         </f7-list>
@@ -28,10 +28,10 @@
                          :disabled="true" :info="(createMode) ? 'Note: cannot be changed after the creation' : ''"
                          @input="rule.uid = $event.target.value" :clear-button="createMode" />
           <f7-list-input label="Name" type="text" placeholder="Required" required validate
-                         :disabled="true" @input="rule.name = $event.target.value" :clear-button="isEditable" />
+                         :disabled="true" @input="rule.name = $event.target.value" :clear-button="editable" />
           <f7-list-input label="Description" type="text" value="__ _____ ___ __ ___"
-                         :disabled="true" @input="rule.description = $event.target.value" :clear-button="isEditable" />
-          <f7-list-item accordion-item title="Tags" :disabled="!isEditable">
+                         :disabled="true" @input="rule.description = $event.target.value" :clear-button="editable" />
+          <f7-list-item accordion-item title="Tags" :disabled="!editable">
             <f7-accordion-content>
               <tag-input :item="rule" :showSemanticTags="true" />
             </f7-accordion-content>
@@ -46,7 +46,7 @@
 import TagInput from '@/components/tags/tag-input.vue'
 
 export default {
-  props: ['rule', 'ready', 'createMode', 'isEditable', 'hasRuleTemplate', 'inScriptEditor', 'inSceneEditor'],
+  props: ['rule', 'ready', 'createMode', 'hasRuleTemplate', 'inScriptEditor', 'inSceneEditor'],
   components: {
     TagInput
   },
@@ -54,6 +54,9 @@ export default {
     numberOfTags () {
       if (!this.rule.tags) return 0
       return this.rule.tags.filter((t) => !this.isScriptTag(t) && !this.isSceneTag(t)).length
+    },
+    editable () {
+      return this.rule && this.rule.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -50,7 +50,7 @@
           </f7-col>
         </f7-block>
 
-        <rule-general-settings :rule="rule" :ready="ready" :createMode="isNewRule" :isEditable="isEditable" :hasTemplate="hasTemplate" />
+        <rule-general-settings :rule="rule" :ready="ready" :createMode="isNewRule" :hasTemplate="hasTemplate" />
 
         <f7-block v-if="ready" class="block-narrow">
           <f7-block-footer v-if="!isEditable" class="no-margin padding-left">

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -50,7 +50,7 @@
           </f7-col>
         </f7-block>
 
-        <rule-general-settings :rule="rule" :ready="ready" :createMode="createMode" :isEditable="isEditable" :isSceneEditor="true" />
+        <rule-general-settings :rule="rule" :ready="ready" :createMode="createMode" :isSceneEditor="true" />
 
         <f7-block v-if="ready" class="block-narrow">
           <f7-block-footer v-if="!isEditable" class="no-margin padding-left">

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
@@ -5,7 +5,7 @@
       <f7-col v-if="!createMode && languages">
         <f7-block-title>Scripting Language</f7-block-title>
         <f7-list media-list>
-          <f7-list-item media-item radio radio-icon="start"
+          <f7-list-item media-item radio radio-icon="start" :disabled="true"
                         :value="mode" :checked="mode === language.contentType" @change="$emit('newLanguage', language.contentType)"
                         v-for="language in languages" :key="language.contentType"
                         :title="language.name" :after="language.version" :footer="language.contentType" />
@@ -23,6 +23,11 @@ export default {
   emits: ['newLanguage'],
   components: {
     RuleGeneralSettings
+  },
+  computed: {
+    editable () {
+      return this.rule && this.rule.editable
+    }
   }
 }
 </script>


### PR DESCRIPTION
Fixes an issue where the configuration of a script action of a file-based rule (e.g. those created using JSRule or Rule Builder of openhab-js) was shown as editable, even though the rule is not editable because it is provisioned from file.

![image](https://github.com/openhab/openhab-webui/assets/73423173/1f1e6fdb-5b7f-4d38-a0fd-db8f4e7025d4)

Always show the tag input, even if there are no rule tags. This is more consistent and avoids confusion, as you can now clearly see that a rule has no tags.