### PR TITLE
Home edit: Fix model card settings drop-down not accessible

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -32,21 +32,20 @@
           <f7-preloader />
           <div>Loading...</div>
         </f7-block>
-        <!-- <f7-block class="block-narrow" v-if="ready && !previewMode">
-          <page-settings :page="page" :createMode="createMode" />
-        </f7-block> -->
 
-        <f7-block class="block-narrow" style="padding-bottom: 8rem" v-else-if="ready && modelReady && !previewMode">
-          <f7-col>
-            <f7-block-title>Page Configuration</f7-block-title>
-            <config-sheet
-              :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
-              :parameters="pageWidgetDefinition.props.parameters || []"
-              :configuration="page.config"
-              @updated="dirty = true" />
-          </f7-col>
+        <div v-else-if="!previewMode">
+          <f7-block class="block-narrow no-padding">
+            <f7-col>
+              <f7-block-title>Page Configuration</f7-block-title>
+              <config-sheet
+                :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
+                :parameters="pageWidgetDefinition.props.parameters || []"
+                :configuration="page.config"
+                @updated="dirty = true" />
+            </f7-col>
+          </f7-block>
 
-          <f7-col>
+          <f7-block>
             <f7-segmented strong tag="p">
               <f7-button v-for="tab in modelTabs" :key="tab.value" @click="showCardControls = false; currentModelTab = tab.value" :active="currentModelTab === tab.value" :text="tab.label" />
             </f7-segmented>
@@ -83,7 +82,9 @@
                 </f7-list-item>
               </f7-list>
             </div>
+          </f7-block>
 
+          <f7-block style="z-index: -1">
             <div v-if="currentModelTab === 'locations'">
               <config-sheet
                 :parameterGroups="locationsTabParameters.props.parameterGroups || []"
@@ -107,9 +108,10 @@
                 :configuration="page.slots.properties[0].config"
                 @updated="dirty = true" />
             </div>
-          </f7-col>
-        </f7-block>
-        <div v-else-if="ready && previewMode && currentTab === 'design'" :context="context" :key="pageKey">
+          </f7-block>
+        </div>
+
+        <div v-else :context="context" :key="pageKey">
           <model-tab style="margin-bottom: 4rem" :context="context" :type="currentModelTab" :model="model" :page="page" />
         </div>
       </f7-tab>
@@ -152,6 +154,7 @@ import { OhHomePageDefinition, OhLocationsTabParameters, OhEquipmentTabParameter
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import ModelTab from '@/pages/home/model-tab.vue'
+import PageSettings from '@/components/pagedesigner/page-settings.vue'
 
 const ConfigurableWidgets = {
   'oh-location-card': OhLocationCardParameters,
@@ -162,6 +165,7 @@ const ConfigurableWidgets = {
 export default {
   mixins: [PageDesigner, HomeCards],
   components: {
+    PageSettings,
     'editor': () => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue'),
     ConfigSheet,
     ModelTab

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -154,7 +154,6 @@ import { OhHomePageDefinition, OhLocationsTabParameters, OhEquipmentTabParameter
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
 import ModelTab from '@/pages/home/model-tab.vue'
-import PageSettings from '@/components/pagedesigner/page-settings.vue'
 
 const ConfigurableWidgets = {
   'oh-location-card': OhLocationCardParameters,
@@ -165,7 +164,6 @@ const ConfigurableWidgets = {
 export default {
   mixins: [PageDesigner, HomeCards],
   components: {
-    PageSettings,
     'editor': () => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue'),
     ConfigSheet,
     ModelTab


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/openhab/openhab-webui/pull/2144#issuecomment-1784114001.

This is not the best solution, but it works now.

The issue looked like this:
![image](https://github.com/openhab/openhab-webui/assets/73423173/a0fc1c21-af04-45eb-aade-eca0e9758cbc)
