### PR TITLE
[blockly] Set output type of oh_check_undefined_value to boolean

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
@@ -94,7 +94,7 @@ export default function defineOHBlocks_Variables (f7, isGraalJs) {
           .appendField('cache')
       }
       this.setInputsInline(true)
-      this.setOutput(true, null)
+      this.setOutput(true, 'Boolean')
       this.setColour(0)
       if (isGraalJs) {
         this.setTooltip('returns whether the given value is undefined in the private rule or shared global cache')


### PR DESCRIPTION
On the default renderer, it isn't obvious that this is wrong, but on Zelos where generic output (rounded) vs Boolean output (angled) have different looks, it's glaringly obvious.