### PR TITLE
Item edit: Fix semantic class cleared when property set to None

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -64,8 +64,7 @@ export default {
         this.semanticClass = value
       }
       this.item.tags = this.item.tags.filter((t) => !this.semanticType(t) && !this.isSemanticPropertyTag(t))
-      if (!value) return
-      this.item.tags.push(this.semanticClass)
+      if (this.semanticClass) this.item.tags.push(this.semanticClass)
       if (this.semanticType(this.semanticClass) === 'Point' && this.semanticProperty.length) {
         this.item.tags.push(this.semanticProperty)
       }


### PR DESCRIPTION
On the Item Editor:

Current behaviour, when we have:
Semantic Class: Control
Property: Light

When changing Property to None, it would clear Semantic Class "Control" too.

The Fix is not to clear the Semantic Class.