### PR TITLE
Config sheet: Show advanced params if not default or not empty

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -111,8 +111,8 @@ export default {
       // exclude advanced parameters, if:
       // - a default value is defined and the actual value differs from the default value
       // - no default value is defined and the param has a value
-      return finalParameters.filter((p) => !p.advanced
-        || (p.default !== undefined && this.configuration[p.name] !== undefined ? this.configuration[p.name].toString() !== p.default : this.configuration[p.name] !== undefined))
+      return finalParameters.filter((p) => !p.advanced ||
+        (p.default !== undefined && this.configuration[p.name] !== undefined ? this.configuration[p.name].toString() !== p.default : this.configuration[p.name] !== undefined))
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -107,7 +107,12 @@ export default {
           finalParameters = [...finalParameters, ...actionParams(g.name, prefix)]
         })
       }
-      return (this.showAdvanced) ? finalParameters : finalParameters.filter((p) => !p.advanced)
+      if (this.showAdvanced) return finalParameters // show all parameters
+      // exclude advanced parameters, if:
+      // - a default value is defined and the actual value differs from the default value
+      // - no default value is defined and the param has a value
+      return finalParameters.filter((p) => !p.advanced
+        || (p.default !== undefined && this.configuration[p.name] !== undefined ? this.configuration[p.name].toString() !== p.default : this.configuration[p.name] !== undefined))
     }
   },
   methods: {


### PR DESCRIPTION
Advanced parameters should be shown to the user if they have:

- a default value defined and the value is not the default value
- no default value defined and they have a value set

This is more transparent to the user and improves the UX, because the user does not need to enable "show advanced" just to check whether he has set up advanced parameters.