### PR TITLE
Widget expressions: (Partly) Fix handling of Item name being `undefined`

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -19,11 +19,13 @@ import jsepTemplate from '@jsep-plugin/template'
 expr.jsep.plugins.register(jsepRegex, jsepArrow, jsepObject, jsepTemplate)
 
 expr.addUnaryOp('@', (itemName) => {
+  if (itemName === undefined) return undefined
   const itemState = store.getters.trackedItems[itemName]
   if (itemState.displayState === undefined) return itemState.state
   return itemState.displayState
 })
 expr.addUnaryOp('@@', (itemName) => {
+  if (itemName === undefined) return undefined
   return store.getters.trackedItems[itemName].state
 })
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -21,8 +21,7 @@ expr.jsep.plugins.register(jsepRegex, jsepArrow, jsepObject, jsepTemplate)
 expr.addUnaryOp('@', (itemName) => {
   if (itemName === undefined) return undefined
   const itemState = store.getters.trackedItems[itemName]
-  if (itemState.displayState === undefined) return itemState.state
-  return itemState.displayState
+  return itemState.displayState || itemState.state
 })
 expr.addUnaryOp('@@', (itemName) => {
   if (itemName === undefined) return undefined


### PR DESCRIPTION
When using the `@` and `@@` shortcuts for Item displayState and state in widget expressions, properly handle cases where the Item name is `undefined`.
Unfortunately I did not find a way to improve that for `items[itemName]` expressions.

Requesting the Item state from the server when the Item name is undefined leads to warnings in the log (which might cause some confusion for the users):
```
[WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: undefined
```