### PR TITLE
Improve item form layout

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -123,11 +123,11 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
         const type = thisBlock.getFieldValue('type')
         switch (type) {
           case 'MAP':
-            return 'transforms an input via a map file. Specify the file as the function.\nREGEX und JSONPATH are also valid.'
+            return 'transforms an input via a map file. Specify the file as the function.\nREGEX and JSONPATH are also valid.'
           case 'REGEX':
-            return 'transforms / filters an input by applying the provided regular expression.\nMAP und JSONPATH are also valid.'
+            return 'transforms / filters an input by applying the provided regular expression.\nMAP and JSONPATH are also valid.'
           case 'JSONPATH':
-            return 'transforms / filters an JSON input by executing the provided JSONPath query.\nMAP und REGEX are also valid.'
+            return 'transforms / filters a JSON input by executing the provided JSONPath query.\nMAP and REGEX are also valid.'
           default:
             return 'transforms the input with the ' + type + ' transformation.'
         }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="item-picker-container">
-    <f7-list-item :title="title" smart-select :smart-select-params="smartSelectParams" v-if="ready" ref="smartSelect" class="item-picker">
+    <f7-list-item :title="title" :disabled="disabled" smart-select :smart-select-params="smartSelectParams" v-if="ready" ref="smartSelect" class="item-picker">
       <select :name="name" :multiple="multiple" @change="select" :required="required">
         <option value="" v-if="!multiple" />
         <option v-for="item in preparedItems" :value="item.name" :key="item.name" :selected="(multiple) ? Array.isArray(value) && value.indexOf(item.name) >= 0 : value === item.name">
@@ -10,7 +10,7 @@
       <f7-button slot="media" icon-f7="list_bullet_indent" @click.native="pickFromModel" />
     </f7-list-item>
     <!-- for placeholder purposes before items are loaded -->
-    <f7-list-item link v-show="!ready" :title="title">
+    <f7-list-item link v-show="!ready" :title="title" :disabled="disabled">
       <f7-button slot="media" icon-f7="list_bullet_indent" @click.native="pickFromModel" />
     </f7-list-item>
   </ul>
@@ -30,7 +30,7 @@
 import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 
 export default {
-  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly'],
+  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly', 'disabled'],
   data () {
     return {
       ready: false,

--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -30,7 +30,7 @@
 import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 
 export default {
-  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly', 'disabled'],
+  props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly', 'disabled', 'setValueText'],
   data () {
     return {
       ready: false,
@@ -48,6 +48,7 @@ export default {
   },
   created () {
     this.smartSelectParams.closeOnSelect = !(this.multiple)
+    if (this.setValueText === false) this.smartSelectParams.setValueText = false
     if (!this.items || !this.items.length) {
       this.$oh.api.get('/rest/items?staticDataOnly=true').then((items) => {
         this.sortAndFilterItems(items)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -63,6 +63,8 @@ import 'codemirror/theme/gruvbox-dark.css'
 import 'codemirror/addon/edit/matchbrackets.js'
 import 'codemirror/addon/edit/closebrackets.js'
 
+import 'codemirror/addon/comment/comment.js'
+
 // for autocomplete
 import 'codemirror/addon/hint/show-hint.js'
 import 'codemirror/addon/hint/show-hint.css'
@@ -317,6 +319,8 @@ export default {
         }
       }
       extraKeys['Shift-Tab'] = 'indentLess'
+      extraKeys['Cmd-/'] = 'toggleComment'
+      extraKeys['Ctrl-/'] = 'toggleComment'
       cm.setOption('extraKeys', extraKeys)
       cm.addOverlay(indentGuidesOverlay)
       cm.refresh()

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,21 +1,20 @@
 <template>
   <div v-if="item.type === 'Group'" class="group-form no-padding">
-    <f7-list-input :disabled="!editable" label="Members Base Type" type="select" :value="groupType" @input="groupType = $event.target.value">
-      <option v-for="type in types.GroupTypes" :key="type" :value="type">
-        {{ type }}
-      </option>
-    </f7-list-input>
-    <f7-list-input v-if="dimensions.length && groupType === 'Number'"
-                   :disabled="!editable"
-                   label="Dimension"
-                   type="select"
-                   :value="groupDimension"
-                   @input="groupDimension = $event.target.value">
-      <option value="" />
-      <option v-for="d in dimensions" :key="d.name" :value="d.name">
-        {{ d.label }}
-      </option>
-    </f7-list-input>
+    <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <select name="select-basetype" @change="groupType = $event.target.value">
+        <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
+          {{ type }}
+        </option>
+      </select>
+    </f7-list-item>
+    <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <select name="select-dimension" @change="groupDimension = $event.target.value">
+        <option key="Number" value="Number" :selected="item.type === 'Number'" />
+        <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
+          {{ d.label }}
+        </option>
+      </select>
+    </f7-list-item>
 
     <template v-if="createMode && groupType && groupDimension">
       <f7-list-input label="Unit"
@@ -30,18 +29,20 @@
                      @input="item.stateDescriptionPattern = $event.target.value" clear-button />
     </template>
 
-    <f7-list-input v-if="aggregationFunctions"
-                   :disabled="!editable"
-                   label="Aggregation Function"
-                   type="select"
-                   :value="groupFunctionKey"
-                   @input="groupFunctionKey = $event.target.value">
-      <option v-for="type in aggregationFunctions" :key="type.name" :value="type.name">
-        {{ type.value }}
-      </option>
-    </f7-list-input>
+    <f7-list-item v-if="aggregationFunctions" :disabled="!editable" title="Aggregation Function" class="align-popup-list-item members" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <select name="select-function" @change="groupFunctionKey = $event.target.value">
+        <option v-for="type in aggregationFunctions" :key="type.name" :value="type.name" :selected="type.name === groupFunctionKey">
+          {{ type.value }}
+        </option>
+      </select>
+    </f7-list-item>
   </div>
 </template>
+
+<style lang="stylus">
+.align-popup-list-item.members
+  padding-left 14px
+</style>
 
 <script>
 import * as types from '@/assets/item-types.js'

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="group-form no-padding">
     <!-- Type -->
-    <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+    <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="align-popup-list-item" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-basetype" @change="groupType = $event.target.value">
         <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
           {{ type }}

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,63 +1,45 @@
 <template>
-  <div v-if="item" class="group-form no-padding">
-    <f7-list inline-labels no-hairlines-md>
-      <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
-        <select name="select-basetype" @change="setGroupType($event.target.value)">
-          <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
-            {{ type }}
-          </option>
-        </select>
-      </f7-list-item>
-      <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
-        <select name="select-dimension" @change="setDimension($event.target.value)">
-          <option key="Number" value="Number" :selected="item.type === 'Number'" />
-          <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
-            {{ d.label }}
-          </option>
-        </select>
-      </f7-list-item>
-      <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" :disabled="!editable" label="Unit" type="text" :value="item.unit"
+  <div v-if="item.type === 'Group'" class="group-form no-padding">
+    <f7-list-input :disabled="!editable" label="Members Base Type" type="select" :value="groupType" @input="groupType = $event.target.value">
+      <option v-for="type in types.GroupTypes" :key="type" :value="type">
+        {{ type }}
+      </option>
+    </f7-list-input>
+    <f7-list-input v-if="dimensions.length && groupType === 'Number'"
+                   :disabled="!editable"
+                   label="Dimension"
+                   type="select"
+                   :value="groupDimension"
+                   @input="groupDimension = $event.target.value">
+      <option value="" />
+      <option v-for="d in dimensions" :key="d.name" :value="d.name">
+        {{ d.label }}
+      </option>
+    </f7-list-input>
+
+    <template v-if="createMode && groupType && groupDimension">
+      <f7-list-input label="Unit"
+                     type="text"
                      info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
+                     :value="item.unit"
                      @input="item.unit = $event.target.value" clear-button />
-      <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" :disabled="!editable" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
+      <f7-list-input label="State Description Pattern"
+                     type="text"
                      info="Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value."
+                     :value="item.stateDescriptionPattern"
                      @input="item.stateDescriptionPattern = $event.target.value" clear-button />
-      <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
-        <select name="select-function" @change="setFunction($event.target.value)">
-          <option v-for="type in types.ArithmeticFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
-            {{ type.value }}
-          </option>
-        </select>
-      </f7-list-item>
-      <f7-list-item key="function-picker-logicalopenclosed" v-else-if="item.type === 'Group' && item.groupType && ['Contact'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
-        <select name="select-function" @change="setFunction($event.target.value)">
-          <option v-for="type in types.LogicalOpenClosedFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
-            {{ type.value }}
-          </option>
-        </select>
-      </f7-list-item>
-      <f7-list-item key="function-picker-logicalplaypause" v-else-if="item.type === 'Group' && item.groupType && ['Player'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
-        <select name="select-function" @change="setFunction($event.target.value)">
-          <option v-for="type in types.LogicalPlayPauseFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
-            {{ type.value }}
-          </option>
-        </select>
-      </f7-list-item>
-      <f7-list-item key="function-picker-datetime" v-else-if="item.type === 'Group' && item.groupType && ['DateTime'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
-        <select name="select-function" @change="setFunction($event.target.value)">
-          <option v-for="type in types.DateTimeFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
-            {{ type.value }}
-          </option>
-        </select>
-      </f7-list-item>
-      <f7-list-item key="function-picker-logicalonoff" v-else-if="item.type === 'Group' && item.groupType && ['Switch', 'None'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
-        <select name="select-function" @change="setFunction($event.target.value)">
-          <option v-for="type in types.LogicalOnOffFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
-            {{ type.value }}
-          </option>
-        </select>
-      </f7-list-item>
-    </f7-list>
+    </template>
+
+    <f7-list-input v-if="aggregationFunctions"
+                   :disabled="!editable"
+                   label="Aggregation Function"
+                   type="select"
+                   :value="groupFunctionKey"
+                   @input="groupFunctionKey = $event.target.value">
+      <option v-for="type in aggregationFunctions" :key="type.name" :value="type.name">
+        {{ type.value }}
+      </option>
+    </f7-list-input>
   </div>
 </template>
 
@@ -77,6 +59,77 @@ export default {
   computed: {
     editable () {
       return this.createMode || (this.item && this.item.editable)
+    },
+    groupType: {
+      get () {
+        return this.item.groupType?.split(':')[0]
+      },
+      set (newType) {
+        const previousAggregationFunctions = this.aggregationFunctions
+        this.$set(this.item, 'groupType', '')
+        this.$nextTick(() => {
+          if (newType !== 'None') {
+            this.$set(this.item, 'groupType', newType)
+            if (previousAggregationFunctions !== this.aggregationFunctions) {
+              this.$set(this.item, 'functionKey', 'None')
+            }
+          }
+        })
+      }
+    },
+    groupDimension: {
+      get () {
+        const parts = this.item.groupType.split(':')
+        return parts.length > 1 ? parts[1] : ''
+      },
+      set (newDimension) {
+        if (!newDimension) {
+          this.groupType = 'Number'
+          return
+        }
+        const dimension = this.dimensions.find((d) => d.name === newDimension)
+        this.$set(this.item, 'groupType', 'Number:' + dimension.name)
+        this.$set(this.item, 'unit', dimension.systemUnit)
+        this.$set(this.item, 'stateDescriptionPattern', `%.0f ${dimension.systemUnit}`)
+      }
+    },
+    groupFunctionKey: {
+      get () {
+        return this.item.functionKey
+      },
+      set (newFunctionKey) {
+        if (!newFunctionKey) {
+          delete this.item.function
+          this.$set(this.item, 'functionKey', '')
+          return
+        }
+        this.$set(this.item, 'functionKey', newFunctionKey)
+        const parts = newFunctionKey.split('_')
+        let func = {
+          name: parts[0]
+        }
+        if (parts.length > 1) {
+          func.params = [parts[1], parts[2]]
+        }
+        this.$set(this.item, 'function', func)
+      }
+    },
+    aggregationFunctions () {
+      switch (this.groupType) {
+        case 'Dimmer':
+        case 'Rollershutter':
+        case 'Number':
+          return types.ArithmeticFunctions
+        case 'Contact':
+          return types.LogicalOpenClosedFunctions
+        case 'Player':
+          return types.LogicalPlayPauseFunctions
+        case 'DateTime':
+          return types.DateTimeFunctions
+        case 'Switch':
+          return types.LogicalOnOffFunctions
+      }
+      return null
     }
   },
   beforeMount () {
@@ -86,41 +139,7 @@ export default {
         this.item.functionKey += '_' + this.item.function.params.join('_')
       }
     } else {
-      this.$set(this.item, 'functionKey', 'None')
-    }
-  },
-  methods: {
-    setGroupType (type) {
-      this.$set(this.item, 'groupType', '')
-      this.$set(this.item, 'functionKey', 'None')
-      this.$nextTick(() => {
-        if (type !== 'None') this.$set(this.item, 'groupType', type)
-      })
-    },
-    setDimension (index) {
-      if (index === 'Number') {
-        this.setGroupType('Number')
-        return
-      }
-      const dimension = this.dimensions[index]
-      this.setGroupType('Number:' + dimension.name)
-      this.$set(this.item, 'unit', dimension.systemUnit)
-      this.$set(this.item, 'stateDescriptionPattern', `%.0f ${dimension.systemUnit}`)
-    },
-    setFunction (key) {
-      if (!key) {
-        delete this.item.function
-        return
-      }
-      this.$set(this.item, 'functionKey', key)
-      const splitted = key.split('_')
-      let func = {
-        name: splitted[0]
-      }
-      if (splitted.length > 1) {
-        func.params = [splitted[1], splitted[2]]
-      }
-      this.$set(this.item, 'function', func)
+      this.$set(this.item, 'functionKey', '')
     }
   }
 }
@@ -128,6 +147,8 @@ export default {
 
 <style lang="stylus">
 .group-form
+  .item-label
+    padding-left 1em
   .list
     margin-top 0
     margin-bottom 0

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -9,8 +9,8 @@
     </f7-list-item>
     <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-dimension" @change="groupDimension = $event.target.value">
-        <option key="Number" value="Number" :selected="item.type === 'Number'" />
-        <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
+        <option key="" value="Number" :selected="item.type === 'Number'" />
+        <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="'Number:' + d.name === item.groupType">
           {{ d.label }}
         </option>
       </select>

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -9,7 +9,7 @@
       </select>
     </f7-list-item>
     <!-- Dimension -->
-    <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+    <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="align-popup-list-item" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-dimension" @change="groupDimension = $event.target.value">
         <option key="" value="Number" :selected="item.type === 'Number'" />
         <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="'Number:' + d.name === item.groupType">
@@ -31,7 +31,7 @@
                      @input="item.stateDescriptionPattern = $event.target.value" clear-button />
     </template>
     <!-- Aggregation Functions -->
-    <f7-list-item v-if="aggregationFunctions" :disabled="!editable" title="Aggregation Function" class="align-popup-list-item members" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+    <f7-list-item v-if="aggregationFunctions" :disabled="!editable" title="Aggregation Function" class="align-popup-list-item" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
       <select name="select-function" @change="groupFunctionKey = $event.target.value">
         <option v-for="type in aggregationFunctions" :key="type.name" :value="type.name" :selected="type.name === groupFunctionKey">
           {{ type.value }}

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,14 +1,14 @@
 <template>
   <div v-if="item" class="group-form no-padding">
     <f7-list inline-labels no-hairlines-md>
-      <f7-list-item v-if="item.type === 'Group'" title="Members Base Type" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-basetype" @change="setGroupType($event.target.value)">
           <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
             {{ type }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.groupType">
@@ -16,41 +16,41 @@
           </option>
         </select>
       </f7-list-item>
-      <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
+      <f7-list-input v-if="item.groupType && item.groupType.startsWith('Number:') && createMode" :disabled="!editable" label="Unit" type="text" :value="item.unit"
                      info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
                      @input="item.unit = $event.target.value" clear-button />
-      <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
+      <f7-list-input v-if="item.type && item.type.startsWith('Number:') && createMode" :disabled="!editable" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value."
                      @input="item.stateDescriptionPattern = $event.target.value" clear-button />
-      <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
+      <f7-list-item key="function-picker-arithmetic" v-if="item.type === 'Group' && item.groupType && (['Dimmer', 'Rollershutter'].indexOf(item.groupType) >= 0 || item.groupType.indexOf('Number') === 0)" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popover', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.ArithmeticFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-logicalopenclosed" v-else-if="item.type === 'Group' && item.groupType && ['Contact'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-logicalopenclosed" v-else-if="item.type === 'Group' && item.groupType && ['Contact'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.LogicalOpenClosedFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-logicalplaypause" v-else-if="item.type === 'Group' && item.groupType && ['Player'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-logicalplaypause" v-else-if="item.type === 'Group' && item.groupType && ['Player'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.LogicalPlayPauseFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-datetime" v-else-if="item.type === 'Group' && item.groupType && ['DateTime'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-datetime" v-else-if="item.type === 'Group' && item.groupType && ['DateTime'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.DateTimeFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item key="function-picker-logicalonoff" v-else-if="item.type === 'Group' && item.groupType && ['Switch', 'None'].indexOf(item.groupType) >= 0" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item key="function-picker-logicalonoff" v-else-if="item.type === 'Group' && item.groupType && ['Switch', 'None'].indexOf(item.groupType) >= 0" :disabled="!editable" title="Aggregation Function" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
         <select name="select-function" @change="setFunction($event.target.value)">
           <option v-for="type in types.LogicalOnOffFunctions" :key="type.name" :value="type.name" :selected="type.name === item.functionKey">
             {{ type.value }}
@@ -72,6 +72,11 @@ export default {
   data () {
     return {
       types
+    }
+  },
+  computed: {
+    editable () {
+      return this.createMode || (this.item && this.item.editable)
     }
   },
   beforeMount () {

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -1,5 +1,6 @@
 <template>
-  <div v-if="item.type === 'Group'" class="group-form no-padding">
+  <div class="group-form no-padding">
+    <!-- Type -->
     <f7-list-item v-if="item.type === 'Group'" :disabled="!editable" title="Members Base Type" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-basetype" @change="groupType = $event.target.value">
         <option v-for="type in types.GroupTypes" :key="type" :value="type" :selected="item.groupType ? type === item.groupType.split(':')[0] : false">
@@ -7,6 +8,7 @@
         </option>
       </select>
     </f7-list-item>
+    <!-- Dimension -->
     <f7-list-item v-if="dimensions.length && item.groupType && item.groupType.startsWith('Number')" :disabled="!editable" title="Dimension" class="align-popup-list-item members" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
       <select name="select-dimension" @change="groupDimension = $event.target.value">
         <option key="" value="Number" :selected="item.type === 'Number'" />
@@ -15,7 +17,7 @@
         </option>
       </select>
     </f7-list-item>
-
+    <!-- (Internal) Unit & State Description -->
     <template v-if="createMode && groupType && groupDimension">
       <f7-list-input label="Unit"
                      type="text"
@@ -28,7 +30,7 @@
                      :value="item.stateDescriptionPattern"
                      @input="item.stateDescriptionPattern = $event.target.value" clear-button />
     </template>
-
+    <!-- Aggregation Functions -->
     <f7-list-item v-if="aggregationFunctions" :disabled="!editable" title="Aggregation Function" class="align-popup-list-item members" smart-select :smart-select-params="{openIn: 'popup', closeOnSelect: true}">
       <select name="select-function" @change="groupFunctionKey = $event.target.value">
         <option v-for="type in aggregationFunctions" :key="type.name" :value="type.name" :selected="type.name === groupFunctionKey">
@@ -40,8 +42,12 @@
 </template>
 
 <style lang="stylus">
-.align-popup-list-item.members
-  padding-left 14px
+.group-form
+  .item-inner
+    padding-left 1em
+  .list
+    margin-top 0
+    margin-bottom 0
 </style>
 
 <script>
@@ -145,12 +151,3 @@ export default {
   }
 }
 </script>
-
-<style lang="stylus">
-.group-form
-  .item-label
-    padding-left 1em
-  .list
-    margin-top 0
-    margin-bottom 0
-</style>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -11,7 +11,7 @@
       </f7-list-group>
       <f7-list-group v-if="item.type && !hideType">
         <!-- Type -->
-        <f7-list-item class="align-popup-list-item" v-if="item.type && !hideType" title="Type" type="text" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+        <f7-list-item v-if="item.type && !hideType" title="Type" class="align-popup-list-item" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
           <select name="select-type" @change="item.type = $event.target.value">
             <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === item.type.split(':')[0]">
               {{ t }}
@@ -19,10 +19,10 @@
           </select>
         </f7-list-item>
         <!-- Dimensions -->
-        <f7-list-item class="align-popup-list-item" v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+        <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" class="align-popup-list-item" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
           <select name="select-dimension" @change="setDimension($event.target.value)">
-            <option key="Number" value="Number" :selected="item.type === 'Number'" />
-            <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.type">
+            <option key="" value="Number" :selected="item.type === 'Number'" />
+            <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="'Number:' + d.name === item.type">
               {{ d.label }}
             </option>
           </select>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -6,15 +6,15 @@
                      required :error-message="nameErrorMessage" :error-message-force="!!nameErrorMessage"
                      @input="onNameInput" :clear-button="createMode" />
       <f7-list-input label="Label" type="text" placeholder="Label" :value="item.label"
-                     @input="item.label = $event.target.value" clear-button />
-      <f7-list-item v-if="item.type && !hideType" title="Type" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+                     @input="item.label = $event.target.value" :disabled="!editable" :clear-button="editable" />
+      <f7-list-item v-if="item.type && !hideType" title="Type" type="text" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-type" @change="item.type = $event.target.value">
           <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === item.type.split(':')[0]">
             {{ t }}
           </option>
         </select>
       </f7-list-item>
-      <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+      <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" type="text" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
         <select name="select-dimension" @change="setDimension($event.target.value)">
           <option key="Number" value="Number" :selected="item.type === 'Number'" />
           <option v-for="(d, i) in dimensions" :key="d.name" :value="i" :selected="'Number:' + d.name === item.type">
@@ -25,12 +25,12 @@
       <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="Unit" type="text" :value="item.unit"
                      info="Used internally, for persistence and external systems. It is independent from the state visualization in the UI, which is defined through the state description."
-                     @input="item.unit = $event.target.value" clear-button />
+                     @input="item.unit = $event.target.value" :disabled="!editable" :clear-button="editable" />
       <f7-list-input v-show="!hideType && item.type && item.type.startsWith('Number:') && createMode" label="State Description Pattern" type="text" :value="item.stateDescriptionPattern"
                      info="Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value."
-                     @input="item.stateDescriptionPattern = $event.target.value" clear-button />
+                     @input="item.stateDescriptionPattern = $event.target.value" :disabled="!editable" :clear-button="editable" />
       <f7-list-input v-if="!hideCategory" ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
-                     @input="item.category = $event.target.value" clear-button>
+                     @input="item.category = $event.target.value" :disabled="!editable" :clear-button="editable">
         <div slot="root-end" style="margin-left: calc(35% + 8px)">
           <oh-icon :icon="item.category" :state="(createMode) ? null : item.state" height="32" width="32" />
         </div>
@@ -40,7 +40,7 @@
     <f7-list inline-labels accordion-list no-hairline-md>
       <f7-list-item accordion-item title="Non-Semantic Tags" :after="numberOfTags">
         <f7-accordion-content>
-          <tag-input :item="item" />
+          <tag-input :disabled="!editable" :item="item" />
         </f7-accordion-content>
       </f7-list-item>
     </f7-list>
@@ -80,6 +80,9 @@ export default {
     }
   },
   computed: {
+    editable () {
+      return this.createMode || (this.item && this.item.editable)
+    },
     numberOfTags () {
       return this.getNonSemanticTags(this.item).length
     }

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -27,6 +27,7 @@
             </option>
           </select>
         </f7-list-item>
+        <!-- (Internal) Unit & State Description -->
         <!-- Use v-show instead of v-if, because otherwise the autocomplete for category would take over the unit -->
         <f7-list-input v-show="itemDimension && createMode"
                        label="Unit"
@@ -45,7 +46,7 @@
                        @input="item.stateDescriptionPattern = $event.target.value"
                        :clear-button="editable" />
 
-        <!-- Group Item -->
+        <!-- Group Item Form -->
         <group-form v-if="item.type === 'Group'" :item="item" :createMode="createMode" />
       </f7-list-group>
       <f7-list-group v-if="!hideCategory">
@@ -59,7 +60,7 @@
     </f7-list>
     <semantics-picker v-if="!hideSemantics" :item="item" :same-class-only="true" :hide-type="true" :hide-none="forceSemantics" :createMode="createMode" />
     <f7-list inline-labels no-hairline-md>
-      <tag-input :disabled="!editable" :item="item" />
+      <tag-input title="Non-Semantic Tags" :disabled="!editable" :item="item" />
     </f7-list>
     <f7-list inline-labels no-hairline-md>
       <f7-list-item title="Parent Groups" :badge="numberOfGroups" />

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -9,20 +9,20 @@
         <f7-list-input label="Label" type="text" placeholder="Label" :value="item.label"
                        @input="item.label = $event.target.value" :disabled="!editable" :clear-button="editable" />
       </f7-list-group>
-      <f7-list-group v-if="item.type && !hideType">
+      <f7-list-group v-if="itemType && !hideType">
         <!-- Type -->
-        <f7-list-item v-if="item.type && !hideType" title="Type" class="align-popup-list-item" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+        <f7-list-item v-if="itemType && !hideType" title="Type" class="align-popup-list-item" :disabled="!editable" :key="'type-' + itemType" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
           <select name="select-type" @change="item.type = $event.target.value">
-            <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === item.type.split(':')[0]">
+            <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === itemType">
               {{ t }}
             </option>
           </select>
         </f7-list-item>
         <!-- Dimensions -->
-        <f7-list-item v-if="dimensions.length && item.type && !hideType && item.type.startsWith('Number')" title="Dimension" class="align-popup-list-item" :disabled="!editable" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+        <f7-list-item v-if="dimensions.length && !hideType && itemType === 'Number'" title="Dimension" class="align-popup-list-item" :disabled="!editable" :key="'dimension-' + itemDimension" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
           <select name="select-dimension" @change="setDimension($event.target.value)">
-            <option key="" value="Number" :selected="item.type === 'Number'" />
-            <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="'Number:' + d.name === item.type">
+            <option key="" value="Number" :selected="itemDimension === ''" />
+            <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="d.name === itemDimension">
               {{ d.label }}
             </option>
           </select>
@@ -47,7 +47,7 @@
                        :clear-button="editable" />
 
         <!-- Group Item Form -->
-        <group-form v-if="item.type === 'Group'" :item="item" :createMode="createMode" />
+        <group-form v-if="itemType === 'Group'" :item="item" :createMode="createMode" />
       </f7-list-group>
       <f7-list-group v-if="!hideCategory">
         <f7-list-input ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="item.category"
@@ -58,7 +58,7 @@
         </f7-list-input>
       </f7-list-group>
     </f7-list>
-    <semantics-picker v-if="!hideSemantics" :item="item" :same-class-only="true" :hide-type="true" :hide-none="forceSemantics" :createMode="createMode" />
+    <semantics-picker v-if="!hideSemantics" :item="item" :same-class-only="true" :hide-type="true" :hide-none="forceSemantics" :createMode="createMode" :key="'semantics-' + item.tags.toString()" />
     <f7-list inline-labels no-hairline-md>
       <tag-input title="Non-Semantic Tags" :disabled="!editable" :item="item" />
     </f7-list>
@@ -130,6 +130,9 @@ export default {
     },
     numberOfGroups () {
       return this.item.groupNames?.length.toString() || '0'
+    },
+    itemType () {
+      return this.item.type.split(':')[0]
     },
     itemDimension () {
       const parts = this.item.type.split(':')

--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -14,10 +14,6 @@
       <div class="padding-top" v-else-if="createMode">
         <item-form :item="editedItem" :items="items" :createMode="true" :force-semantics="forceSemantics" />
       </div>
-      <div v-if="(createMode || editMode) && editedItem && editedItem.type === 'Group'">
-        <f7-block-title>Group Settings</f7-block-title>
-        <group-form :item="editedItem" :createMode="createMode" />
-      </div>
     </f7-card-content>
     <f7-card-footer v-if="createMode || editMode" key="item-card-buttons">
       <f7-button v-if="createMode" color="blue" fill raised @click="create">
@@ -44,7 +40,6 @@
 <script>
 import Item from '@/components/item/item.vue'
 import ItemForm from '@/components/item/item-form.vue'
-import GroupForm from '@/components/item/group-form.vue'
 
 import ItemMixin from '@/components/item/item-mixin'
 
@@ -52,7 +47,6 @@ export default {
   mixins: [ItemMixin],
   props: ['model', 'links', 'items', 'context'],
   components: {
-    GroupForm,
     Item,
     ItemForm
   },

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -30,7 +30,7 @@
       </f7-list-item>
     </f7-list>
     <f7-list inline-labels no-hairline-md>
-      <tag-input title="Tags" :item="page" :disabled="page.uid === 'overview'" />
+      <tag-input :item="page" :disabled="page.uid === 'overview'" />
     </f7-list>
   </f7-col>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -31,7 +31,7 @@
                          :disabled="true" @input="rule.description = $event.target.value" :clear-button="editable" />
         </f7-list>
         <f7-list inline-labels no-hairlines-md>
-          <tag-input v-if="!createMode || !hasRuleTemplate" title="Tags" :item="rule" :disabled="!editable" :showSemanticTags="true" :inScriptEditor="inScriptEditor" :inSceneEditor="inSceneEditor" />
+          <tag-input v-if="!createMode || !hasRuleTemplate" :item="rule" :disabled="!editable" :showSemanticTags="true" :inScriptEditor="inScriptEditor" :inSceneEditor="inSceneEditor" />
         </f7-list>
       </f7-col>
     </f7-block>

--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -1,44 +1,40 @@
 <template>
-  <f7-list no-hairlines-md v-if="show">
-    <f7-list-item :disabled="!editable" title="Semantic Class" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
-      <select name="select-semantics-class" @change="update('class', $event.target.value)">
-        <option v-if="!hideNone" :value="''">
-          None
-        </option>
-        <optgroup label="Location" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Location')">
-          <option v-for="type in orderedLocations" :key="type" :value="type" :selected="type === semanticClass">
-            {{ type }}
-          </option>
-        </optgroup>
-        <optgroup label="Equipment" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Equipment')">
-          <option v-for="type in orderedEquipment" :key="type" :value="type" :selected="type === semanticClass">
-            {{ type }}
-          </option>
-        </optgroup>
-        <optgroup label="Point" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Point')">
-          <option v-for="type in orderedPoints" :key="type" :value="type" :selected="type === semanticClass">
-            {{ type }}
-          </option>
-        </optgroup>
-      </select>
-    </f7-list-item>
-    <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" :after="currentSemanticType" />
-    <f7-list-item v-if="currentSemanticType == 'Point'" :disabled="!editable" title="Semantic Property" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
-      <select name="select-semantics-proerty" :value="semanticProperty" @change="update('property', $event.target.value)">
-        <option :value="''">
-          None
-        </option>
-        <option v-for="type in orderedProperties" :key="type" :value="type" :selected="type === semanticProperty">
+  <f7-list inline-labels no-hairlines-md v-if="show">
+    <f7-list-input :disabled="!editable" label="Semantic Class" type="select" :value="semanticClass" @input="update('class', $event.target.value)">
+      <option v-if="!hideNone" value="">
+        None
+      </option>
+      <optgroup label="Location" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Location')">
+        <option v-for="type in orderedLocations" :key="type" :value="type">
           {{ type }}
         </option>
-      </select>
-    </f7-list-item>
+      </optgroup>
+      <optgroup label="Equipment" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Equipment')">
+        <option v-for="type in orderedEquipment" :key="type" :value="type">
+          {{ type }}
+        </option>
+      </optgroup>
+      <optgroup label="Point" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Point')">
+        <option v-for="type in orderedPoints" :key="type" :value="type">
+          {{ type }}
+        </option>
+      </optgroup>
+    </f7-list-input>
+    <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" :after="currentSemanticType" />
+    <f7-list-input v-if="currentSemanticType == 'Point'" :disabled="!editable" label="Semantic Property" type="select" :value="semanticProperty" @input="update('property', $event.target.value)">
+      <option value="">
+        None
+      </option>
+      <option v-for="type in orderedProperties" :key="type" :value="type">
+        {{ type }}
+      </option>
+    </f7-list-input>
   </f7-list>
 </template>
 
 <script>
 export default {
-  props: ['item', 'sameClassOnly', 'hideType', 'hideNone'],
+  props: ['item', 'sameClassOnly', 'hideType', 'hideNone', 'createMode'],
   data () {
     return {
       semanticClasses: this.$store.getters.semanticClasses,
@@ -106,7 +102,7 @@ export default {
   },
   computed: {
     editable () {
-      return this.item && this.item.editable
+      return this.createMode || (this.item && this.item.editable)
     },
     orderedLocations () {
       return [...this.semanticClasses.Locations].sort((a, b) => {

--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-list inline-labels no-hairlines-md v-if="show">
-    <f7-list-item :disabled="!editable" title="Semantic Class" class="align-popup-list-item" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+    <f7-list-item :disabled="!editable" title="Semantic Class" class="align-popup-list-item" :key="'class-' + semanticClass" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
       <select name="select-semantics-class" @change="update('class', $event.target.value)">
         <option v-if="!hideNone" value="">
           None
@@ -23,8 +23,8 @@
       </select>
     </f7-list-item>
     <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" class="align-popup-list-item" :after="currentSemanticType" />
-    <f7-list-item v-if="currentSemanticType === 'Point'" :disabled="!editable" title="Semantic Property" class="align-popup-list-item" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
-      <select name="select-semantics-proerty" :value="semanticProperty" @change="update('property', $event.target.value)">
+    <f7-list-item v-if="currentSemanticType === 'Point'" :disabled="!editable" title="Semantic Property" class="align-popup-list-item" :key="'property-' + semanticProperty" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+      <select name="select-semantics-property" :value="semanticProperty" @change="update('property', $event.target.value)">
         <option :value="''">
           None
         </option>

--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-list no-hairlines-md v-if="show">
-    <f7-list-item title="Semantic Class" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+    <f7-list-item :disabled="!editable" title="Semantic Class" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
       <select name="select-semantics-class" @change="update('class', $event.target.value)">
         <option v-if="!hideNone" :value="''">
           None
@@ -22,8 +22,8 @@
         </optgroup>
       </select>
     </f7-list-item>
-    <f7-list-item v-if="currentSemanticType && !hideType" title="Semantic Type" :after="currentSemanticType" />
-    <f7-list-item v-if="currentSemanticType == 'Point'" title="Semantic Property" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+    <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" :after="currentSemanticType" />
+    <f7-list-item v-if="currentSemanticType == 'Point'" :disabled="!editable" title="Semantic Property" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
       <select name="select-semantics-proerty" :value="semanticProperty" @change="update('property', $event.target.value)">
         <option :value="''">
           None
@@ -105,6 +105,9 @@ export default {
     }
   },
   computed: {
+    editable () {
+      return this.item && this.item.editable
+    },
     orderedLocations () {
       return [...this.semanticClasses.Locations].sort((a, b) => {
         return a.localeCompare(b)

--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -1,34 +1,38 @@
 <template>
   <f7-list inline-labels no-hairlines-md v-if="show">
-    <f7-list-input :disabled="!editable" label="Semantic Class" type="select" :value="semanticClass" @input="update('class', $event.target.value)">
-      <option v-if="!hideNone" value="">
-        None
-      </option>
-      <optgroup label="Location" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Location')">
-        <option v-for="type in orderedLocations" :key="type" :value="type">
+    <f7-list-item :disabled="!editable" title="Semantic Class" class="align-popup-list-item" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+      <select name="select-semantics-class" @change="update('class', $event.target.value)">
+        <option v-if="!hideNone" value="">
+          None
+        </option>
+        <optgroup label="Location" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Location')">
+          <option v-for="type in orderedLocations" :key="type" :value="type" :selected="type === semanticClass">
+            {{ type }}
+          </option>
+        </optgroup>
+        <optgroup label="Equipment" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Equipment')">
+          <option v-for="type in orderedEquipment" :key="type" :value="type" :selected="type === semanticClass">
+            {{ type }}
+          </option>
+        </optgroup>
+        <optgroup label="Point" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Point')">
+          <option v-for="type in orderedPoints" :key="type" :value="type" :selected="type === semanticClass">
+            {{ type }}
+          </option>
+        </optgroup>
+      </select>
+    </f7-list-item>
+    <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" class="align-popup-list-item" :after="currentSemanticType" />
+    <f7-list-item v-if="currentSemanticType === 'Point'" :disabled="!editable" title="Semantic Property" class="align-popup-list-item" smart-select :smart-select-params="{view: $f7.view.main, searchbar: true, openIn: 'popup', closeOnSelect: true, scrollToSelectedItem: true}">
+      <select name="select-semantics-proerty" :value="semanticProperty" @change="update('property', $event.target.value)">
+        <option :value="''">
+          None
+        </option>
+        <option v-for="type in orderedProperties" :key="type" :value="type" :selected="type === semanticProperty">
           {{ type }}
         </option>
-      </optgroup>
-      <optgroup label="Equipment" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Equipment')">
-        <option v-for="type in orderedEquipment" :key="type" :value="type">
-          {{ type }}
-        </option>
-      </optgroup>
-      <optgroup label="Point" v-if="!sameClassOnly || semanticClass === '' || (sameClassOnly && currentSemanticType === 'Point')">
-        <option v-for="type in orderedPoints" :key="type" :value="type">
-          {{ type }}
-        </option>
-      </optgroup>
-    </f7-list-input>
-    <f7-list-item v-if="currentSemanticType && !hideType" :disabled="!editable" title="Semantic Type" :after="currentSemanticType" />
-    <f7-list-input v-if="currentSemanticType === 'Point'" :disabled="!editable" label="Semantic Property" type="select" :value="semanticProperty" @input="update('property', $event.target.value)">
-      <option value="">
-        None
-      </option>
-      <option v-for="type in orderedProperties" :key="type" :value="type">
-        {{ type }}
-      </option>
-    </f7-list-input>
+      </select>
+    </f7-list-item>
   </f7-list>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="item && item.tags" class="tag-editor">
     <f7-list>
-      <f7-list-item :title="title || 'Non-Semantic Tags'" :badge="tags.length.toString()" />
+      <f7-list-item :title="title || 'Tags'" :badge="tags.length.toString()" />
       <f7-list-item v-if="tags.length > 0">
         <div slot="inner">
           <f7-chip v-for="tag in tags" :key="tag" :text="tag" :deleteable="!disabled" @delete="deleteTag" media-bg-color="blue">

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -2,8 +2,11 @@
   <f7-page class="item-details-page" @page:beforein="onPageBeforeIn" @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar :title="item.name" back-link="Back" no-shadow no-hairline class="item-details-navbar">
       <f7-nav-right>
-        <f7-link icon-md="material:edit" href="edit">
+        <f7-link v-if="item.editable" icon-md="material:edit" href="edit">
           {{ $theme.md ? '' : 'Edit' }}
+        </f7-link>
+        <f7-link v-else icon-f7="lock_fill" tooltip="This item is not editable through the UI" href="edit">
+          Details
         </f7-link>
       </f7-nav-right>
       <f7-subnavbar sliding class="item-header">

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -20,7 +20,7 @@
     <f7-tabs class="sitemap-editor-tabs">
       <f7-tab id="design" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
         <f7-block class="block-narrow" v-if="item.name || item.created === false">
-          <f7-col v-if="item.editable === false">
+          <f7-col v-if="editable === false">
             <div class="padding-left">
               Note: {{ notEditableMgs }}
             </div>
@@ -28,16 +28,12 @@
           <f7-col>
             <item-form :item="item" :items="items" :createMode="createMode" />
           </f7-col>
-          <f7-col>
-            <f7-block-title>Group Membership</f7-block-title>
-            <f7-list v-if="ready">
-              <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" :disabled="!editable" @input="(value) => item.groupNames = value" :items="items" :multiple="true" filterType="Group" />
-            </f7-list>
-          </f7-col>
-          <f7-col v-if="item && item.type === 'Group'">
-            <f7-block-title>Group Settings</f7-block-title>
-            <group-form :item="item" :createMode="createMode" />
-          </f7-col>
+
+          <div v-if="ready" class="flex-shrink-0 if-aurora display-flex justify-content-center">
+            <f7-button text="Create" v-if="createMode" style="width: 150px" class="margin-horizontal" color="blue" raised fill @click="save" />
+            <f7-button text="Save" v-else-if="editable" style="width: 150px" class="margin-horizontal" color="blue" raised fill @click="save" />
+            <f7-button text="Cancel" color="blue" @click="$f7router.back()" />
+          </div>
         </f7-block>
       </f7-tab>
 
@@ -46,14 +42,6 @@
         <editor class="item-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :readOnly="!editable" />
       </f7-tab>
     </f7-tabs>
-
-    <div v-if="ready && createMode && currentTab === 'design'" class="if-aurora display-flex justify-content-center margin padding">
-      <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">
-          Create
-        </f7-button>
-      </div>
-    </div>
   </f7-page>
 </template>
 
@@ -75,8 +63,6 @@ import * as Types from '@/assets/item-types.js'
 import YAML from 'yaml'
 
 import ItemForm from '@/components/item/item-form.vue'
-import GroupForm from '@/components/item/group-form.vue'
-import ItemPicker from '@/components/config/controls/item-picker.vue'
 
 import DirtyMixin from '../dirty-mixin'
 import ItemMixin from '@/components/item/item-mixin'
@@ -87,9 +73,7 @@ export default {
   mixins: [DirtyMixin, ItemMixin],
   props: ['itemName', 'createMode'],
   components: {
-    ItemPicker,
     ItemForm,
-    GroupForm,
     'editor': () => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue')
   },
   data () {
@@ -223,10 +207,12 @@ export default {
       this.itemYaml = YAML.stringify(yamlObj)
     },
     fromYaml () {
-      if (!this.item.editable) return false
+      if (!this.editable) return false
       try {
         const updatedItem = YAML.parse(this.itemYaml)
         if (updatedItem === null) return false
+        if (updatedItem.groupNames == null) updatedItem.groupNames = []
+        if (updatedItem.tags == null) updatedItem.tags = []
         this.$set(this.item, 'label', updatedItem.label)
         this.$set(this.item, 'type', updatedItem.type)
         this.$set(this.item, 'category', updatedItem.category)

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
-    <f7-navbar :title="createMode ? 'Create New Item': 'Edit Item'" back-link="Cancel">
+    <f7-navbar :title="createMode ? 'Create New Item': (editable ? 'Edit Item' : 'Item Details')" :back-link="editable ? 'Cancel': 'Back'">
       <f7-nav-right>
         <f7-link @click="save()" v-if="editable && $theme.md" icon-md="material:save" icon-only />
         <f7-link @click="save()" v-if="editable && !$theme.md">
@@ -32,7 +32,7 @@
           <div v-if="ready" class="flex-shrink-0 if-aurora display-flex justify-content-center">
             <f7-button text="Create" v-if="createMode" style="width: 150px" class="margin-horizontal" color="blue" raised fill @click="save" />
             <f7-button text="Save" v-else-if="editable" style="width: 150px" class="margin-horizontal" color="blue" raised fill @click="save" />
-            <f7-button text="Cancel" color="blue" @click="$f7router.back()" />
+            <f7-button :text="editable ? 'Cancel' : 'Back'" color="blue" @click="$f7router.back()" />
           </div>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -94,7 +94,7 @@ export default {
   },
   computed: {
     editable () {
-      return this.createMode || this.item.editable
+      return this.createMode || (this.item && this.item.editable)
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -1,11 +1,12 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
     <f7-navbar :title="createMode ? 'Create New Item': 'Edit Item'" back-link="Cancel">
-      <f7-nav-right v-if="createMode || item.editable">
-        <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only />
-        <f7-link @click="save()" v-if="!$theme.md">
+      <f7-nav-right>
+        <f7-link @click="save()" v-if="editable && $theme.md" icon-md="material:save" icon-only />
+        <f7-link @click="save()" v-if="editable && !$theme.md">
           Save<span v-if="$device.desktop">&nbsp;(Ctrl-S)</span>
         </f7-link>
+        <f7-link v-else icon-f7="lock_fill" icon-only tooltip="This item is not editable through the UI" />
       </f7-nav-right>
     </f7-navbar>
     <f7-toolbar tabbar position="top">
@@ -30,7 +31,7 @@
           <f7-col>
             <f7-block-title>Group Membership</f7-block-title>
             <f7-list v-if="ready">
-              <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" @input="(value) => item.groupNames = value" :items="items" :multiple="true" filterType="Group" />
+              <item-picker title="Parent Group(s)" name="parent-groups" :value="item.groupNames" :disabled="!editable" @input="(value) => item.groupNames = value" :items="items" :multiple="true" filterType="Group" />
             </f7-list>
           </f7-col>
           <f7-col v-if="item && item.type === 'Group'">
@@ -41,8 +42,8 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code'; toYaml() }" :tab-active="currentTab === 'code'">
-        <f7-icon v-if="item.editable === false" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" :tooltip="notEditableMgs" />
-        <editor class="item-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :read-only="item.editable === false" />
+        <f7-icon v-if="!editable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" :tooltip="notEditableMgs" />
+        <editor class="item-code-editor" mode="application/vnd.openhab.item+yaml" :value="itemYaml" @input="onEditorInput" :readOnly="!editable" />
       </f7-tab>
     </f7-tabs>
 
@@ -79,6 +80,8 @@ import ItemPicker from '@/components/config/controls/item-picker.vue'
 
 import DirtyMixin from '../dirty-mixin'
 import ItemMixin from '@/components/item/item-mixin'
+import cloneDeep from 'lodash/cloneDeep'
+import fastDeepEqual from 'fast-deep-equal/es6'
 
 export default {
   mixins: [DirtyMixin, ItemMixin],
@@ -93,6 +96,7 @@ export default {
     return {
       ready: false,
       item: {},
+      savedItem: {},
       itemYaml: '',
       items: [],
       types: Types,
@@ -104,11 +108,19 @@ export default {
       notEditableMgs: 'This Item is not editable because it has been provisioned from a file.'
     }
   },
+  computed: {
+    editable () {
+      return this.createMode || this.item.editable
+    }
+  },
   watch: {
     item: {
       handler: function () {
         if (this.ready) {
-          this.dirty = true
+          // create rule object clone in order to be able to delete status part
+          // which can change from eventsource but doesn't mean a rule modification
+          let itemClone = cloneDeep(this.item)
+          this.dirty = !fastDeepEqual(itemClone, this.savedItem)
         }
       },
       deep: true
@@ -127,11 +139,13 @@ export default {
           created: false
         }
         this.$set(this, 'item', newItem)
+        this.$set(this, 'savedItem', cloneDeep(this.item))
         this.$oh.api.get('/rest/items?staticDataOnly=true').then((items) => {
           this.items = items
           this.ready = true
         })
       } else {
+        this.$set(this, 'savedItem', cloneDeep(this.item))
         const loadItem = this.$oh.api.get('/rest/items/' + this.itemName + '?metadata=.*')
         loadItem.then((data) => {
           this.item = data
@@ -192,7 +206,6 @@ export default {
     },
     onEditorInput (value) {
       this.itemYaml = value
-      this.dirty = true
     },
     toYaml () {
       const yamlObj = {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -415,6 +415,8 @@ export default {
       this.$refs.blocklyEditor.showHideLabels(this.blocklyShowLabels)
     },
     showBlocklyCode () {
+      if (this.blocklyCodePreview) return
+
       try {
         this.currentModule.configuration.blockSource = this.$refs.blocklyEditor.getBlocks()
         this.script = this.$refs.blocklyEditor.getCode()

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -25,10 +25,10 @@
                  :tooltip="rule.status.description" />
       </span>
       <span class="display-flex flex-direction-row align-items-center">
-        <f7-button v-if="!newScript && isBlockly && !blocklyCodePreview" outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" style="margin-right: 5px" @click="toggleBlocklyItemLabelId" :tooltip="'Toggle to show either Item labels or IDs'" />
+        <f7-button v-if="!newScript && isBlockly && !blocklyCodePreview" outline small :active="blocklyShowLabels" icon-f7="square_on_circle" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" style="margin-right: 5px" @click="toggleBlocklyItemLabelId" tooltip="Toggle to show either Item labels or IDs" />
         <f7-segmented v-if="!newScript && isBlockly" class="margin-right">
-          <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" />
-          <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" />
+          <f7-button outline small :active="!blocklyCodePreview" icon-f7="ticket" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="blocklyCodePreview = false" tooltip="Show blocks" />
+          <f7-button outline small :active="blocklyCodePreview" icon-f7="doc_text" :icon-size="($theme.aurora) ? 20 : 22" class="no-ripple" @click="showBlocklyCode" tooltip="Show generated code" />
         </f7-segmented>
         <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
       </span>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -44,9 +44,6 @@
         <!-- Create new item -->
         <f7-col v-else>
           <item-form :item="newItem" :items="items" :createMode="true" />
-          <f7-list>
-            <item-picker key="newItem-groups" title="Parent Group(s)" name="parent-groups" :value="newItem.groupNames" :items="items" @input="(value) => newItem.groupNames = value" :multiple="true" filterType="Group" />
-          </f7-list>
         </f7-col>
       </template>
 


### PR DESCRIPTION
- Make Type, Dimension, Semantic Class, Semantic Property all lined up with Name, Label, and Category
- Make their input a dropdown instead of a popup. This drop down list is still keyboard searchable
- Slightly shift Category icon to the right to line it up with the rest
- Make non-semantic tags section always expanded
- Show the number zero when there are no non-semantic tags
- Move the "Group" settings (Group base type, aggregation function, etc) directly underneath the item Type
- Minor bug fixes, DRY-ing, usability improvements, and code refactoring
- Make the item form fields update their states after switching back from the Code editor

## Field values line up
- The Parent Groups are visible without having to scroll through the items picker, and easily deleteable 
- Add Save/Cancel buttons at the bottom of the form. The top right link remains as is.
- Non-Semantic tags and parent groups count are shown inside a little circle badge element.

## Group base type, function, etc are indented
<img width="802" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/a094967b-b1e2-40b0-b305-7a3e1471c3e4">


