### PR TITLE
Change add item route to avoid clashing with item name

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -272,7 +272,7 @@
               Inbox
             </f7-list-button>
             <f7-list-item divider title="Items" />
-            <f7-list-button href="/settings/items/add" color="blue" :animate="false">
+            <f7-list-button href="/settings/items/add-item" color="blue" :animate="false">
               Create Item
             </f7-list-button>
             <f7-list-button href="/settings/items/add-from-textual-definition" color="blue" :animate="false">

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -176,7 +176,7 @@ export default [
         async: loadAsync(ItemsListPage),
         routes: [
           {
-            path: 'add',
+            path: 'add-item',
             beforeEnter: [enforceAdminForRoute],
             async: loadAsync(ItemEditPage, { createMode: true })
           },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -114,7 +114,7 @@
       <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
       <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
       <f7-fab-buttons position="top">
-        <f7-fab-button fab-close label="Add Item" href="add">
+        <f7-fab-button fab-close label="Add Item" href="add-item">
           <f7-icon ios="material:label_outline" md="material:label_outline" aurora="material:label_outline" />
         </f7-fab-button>
         <f7-fab-button fab-close label="Add Items from Textual Definition" href="add-from-textual-definition">


### PR DESCRIPTION
Fix #2333

Change the route from `/settings/items/add` -> `/settings/items/add-item`