### PR TITLE
Fix regressions caused by wrong YAML library usage

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -294,11 +294,10 @@ export default {
           if (parsed.errors.length > 0) {
             parsed.errors.forEach((e) => {
               const message = e.message
-              e.makePretty()
               found.push({
                 message: message,
-                from: (e.linePos.end) ? { line: e.linePos.start.line - 1, ch: e.linePos.start.col - 1 } : undefined,
-                to: (e.linePos.end) ? { line: e.linePos.end.line - 1, ch: e.linePos.end.col - 1 } : undefined
+                from: (e.linePos[0]) ? { line: e.linePos[0].line - 1, ch: e.linePos[0].col - 1 } : undefined,
+                to: (e.linePos[1]) ? { line: e.linePos[1].line - 1, ch: e.linePos[1].col - 1 } : undefined
               })
             })
           }

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -101,13 +101,13 @@
 </style>
 
 <script>
-import YAML, { Schema } from 'yaml'
+import YAML from 'yaml'
 
 import BlocklyEditor from '@/components/config/controls/blockly-editor.vue'
 import BlockPreview from './block-preview.vue'
 import DirtyMixin from '@/pages/settings/dirty-mixin'
 
-Schema.toStringDefaults.lineWidth = 0
+const toStringOptions = { toStringDefaults: { lineWidth: 0 } }
 
 export default {
   mixins: [DirtyMixin],
@@ -138,7 +138,7 @@ export default {
     blocks () {
       try {
         if (!this.blocksDefinition) return {}
-        return YAML.parse(this.blocksDefinition, { prettyErrors: true })
+        return YAML.parse(this.blocksDefinition, { prettyErrors: true, toStringOptions })
       } catch (e) {
         return { component: 'Error', config: { error: e.message } }
       }
@@ -281,14 +281,14 @@ export default {
               }
             ]
           }
-        })
+        }, { toStringOptions })
         this.$nextTick(() => {
           this.loading = false
           this.ready = true
         })
       } else {
         this.$oh.api.get('/rest/ui/components/ui:blocks/' + this.uid).then((data) => {
-          this.$set(this, 'blocksDefinition', YAML.stringify(data))
+          this.$set(this, 'blocksDefinition', YAML.stringify(data, { toStringOptions }))
           this.$nextTick(() => {
             this.loading = false
             this.ready = true

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -100,14 +100,14 @@
 </style>
 
 <script>
-import YAML, { Schema } from 'yaml'
+import YAML from 'yaml'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import DirtyMixin from '@/pages/settings/dirty-mixin'
 
 import * as StandardListWidgets from '@/components/widgets/standard/list'
 
-Schema.toStringDefaults.lineWidth = 0
+const toStringOptions = { toStringDefaults: { lineWidth: 0 } }
 
 export default {
   mixins: [DirtyMixin],
@@ -152,7 +152,7 @@ export default {
     widget () {
       try {
         if (!this.widgetDefinition) return {}
-        return YAML.parse(this.widgetDefinition, { prettyErrors: true })
+        return YAML.parse(this.widgetDefinition, { prettyErrors: true, toStringOptions })
       } catch (e) {
         return { component: 'Error', config: { error: e.message } }
       }
@@ -235,14 +235,14 @@ export default {
             footer: '=props.prop1',
             content: '=items[props.item].displayState || items[props.item].state'
           }
-        })
+        }, { toStringOptions })
         this.$nextTick(() => {
           this.loading = false
           this.ready = true
         })
       } else {
         this.$oh.api.get('/rest/ui/components/ui:widget/' + this.uid).then((data) => {
-          this.$set(this, 'widgetDefinition', YAML.stringify(data))
+          this.$set(this, 'widgetDefinition', YAML.stringify(data, { toStringOptions }))
           this.$nextTick(() => {
             this.loading = false
             this.ready = true


### PR DESCRIPTION
Regression from #2267.

In #2267 the YAML library was upgraded to a new version, but the usage of the library was not adjusted to breaking changes.
This PR fixes all issues discouvered in the browser console.