### PR TITLE
Disable Item editor fields for unmanaged items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="item-picker-container">
-    <f7-list-item :title="title" smart-select :smart-select-params="smartSelectParams" v-if="ready" ref="smartSelect" class="item-picker">
+    <f7-list-item :title="title" :disabled="disabled" smart-select :smart-select-params="smartSelectParams" v-if="ready" ref="smartSelect" class="item-picker">
       <select :name="name" :multiple="multiple" @change="select" :required="required">
         <option value="" v-if="!multiple" />
         <option v-for="item in preparedItems" :value="item.name" :key="item.name" :selected="(multiple) ? Array.isArray(value) && value.indexOf(item.name) >= 0 : value === item.name">
@@ -10,7 +10,7 @@
       <f7-button slot="media" icon-f7="list_bullet_indent" @click.native="pickFromModel" />
     </f7-list-item>
     <!-- for placeholder purposes before items are loaded -->
-    <f7-list-item link v-show="!ready" :title="title">
+    <f7-list-item link v-show="!ready" :title="title" :disabled="disabled">
       <f7-button slot="media" icon-f7="list_bullet_indent" @click.native="pickFromModel" />
     </f7-list-item>
   </ul>
@@ -30,7 +30,7 @@
 import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 
 export default {
-  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly'],
+  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly', 'disabled'],
   data () {
     return {
       ready: false,

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,14 +1,14 @@
 <template>
   <div v-if="item" class="group-form no-padding">
     <f7-list inline-labels no-hairlines-md>
-      <f7-list-item v-if="item.type === 'Group'" title="Members Base Type" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-basetype" @change="setGroupType($event.target.value)">
           <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
             {{ type }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
@@ -16,41 +16,41 @@
           </option>
         </select>
       </f7-list-item>
-      <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
+      <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" :disabled="!editable" label="Unit" type="text" :value="item.unit"
                      info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
                      @input="item.unit = $event.target.value" clear-button />
-      <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
+      <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" :disabled="!editable" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value."
                      @input="item.stateDescriptionPattern = $event.target.value" clear-button />
-      <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
+      <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.ArithmeticFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-logicalopenclosed" v-else-if="item.type === 'Group' && item.groupType && ['Contact'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-logicalopenclosed" v-else-if="item.type === 'Group' && item.groupType && ['Contact'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.LogicalOpenClosedFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-logicalplaypause" v-else-if="item.type === 'Group' && item.groupType && ['Player'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-logicalplaypause" v-else-if="item.type === 'Group' && item.groupType && ['Player'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.LogicalPlayPauseFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-datetime" v-else-if="item.type === 'Group' && item.groupType && ['DateTime'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-datetime" v-else-if="item.type === 'Group' && item.groupType && ['DateTime'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.DateTimeFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-logicalonoff" v-else-if="item.type === 'Group' && item.groupType && ['Switch', 'None'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-logicalonoff" v-else-if="item.type === 'Group' && item.groupType && ['Switch', 'None'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.LogicalOnOffFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
@@ -72,6 +72,11 @@ export default {
   data () {
     return {
       types
+    }
+  },
+  computed: {
+    editable () {
+      return this.createMode || (this.item && this.item.editable)
     }
   },
   beforeMount () {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -6,15 +6,15 @@
                      required :error-message="nameErrorMessage" :error-message-force="!!nameErrorMessage"
                      @input="onNameInput" :clear-button="createMode" />
       <f7-list-input label="Label" type="text" placeholder="Label" :value="item.label"
-                     @input="item.label = $event.target.value" clear-button />
-      <f7-list-item v-if="item.type && !hideType" title="Type" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+                     @input="item.label = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true" />
+      <f7-list-item v-if="item.type && !hideType" title="Type" type="text" :disabled="item.editable !== true" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-type" @change="item.type = $event.target.value">
           <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === item.type.split(':')[0]">
             {{ t }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" :disabled="item.editable !== true" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.type">
@@ -25,12 +25,12 @@
       <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
                      info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
-                     @input="item.unit = $event.target.value" clear-button />
+                     @input="item.unit = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true" />
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value."
-                     @input="item.stateDescriptionPattern = $event.target.value" clear-button />
+                     @input="item.stateDescriptionPattern = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true" />
       <f7-list-input v-if="!hideCategory" ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
-                     @input="item.category = $event.target.value" clear-button>
+                     @input="item.category = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true">
         <div slot="root-end" style="margin-left: calc(35% + 8px)">
           <oh-icon :icon="item.category" :state="(createMode) ? null : item.state" height="32" width="32" />
         </div>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -6,15 +6,15 @@
                      required :error-message="nameErrorMessage" :error-message-force="!!nameErrorMessage"
                      @input="onNameInput" :clear-button="createMode" />
       <f7-list-input label="Label" type="text" placeholder="Label" :value="item.label"
-                     @input="item.label = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true" />
-      <f7-list-item v-if="item.type && !hideType" title="Type" type="text" :disabled="item.editable !== true" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+                     @input="item.label = $event.target.value" :disabled="!editable" :clear-button="editable" />
+      <f7-list-item v-if="item.type && !hideType" title="Type" type="text" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-type" @change="item.type = $event.target.value">
           <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === item.type.split(':')[0]">
             {{ t }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" :disabled="item.editable !== true" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.type">
@@ -25,12 +25,12 @@
       <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
                      info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
-                     @input="item.unit = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true" />
+                     @input="item.unit = $event.target.value" :disabled="!editable" :clear-button="editable" />
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value."
-                     @input="item.stateDescriptionPattern = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true" />
+                     @input="item.stateDescriptionPattern = $event.target.value" :disabled="!editable" :clear-button="editable" />
       <f7-list-input v-if="!hideCategory" ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
-                     @input="item.category = $event.target.value" :disabled="item.editable !== true" :clear-button="item.editable === true">
+                     @input="item.category = $event.target.value" :disabled="!editable" :clear-button="editable">
         <div slot="root-end" style="margin-left: calc(35% + 8px)">
           <oh-icon :icon="item.category" :state="(createMode) ? null : item.state" height="32" width="32" />
         </div>
@@ -40,7 +40,7 @@
     <f7-list inline-labels accordion-list no-hairline-md>
       <f7-list-item accordion-item title="Non-Semantic Tags" :after="numberOfTags">
         <f7-accordion-content>
-          <tag-input :item="item" />
+          <tag-input :disabled="!editable" :item="item" />
         </f7-accordion-content>
       </f7-list-item>
     </f7-list>
@@ -80,6 +80,9 @@ export default {
     }
   },
   computed: {
+    editable () {
+      return this.createMode || (this.item && this.item.editable)
+    },
     numberOfTags () {
       return this.getNonSemanticTags(this.item).length
     }

--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-list no-hairlines-md v-if="show">
-    <f7-list-item title="Semantic Class" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+    <f7-list-item :disabled="!editable" title="Semantic Class" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
       <select name="select-semantics-class" @change="update('class', $event.target.value)">
         <option v-if="!hideNone" :value="''">
           None
@@ -22,8 +22,8 @@
         </optgroup>
       </select>
     </f7-list-item>
-    <f7-list-item v-if="currentSemanticType && !hideType" title="Semantic Type" :after="currentSemanticType" />
-    <f7-list-item v-if="currentSemanticType == 'Point'" title="Semantic Property" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+    <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" :after="currentSemanticType" />
+    <f7-list-item v-if="currentSemanticType == 'Point'" :disabled="!editable" title="Semantic Property" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
       <select name="select-semantics-proerty" :value="semanticProperty" @change="update('property', $event.target.value)">
         <option :value="''">
           None
@@ -105,6 +105,9 @@ export default {
     }
   },
   computed: {
+    editable () {
+      return this.item && this.item.editable
+    },
     orderedLocations () {
       return [...this.semanticClasses.Locations].sort((a, b) => {
         return a.localeCompare(b)

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -2,8 +2,11 @@
   <f7-page class="item-details-page" @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar :title="item.name" back-link="Back" no-shadow no-hairline class="item-details-navbar">
       <f7-nav-right>
-        <f7-link icon-md="material:edit" href="edit">
+        <f7-link v-if="item.editable" icon-md="material:edit" href="edit">
           {{ $theme.md ? '' : 'Edit' }}
+        </f7-link>
+        <f7-link v-else slot="right" icon-f7="lock_fill" tooltip="This item is not editable through the UI" href="edit">
+          Details
         </f7-link>
       </f7-nav-right>
       <f7-subnavbar sliding class="item-header">

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -5,7 +5,7 @@
         <f7-link v-if="item.editable" icon-md="material:edit" href="edit">
           {{ $theme.md ? '' : 'Edit' }}
         </f7-link>
-        <f7-link v-else slot="right" icon-f7="lock_fill" tooltip="This item is not editable through the UI" href="edit">
+        <f7-link v-else icon-f7="lock_fill" tooltip="This item is not editable through the UI" href="edit">
           Details
         </f7-link>
       </f7-nav-right>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -7,6 +7,7 @@
           Save<span v-if="$device.desktop">&nbsp;(Ctrl-S)</span>
         </f7-link>
       </f7-nav-right>
+      <f7-link v-else slot="right" icon-f7="lock_fill" icon-only tooltip="This item is not editable through the UI" />
     </f7-navbar>
     <f7-toolbar tabbar position="top">
       <f7-link @click="switchTab('design', fromYaml)" :tab-link-active="currentTab === 'design'" class="tab-link">
@@ -42,7 +43,7 @@
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
         <f7-icon v-if="item.editable === false" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" :tooltip="notEditableMgs" />
-        <editor class="item-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :read-only="item.editable === false" />
+        <editor class="item-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :readOnly="item.editable === false" />
       </f7-tab>
     </f7-tabs>
 
@@ -102,6 +103,11 @@ export default {
       pendingTag: '',
       currentTab: 'design',
       notEditableMgs: 'This Item is not editable because it has been provisioned from a file.'
+    }
+  },
+  computed: {
+    editable () {
+      return this.createMode || this.item.editable
     }
   },
   watch: {


### PR DESCRIPTION
Currently the UI would allow editing an uneditable item, despite giving errors when trying to save it. This PR marks the relevant fields as read-only or disabled, preventing them from being edited in the first place.