### PR TITLE
[blockly] Fix warning when show code button is clicked twice

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -415,6 +415,8 @@ export default {
       this.$refs.blocklyEditor.showHideLabels(this.blocklyShowLabels)
     },
     showBlocklyCode () {
+      if (this.blocklyCodePreview) return
+
       try {
         this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
         this.script = this.$refs.blocklyEditor.getCode()


### PR DESCRIPTION
Avoid this warning popup when clicking the show code button when already in show code mode.

<img width="375" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/3aae3f76-0b14-44b1-8456-be2de896d9fc">
