### PR TITLE
Help Feature FAQ: Remove persistence FAQs

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/help/help-faq-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/help/help-faq-defs.json
@@ -38,22 +38,6 @@
     "text" : "Use the Settings page to go to the listing page for the type of configurations you want to delete and then click on Select in the upper-right corner (or Ctrl + Click on any listing).  Select all configurations to be deleted using the checkboxes and then click on the <span style=\"color: red\">Remove</span> button at the bottom of the screen."
   },
   {
-    "title": "Configure the default persistence service",
-    "goto": {
-      "target": "/settings/services/org.openhab.persistence",
-      "text": "System Settings: Persistence"
-    }
-  },
-  {
-    "title": "Configure which Items to persist",
-    "goto": {
-      "target": "/settings/",
-      "text": "Settings"
-    },
-    "text": "Use the Settings page to open the add-on settings for a persistence service, then click on <span style=\"color: red\">Persistence configuration</span>.",
-    "doclink": "link/persistence"
-  },
-  {
     "title" : "Find available icons",
     "text" : "OpenHAB specific icons can be found at the docs page linked below. F7 icons are listed in the <a class=\"external\" target=\"_blank\" href=\"https://framework7.io/icons/\">F7 docs</a>. Material icons can be found <a class=\"external\" target=\"_blank\" href=\"https://jossef.github.io/material-design-icons-iconfont/\">here</a>. The entire <a class=\"external\" target=\"_blank\" href=\"https://icon-sets.iconify.design/\">Iconify library</a> is also available for use.",
     "doclink" : "docs/configuration/iconsets/classic/"


### PR DESCRIPTION
As there now is a dedicated persistence config page, persistence config is well visible and does not need the outdated FAQ entries anymore.