### PR TITLE
Item details: Fix group member selection allows to select unmanaged Items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -109,7 +109,8 @@ export default {
           multiple: this.multiple,
           allowEmpty: true,
           popupTitle: this.title,
-          groupsOnly: this.filterType && this.filterType === 'Group'
+          groupsOnly: this.filterType && this.filterType === 'Group',
+          editableOnly: this.editableOnly
         }
       })
 

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -10,7 +10,7 @@
             :ignore-editable="true" />
           <!-- <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" /> -->
         </ul>
-        <item-picker v-if="editMembers" :multiple="true" name="groupMembers" :value="memberNames" title="Members" @input="(members) => memberNames = members" />
+        <item-picker v-if="editMembers" :multiple="true" name="groupMembers" :value="memberNames" title="Members" :editableOnly="true" @input="(members) => memberNames = members" />
       </f7-list>
     </f7-card-content>
     <f7-card-footer>

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -69,7 +69,7 @@ function compareModelItems (o1, o2) {
 }
 
 export default {
-  props: ['value', 'multiple', 'semanticOnly', 'groupsOnly', 'allowEmpty', 'popupTitle', 'actionLabel'],
+  props: ['value', 'multiple', 'semanticOnly', 'groupsOnly', 'editableOnly', 'allowEmpty', 'popupTitle', 'actionLabel'],
   components: {
     ModelTreeview
   },
@@ -166,7 +166,11 @@ export default {
       const items = this.$oh.api.get('/rest/items?staticDataOnly=true&metadata=.+')
       const links = this.$oh.api.get('/rest/links')
       Promise.all([items, links]).then((data) => {
-        this.items = data[0]
+        if (this.editableOnly) {
+          this.items = data[0].filter((i) => i.editable)
+        } else {
+          this.items = data[0]
+        }
         this.links = data[1]
 
         if (this.newItem) {


### PR DESCRIPTION
This lead to an error being thrown because openHAB core does not allow to modify group membership of unmanaged Items and returns a 405.