### PR TITLE
Thing page: Fix dirty checks & Fix not-editable handling

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -43,7 +43,7 @@
     <f7-list-item class="searchbar-ignore" link color="blue" subtitle="Add Link to Item..." @click="addLink()">
       <f7-icon slot="media" color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
     </f7-list-item>
-    <f7-list-button class="searchbar-ignore" color="blue" :title="(channelType.parameterGroups.length || channelType.parameters.length) ? 'Configure Channel' : 'Channel Details'" @click="configureChannel()" />
+    <f7-list-button class="searchbar-ignore" color="blue" :title="thing.editable && (channelType.parameterGroups.length || channelType.parameters.length) ? 'Configure Channel' : 'Channel Details'" @click="configureChannel()" />
     <f7-list-button class="searchbar-ignore" v-if="extensible && thing.editable" color="blue" title="Copy Channel" @click="copyChannel()" />
     <f7-list-button class="searchbar-ignore" v-if="extensible && thing.editable" color="red" title="Remove Channel" @click="removeChannel()" />
   </f7-list>
@@ -132,7 +132,6 @@ export default {
       })
     },
     configureLink (link) {
-      const self = this
       const path = 'links/' + link.itemName + '/' + this.channelId
       this.$f7router.navigate({
         url: path,
@@ -175,7 +174,6 @@ export default {
                 // replace the channel in-place
                 const idx = self.thing.channels.findIndex((c) => c.uid === finalChannel.uid)
                 self.$set(self.thing.channels, idx, finalChannel)
-                self.channel = finalChannel
                 self.$emit('channel-updated', true)
               } else {
                 self.$emit('channel-updated', false)

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -104,24 +104,11 @@ export default {
       }
     },
     addLink () {
-      const self = this
       this.$f7router.navigate({
         url: 'links/new',
         route: {
           component: AddLinkPage,
-          path: 'links/new',
-          props: {
-          },
-          on: {
-            pageAfterOut (event, page) {
-              // const finalChannel = page.app.data.finalChannel
-              // if (finalChannel) {
-              //   delete page.app.data.finalChannel
-              //   self.thing.channels.push(finalChannel)
-              //   self.$emit('links-updated')
-              // }
-            }
-          }
+          path: 'links/new'
         }
       }, {
         props: {

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -26,10 +26,11 @@
               This type of Thing needs to be associated to a working Bridge to function properly.
             </f7-block-footer>
             <f7-list v-if="ready && thingType.supportedBridgeTypeUIDs.length" inline-labels no-hairlines-md>
-              <thing-picker
-                title="Bridge" name="bridge" :value="thing.bridgeUID"
-                @input="updateBridge"
-                :filterType="thingType.supportedBridgeTypeUIDs" />
+              <thing-picker v-if="thing.editable"
+                            title="Bridge" name="bridge" :value="thing.bridgeUID"
+                            @input="updateBridge"
+                            :filterType="thingType.supportedBridgeTypeUIDs" />
+              <f7-list-item v-else title="Bridge" :after="thing.bridgeUID" />
             </f7-list>
           </f7-col>
         </f7-row>

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -14,9 +14,9 @@
                 </span>
               </f7-list-input>
               <f7-list-input label="Label" type="text" :disabled="!ready || readOnly" placeholder="e.g. My Thing" :value="thing.label"
-                             @input="thing.label = $event.target.value; $emit('updated')" required validate />
+                             @input="thing.label = $event.target.value" required validate />
               <f7-list-input label="Location" type="text" :disabled="!ready || readOnly" placeholder="e.g. Kitchen" :value="thing.location"
-                             @input="thing.location = $event.target.value; $emit('updated')" :clear-button="ready && !readOnly" />
+                             @input="thing.location = $event.target.value" :clear-button="ready && !readOnly" />
             </f7-list>
             <f7-block-title v-if="ready && thingType.supportedBridgeTypeUIDs.length">
               Parent Bridge
@@ -60,7 +60,6 @@ export default {
     },
     updateBridge (value) {
       this.thing.bridgeUID = value
-      this.$emit('updated')
       if (this.createMode) this.thing.UID = this.computedThingUid()
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -11,7 +11,7 @@
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
         <f7-block-title>Channel</f7-block-title>
-        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" />
+        <channel-general-settings :channel="channel" :channelType="channelType" :createMode="false" :disabled="!thing.editable" />
       </f7-col>
       <f7-col v-if="channelType != null">
         <f7-block-title v-if="configDescription.parameters">
@@ -25,7 +25,8 @@
         <config-sheet
           :parameter-groups="configDescription.parameterGroups"
           :parameters="configDescription.parameters"
-          :configuration="config" />
+          :configuration="config"
+          :read-only="!thing.editable"/>
       </f7-col>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -26,7 +26,7 @@
           :parameter-groups="configDescription.parameterGroups"
           :parameters="configDescription.parameters"
           :configuration="config"
-          :read-only="!thing.editable"/>
+          :read-only="!thing.editable" />
       </f7-col>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -2,19 +2,19 @@
   <f7-block class="padding-vertical no-padding-horizontal">
     <f7-col>
       <f7-list class="no-margin" inline-labels no-hairlines-md>
-        <f7-list-input v-if="createMode" label="Channel Identifier" type="text" placeholder="Required" :value="channel.id"
+        <f7-list-input v-if="createMode" :disabled="disabled" label="Channel Identifier" type="text" placeholder="Required" :value="channel.id"
                        info="Note: cannot be changed after the creation"
                        required validate pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
                        @input="channel.id = $event.target.value" />
-        <f7-list-item v-if="!createMode" media-item class="channel-item" title="Channel UID">
+        <f7-list-item v-if="!createMode" :disabled="disabled" media-item class="channel-item" title="Channel UID">
           <div slot="subtitle">
             {{ channel.uid }}
             <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
           </div>
         </f7-list-item>
-        <f7-list-input label="Label" type="text" :placeholder="(channelType !== null) ? channelType.label : 'Required'" :value="channel.label" required validate
+        <f7-list-input label="Label" type="text" :disabled="disabled" :placeholder="(channelType !== null) ? channelType.label : 'Required'" :value="channel.label" required validate
                        @input="channel.label = $event.target.value" clear-button />
-        <f7-list-input label="Description" type="text" :placeholder="(channelType !== null) ? channelType.description : ''" :value="channel.description"
+        <f7-list-input label="Description" type="text" :disabled="disabled" :placeholder="(channelType !== null) ? channelType.description : ''" :value="channel.description"
                        @input="channel.description = $event.target.value" clear-button />
       </f7-list>
     </f7-col>
@@ -24,7 +24,7 @@
 <script>
 import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 export default {
-  props: ['channel', 'channelType', 'createMode'],
+  props: ['channel', 'channelType', 'createMode', 'disabled'],
   components: {
     ClipboardIcon
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -54,11 +54,11 @@
 
         <f7-block v-if="ready && !error" class="block-narrow">
           <f7-col>
-            <thing-general-settings :thing="thing" :thing-type="thingType" @updated="thingDirty = true" :ready="true" :read-only="thing.editable === false" />
+            <thing-general-settings :thing="thing" :thing-type="thingType" :ready="true" :read-only="!editable" />
             <f7-block-title v-if="thingType && thingType.UID" medium style="margin-bottom: var(--f7-list-margin-vertical)">
               Information
             </f7-block-title>
-            <f7-block-footer v-if="thing.editable === false" class="no-margin padding-left">
+            <f7-block-footer v-if="!editable" class="no-margin padding-left">
               <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: {{ notEditableMsg }}
             </f7-block-footer>
             <f7-list accordion-opposite>
@@ -90,14 +90,13 @@
                           :configuration="thing.configuration"
                           :status="configStatusInfo"
                           :set-empty-config-as-null="true"
-                          :read-only="thing.editable === false"
-                          @updated="configDirty = true" />
+                          :read-only="!editable" />
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
         <f7-block v-else-if="!error" class="block-narrow skeleton-text skeleton-effect-blink">
           <f7-col>
-            <thing-general-settings :thing="thing" :thing-type="thingType" @updated="thingDirty = true" :ready="false" />
+            <thing-general-settings :thing="thing" :thing-type="thingType" :ready="false" />
             <f7-block-title medium>
               ____ _______
             </f7-block-title>
@@ -124,7 +123,7 @@
           </f7-block>
         </div>
 
-        <f7-block class="block-narrow" v-if="ready && thing.editable">
+        <f7-block class="block-narrow" v-if="ready && editable">
           <f7-col>
             <f7-list>
               <f7-list-button color="red" title="Delete Thing" @click="deleteThing" />
@@ -139,7 +138,7 @@
                         @channels-updated="onChannelsUpdated" :context="context" />
           <f7-col v-if="isExtensible || thing.channels.length > 0">
             <f7-list>
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Channel" v-if="isExtensible && thing.editable" @click="addChannel()" />
+              <f7-list-button class="searchbar-ignore" color="blue" title="Add Channel" v-if="isExtensible && editable" @click="addChannel()" />
               <f7-list-button class="searchbar-ignore" color="blue" title="Add Equipment to Model" @click="addToModel(true)" />
               <f7-list-button class="searchbar-ignore" color="blue" title="Add Points to Model" @click="addToModel(false)" />
               <f7-list-button class="searchbar-ignore" color="red" title="Unlink all Items" @click="unlinkAll(false)" />
@@ -150,8 +149,8 @@
       </f7-tab>
 
       <f7-tab id="code" :tab-active="currentTab === 'code'">
-        <f7-icon v-if="thing.editable === false" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" :tooltip="notEditableMsg" />
-        <editor class="thing-code-editor" mode="application/vnd.openhab.thing+yaml" :value="thingYaml" :hint-context="{ thingType: thingType, channelTypes: channelTypes }" @input="onEditorInput" :read-only="thing.editable === false" />
+        <f7-icon v-if="!editable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" :tooltip="notEditableMsg" />
+        <editor class="thing-code-editor" mode="application/vnd.openhab.thing+yaml" :value="thingYaml" :hint-context="{ thingType: thingType, channelTypes: channelTypes }" @input="onEditorInput" :read-only="!editable" />
         <!-- <pre class="yaml-message padding-horizontal" :class="[yamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{yamlError}}</pre> -->
       </f7-tab>
     </f7-tabs>
@@ -264,6 +263,8 @@ import buildTextualDefinition from './thing-textual-definition'
 import ThingStatus from '@/components/thing/thing-status-mixin'
 
 import DirtyMixin from '../dirty-mixin'
+import cloneDeep from 'lodash/cloneDeep'
+import fastDeepEqual from 'fast-deep-equal/es6'
 
 let copyToast = null
 
@@ -285,6 +286,7 @@ export default {
       thingDirty: false,
       currentTab: 'thing',
       thing: {},
+      savedThing: {},
       thingType: {},
       channelTypes: {},
       configDescriptions: {},
@@ -304,6 +306,9 @@ export default {
     })
   },
   computed: {
+    editable () {
+      return this.thing && this.thing.editable
+    },
     isExtensible () {
       if (!this.thingType || !this.thingType.extensibleChannelTypeIds) return false
       return this.thingType.extensibleChannelTypeIds.length > 0
@@ -329,7 +334,22 @@ export default {
   },
   watch: {
     configDirty: function () { this.dirty = this.configDirty || this.thingDirty },
-    thingDirty: function () { this.dirty = this.configDirty || this.thingDirty }
+    thingDirty: function () { this.dirty = this.configDirty || this.thingDirty },
+    thing: {
+      handler () {
+        if (!this.loading) { // ignore initial rule assignment
+          // create rule object clone in order to be able to delete status part
+          // which can change from eventsource but doesn't mean a rule modification
+          let thingClone = cloneDeep(this.thing)
+          delete thingClone.statusInfo
+          delete this.savedThing.statusInfo
+
+          this.configDirty = !fastDeepEqual(thingClone.configuration, this.savedThing.configuration)
+          this.thingDirty = !fastDeepEqual(thingClone, this.savedThing)
+        }
+      },
+      deep: true
+    }
   },
   methods: {
     onPageAfterIn (event) {
@@ -352,7 +372,6 @@ export default {
     },
     onEditorInput (value) {
       this.thingYaml = value
-      this.dirty = true
     },
     switchTab (tab) {
       if (this.currentTab === tab) return
@@ -371,6 +390,15 @@ export default {
       // if (this.ready) return
       if (this.loading) return
       this.loading = true
+
+      const loadingFinished = () => {
+        this.$nextTick(() => {
+          this.savedThing = cloneDeep(this.thing)
+          this.ready = true
+          this.loading = false
+        })
+      }
+
       this.$oh.api.get('/rest/things/' + this.thingId).then(data => {
         this.$set(this, 'thing', data)
 
@@ -383,10 +411,6 @@ export default {
 
           this.$oh.api.get('/rest/config-descriptions/thing:' + this.thingId).then(data3 => {
             this.configDescriptions = data3
-            this.ready = true
-            this.loading = false
-            this.configDirty = false
-            this.thingDirty = false
 
             // gather actions (rendered as buttons at the bottom)
             let bindingActionsGrouped = this.getBindingActions(this.configDescriptions)
@@ -409,18 +433,16 @@ export default {
             })
             this.configActionsByGroup = allActions
 
+            loadingFinished()
             if (!this.eventSource) this.startEventSource()
           }).catch(err => {
             console.log('No config descriptions for this thing, using those on the thing type: ' + err)
-            this.ready = true
-            this.loading = false
-            this.configDirty = false
-            this.thingDirty = false
             this.configDescriptions = {
               parameterGroups: this.thingType.parameterGroups,
               parameters: this.thingType.configParameters
             }
 
+            loadingFinished()
             if (!this.eventSource) this.startEventSource()
           })
 
@@ -431,7 +453,7 @@ export default {
         }).catch((err) => {
           console.warn('Cannot load the related info: ' + err)
           this.error = true
-          this.ready = true
+          loadingFinished()
         })
       })
     },
@@ -482,13 +504,13 @@ export default {
         }
       }
 
-      // if set dirty flag is set, assume the config has to be saved with PUT /rest/things/:thingId/config
-      // otherwise (for example, channels or label) use the regular PUT /rest/thing/:thingId
       let endpoint, payload, successMessage
+      // if configDirty flag is set, assume the config has to be saved with PUT /rest/things/:thingId/config
       if (this.configDirty && !this.thingDirty && !saveThing) {
         endpoint = '/rest/things/' + this.thingId + '/config'
         payload = this.thing.configuration
         successMessage = 'Thing configuration updated'
+        // otherwise (for example, channels or label) use the regular PUT /rest/thing/:thingId
       } else {
         endpoint = '/rest/things/' + this.thingId
         payload = this.thing
@@ -532,7 +554,6 @@ export default {
         this.thing.label,
         () => {
           thing.configuration[action.name] = true
-          this.configDirty = true
           save()
         }
       )
@@ -784,7 +805,6 @@ export default {
     },
     fromYaml () {
       const updatedThing = YAML.parse(this.thingYaml)
-      let dirty = false
 
       const isExtensible = (channel, thingType) => {
         if (!channel || !channel.channelTypeUID) return false
@@ -795,13 +815,12 @@ export default {
       try {
         if (updatedThing.UID !== this.thing.UID) throw new Error('Changing the thing UID is not supported')
         if (updatedThing.thingTypeUID !== this.thing.thingTypeUID) throw new Error('Changing the thing type is not supported')
-        if (updatedThing.label) { this.$set(this.thing, 'label', updatedThing.label); this.thingDirty = dirty = true }
-        if (updatedThing.location) { this.$set(this.thing, 'location', updatedThing.location); this.thingDirty = dirty = true }
-        if (updatedThing.bridgeUID) { this.$set(this.thing, 'bridgeUID', updatedThing.bridgeUID); this.thingDirty = dirty = true }
+        if (updatedThing.label) this.$set(this.thing, 'label', updatedThing.label)
+        if (updatedThing.location) this.$set(this.thing, 'location', updatedThing.location)
+        if (updatedThing.bridgeUID) this.$set(this.thing, 'bridgeUID', updatedThing.bridgeUID)
 
         if (updatedThing.configuration && JSON.stringify(this.thing.configuration) !== JSON.stringify(updatedThing.configuration)) {
           this.$set(this.thing, 'configuration', updatedThing.configuration)
-          this.configDirty = dirty = true
         }
 
         if (updatedThing.channels && Array.isArray(updatedThing.channels)) {
@@ -835,7 +854,6 @@ export default {
               }
               if (!isExtensible(newChannel, this.thingType)) continue
               this.thing.channels.push(newChannel)
-              this.thingDirty = dirty = true
             }
           }
 
@@ -851,13 +869,11 @@ export default {
                   continue
                 }
                 this.thing.channels.splice(this.thing.channels.findIndex((c) => c.id === existingChannel.id), 1)
-                this.thingDirty = dirty = true
               }
             }
           }
         }
-
-        return dirty
+        return true
       } catch (e) {
         this.$f7.dialog.alert(e).open()
         return false

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -784,11 +784,6 @@ export default {
 
       const editableChannels = []
 
-      const isExtensible = (channel, thingType) => {
-        const bindingId = thingType.UID.split(':')[0]
-        return thingType.extensibleChannelTypeIds.map((t) => bindingId + ':' + t).indexOf(channel.channelTypeUID) >= 0
-      }
-
       for (const channel of this.thing.channels) {
         const editableChannel = {
           id: channel.id,

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -2,10 +2,11 @@
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" class="thing-details-page">
     <f7-navbar :title="thing.label || thing.UID" back-link="Back" no-hairline>
       <f7-nav-right v-show="!error">
-        <f7-link @click="save()" v-if="$theme.md && thing.editable" icon-md="material:save" icon-only />
-        <f7-link @click="save()" v-if="!$theme.md && thing.editable">
+        <f7-link @click="save()" v-if="$theme.md && editable" icon-md="material:save" icon-only />
+        <f7-link @click="save()" v-if="!$theme.md && editable">
           Save<span v-if="$device.desktop">&nbsp;(Ctrl-S)</span>
         </f7-link>
+        <f7-link v-else icon-f7="lock_fill" icon-only tooltip="This Thing is not editable through the UI" />
       </f7-nav-right>
     </f7-navbar>
     <f7-toolbar tabbar position="top">
@@ -496,7 +497,7 @@ export default {
       })
     },
     save (saveThing) {
-      if (!this.ready) return
+      if (!this.ready || !this.editable) return
 
       if (this.currentTab === 'code') {
         if (!this.fromYaml()) {


### PR DESCRIPTION
Fixes dirty checks: When the code tab was opened, the page always wanted to be saved before leave, even though nothing was modified.

Fixes not-editable handling: Channels were configurable even though the Thing was not editable and the save keyboard shortcut attemted a save. In both cases, the according API requests failed, because the Thing was not editable.