### PR TITLE
[blockly] Fix persistence block ZDT disconnection

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -82,15 +82,20 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
         if (this.getInput('skipPrevious')) {
           this.removeInput('skipPrevious')
         }
-        if (this.getInput('dayInfo')) {
-          this.removeInput('dayInfo')
-        }
+
         const preposition = (this.methodName === 'historicState') ? 'at' : 'since'
 
-        this.appendValueInput('dayInfo')
-          .appendField(preposition)
-          .setAlign(Blockly.ALIGN_RIGHT)
-          .setCheck(['ZonedDateTime'])
+        if (!this.getInput('dayInfo')) {
+          this.appendValueInput('dayInfo')
+            .appendField(preposition, 'preposition')
+            .setCheck(['ZonedDateTime'])
+          this.moveInputBefore('dayInfo', 'persistenceName')
+        } else {
+          const prepositionField = this.getField('preposition')
+          if (prepositionField.getText() !== preposition) {
+            prepositionField.setValue(preposition)
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Fix so oh_get_persistvalue block does not unnecessarily disconnect the ZDT input every time a different methodname is selected.