### PR TITLE
Fix fields should be editable for a new script

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -56,7 +56,7 @@ export default {
       return this.rule.tags.filter((t) => !this.isScriptTag(t) && !this.isSceneTag(t)).length
     },
     editable () {
-      return this.rule && this.rule.editable
+      return this.createMode || (this.rule && this.rule.editable)
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
@@ -1,11 +1,11 @@
 <template>
   <div>
-    <rule-general-settings v-if="createMode || isScriptRule" :ready="true" :rule="rule" :createMode="createMode" :isEditable="true" :inScriptEditor="true" />
+    <rule-general-settings v-if="createMode || isScriptRule" :ready="true" :rule="rule" :createMode="createMode" :inScriptEditor="true" />
     <f7-block class="block-narrow">
       <f7-col v-if="!createMode && languages">
         <f7-block-title>Scripting Language</f7-block-title>
         <f7-list media-list>
-          <f7-list-item media-item radio radio-icon="start" :disabled="true"
+          <f7-list-item media-item radio radio-icon="start" :disabled="!editable"
                         :value="mode" :checked="mode === language.contentType" @change="$emit('newLanguage', language.contentType)"
                         v-for="language in languages" :key="language.contentType"
                         :title="language.name" :after="language.version" :footer="language.contentType" />
@@ -26,7 +26,7 @@ export default {
   },
   computed: {
     editable () {
-      return this.rule && this.rule.editable
+      return this.createMode || (this.rule && this.rule.editable)
     }
   }
 }


### PR DESCRIPTION
Regression from #2276 which caused a new rule unable to be created because the rule name/description couldn't be entered (fields are disabled)