### PR TITLE
Provide meaningful list of units in item form

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -160,5 +160,5 @@ export const Units = [{
   baseUnitsMetric: ['m³/s', 'm³/min', 'm³/h', 'm³/d']
 }]
 
-export const prefixesMetric = ['y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm', 'c', 'd', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
-export const prefixesBinary = ['ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']
+export const MetricPrefixes = ['y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm', 'c', 'd', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+export const BinaryPrefixes = ['ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -1,67 +1,164 @@
+// Units defines the possible units for UI unit selection. Each unit is defined by one or more fields:
+//   dimension: required field, unit dimension
+//   units: units used in a curated shortlist of units, not specific to SI or Imperial measurement system
+//   unitsSI: units used in a curated shortlist of units, specific to the SI measurement system
+//   unitsUS: units used in a curated shortlist of units, specific to the Imperial measurement system
+//   default: default unit, to be set to override core default unit, not specific to SI or Imperial measurement system
+//   defaultSI: default unit in SI measurement system, to be set to override OH core default SI unit
+//   defaultUS: default unit in Imperial measurement system, to be set to override OH core default Imperial unit
+//   baseUnits: all supported base units that don't allow metric or binary prefixes
+//   baseUnitsMetric: metric base units, the full list of units will include all of these with all metric prefixes
+//   baseUnitsBinary: binary base units, the full list of units will include all of these with all binary prefixes
+// If nothing is defined for an allowed dimension, the UI will fall back on the OH core default unit in the configured
+// measurement system.
+// For dimensions defined, any of the fields can be ommitted. Logical defaults will be used.
+// Units from curated units lists will always be added to the full unit list constructed from baseUnits and prefixes. So it
+// is not necessary to explicitely add what is already in the curated units for the full units list. However, no prefixes
+// will be applied to these. If you want prefixes to be applied, you should add them in the respective baseUnits Array as well.
+
 export const Units = [{
+  dimension: 'Acceleration',
+  baseUnits: ['gₙ'],
+  baseUnitsSI: ['m/s²']
+}, {
+  dimension: 'AmountOfSubstance',
+  baseUnits: ['°dH'],
+  baseUnitsSI: ['mol']
+}, {
   dimension: 'Angle',
-  units: ['°', 'rad']
+  units: ['°', '\'', '"', 'rad']
 }, {
   dimension: 'Area',
   unitsSI: ['m²', 'km²', 'ha'],
-  unitsUS: ['ft²', 'mi²']
+  unitsUS: ['ft²', 'mi²'],
+  baseUnits: ['ca', 'a', 'in²', 'ac'],
+  baseUnitsMetric: ['m²']
 }, {
   dimension: 'DataAmount',
-  units: ['bit', 'B', 'KB', 'KiB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB']
+  units: ['bit', 'B', 'kB', 'kiB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB'],
+  baseUnitsMetric: ['bit', 'B', 'o'],
+  baseUnitsBinary: ['bit', 'B', 'o']
 }, {
   dimension: 'DataTransferRate',
-  units: ['bit/s', 'Kbit/s', 'Mbit/s', 'GBit/s']
+  units: ['bit/s', 'kbit/s', 'Mbit/s', 'GBit/s'],
+  baseUnitsMetric: ['bit/s'],
+  baseUnitsBinary: ['bit/s']
 }, {
   dimension: 'Density',
-  units: ['g/l', 'g/m³', 'kg/m³']
+  units: ['g/l', 'g/m³', 'kg/m³'],
+  baseUnits: ['lb/in³'],
+  baseUnitsMetric: ['g/m³', 'g/mm³', 'g/cm³', 'g/dm³', 'g/ml', 'g/cl', 'g/dl', 'g/l']
 }, {
   dimension: 'Dimensionless',
-  units: ['one', '%', 'dB', 'ppm'],
+  units: ['one', '%', 'dB', 'ppm', 'ppb'],
   default: '%'
 }, {
+  dimension: 'ElectricCapcitance',
+  baseUnitsMetric: ['F']
+}, {
   dimension: 'ElectricCharge',
-  units: ['Ah', 'C']
+  units: ['Ah', 'C'],
+  baseUnitsMetric: ['C']
+}, {
+  dimension: 'ElectricConductance',
+  baseUnitsMetric: ['S']
+}, {
+  dimension: 'ElectricConductivity',
+  baseUnitsMetric: ['S/m']
+}, {
+  dimension: 'ElectricCurrent',
+  baseUnitsMetric: ['A']
+}, {
+  dimension: 'ElectricInductance',
+  baseUnitsMetric: ['H']
+}, {
+  dimension: 'ElectricPotential',
+  baseUnitsMetric: ['V']
+}, {
+  dimension: 'ElectricResistance',
+  baseUnitsMetric: ['Ω']
 }, {
   dimension: 'Energy',
-  units: ['kWh', 'Wh', 'VAh', 'varh', 'J', 'kJ', 'cal', 'kcal']
+  units: ['kWh', 'Wh', 'VAh', 'varh', 'J', 'kJ', 'cal', 'kcal'],
+  baseUnitsMetric: ['Ws', 'Wh', 'VAs', 'VAh', 'vars', 'varh', 'J', 'cal']
 }, {
   dimension: 'Force',
-  units: ['N', 'kN']
+  units: ['N', 'kN'],
+  baseUnitsMetric: ['N']
 }, {
   dimension: 'Frequency',
-  units: ['Hz', 'kHz', 'MHz', 'GHz', 'rpm']
+  units: ['Hz', 'kHz', 'MHz', 'GHz', 'rpm'],
+  baseUnitsMetric: ['Hz']
 }, {
   dimension: 'Intensity',
-  units: ['W/m²', 'µW/cm²']
+  units: ['W/m²', 'µW/cm²'],
+  baseUnitsMetric: ['W/mm²', 'W/cm²', 'W/dm²', 'W/m²']
 }, {
   dimension: 'Length',
   unitsSI: ['mm', 'cm', 'dm', 'm', 'km'],
-  unitsUS: ['in', 'ft', 'mi']
+  unitsUS: ['in', 'ft', 'mi'],
+  baseUnits: ['yd', 'ch', 'fur', 'lea']
+}, {
+  dimension: 'LuminousFlux',
+  baseUnitsMetric: ['lm']
+}, {
+  dimension: 'LuminousIntensity',
+  baseUnitsMetric: ['cd']
+}, {
+  dimension: 'MagneticFlux',
+  baseUnitsMetric: ['T']
 }, {
   dimension: 'Mass',
-  unitsSI: ['mg', 'g', 'kg', 't']
+  unitsSI: ['mg', 'g', 'kg', 't'],
+  baseUnits: ['lb', 'oz', 'st'],
+  baseUnitsMetric: ['g', 't']
 }, {
   dimension: 'Power',
-  units: ['W', 'kW', 'VA', 'kVA', 'var', 'kvar', 'dBm']
+  units: ['W', 'kW', 'VA', 'kVA', 'var', 'kvar', 'dBm'],
+  baseUnits: ['hp', 'kgf', 'lbf'],
+  baseUnitsMetric: ['W', 'VA', 'var']
 }, {
   dimension: 'Pressure',
   unitsSI: ['Pa', 'hPa', 'bar', 'mbar', 'mmHg'],
-  unitsUS: ['inHg', 'psi']
+  unitsUS: ['inHg', 'psi'],
+  baseUnits: ['atm'],
+  baseUnitsMetric: ['Pa', 'bar']
+}, {
+  dimension: 'RadiationAbsorbedDose',
+  baseUnitsMetric: ['Gy']
+}, {
+  dimension: 'RadiationEffectiveDose',
+  baseUnitsMetric: ['Sv']
+}, {
+  dimension: 'Radioactivity',
+  unitsSI: ['Bq', 'Ci'],
+  baseUnitsMetric: ['Ci']
 }, {
   dimension: 'Speed',
   unitsSI: ['km/h', 'm/s'],
-  unitsUS: ['mph', 'in/h']
+  unitsUS: ['mph', 'in/h'],
+  baseUnits: ['kn'],
+  baseUnitsMetric: ['m/s', 'm/h']
 }, {
   dimension: 'Temperature',
   unitsSI: ['°C', 'K'],
-  unitsUS: ['°F', 'K']
+  unitsUS: ['°F', 'K'],
+  baseUnits: ['mired']
 }, {
   dimension: 'Time',
   units: ['s', 'min', 'h', 'd', 'wk', 'mo', 'y']
 }, {
   dimension: 'Volume',
-  unitsSI: ['ml', 'cl', 'l', 'm³']
+  unitsSI: ['ml', 'cl', 'l', 'm³'],
+  unitsUS: ['gal'],
+  baseUnits: ['in³', 'ft³'],
+  baseUnitsMetric: ['l', 'm³']
 }, {
   dimension: 'VolumetricFlowRate',
-  unitsSI: ['l/min', 'm³/s', 'm³/min', 'm³/h', 'm³/d']
+  unitsSI: ['l/s', 'l/min', 'm³/s', 'm³/min', 'm³/h', 'm³/d'],
+  unitsUS: ['gal/min'],
+  baseUnitsMetric: ['m³/s', 'm³/min', 'm³/h', 'm³/d']
 }]
+
+export const prefixesMetric = ['y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm', 'c', 'd', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+export const prefixesBinary = ['ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -1,21 +1,28 @@
-// Units defines the possible units for UI unit selection. Each unit is defined by one or more fields:
-//   dimension: required field, unit dimension
-//   units: units used in a curated shortlist of units, not specific to SI or Imperial measurement system
-//   unitsSI: units used in a curated shortlist of units, specific to the SI measurement system
-//   unitsUS: units used in a curated shortlist of units, specific to the Imperial measurement system
-//   default: default unit, to be set to override core default unit, not specific to SI or Imperial measurement system
-//   defaultSI: default unit in SI measurement system, to be set to override OH core default SI unit
-//   defaultUS: default unit in Imperial measurement system, to be set to override OH core default Imperial unit
-//   baseUnits: all supported base units that don't allow metric or binary prefixes
-//   baseUnitsMetric: metric base units, the full list of units will include all of these with all metric prefixes
-//   baseUnitsBinary: binary base units, the full list of units will include all of these with all binary prefixes
-// If nothing is defined for an allowed dimension, the UI will fall back on the OH core default unit in the configured
-// measurement system.
-// For dimensions defined, any of the fields can be ommitted. Logical defaults will be used.
-// Units from curated units lists will always be added to the full unit list constructed from baseUnits and prefixes. So it
-// is not necessary to explicitely add what is already in the curated units for the full units list. However, no prefixes
-// will be applied to these. If you want prefixes to be applied, you should add them in the respective baseUnits Array as well.
+// Units defines the possible units for UI unit selection.
+// If nothing is defined for an allowed dimension, the UI will fall back on the OH core default unit in the configured measurement system.
+// For dimensions defined, any of the fields can be omitted. Logical defaults will be used.
+// Units from curated units lists will always be added to the full unit list constructed from baseUnits and prefixes.
+// So it is not necessary to explicitly add what is already in the curated units for the full units list.
+// However, no prefixes will be applied to these. If you want prefixes to be applied, you should add them in the respective baseUnits Array as well.
 
+/**
+ * @typedef Unit
+ * @property {string} dimension unit dimension (required)
+ * @property {string[]} [units] units used in a curated shortlist of units, not specific to SI or Imperial measurement system
+ * @property {string[]} [unitsSI] units used in a curated shortlist of units, specific to the SI measurement system
+ * @property {string[]} [unitsUS] units used in a curated shortlist of units, specific to the Imperial measurement system
+ * @property {string} [default] default unit, to be set to override core default unit, not specific to SI or Imperial measurement system
+ * @property {string} [defaultsSI] default unit in SI measurement system, to be set to override OH core default SI unit
+ * @property {string} [defaultUS] default unit in Imperial measurement system, to be set to override OH core default Imperial unit
+ * @property {string[]} [baseUnits] all supported base units that don't allow metric or binary prefixes
+ * @property {string[]} [baseUnitsMetric] metric base units, the full list of units will include all of these with all metric prefixes
+ * @property {string[]} [baseUnitsBinary] binary base units, the full list of units will include all of these with all binary prefixes
+ */
+
+/**
+ * Defines the possible units for UI unit selection.
+ * @type {Unit[]}
+ */
 export const Units = [{
   dimension: 'Acceleration',
   baseUnits: ['gₙ'],
@@ -160,5 +167,14 @@ export const Units = [{
   baseUnitsMetric: ['m³/s', 'm³/min', 'm³/h', 'm³/d']
 }]
 
+/**
+ * Metric prefixes for metric base units.
+ * @type {string[]}
+ */
 export const MetricPrefixes = ['y', 'z', 'a', 'f', 'p', 'n', 'µ', 'm', 'c', 'd', 'da', 'h', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']
+
+/**
+ * Binary prefixes for binary base units.
+ * @type {string[]}
+ */
 export const BinaryPrefixes = ['ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi']

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -79,7 +79,7 @@ export const Units = [{
   baseUnitsMetric: ['Ω']
 }, {
   dimension: 'Energy',
-  units: ['kWh', 'Wh', 'VAh', 'varh', 'J', 'kJ', 'cal', 'kcal'],
+  units: ['kWh', 'Wh', 'kVAh', 'kvarh', 'J', 'kJ', 'cal', 'kcal'],
   baseUnitsMetric: ['Ws', 'Wh', 'VAs', 'VAh', 'vars', 'varh', 'J', 'cal']
 }, {
   dimension: 'Force',

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -1,0 +1,9 @@
+export const Units = [{
+    dimension: 'Dimensionless',
+    units: ['one', '%', 'dB', 'ppm'],
+    default: '%'
+} , {
+    dimension: 'Length',
+    unitsSI: ['mm', 'cm', 'dm', 'm', 'km'],
+    unitsUS: ['in', 'ft', 'mi']
+}]

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -47,7 +47,7 @@ export const Units = [{
   baseUnitsBinary: ['bit', 'B', 'o']
 }, {
   dimension: 'DataTransferRate',
-  units: ['bit/s', 'kbit/s', 'Mbit/s', 'GBit/s'],
+  units: ['bit/s', 'kbit/s', 'Mbit/s', 'Gbit/s'],
   baseUnitsMetric: ['bit/s'],
   baseUnitsBinary: ['bit/s']
 }, {

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -79,8 +79,8 @@ export const Units = [{
   baseUnitsMetric: ['Ω']
 }, {
   dimension: 'Energy',
-  units: ['kWh', 'Wh', 'kVAh', 'kvarh', 'J', 'kJ', 'cal', 'kcal'],
-  baseUnitsMetric: ['Ws', 'Wh', 'VAs', 'VAh', 'vars', 'varh', 'J', 'cal']
+  units: ['kWh', 'Wh', 'J', 'kJ', 'cal', 'kcal'],
+  baseUnitsMetric: ['Ws', 'Wh', 'J', 'cal']
 }, {
   dimension: 'Force',
   units: ['N', 'kN'],

--- a/bundles/org.openhab.ui/web/src/assets/units.js
+++ b/bundles/org.openhab.ui/web/src/assets/units.js
@@ -1,9 +1,67 @@
 export const Units = [{
-    dimension: 'Dimensionless',
-    units: ['one', '%', 'dB', 'ppm'],
-    default: '%'
-} , {
-    dimension: 'Length',
-    unitsSI: ['mm', 'cm', 'dm', 'm', 'km'],
-    unitsUS: ['in', 'ft', 'mi']
+  dimension: 'Angle',
+  units: ['°', 'rad']
+}, {
+  dimension: 'Area',
+  unitsSI: ['m²', 'km²', 'ha'],
+  unitsUS: ['ft²', 'mi²']
+}, {
+  dimension: 'DataAmount',
+  units: ['bit', 'B', 'KB', 'KiB', 'MB', 'MiB', 'GB', 'GiB', 'TB', 'TiB']
+}, {
+  dimension: 'DataTransferRate',
+  units: ['bit/s', 'Kbit/s', 'Mbit/s', 'GBit/s']
+}, {
+  dimension: 'Density',
+  units: ['g/l', 'g/m³', 'kg/m³']
+}, {
+  dimension: 'Dimensionless',
+  units: ['one', '%', 'dB', 'ppm'],
+  default: '%'
+}, {
+  dimension: 'ElectricCharge',
+  units: ['Ah', 'C']
+}, {
+  dimension: 'Energy',
+  units: ['kWh', 'Wh', 'VAh', 'varh', 'J', 'kJ', 'cal', 'kcal']
+}, {
+  dimension: 'Force',
+  units: ['N', 'kN']
+}, {
+  dimension: 'Frequency',
+  units: ['Hz', 'kHz', 'MHz', 'GHz', 'rpm']
+}, {
+  dimension: 'Intensity',
+  units: ['W/m²', 'µW/cm²']
+}, {
+  dimension: 'Length',
+  unitsSI: ['mm', 'cm', 'dm', 'm', 'km'],
+  unitsUS: ['in', 'ft', 'mi']
+}, {
+  dimension: 'Mass',
+  unitsSI: ['mg', 'g', 'kg', 't']
+}, {
+  dimension: 'Power',
+  units: ['W', 'kW', 'VA', 'kVA', 'var', 'kvar', 'dBm']
+}, {
+  dimension: 'Pressure',
+  unitsSI: ['Pa', 'hPa', 'bar', 'mbar', 'mmHg'],
+  unitsUS: ['inHg', 'psi']
+}, {
+  dimension: 'Speed',
+  unitsSI: ['km/h', 'm/s'],
+  unitsUS: ['mph', 'in/h']
+}, {
+  dimension: 'Temperature',
+  unitsSI: ['°C', 'K'],
+  unitsUS: ['°F', 'K']
+}, {
+  dimension: 'Time',
+  units: ['s', 'min', 'h', 'd', 'wk', 'mo', 'y']
+}, {
+  dimension: 'Volume',
+  unitsSI: ['ml', 'cl', 'l', 'm³']
+}, {
+  dimension: 'VolumetricFlowRate',
+  unitsSI: ['l/min', 'm³/s', 'm³/min', 'm³/h', 'm³/d']
 }]

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="group-form no-padding">
     <!-- Type -->
-    <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="align-popup-list-item" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+    <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="aligned-smart-select" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-basetype" @change="groupType = $event.target.value">
         <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType : false">
           {{ type }}
@@ -9,7 +9,7 @@
       </select>
     </f7-list-item>
     <!-- Dimension -->
-    <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="align-popup-list-item" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+    <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="aligned-smart-select" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-dimension" @change="groupDimension = $event.target.value">
         <option key="" value="Number" :selected="item.type === 'Number'" />
         <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="'Number:' + d.name === item.groupType">

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -61,7 +61,9 @@ export default {
   props: ['item', 'createMode'],
   data () {
     return {
-      types
+      types,
+      unitAutocomplete: null,
+      unitInitialized: !this.createMode
     }
   },
   computed: {
@@ -185,12 +187,16 @@ export default {
       this.unitAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',
+        typeahead: true,
         source (query, render) {
-          if (!query || !query.length) {
+          if (!query || !query.length || !this.unitInitialized) {
           // Render curated list by default
             render(curatedUnits)
+            this.unitInitialized = true
           } else {
-            render(allUnits.filter(u => u.toLowerCase().indexOf(query.toLowerCase()) >= 0))
+            // Always show currated units on top (don't filter them)
+            let units = [...new Set(curatedUnits.concat(allUnits.filter(u => u.indexOf(query) >= 0)))]
+            render(units)
           }
         }
       })
@@ -209,6 +215,11 @@ export default {
         func.params = [splitted[1], splitted[2]]
       }
       this.$set(this.item, 'function', func)
+    }
+  },
+  beforeDestroy () {
+    if (this.unitAutocomplete) {
+      this.$f7.autocomplete.destroy(this.unitAutocomplete)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -18,7 +18,7 @@
       </select>
     </f7-list-item>
     <!-- (Internal) Unit & State Description -->
-    <f7-list-input v-show="groupType && groupDimension && unitsReady"
+    <f7-list-input v-show="groupType && groupDimension && dimensionsReady"
                    ref="groupUnit"
                    label="Unit"
                    type="text"
@@ -66,6 +66,11 @@ export default {
       groupUnitAutocomplete: null,
       oldGroupDimension: '',
       oldGroupUnit: ''
+    }
+  },
+  watch: {
+    dimensionsReady (newValue, oldValue) {
+      if (oldValue === false && newValue === true) this.initializeAutocompleteGroupUnit()
     }
   },
   computed: {
@@ -226,7 +231,7 @@ export default {
     if (!this.createMode && this.groupDimension) {
       this.oldGroupDimension = this.groupDimension
       this.oldGroupUnit = this.groupUnit
-      this.initializeAutocompleteGroupUnit()
+      if (this.dimensionsReady) this.initializeAutocompleteGroupUnit()
     }
   },
   beforeDestroy () {

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -19,7 +19,8 @@
     </f7-list-item>
     <!-- (Internal) Unit & State Description -->
     <template v-if="createMode && groupType && groupDimension">
-      <f7-list-input label="Unit"
+      <f7-list-input ref="unit"
+                     label="Unit"
                      type="text"
                      :info="(createMode) ? 'Type any valid unit or select from one of the proposed (non-exhaustive list of) units. Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"
                      :value="item.unit"

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -180,13 +180,18 @@ export default {
         this.$f7.autocomplete.destroy(this.unitAutocomplete)
       }
       // item.unit can be set to unitHint from channel type, make sure it is at beginning of list
-      let units = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
+      let curatedUnits = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
+      let allUnits = this.getFullUnitList(dimension.name)
       this.unitAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',
         source (query, render) {
-          // Always render full list
-          render(units)
+          if (!query || !query.length) {
+          // Render curated list by default
+            render(curatedUnits)
+          } else {
+            render(allUnits.filter(u => u.toLowerCase().indexOf(query.toLowerCase()) >= 0))
+          }
         }
       })
     },

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -180,12 +180,7 @@ export default {
         this.$f7.autocomplete.destroy(this.unitAutocomplete)
       }
       // item.unit can be set to unitHint from channel type, make sure it is at beginning of list
-      let units = this.getUnitList(dimension)
-      const index = units.indexOf(this.item.unit)
-      if (index >= 0) {
-        units.splice(index, 1)
-      }
-      units = [this.item.unit].concat(units)
+      let units = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
       this.unitAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -62,8 +62,7 @@ export default {
   data () {
     return {
       types,
-      unitAutocomplete: null,
-      unitInitialized: !this.createMode
+      unitAutocomplete: null
     }
   },
   computed: {
@@ -189,13 +188,16 @@ export default {
         openIn: 'dropdown',
         typeahead: true,
         source (query, render) {
-          if (!query || !query.length || !this.unitInitialized) {
+          if (!query || !query.length) {
           // Render curated list by default
             render(curatedUnits)
-            this.unitInitialized = true
           } else {
-            // Always show currated units on top (don't filter them)
-            let units = [...new Set(curatedUnits.concat(allUnits.filter(u => u.indexOf(query) >= 0)))]
+            // First filter on curated list
+            let units = curatedUnits.filter(u => u.indexOf(query) >= 0)
+            if (!units.length) {
+              // If no match filter on full list
+              units = allUnits.filter(u => u.indexOf(query) >= 0)
+            }
             render(units)
           }
         }

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -22,8 +22,7 @@
                    ref="groupUnit"
                    label="Unit"
                    type="text"
-                   :info="(createMode) ? 'Type any valid unit for the dimension or select from one of the proposed units. Used internally, for persistence and external systems. \
-                                          It is independent from the state visualization in the UI, which is defined through the state description pattern.' : ''"
+                   :info="(createMode) ? 'Type a valid unit for the dimension or select from the proposed units. Used internally, for persistence and external systems. Is independent from state visualization in the UI, which is defined through the state description pattern.' : ''"
                    :value="groupDimension ? groupUnit : ''"
                    @change="groupUnit = $event.target.value" :clear-button="editable" />
     <f7-list-input v-show="groupType && groupDimension"

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -146,7 +146,43 @@ export default {
         this.item.functionKey += '_' + this.item.function.params.join('_')
       }
     } else {
-      this.$set(this.item, 'functionKey', '')
+      this.$set(this.item, 'functionKey', 'None')
+    }
+  },
+  methods: {
+    setGroupType (type) {
+      this.$set(this.item, 'groupType', '')
+      this.$set(this.item, 'functionKey', 'None')
+      this.$nextTick(() => {
+        if (type !== 'None') this.$set(this.item, 'groupType', type)
+      })
+    },
+    setDimension (index) {
+      if (index === 'Number') {
+        this.setGroupType('Number')
+        return
+      }
+      const dimension = this.dimensions[index]
+      this.setGroupType('Number:' + dimension.name)
+      if (!this.item.unit) {
+        this.$set(this.item, 'unit', dimension.systemUnit)
+      }
+      this.$set(this.item, 'stateDescriptionPattern', '%.0f %unit%')
+    },
+    setFunction (key) {
+      if (!key) {
+        delete this.item.function
+        return
+      }
+      this.$set(this.item, 'functionKey', key)
+      const splitted = key.split('_')
+      let func = {
+        name: splitted[0]
+      }
+      if (splitted.length > 1) {
+        func.params = [splitted[1], splitted[2]]
+      }
+      this.$set(this.item, 'function', func)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -21,7 +21,7 @@
     <template v-if="createMode && groupType && groupDimension">
       <f7-list-input label="Unit"
                      type="text"
-                     :info="(createMode) ? 'Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"
+                     :info="(createMode) ? 'Type any valid unit or select from one of the proposed (non-exhaustive list of) units. Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"
                      :value="item.unit"
                      @input="item.unit = $event.target.value" :clear-button="editable" />
       <f7-list-input label="State Description Pattern"

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -3,7 +3,7 @@
     <!-- Type -->
     <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="align-popup-list-item" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-basetype" @change="groupType = $event.target.value">
-        <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
+        <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType : false">
           {{ type }}
         </option>
       </select>
@@ -18,21 +18,21 @@
       </select>
     </f7-list-item>
     <!-- (Internal) Unit & State Description -->
-    <template v-if="createMode && groupType && groupDimension">
-      <f7-list-input ref="unit"
-                     label="Unit"
-                     type="text"
-                     :info="(createMode) ? 'Type any valid unit or select from one of the proposed (non-exhaustive list of) units. Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"
-                     :value="item.unit"
-                     @input="item.unit = $event.target.value" :clear-button="editable" />
-      <f7-list-input label="State Description Pattern"
-                     type="text"
-                     :info="(createMode) ? 'Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value.' : ''"
-                     :value="item.stateDescriptionPattern"
-                     @input="item.stateDescriptionPattern = $event.target.value" :clear-button:="editable" />
-    </template>
+    <f7-list-input v-show="groupType && groupDimension && unitsReady"
+                   ref="groupUnit"
+                   label="Unit"
+                   type="text"
+                   :info="(createMode) ? 'Type any valid unit for the dimension or select from one of the proposed units. Used internally, for persistence and external systems. \
+                                          It is independent from the state visualization in the UI, which is defined through the state description pattern.' : ''"
+                   :value="groupDimension ? unit : ''"
+                   @change="groupUnit = $event.target.value" :clear-button="editable" />
+    <f7-list-input v-show="groupType && groupDimension"
+                   label="State Description Pattern"
+                   type="text"
+                   :info="(createMode) ? 'Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value.' : ''"
+                   :value="getStateDescription()"
+                   @input="item.stateDescriptionPattern = $event.target.value" :clear-button:="editable" />
     <!-- Aggregation Functions -->
-
     <f7-list-item v-if="aggregationFunctions" :disabled="!editable" title="Aggregation Function" class="align-popup-list-item" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
       <select name="select-function" @change="groupFunctionKey = $event.target.value">
         <option v-for="type in aggregationFunctions" :key="type.name" :value="type.name" :selected="type.name === groupFunctionKey">
@@ -63,7 +63,9 @@ export default {
   data () {
     return {
       types,
-      unitAutocomplete: null
+      groupUnitAutocomplete: null,
+      oldGroupDimension: '',
+      oldGroupUnit: ''
     }
   },
   computed: {
@@ -77,6 +79,9 @@ export default {
       set (newType) {
         const previousAggregationFunctions = this.aggregationFunctions
         this.$set(this.item, 'groupType', '')
+        if (!this.createMode) {
+          this.$set(this, 'oldGroupDimension', '')
+        }
         this.$nextTick(() => {
           if (newType !== 'None') {
             this.$set(this.item, 'groupType', newType)
@@ -89,18 +94,33 @@ export default {
     },
     groupDimension: {
       get () {
-        const parts = this.item.groupType.split(':')
-        return parts.length > 1 ? parts[1] : ''
+        const parts = this.item.groupType?.split(':')
+        return parts && parts.length > 1 ? parts[1] : ''
       },
       set (newDimension) {
+        if (!this.createMode) {
+          this.$set(this, 'oldGroupDimension', this.groupDimension)
+        }
         if (!newDimension) {
           this.groupType = 'Number'
           return
         }
         const dimension = this.dimensions.find((d) => d.name === newDimension)
         this.$set(this.item, 'groupType', 'Number:' + dimension.name)
-        this.$set(this.item, 'unit', dimension.systemUnit)
-        this.$set(this.item, 'stateDescriptionPattern', `%.0f ${dimension.systemUnit}`)
+        this.groupUnit = this.getUnitHint(dimension.name)
+        this.$set(this.item, 'stateDescriptionPattern', this.getStateDescription())
+        this.$nextTick(() => this.initializeAutocompleteGroupUnit(this.groupDimension))
+      }
+    },
+    groupUnit: {
+      get () {
+        return this.unit
+      },
+      set (newUnit) {
+        if (!this.createMode) {
+          this.$set(this, 'oldGroupUnit', this.unit)
+        }
+        this.$set(this.item, 'unit', newUnit)
       }
     },
     groupFunctionKey: {
@@ -153,76 +173,74 @@ export default {
     }
   },
   methods: {
-    setGroupType (type) {
-      this.$set(this.item, 'groupType', '')
-      this.$set(this.item, 'functionKey', 'None')
-      this.$nextTick(() => {
-        if (type !== 'None') this.$set(this.item, 'groupType', type)
-      })
+    dimensionChanged () {
+      if (!this.oldGroupDimension) {
+        return false
+      }
+      return this.oldGroupDimension !== this.dimension
     },
-    setDimension (index) {
-      if (index === 'Number') {
-        this.setGroupType('Number')
+    unitChanged () {
+      return this.oldGroupUnit && this.item.unit && this.oldGroupUnit !== this.item.unit
+    },
+    revertDimensionChange () {
+      if (!this.oldGroupDimension) {
+        this.groupType = 'Number'
+        this.$set(this.item, 'unit', '')
+      } else {
+        this.groupType = 'Number:' + this.oldGroupDimension
+        this.$set(this.item, 'unit', this.oldGroupUnit)
+      }
+      this.initializeAutocompleteGroupUnit(this.groupDimension)
+    },
+    getStateDescription () {
+      return this.item.stateDescriptionPattern ? this.item.stateDescriptionPattern : '%.0f %unit%'
+    },
+    initializeAutocompleteGroupUnit (dimension) {
+      const unitControl = this.$refs.groupUnit
+      if (!(unitControl && unitControl.$el)) {
         return
       }
-      const dimension = this.dimensions[index]
-      this.setGroupType('Number:' + dimension.name)
-      if (!this.item.unit) {
-        this.$set(this.item, 'unit', this.getUnitHint(dimension.name))
+      const inputElement = this.$$(unitControl.$el).find('input')
+      if (this.groupUnitAutocomplete) {
+        this.$f7.autocomplete.destroy(this.groupUnitAutocomplete)
+        this.$set(this, 'groupUnitAutocomplete', '')
       }
-      const unitControl = this.$refs.unit
-      if (unitControl && unitControl.$el) {
-        const inputElement = this.$$(unitControl.$el).find('input')
-        this.initializeAutocompleteUnit(inputElement)
-      }
-      this.$set(this.item, 'stateDescriptionPattern', '%.0f %unit%')
-    },
-    initializeAutocompleteUnit (inputElement, dimension) {
-      if (this.unitAutocomplete) {
-        this.$f7.autocomplete.destroy(this.unitAutocomplete)
-      }
-      // item.unit can be set to unitHint from channel type, make sure it is at beginning of list
-      let curatedUnits = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
-      let allUnits = this.getFullUnitList(dimension.name)
-      this.unitAutocomplete = this.$f7.autocomplete.create({
+      if (!dimension) return
+
+      let curatedUnits = this.getUnitList(dimension)
+      let allUnits = this.getFullUnitList(dimension)
+      this.groupUnitAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',
-        typeahead: true,
+        dropdownPlaceHolderText: this.getUnitHint(dimension),
         source (query, render) {
           if (!query || !query.length) {
           // Render curated list by default
             render(curatedUnits)
           } else {
-            // First filter on curated list
             let units = curatedUnits.filter(u => u.indexOf(query) >= 0)
-            if (!units.length) {
+            if (units.length) {
+              // Show full curated list if in curated list
+              render(curatedUnits)
+            } else {
               // If no match filter on full list
-              units = allUnits.filter(u => u.indexOf(query) >= 0)
+              render(allUnits.filter(u => u.indexOf(query) >= 0))
             }
-            render(units)
           }
         }
       })
-    },
-    setFunction (key) {
-      if (!key) {
-        delete this.item.function
-        return
-      }
-      this.$set(this.item, 'functionKey', key)
-      const splitted = key.split('_')
-      let func = {
-        name: splitted[0]
-      }
-      if (splitted.length > 1) {
-        func.params = [splitted[1], splitted[2]]
-      }
-      this.$set(this.item, 'function', func)
+    }
+  },
+  mounted () {
+    if (!this.createMode && this.groupDimension) {
+      this.$set(this, 'oldGroupDimension', this.groupDimension)
+      this.$set(this, 'oldGroupUnit', this.groupUnit)
     }
   },
   beforeDestroy () {
-    if (this.unitAutocomplete) {
-      this.$f7.autocomplete.destroy(this.unitAutocomplete)
+    if (this.groupUnitAutocomplete) {
+      this.$f7.autocomplete.destroy(this.groupUnitAutocomplete)
+      this.$set(this, 'groupUnitAutocomplete', '')
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -30,6 +30,7 @@
         <!-- (Internal) Unit & State Description -->
         <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
         <f7-list-input v-show="itemDimension"
+                       ref="unit"
                        label="Unit"
                        type="text"
                        :info="(createMode) ? 'Type any valid unit or select from one of the proposed (non-exhaustive list of) units. Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -32,7 +32,7 @@
         <f7-list-input v-show="itemDimension"
                        label="Unit"
                        type="text"
-                       :info="(createMode) ? 'Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"
+                       :info="(createMode) ? 'Type any valid unit or select from one of the proposed (non-exhaustive list of) units. Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description.' : ''"
                        :disabled="!editable"
                        :value="item.unit"
                        @input="item.unit = $event.target.value"

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -109,6 +109,7 @@ export default {
     return {
       types,
       unitAutocomplete: null,
+      unitInitialized: !this.createMode,
       categoryInputId: '',
       categoryAutocomplete: null,
       nameErrorMessage: ''
@@ -163,12 +164,17 @@ export default {
       this.unitAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',
+        typeahead: true,
+        dropdownPlaceHolderText: this.getUnitHint(dimension.name),
         source (query, render) {
-          if (!query || !query.length) {
+          if (!query || !query.length || !this.unitInitialized) {
           // Render curated list by default
             render(curatedUnits)
+            this.unitInitialized = true
           } else {
-            render(allUnits.filter(u => u.toLowerCase().indexOf(query.toLowerCase()) >= 0))
+            // Always show currated units on top (don't filter them)
+            let units = [...new Set(curatedUnits.concat(allUnits.filter(u => u.indexOf(query) >= 0)))]
+            render(units)
           }
         }
       })

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -51,10 +51,10 @@
         <group-form ref="groupForm" v-if="itemType === 'Group'" :item="item" :createMode="createMode" />
       </f7-list-group>
       <f7-list-group v-if="!hideCategory">
-        <f7-list-input ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
-                       @input="item.category = $event.target.value" :disabled="!editable" :clear-button="editable">
+        <f7-list-input ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="itemCategory"
+                       @input="itemCategory = $event.target.value" :disabled="!editable" :clear-button="editable">
           <div slot="root-end" style="margin-left: calc(35% + 14px)">
-            <oh-icon :icon="item.category" :state="(createMode) ? null : item.state" height="32" width="32" />
+            <oh-icon :icon="itemCategory" :state="(createMode) ? null : item.state" height="32" width="32" />
           </div>
         </f7-list-input>
       </f7-list-group>
@@ -112,8 +112,8 @@ export default {
       unitAutocomplete: null,
       categoryAutocomplete: null,
       nameErrorMessage: '',
-      oldItemDimension: '',
-      oldItemUnit: ''
+      oldItemDimension: (!this.createMode && this.item.type.split(':').length > 1) ? this.item.type.split(':')[1] : '',
+      oldItemUnit: !this.createMode ? (this.unit || '') : ''
     }
   },
   watch: {
@@ -168,6 +168,9 @@ export default {
         }
         this.$set(this.item, 'unit', newUnit)
       }
+    },
+    itemCategory () {
+      return this.item.category || ''
     }
   },
   methods: {
@@ -263,16 +266,6 @@ export default {
   },
   mounted () {
     if (!this.item) return
-    if (!this.item.category) this.$set(this.item, 'category', '')
-    if (!this.item.groupNames) this.$set(this.item, 'groupNames', [])
-    if (this.createMode) {
-      if (!this.items) this.items = []
-      this.nameErrorMessage = this.validateItemName(this.item.name)
-    }
-    if (!this.createMode && this.itemDimension) {
-      this.oldItemDimension = this.itemDimension
-      this.oldItemUnit = this.itemUnit
-    }
     this.initializeAutocompleteCategory()
     if (this.dimensionsReady) this.initializeAutocompleteUnit()
   },

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -158,7 +158,7 @@ export default {
         this.$f7.autocomplete.destroy(this.unitAutocomplete)
       }
       // item.unit can be set to unitHint from channel type, make sure it is at beginning of list
-      let units = this.getUnitList(dimension.name)
+      let units = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
       const index = units.indexOf(this.item.unit)
       if (index >= 0) {
         units.splice(index, 1)

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -158,18 +158,18 @@ export default {
         this.$f7.autocomplete.destroy(this.unitAutocomplete)
       }
       // item.unit can be set to unitHint from channel type, make sure it is at beginning of list
-      let units = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
-      const index = units.indexOf(this.item.unit)
-      if (index >= 0) {
-        units.splice(index, 1)
-      }
-      units = [this.item.unit].concat(units)
+      let curatedUnits = [...new Set([this.item.unit].concat(this.getUnitList(dimension.name)))]
+      let allUnits = this.getFullUnitList(dimension.name)
       this.unitAutocomplete = this.$f7.autocomplete.create({
         inputEl: inputElement,
         openIn: 'dropdown',
         source (query, render) {
-          // Always render full list
-          render(units)
+          if (!query || !query.length) {
+          // Render curated list by default
+            render(curatedUnits)
+          } else {
+            render(allUnits.filter(u => u.toLowerCase().indexOf(query.toLowerCase()) >= 0))
+          }
         }
       })
     },

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -109,7 +109,6 @@ export default {
     return {
       types,
       unitAutocomplete: null,
-      unitInitialized: !this.createMode,
       categoryInputId: '',
       categoryAutocomplete: null,
       nameErrorMessage: ''
@@ -167,13 +166,16 @@ export default {
         typeahead: true,
         dropdownPlaceHolderText: this.getUnitHint(dimension.name),
         source (query, render) {
-          if (!query || !query.length || !this.unitInitialized) {
+          if (!query || !query.length) {
           // Render curated list by default
             render(curatedUnits)
-            this.unitInitialized = true
           } else {
-            // Always show currated units on top (don't filter them)
-            let units = [...new Set(curatedUnits.concat(allUnits.filter(u => u.indexOf(query) >= 0)))]
+            // First filter on curated list
+            let units = curatedUnits.filter(u => u.indexOf(query) >= 0)
+            if (!units.length) {
+              // If no match filter on full list
+              units = allUnits.filter(u => u.indexOf(query) >= 0)
+            }
             render(units)
           }
         }

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -98,7 +98,7 @@ import uomMixin from '@/components/item/uom-mixin'
 
 export default {
   mixins: [ItemMixin, uomMixin],
-  props: ['item', 'items', 'createMode', 'hideCategory', 'hideType', 'hideSemantics', 'forceSemantics'],
+  props: ['item', 'items', 'createMode', 'hideCategory', 'hideType', 'hideSemantics', 'forceSemantics', 'unitHint'],
   components: {
     SemanticsPicker,
     ItemPicker,
@@ -144,8 +144,10 @@ export default {
       }
       const dimension = this.dimensions.find((d) => d.name === newDimension)
       this.$set(this.item, 'type', 'Number:' + dimension.name)
-      this.$set(this.item, 'unit', dimension.systemUnit)
-      this.$set(this.item, 'stateDescriptionPattern', `%.0f ${dimension.systemUnit}`)
+      if (!this.item.unit) {
+        this.$set(this.item, 'unit', dimension.systemUnit)
+      }
+      this.$set(this.item, 'stateDescriptionPattern', '%.0f %unit%')
     },
     initializeAutocomplete (inputElement) {
       this.categoryAutocomplete = this.$f7.autocomplete.create({

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -20,7 +20,7 @@
         </f7-list-item>
         <!-- Dimensions -->
         <f7-list-item v-if="dimensions.length && !hideType && itemType === 'Number'" title="Dimension" class="aligned-smart-select" :disabled="!editable" :key="'dimension-' + itemDimension" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
-          <select name="select-dimension" @change="setDimension($event.target.value)">
+          <select name="select-dimension" @change="itemDimension = $event.target.value">
             <option key="" value="Number" :selected="itemDimension === ''" />
             <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="d.name === itemDimension">
               {{ d.label }}
@@ -168,16 +168,6 @@ export default {
       }
     }
   },
-  /*
-  watch: {
-    // Required for pre-filling unit and state description pattern fields in "Add Items from Thing" functionality
-    unitsReady () {
-      if (this.createMode && this.item.type && this.item.type.startsWith('Number:')) {
-        this.itemDimension = this.item.type.split(':')[1]
-      }
-    }
-  },
-  */
   methods: {
     dimensionChanged () {
       if (this.$refs.groupForm && this.$refs.groupForm.dimensionChanged()) return true

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -33,8 +33,7 @@
                        ref="unit"
                        label="Unit"
                        type="text"
-                       :info="(createMode) ? 'Type any valid unit for the dimension or select from one of the proposed units. Used internally, for persistence and external systems. \
-                                              It is independent from the state visualization in the UI, which is defined through the state description pattern.' : ''"
+                       :info="(createMode) ? 'Type a valid unit for the dimension or select from the proposed units. Used internally, for persistence and external systems. Is independent from state visualization in the UI, which is defined through the state description pattern.' : ''"
                        :disabled="!editable"
                        :value="itemDimension ? itemUnit : ''"
                        @change="itemUnit = $event.target.value" />

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -168,8 +168,13 @@ export default {
         this.$set(this.item, 'unit', newUnit)
       }
     },
-    itemCategory () {
-      return this.item.category || ''
+    itemCategory: {
+      get () {
+        return this.item.category || ''
+      },
+      set (newCategory) {
+        this.$set(this.item, 'category', newCategory)
+      }
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -44,9 +44,9 @@ export default {
     },
     /**
      * Save an Item, i.e. add a new Item or update an existing Item.
-     * Unit metadata is saved as well for a UoM Item.
+     * If the Item is an UoM Item, unit metadata is saved as well.
      *
-     * If a new Item is created (checks `this.createMode`), and it is an UoM Item, state description (if changed from the default) metadata are saved as well.
+     * If a new Item is created (checks `this.createMode`), and it is an UoM Item, state description (if changed from the default) metadata is also saved.
      *
      * @param item
      * @returns {Promise}

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -62,7 +62,7 @@ export default {
       // TODO: Add support for saving metadata
       return this.$oh.api.put('/rest/items/' + item.name, item).then(() => {
         // Save unit metadata if Item is an UoM Item
-        if (this.createMode && (item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && unit) {
+        if ((item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && unit) {
           const metadata = {
             value: unit,
             config: {}

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -73,7 +73,7 @@ export default {
       }).then(() => {
         // Save state description if Item is an UoM Item and if state description changed from the default value
         if (this.createMode && (item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && stateDescriptionPattern) {
-          if (stateDescriptionPattern !== `%.0f ${unit}`) {
+          if (stateDescriptionPattern !== '%.0f %unit%') {
             const metadata = {
               value: ' ',
               config: {

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -44,8 +44,9 @@ export default {
     },
     /**
      * Save an Item, i.e. add a new Item or update an existing Item.
+     * Unit metadata is saved as well for a UoM Item.
      *
-     * If a new Item is created (checks `this.createMode`), and it is an UoM Item, unit metadata and state description (if changed from the default) metadata are saved as well.
+     * If a new Item is created (checks `this.createMode`), and it is an UoM Item, state description (if changed from the default) metadata are saved as well.
      *
      * @param item
      * @returns {Promise}

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -1,10 +1,14 @@
 export default {
   data () {
     return {
+      measurementSystem: 'SI',
       dimensions: []
     }
   },
   created () {
+    this.$oh.api.get('/').then((root) => {
+      this.measurementSystem = root.measurementSystem
+    }),
     this.$oh.api.get('/rest/systeminfo/uom').then((data) => {
       data.uomInfo.dimensions.forEach((d) => {
         this.dimensions.push({
@@ -14,5 +18,11 @@ export default {
         })
       })
     })
+  },
+  methods: {
+    getUnitHint (channelType) {
+      let units = ((channelType && channelType.unitHint) ? channelType.unitHint : '').split(',')
+      return (this.measurementSystem === 'US' && units.length > 1) ? units[1].trim() : units[0].trim()
+    }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -46,18 +46,31 @@ export default {
       let unitList = []
       const unitCurated = Units.Units.find(u => u.dimension === dimension)
       if (unitCurated) {
-        if (this.measurementSystem === 'SI' && unitCurated.unitsSI) {
-          unitList = unitList.concat(unitCurated.unitsSI)
-        } else if (this.measurementSystem === 'US' && unitCurated.unitsUS) {
-          unitList = unitList.concat(unitCurated.unitsUS)
-        } else {
+        if (unitCurated.units()) {
           unitList = unitList.concat(unitCurated.units)
+        }
+        if (this.measurementSystem === 'SI') {
+          if (unitCurated.unitsSI) {
+            unitList = unitList.concat(unitCurated.unitsSI)
+          }
+          if (unitCurated.unitsUS) {
+            unitList = unitList.concat(unitCurated.unitsUS)
+          }
+        } else if (this.measurementSystem === 'US') {
+          if (unitCurated.unitsUS) {
+            unitList = unitList.concat(unitCurated.unitsUS)
+          }
+          if (unitCurated.unitsSI) {
+            unitList = unitList.concat(unitCurated.unitsSI)
+          }
         }
       }
       const systemUnit = this.dimensions.find(d => d.name === dimension).systemUnit
       if (!unitList.includes(systemUnit)) {
         unitList = [systemUnit].concat(unitList)
       }
+      // remove duplicates
+      unitList = [...new Set(unitList)]
       return unitList
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -27,7 +27,7 @@ export default {
     configuredUnit () {
       if (this.item.unitSymbol) return this.item.unitSymbol
       if (!this.dimensionsReady) return ''
-      return this.item.type === 'Group' ? this.systemUnit(this.groupDimension) : this.systemUnit(this.itemDimension)
+      return this.item.type === 'Group' ? this.getSystemUnit(this.groupDimension) : this.getSystemUnit(this.itemDimension)
     },
     dimension () {
       const parts = this.item.type === 'Group' ? this.item.groupType?.split(':') : this.item.type?.split(':')
@@ -35,7 +35,7 @@ export default {
     }
   },
   methods: {
-    systemUnit (dimension) {
+    getSystemUnit (dimension) {
       return this.dimensions.find(d => d.name === dimension)?.systemUnit
     },
     getUnitHint (dimension, channelType) {
@@ -54,7 +54,7 @@ export default {
         }
       }
       if (!unitHint) {
-        unitHint = this.systemUnit(dimension)
+        unitHint = this.getSystemUnit(dimension)
       }
       return unitHint
     },
@@ -79,7 +79,7 @@ export default {
           unitList = unitList.concat(unitCurated.unitsSI)
         }
       }
-      const systemUnit = this.systemUnit(dimension)
+      const systemUnit = this.getSystemUnit(dimension)
       if (systemUnit && !unitList.includes(systemUnit)) {
         unitList = [systemUnit].concat(unitList)
       }

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -72,6 +72,34 @@ export default {
       // remove duplicates
       unitList = [...new Set(unitList)]
       return unitList
+    },
+    getFullUnitList (dimension) {
+      let unitList = []
+      const unit = Units.Units.find(u => u.dimension === dimension)
+      let units = unit.baseUnits
+      if (units) {
+        unitList = unitList.concat(units)
+      }
+      let metricUnits = unit.baseUnitsMetric?.map(
+        u => Units.prefixesMetric.map(
+          p => unitList.concat(p.concat(u))
+        ).concat())
+      if (metricUnits) {
+        unitList = unitList.concat(metricUnits)
+      }
+      let binaryUnits = unit.baseUnitsBinary?.map(
+        u => Units.prefixesBinary.map(
+          p => unitList.concat(p.concat(u))
+        ).concat())
+      if (binaryUnits) {
+        unitList = unitList.concat(binaryUnits)
+      }
+      // Make sure all curated units are also included, even if missing info in units.js
+      // This avoids having to double define them if they are already all in the curated list
+      unitList = unitList.concat(this.getUnitList(dimension))
+      unitList = [...new Set(unitList)]
+      unitList.sort()
+      return unitList
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -24,7 +24,7 @@ export default {
   methods: {
     getUnitHint (dimension, channelType) {
       const units = ((channelType && channelType.unitHint) ? channelType.unitHint : '').split(',')
-      let unit = (this.measurementSystem === 'US' && units.length > 1) ? units[1].trim() : units[0].trim() 
+      let unit = (this.measurementSystem === 'US' && units.length > 1) ? units[1].trim() : units[0].trim()
       if (!unit) {
         const unitCurated = Units.Units.find(u => u.dimension === dimension)
         if (unitCurated) {
@@ -34,7 +34,7 @@ export default {
             unit = unitCurated.defaultUS
           } else if (unitCurated.default) {
             unit = unitCurated.default
-          }            
+          }
         }
       }
       if (!unit) {

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -45,24 +45,22 @@ export default {
     getUnitList (dimension) {
       let unitList = []
       const unitCurated = Units.Units.find(u => u.dimension === dimension)
-      if (unitCurated) {
-        if (unitCurated.units()) {
-          unitList = unitList.concat(unitCurated.units)
+      if (unitCurated?.units) {
+        unitList = unitList.concat(unitCurated.units)
+      }
+      if (this.measurementSystem === 'SI') {
+        if (unitCurated?.unitsSI) {
+          unitList = unitList.concat(unitCurated.unitsSI)
         }
-        if (this.measurementSystem === 'SI') {
-          if (unitCurated.unitsSI) {
-            unitList = unitList.concat(unitCurated.unitsSI)
-          }
-          if (unitCurated.unitsUS) {
-            unitList = unitList.concat(unitCurated.unitsUS)
-          }
-        } else if (this.measurementSystem === 'US') {
-          if (unitCurated.unitsUS) {
-            unitList = unitList.concat(unitCurated.unitsUS)
-          }
-          if (unitCurated.unitsSI) {
-            unitList = unitList.concat(unitCurated.unitsSI)
-          }
+        if (unitCurated?.unitsUS) {
+          unitList = unitList.concat(unitCurated.unitsUS)
+        }
+      } else if (this.measurementSystem === 'US') {
+        if (unitCurated?.unitsUS) {
+          unitList = unitList.concat(unitCurated.unitsUS)
+        }
+        if (unitCurated?.unitsSI) {
+          unitList = unitList.concat(unitCurated.unitsSI)
         }
       }
       const systemUnit = this.dimensions.find(d => d.name === dimension).systemUnit
@@ -76,29 +74,28 @@ export default {
     getFullUnitList (dimension) {
       let unitList = []
       const unit = Units.Units.find(u => u.dimension === dimension)
-      let units = unit.baseUnits
+      let units = unit?.baseUnits
       if (units) {
         unitList = unitList.concat(units)
       }
-      let metricUnits = unit.baseUnitsMetric?.map(
+      let metricUnits = unit?.baseUnitsMetric?.flatMap(
         u => Units.prefixesMetric.map(
-          p => unitList.concat(p.concat(u))
-        ).concat())
+          p => p.concat(u)
+        ))
       if (metricUnits) {
         unitList = unitList.concat(metricUnits)
       }
-      let binaryUnits = unit.baseUnitsBinary?.map(
+      let binaryUnits = unit?.baseUnitsBinary?.flatMap(
         u => Units.prefixesBinary.map(
-          p => unitList.concat(p.concat(u))
-        ).concat())
+          p => p.concat(u)
+        ))
       if (binaryUnits) {
         unitList = unitList.concat(binaryUnits)
       }
-      // Make sure all curated units are also included, even if missing info in units.js
+      // Make sure all curated units are also included at top, even if missing info in units.js
       // This avoids having to double define them if they are already all in the curated list
       unitList = unitList.concat(this.getUnitList(dimension))
       unitList = [...new Set(unitList)]
-      unitList.sort()
       return unitList
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -8,7 +8,7 @@ export default {
   created () {
     this.$oh.api.get('/').then((root) => {
       this.measurementSystem = root.measurementSystem
-    }),
+    })
     this.$oh.api.get('/rest/systeminfo/uom').then((data) => {
       data.uomInfo.dimensions.forEach((d) => {
         this.dimensions.push({

--- a/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/uom-mixin.js
@@ -20,11 +20,22 @@ export default {
     }).then(this.dimensionsReady = true)
   },
   computed: {
+    /**
+     * The unit shown in the UI when configuring the Item.
+     * It is pre-filled with the unit hint if in `createMode`, or else the {@link configuredUnit}.
+     * @returns {string}
+     */
     unit () {
+      if (!this.item) return ''
       if (!this.dimensionsReady) return ''
       return this.item.unit ? this.item.unit : (this.createMode ? this.getUnitHint(this.dimension) : this.configuredUnit)
     },
+    /**
+     * The unit currently configured and used by the openHAB server.
+     * @returns {string}
+     */
     configuredUnit () {
+      if (!this.item) return ''
       if (this.item.unitSymbol) return this.item.unitSymbol
       if (!this.dimensionsReady) return ''
       return this.item.type === 'Group' ? this.getSystemUnit(this.groupDimension) : this.getSystemUnit(this.itemDimension)
@@ -58,6 +69,11 @@ export default {
       }
       return unitHint
     },
+    /**
+     * Get the list of curated units for the given dimension.
+     * @param dimension
+     * @returns {string[]}
+     */
     getUnitList (dimension) {
       let unitList = []
       const unitCurated = Units.find(u => u.dimension === dimension)
@@ -87,6 +103,11 @@ export default {
       unitList = [...new Set(unitList)]
       return unitList
     },
+    /**
+     * Get the full list of units for the given dimensions, i.e. the curated units plus all base units with all prefixes.
+     * @param dimension
+     * @returns {string[]}
+     */
     getFullUnitList (dimension) {
       let unitList = []
       const unit = Units.find(u => u.dimension === dimension)

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -207,7 +207,7 @@ export default {
     },
     channelUnit (channel, channelType) {
       const dimension = channel.itemType.startsWith('Number:') ? channel.itemType.split(':')[1] : ''
-      return dimension ? this.getUnitHint(dimension.name, channelType) : ''
+      return dimension ? this.getUnitHint(dimension, channelType) : ''
     },
     toggleAllChecks (checked) {
       this.thing.channels.forEach((c) => {

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -47,8 +47,8 @@
                               :thing="thing" :channelId="channelId" :channelType="channelType" :channel="channel" :extensible="extensible" :context="context"
                               @channel-updated="(e) => $emit('channels-updated', e)" />
               </template>
-              <template #default="{ channel }" v-else-if="multipleLinksMode">
-                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :items="items" :createMode="true" :channel="channel" :checked="isChecked(channel)" />
+              <template #default="{ channelType, channel }" v-else-if="multipleLinksMode">
+                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :items="items" :createMode="true" :channel="channel" :checked="isChecked(channel)" :unitHint="unit(channel, channelType)" />
               </template>
               <!-- <channel-link #default="{ channelId }" /> -->
             </channel-group>
@@ -192,7 +192,6 @@ export default {
         }
         newItemName += this.$oh.utils.normalizeLabel(suffix)
         const defaultTags = (channel.defaultTags.length > 0) ? channel.defaultTags : channelType.tags
-        const unit = this.getUnitHint(channelType)
         const newItem = {
           channel: channel,
           channelType: channelType,
@@ -200,11 +199,15 @@ export default {
           label: channel.label || channelType.label,
           category: (channelType) ? channelType.category : '',
           type: channel.itemType,
-          unit: unit,
+          unit: this.unit(channel, channelType),
           tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
         }
         this.newItems.push(newItem)
       }
+    },
+    unit (channel, channelType) {
+      const dimension = channel.itemType.startsWith('Number:') ? this.dimensions.find(d => d.name === channel.itemType.split(':')[1]) : ''
+      return dimension ? this.getUnitHint(dimension.name, channelType) : ''
     },
     toggleAllChecks (checked) {
       this.thing.channels.forEach((c) => {

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -48,7 +48,7 @@
                               @channel-updated="(e) => $emit('channels-updated', e)" />
               </template>
               <template #default="{ channelType, channel }" v-else-if="multipleLinksMode">
-                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :items="items" :createMode="true" :channel="channel" :checked="isChecked(channel)" :unitHint="unit(channel, channelType)" />
+                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :items="items" :createMode="true" :channel="channel" :checked="isChecked(channel)" :unitHint="getUnitHint(channel, channelType)" />
               </template>
               <!-- <channel-link #default="{ channelId }" /> -->
             </channel-group>
@@ -199,13 +199,13 @@ export default {
           label: channel.label || channelType.label,
           category: (channelType) ? channelType.category : '',
           type: channel.itemType,
-          unit: this.unit(channel, channelType),
+          unit: this.channelUnit(channel, channelType),
           tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
         }
         this.newItems.push(newItem)
       }
     },
-    unit (channel, channelType) {
+    channelUnit (channel, channelType) {
       const dimension = channel.itemType.startsWith('Number:') ? this.dimensions.find(d => d.name === channel.itemType.split(':')[1]) : ''
       return dimension ? this.getUnitHint(dimension.name, channelType) : ''
     },

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -93,7 +93,10 @@ import ChannelGroup from './channel-group.vue'
 import ChannelLink from './channel-link.vue'
 import ItemForm from '@/components/item/item-form.vue'
 
+import uomMixin from '@/components/item/uom-mixin'
+
 export default {
+  mixins: [uomMixin],
   props: ['thingType', 'thing', 'channelTypes', 'items', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems', 'context'],
   components: {
     ChannelGroup,
@@ -189,6 +192,7 @@ export default {
         }
         newItemName += this.$oh.utils.normalizeLabel(suffix)
         const defaultTags = (channel.defaultTags.length > 0) ? channel.defaultTags : channelType.tags
+        const unit = this.getUnitHint(channelType);
         const newItem = {
           channel: channel,
           channelType: channelType,
@@ -196,6 +200,7 @@ export default {
           label: channel.label || channelType.label,
           category: (channelType) ? channelType.category : '',
           type: channel.itemType,
+          unit: unit,
           tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
         }
         this.newItems.push(newItem)

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -192,7 +192,7 @@ export default {
         }
         newItemName += this.$oh.utils.normalizeLabel(suffix)
         const defaultTags = (channel.defaultTags.length > 0) ? channel.defaultTags : channelType.tags
-        const unit = this.getUnitHint(channelType);
+        const unit = this.getUnitHint(channelType)
         const newItem = {
           channel: channel,
           channelType: channelType,

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -206,7 +206,7 @@ export default {
       }
     },
     channelUnit (channel, channelType) {
-      const dimension = channel.itemType.startsWith('Number:') ? this.dimensions.find(d => d.name === channel.itemType.split(':')[1]) : ''
+      const dimension = channel.itemType.startsWith('Number:') ? channel.itemType.split(':')[1] : ''
       return dimension ? this.getUnitHint(dimension.name, channelType) : ''
     },
     toggleAllChecks (checked) {

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -20,6 +20,7 @@ const store = new Vuex.Store({
   },
   state: {
     apiVersion: null,
+    measurementSystem: null,
     apiEndpoints: null,
     locale: null,
     runtimeInfo: null,
@@ -34,6 +35,7 @@ const store = new Vuex.Store({
   mutations: {
     setRootResource (state, { rootResponse }) {
       state.apiVersion = rootResponse.version
+      state.measurementSystem = rootResponse.measurementSystem
       state.runtimeInfo = rootResponse.runtimeInfo
       state.apiEndpoints = rootResponse.links
       state.websiteUrl = `https://${rootResponse.runtimeInfo?.buildString !== 'Release Build' ? 'next' : 'www'}.openhab.org`

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -27,7 +27,7 @@
             </div>
           </f7-col>
           <f7-col>
-            <item-form :item="item" :items="items" :createMode="createMode" />
+            <item-form ref="itemForm" :item="item" :items="items" :createMode="createMode" />
           </f7-col>
 
           <div class="flex-shrink-0 if-aurora display-flex justify-content-center">
@@ -179,6 +179,25 @@ export default {
       if (this.validateItemName(this.item.name) !== '') return this.$f7.dialog.alert('Please give the Item a valid name: ' + this.validateItemName(this.item.name)).open()
       if (!this.item.type || !this.types.ItemTypes.includes(this.item.type.split(':')[0])) return this.$f7.dialog.alert('Please give Item a valid type').open()
 
+      const dimensionChange = this.$refs.itemForm.dimensionChanged()
+      const unitChange = this.$refs.itemForm.unitChanged()
+      if (dimensionChange || unitChange) {
+        const title = 'WARNING: ' + (dimensionChange ? 'Dimension' : 'Unit') + ' Changed'
+        const text = dimensionChange ? 'Existing links to channels with dimension may no longer be valid!' : 'Changing the internal unit can corrupt your persisted data!'
+        return this.$f7.dialog.create({
+          title: title,
+          text: text,
+          buttons: [
+            { text: 'Cancel', color: 'gray', close: true, onClick: () => this.$refs.itemForm.revertDimensionChange() },
+            { text: 'Save Anyway', color: 'red', close: true, onClick: () => this.saveConfirmed() }
+          ],
+          destroyOnClose: true
+        }).open()
+      } else {
+        this.saveConfirmed()
+      }
+    },
+    saveConfirmed () {
       this.saveItem(this.item).then(() => {
         if (this.createMode) {
           this.$f7.toast.create({

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -183,21 +183,21 @@ export default {
       const unitChange = this.$refs.itemForm.unitChanged()
       if (dimensionChange || unitChange) {
         const title = 'WARNING: ' + (dimensionChange ? 'Dimension' : 'Unit') + ' Changed'
-        const text = dimensionChange ? 'Existing links to channels with dimension may no longer be valid!' : 'Changing the internal unit can corrupt your persisted data!'
+        const text = dimensionChange ? 'Existing links to channels with dimension may no longer be valid!' : 'Changing the internal unit can corrupt your persisted data and affect rules!'
         return this.$f7.dialog.create({
           title: title,
           text: text,
           buttons: [
             { text: 'Cancel', color: 'gray', close: true, onClick: () => this.$refs.itemForm.revertDimensionChange() },
-            { text: 'Save Anyway', color: 'red', close: true, onClick: () => this.saveConfirmed() }
+            { text: 'Save Anyway', color: 'red', close: true, onClick: () => this.doSave() }
           ],
           destroyOnClose: true
         }).open()
       } else {
-        this.saveConfirmed()
+        this.doSave()
       }
     },
-    saveConfirmed () {
+    doSave () {
       this.saveItem(this.item).then(() => {
         if (this.createMode) {
           this.$f7.toast.create({

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -204,7 +204,7 @@ export default {
       })
     },
     linkUnit () {
-      const dimension = this.channel.itemType.startsWith('Number:') ? this.dimensions.find(d => d.name === this.channel.itemType.split(':')[1]) : ''
+      const dimension = this.channel.itemType.startsWith('Number:') ? this.channel.itemType.split(':')[1] : ''
       return dimension ? this.getUnitHint(dimension.name, this.channelType) : ''
     },
     loadProfileTypes (channel) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -205,7 +205,7 @@ export default {
     },
     linkUnit () {
       const dimension = this.channel.itemType.startsWith('Number:') ? this.channel.itemType.split(':')[1] : ''
-      return dimension ? this.getUnitHint(dimension.name, this.channelType) : ''
+      return dimension ? this.getUnitHint(dimension, this.channelType) : ''
     },
     loadProfileTypes (channel) {
       this.ready = false

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -153,6 +153,7 @@ export default {
         channelUID: null,
         configuration: {}
       },
+      measurementSystem: 'SI',
       selectedItemName: null,
       selectedThingId: '',
       selectedThing: {},
@@ -172,6 +173,9 @@ export default {
       this.$oh.api.get('/rest/items').then((items) => {
         this.items = items
       })
+      this.$oh.api.get('/').then((root) => {
+        this.measurementSystem = root.measurementSystem
+      })
     }
   },
   computed: {
@@ -181,6 +185,10 @@ export default {
     compatibleProfileTypes () {
       let currentItemType = this.currentItem && this.currentItem.type ? this.currentItem.type : ''
       return this.profileTypes.filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
+    },
+    unit () {
+      let units = (this.channelType ? this.channelType.unitHint : '').split(',')
+      return (this.measurementSystem === 'US' && units.length > 1) ? units[1].trim() : units[0].trim
     }
   },
   methods: {
@@ -197,6 +205,7 @@ export default {
         category: (this.channelType) ? this.channelType.category : '',
         groupNames: [],
         type: this.channel.itemType || 'Switch',
+        unit: this.unit,
         tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -43,7 +43,7 @@
 
         <!-- Create new item -->
         <f7-col v-else>
-          <item-form :item="newItem" :items="items" :createMode="true" />
+          <item-form :item="newItem" :items="items" :createMode="true" :unitHint="unit()" />
         </f7-col>
       </template>
 
@@ -193,16 +193,19 @@ export default {
       newItemName += '_'
       newItemName += this.$oh.utils.normalizeLabel(this.channel.label || this.channelType.label)
       const defaultTags = (this.channel.defaultTags.length > 0) ? this.channel.defaultTags : this.channelType.tags
-      const unit = this.getUnitHint(this.channelType)
       this.$set(this, 'newItem', {
         name: newItemName,
         label: this.channel.label || this.channelType.label,
         category: (this.channelType) ? this.channelType.category : '',
         groupNames: [],
         type: this.channel.itemType || 'Switch',
-        unit: unit,
+        unit: this.unit(),
         tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
       })
+    },
+    unit () {
+      const dimension = this.channel.itemType.startsWith('Number:') ? this.dimensions.find(d => d.name === this.channel.itemType.split(':')[1]) : ''
+      return dimension ? this.getUnitHint(dimension.name, this.channelType) : ''
     },
     loadProfileTypes (channel) {
       this.ready = false

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -132,8 +132,10 @@ import Item from '@/components/item/item.vue'
 import * as Types from '@/assets/item-types.js'
 import ItemMixin from '@/components/item/item-mixin'
 
+import uomMixin from '@/components/item/uom-mixin'
+
 export default {
-  mixins: [ItemMixin],
+  mixins: [ItemMixin, uomMixin],
   components: {
     ConfigSheet,
     ItemPicker,
@@ -153,7 +155,6 @@ export default {
         channelUID: null,
         configuration: {}
       },
-      measurementSystem: 'SI',
       selectedItemName: null,
       selectedThingId: '',
       selectedThing: {},
@@ -173,9 +174,6 @@ export default {
       this.$oh.api.get('/rest/items').then((items) => {
         this.items = items
       })
-      this.$oh.api.get('/').then((root) => {
-        this.measurementSystem = root.measurementSystem
-      })
     }
   },
   computed: {
@@ -186,10 +184,6 @@ export default {
       let currentItemType = this.currentItem && this.currentItem.type ? this.currentItem.type : ''
       return this.profileTypes.filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
     },
-    unit () {
-      let units = (this.channelType ? this.channelType.unitHint : '').split(',')
-      return (this.measurementSystem === 'US' && units.length > 1) ? units[1].trim() : units[0].trim
-    }
   },
   methods: {
     onPageAfterIn (event) {
@@ -199,13 +193,14 @@ export default {
       newItemName += '_'
       newItemName += this.$oh.utils.normalizeLabel(this.channel.label || this.channelType.label)
       const defaultTags = (this.channel.defaultTags.length > 0) ? this.channel.defaultTags : this.channelType.tags
+      const unit = this.getUnitHint(this.channelType)
       this.$set(this, 'newItem', {
         name: newItemName,
         label: this.channel.label || this.channelType.label,
         category: (this.channelType) ? this.channelType.category : '',
         groupNames: [],
         type: this.channel.itemType || 'Switch',
-        unit: this.unit,
+        unit: unit,
         tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -43,7 +43,7 @@
 
         <!-- Create new item -->
         <f7-col v-else>
-          <item-form :item="newItem" :items="items" :createMode="true" :unitHint="unit()" />
+          <item-form ref="itemForm" :item="newItem" :items="items" :createMode="true" :unitHint="linkUnit()" />
         </f7-col>
       </template>
 
@@ -199,11 +199,11 @@ export default {
         category: (this.channelType) ? this.channelType.category : '',
         groupNames: [],
         type: this.channel.itemType || 'Switch',
-        unit: this.unit(),
+        unit: this.linkUnit(),
         tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
       })
     },
-    unit () {
+    linkUnit () {
       const dimension = this.channel.itemType.startsWith('Number:') ? this.dimensions.find(d => d.name === this.channel.itemType.split(':')[1]) : ''
       return dimension ? this.getUnitHint(dimension.name, this.channelType) : ''
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -183,7 +183,7 @@ export default {
     compatibleProfileTypes () {
       let currentItemType = this.currentItem && this.currentItem.type ? this.currentItem.type : ''
       return this.profileTypes.filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
-    },
+    }
   },
   methods: {
     onPageAfterIn (event) {


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-core/issues/4082

This PR adds:

1. A curated list of units to show as a drop-down list when creating a Number item with dimension.
2. The possibility to use a different default unit on item creation than the system default unit.
3. The ability to change unit and state description for items.

By default, the system default unit (for the configured measurement system) will be shown when editing or creating an item. [`units.js`](https://github.com/openhab/openhab-webui/blob/7256bc1a3c38d38f16279d7c763d64556ca6e973/bundles/org.openhab.ui/web/src/assets/units.js) contains a number of frequently used units by dimension and measurement system. These will be available in a autosuggest dropdown list. It is still possible to not select from the list and use any other string as a unit. [`units.js`](https://github.com/openhab/openhab-webui/blob/7256bc1a3c38d38f16279d7c763d64556ca6e973/bundles/org.openhab.ui/web/src/assets/units.js) now only contains a relatively small list, but can easily be extended with other frequently used units.
All units for the dimension in `units.js` will be in the dropdown list, but they will be sorted by measurement system. If the measurement system is set to US, imperial units will appear higher in the list. Units that have not explicitely been listed as SI or US will always appear higher.
When typing a unit that is not in the curated list, a longer list will be used for autocompletion that considers allowed prefixes to base units and constructs all combinations.

[`units.js`](https://github.com/openhab/openhab-webui/blob/7256bc1a3c38d38f16279d7c763d64556ca6e973/bundles/org.openhab.ui/web/src/assets/units.js) also contains a field to set a different default unit on item creation than the system default unit.

With https://github.com/openhab/openhab-core/pull/4079, the REST API of channel types would provide a unit hint if defined in the binding channel types.

If such information is available, this PR adds support for this in the UI. When creating an item from a thing channel, it will suggest to use the unit from the unit hint if available. If not available, it will suggest the webui defined default from `units.js`, if not available, the system default unit for the dimension.

For dimensions with different units in SI or US measurement systems, it is possible to provide 2 units separated by comma in binding channel types. The first one will be SI, the second US. The suggested one will depend on the measurement system setting.

See also:

- https://github.com/openhab/openhab-core/issues/4082
- https://github.com/openhab/openhab-core/issues/4077
- https://github.com/openhab/openhab-core/issues/3854
- https://github.com/openhab/openhab-core/pull/4079
- https://github.com/openhab/openhab-core/pull/4078