### PR TITLE
[BasicUI] Fix SSE reconnection to the current page

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -2955,9 +2955,7 @@
 				responseJSON,
 				subscribeLocation,
 				subscribeLocationArray,
-				sitemap,
-				subscriptionId,
-				page;
+				subscriptionId;
 
 			try {
 				responseJSON = JSON.parse(response.responseText);
@@ -2978,14 +2976,11 @@
 			subscribeLocationArray = subscribeLocation.split("/");
 			subscriptionId = subscribeLocationArray[subscribeLocationArray.length - 1];
 
-			sitemap = document.body.getAttribute("data-sitemap");
-			page = document.body.getAttribute("data-page-id");
-
 			smarthome.subscriptionId = subscriptionId;
 
 			initSubscription(subscribeLocation +
-				"?sitemap=" + sitemap +
-				"&pageid=" + page);
+				"?sitemap=" + smarthome.UI.sitemap +
+				"&pageid=" + smarthome.UI.page);
 		};
 
 		_t.subscriberError = function(xhr) {


### PR DESCRIPTION
After an error in the SSE connection, the event source is now reconnected to the right sitemap page.

Fix one of both problems explained in #1757

Signed-off-by: Laurent Garnier <lg.hc@free.fr>