### PR TITLE
Fixes & Improvements to persistence edit, channel details & doc links logic

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -129,7 +129,7 @@ export default {
           id: 'documentationLink',
           title: 'Documentation',
           afterIcon: 'question_circle_fill',
-          linkUrl: `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id}` // this.addon.link
+          linkUrl: `${this.$store.state.websiteUrl}/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}/${this.addon.id}` // this.addon.link
         })
 
         let repository

--- a/bundles/org.openhab.ui/web/src/components/developer/help-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help-sidebar.vue
@@ -15,7 +15,7 @@
                   <f7-list-item v-for="step in instruct.steps" :key="step.title" :link="step.link" :title="step.title">
                     <div class="item-text" v-html="step.text" />
                   </f7-list-item>
-                  <f7-list-button v-if="instruct.button" :external="true" :title="instruct.button.title" :href="documentationLinkPrefix + instruct.button.link" target="_blank" />
+                  <f7-list-button v-if="instruct.button" :external="true" :title="instruct.button.title" :href="$store.state.websiteUrl + '/' + instruct.button.link" target="_blank" />
                 </f7-list>
               </f7-accordion-content>
             </f7-list-item>
@@ -41,7 +41,7 @@
                   </p>
                   <p v-html="faq.text" />
                   <p v-if="faq.doclink">
-                    <f7-link external target="_blank" :href="documentationLinkPrefix+faq.doclink">
+                    <f7-link external target="_blank" :href="$store.state.websiteUrl + '/' + faq.doclink">
                       Full Help Docs
                     </f7-link>
                   </p>
@@ -60,7 +60,7 @@
         </f7-block>
         <f7-block class="no-margin no-padding">
           <f7-list media-list>
-            <f7-list-item v-for="addon in addons" :key="addon.uid" :link="addon.link.replace('https://www.openhab.org/', documentationLinkPrefix)" :external="true" target="_blank" :title="addon.label.replaceAll(/Binding|Transformation|Persistence/gi,'')" :text="addon.type" />
+            <f7-list-item v-for="addon in addons" :key="addon.uid" :link="addon.link.replace('https://www.openhab.org', $store.state.websiteUrl)" :external="true" target="_blank" :title="addon.label.replaceAll(/Binding|Transformation|Persistence/gi,'')" :text="addon.type" />
           </f7-list>
         </f7-block>
       </div>
@@ -94,8 +94,8 @@
           You can find many more details and help at these resources:
           <ul>
             <li><f7-link external target="_blank" href="https://www.openhab.org/" v-t="'about.homePage'" /></li>
-            <li><f7-link external target="_blank" :href="`${documentationLinkPrefix}link/docs`" v-t="'about.documentation'" /></li>
-            <li><f7-link external :href="`${documentationLinkPrefix}link/tutorial`" target="_blank" v-t="'home.overview.button.tutorial'" /></li>
+            <li><f7-link external target="_blank" :href="`${$store.state.websiteUrl}/link/docs`" v-t="'about.documentation'" /></li>
+            <li><f7-link external :href="`${$store.state.websiteUrl}/link/tutorial`" target="_blank" v-t="'home.overview.button.tutorial'" /></li>
             <li><f7-link external target="_blank" href="https://community.openhab.org/" v-t="'about.communityForum'" /></li>
           </ul>
         </f7-block>
@@ -155,11 +155,6 @@ export default {
       addons: [],
       faqs: require('@/assets/definitions/help/help-faq-defs.json'),
       qstart: require('@/assets/definitions/help/help-qstart-defs.json')
-    }
-  },
-  computed: {
-    documentationLinkPrefix () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/`
     }
   },
   created () {

--- a/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
@@ -24,9 +24,6 @@ export default {
       if (this.$store.state.runtimeInfo.buildString === 'Release Build') return 'final-stable'
       return 'final'
     },
-    docUrl () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/docs`
-    },
     docSrcUrl () {
       return `https://raw.githubusercontent.com/openhab/openhab-docs/${this.docsBranch}/mainui`
     },
@@ -35,8 +32,8 @@ export default {
       return this.$store.state.pagePath
     },
     documentationLink () {
-      if (this.path.endsWith('index')) return `${this.docUrl}/mainui${this.path.replace('index', '')}`
-      return `${this.docUrl}/mainui${this.path}`
+      if (this.path.endsWith('index')) return `${this.$store.state.websiteUrl}/docs/mainui${this.path.replace('index', '')}`
+      return `${this.$store.state.websiteUrl}/docs/mainui${this.path}`
     }
   },
   watch: {
@@ -91,7 +88,7 @@ export default {
             body = body.replace(/<img src=".*$/gm, '') // Remove images
 
             // Fix {{base}} and /docs anchor href for doc pages
-            body = body.replace(/<a href="(%7B%7Bbase%7D%7D|\/docs)/gm, `<a class="external" target="_blank" href="${this.docUrl}`)
+            body = body.replace(/<a href="(%7B%7Bbase%7D%7D|\/docs)/gm, `<a class="external" target="_blank" href="${this.$store.state.websiteUrl}/docs`)
             // Fix local folder anchor href: Rewrite folder to /folder/
             body = body.replace(/(<a href=")([A-z]+)(")/gm, '$1' + this.localUrl + '$2/$3')
 

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -87,9 +87,7 @@ export default {
       itemType: this.item.groupType || this.item.type,
       multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
       classSelectKey: this.$f7.utils.id(),
-      docUrl:
-        `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org` +
-        '/link/alexa',
+      docUrl: `${this.$store.state.websiteUrl}/link/alexa`,
       ready: false
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -28,7 +28,7 @@
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
     </div>
     <p class="padding">
-      <f7-link color="blue" external target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/google-assistant`">
+      <f7-link color="blue" external target="_blank" :href="`${$store.state.websiteUrl}/link/google-assistant`">
         Google Assistant Integration Documentation
       </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -53,7 +53,7 @@
       </f7-block-footer>
     </f7-block>
     <p class="padding">
-      <f7-link color="blue" external target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/homekit`">
+      <f7-link color="blue" external target="_blank" :href="`${$store.state.websiteUrl}/link/homekit`">
         HomeKit integration documentation
       </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -23,6 +23,7 @@ const store = new Vuex.Store({
     apiEndpoints: null,
     locale: null,
     runtimeInfo: null,
+    websiteUrl: null,
     developerDock: false,
     pagePath: null
   },
@@ -35,6 +36,7 @@ const store = new Vuex.Store({
       state.apiVersion = rootResponse.version
       state.runtimeInfo = rootResponse.runtimeInfo
       state.apiEndpoints = rootResponse.links
+      state.websiteUrl = `https://${rootResponse.runtimeInfo?.buildString !== 'Release Build' ? 'next' : 'www'}.openhab.org`
     },
     setLocale (state, locale) {
       state.locale = locale

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
@@ -237,10 +237,9 @@ export default {
     docLinkUrl () {
       if (!this.addon) return ''
       if (this.serviceId && this.serviceId !== 'karaf') return this.addon.link ? this.addon.link : ''
-      let url = `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org` +
+      return this.$store.state.websiteUrl +
         `/addons/${this.addon.type.replace('misc', 'integrations').replace('binding', 'bindings').replace('transformation', 'transformations')}` +
         `/${this.addon.id}`
-      return url
     },
     showInstallActions () {
       let splitted = this.addon.uid.split(':')

--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -16,9 +16,9 @@
     <div class="empty-overview" v-else-if="!inChatSession">
       <empty-state-placeholder icon="house" title="overview.title" text="overview.text" />
       <f7-row v-if="!$store.getters.isAdmin || $f7.width < 1280" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" external :href="`${documentationLinkPrefix}link/docs`" target="_blank" v-t="'home.overview.button.documentation'" />
+        <f7-button large fill color="blue" external :href="`${$store.state.websiteUrl}/link/docs`" target="_blank" v-t="'home.overview.button.documentation'" />
         <span style="width: 8px" />
-        <f7-button large color="blue" external :href="`${documentationLinkPrefix}link/tutorial`" target="_blank" v-t="'home.overview.button.tutorial'" />
+        <f7-button large color="blue" external :href="`${$store.state.websiteUrl}/link/tutorial`" target="_blank" v-t="'home.overview.button.tutorial'" />
       </f7-row>
       <f7-row v-else class="display-flex justify-content-center">
         <f7-button large fill color="blue" @click="$f7.emit('selectDeveloperDock',{'dock':'help','helpTab':'quick'})" v-t="'home.overview.button.quickstart'" />
@@ -80,9 +80,6 @@ export default {
     pageStyle () {
       if (!this.overviewPage) return null
       return this.overviewPage.config.style
-    },
-    documentationLinkPrefix () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/`
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -171,8 +171,9 @@ export default {
       }
     },
     save () {
+      if (!this.item.editable) return
       if (this.currentTab === 'code') {
-        if (!this.fromYaml()) return Promise.reject()
+        if (!this.fromYaml()) return
       }
       if (this.validateItemName(this.item.name) !== '') return this.$f7.dialog.alert('Please give the Item a valid name: ' + this.validateItemName(this.item.name)).open()
       if (!this.item.type || !this.types.ItemTypes.includes(this.item.type.split(':')[0])) return this.$f7.dialog.alert('Please give Item a valid type').open()

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -103,7 +103,7 @@
     <f7-block v-if="ready && !items.length" class="block-narrow">
       <empty-state-placeholder icon="square_on_circle" title="items.title" text="items.text" />
       <f7-row v-if="$f7.width < 1280" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" external :href="documentationLink" target="_blank" v-t="'home.overview.button.documentation'" />
+        <f7-button large fill color="blue" external :href="`${$store.state.websiteUrl}/link/items`" target="_blank" v-t="'home.overview.button.documentation'" />
       </f7-row>
     </f7-block>
 
@@ -304,9 +304,6 @@ export default {
     }
   },
   computed: {
-    documentationLink () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/items`
-    },
     searchPlaceholder () {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -23,12 +23,15 @@
       <f7-tab id="design" @tab:show="() => this.currentTab = 'design'" :tab-active="currentTab === 'design'">
         <f7-block class="block-narrow">
           <f7-col>
-            <f7-block-footer>
-              Persistence stores data over time, which can be retrieved at a later time, e.g. to restore Item states after startup, or to display graphs in the UI.
-              <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/persistence`">
-                Learn more about persistence.
-              </f7-link>
-            </f7-block-footer>
+            <div>
+              <f7-block-footer style="padding-left: 16px; padding-right: 16px">
+                Persistence stores data over time, which can be retrieved at a later time, e.g. to restore Item states after startup, or to display graphs in the UI.
+                <f7-link external color="blue" target="_blank" :href="`${$store.state.runtimeInfo.websiteUrl}/link/persistence`">
+                  Learn more about persistence.
+                </f7-link>
+              </f7-block-footer>
+            </div>
+
           </f7-col>
         </f7-block>
         <!-- Skeletons for not ready -->
@@ -405,7 +408,6 @@ export default {
   },
   methods: {
     onPageAfterIn () {
-      if (this.ready) return
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -31,7 +31,6 @@
                 </f7-link>
               </f7-block-footer>
             </div>
-
           </f7-col>
         </f7-block>
         <!-- Skeletons for not ready -->

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -46,7 +46,7 @@
     <f7-block v-if="ready && !persistenceList.length" class="block-narrow">
       <empty-state-placeholder icon="tray-arrow-down" title="persistence.title" text="persistence.text" />
       <f7-row class="display-flex justify-content-center">
-        <f7-button large fill color="blue" external :href="documentationLink" target="_blank" v-t="'home.overview.button.documentation'" />
+        <f7-button large fill color="blue" external :href="`${$store.state.websiteUrl}/link/persistence`" target="_blank" v-t="'home.overview.button.documentation'" />
         <span style="width: 8px" />
         <f7-button large fill color="blue" href="/addons/other/">
           Install a persistence add-on
@@ -81,11 +81,6 @@ export default {
       persistenceList: [],
       configDescriptions: null,
       config: null
-    }
-  },
-  computed: {
-    documentationLink () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/persistence`
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
@@ -23,6 +23,8 @@
     padding 0
   .item-inner:after
     display none
+  .item-title
+    padding-left 8px
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -137,7 +137,7 @@
       <empty-state-placeholder v-else-if="showScenes" icon="film" title="scenes.title" text="scenes.text" />
       <empty-state-placeholder v-else icon="wand_stars" title="rules.title" text="rules.text" />
       <f7-row v-if="$f7.width < 1280" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" external :href="documentationLink" target="_blank" v-t="'home.overview.button.documentation'" />
+        <f7-button large fill color="blue" external :href="`${$store.state.websiteUrl}/link/${type.toLowerCase()}`" target="_blank" v-t="'home.overview.button.documentation'" />
       </f7-row>
     </f7-block>
 
@@ -174,9 +174,6 @@ export default {
   computed: {
     type () {
       return this.showScripts ? 'Scripts' : (this.showScenes ? 'Scenes' : 'Rules')
-    },
-    documentationLink () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/${this.type.toLowerCase()}`
     },
     filteredRules () {
       if (this.selectedTags.length === 0) return this.rules

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -13,9 +13,9 @@
           </div>
         </f7-list-item>
         <f7-list-input label="Label" type="text" :disabled="disabled" :placeholder="(channelType !== null) ? channelType.label : 'Required'" :value="channel.label" required validate
-                       @input="channel.label = $event.target.value" clear-button />
+                       @input="channel.label = $event.target.value" :clear-button="disabled !== true" />
         <f7-list-input label="Description" type="text" :disabled="disabled" :placeholder="(channelType !== null) ? channelType.description : ''" :value="channel.description"
-                       @input="channel.description = $event.target.value" clear-button />
+                       @input="channel.description = $event.target.value" :clear-button="disabled !== true" />
       </f7-list>
     </f7-col>
   </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -80,7 +80,7 @@
         <f7-block-title>Profile</f7-block-title>
         <f7-block-footer class="padding-left padding-right">
           Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/profiles`">
+          <f7-link external color="blue" target="_blank" :href="`${$store.state.websiteUrl}/link/profiles`">
             Learn more about profiles.
           </f7-link>
         </f7-block-footer>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -48,7 +48,7 @@
         <f7-block-title>Profile</f7-block-title>
         <f7-block-footer class="padding-left padding-right">
           Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="blue" target="_blank" :href="`https://${$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/profiles`">
+          <f7-link external color="blue" target="_blank" :href="`${$store.state.websiteUrl}/link/profiles`">
             Learn more about profiles.
           </f7-link>
           <f7-block v-if="!ready" class="text-align-center">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -123,7 +123,7 @@
     <f7-block v-if="ready && !things.length" class="block-narrow">
       <empty-state-placeholder icon="lightbulb" title="things.title" text="things.text" />
       <f7-row v-if="$f7.width < 1280" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" external :href="documentationLink" target="_blank" v-t="'home.overview.button.documentation'" />
+        <f7-button large fill color="blue" external :href="`${$store.state.websiteUrl}/link/thing`" target="_blank" v-t="'home.overview.button.documentation'" />
       </f7-row>
     </f7-block>
 
@@ -172,9 +172,6 @@ export default {
 
   },
   computed: {
-    documentationLink () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/thing`
-    },
     indexedThings () {
       if (this.groupBy === 'alphabetical') {
         return this.things.reduce((prev, thing, i, things) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -107,7 +107,7 @@
     <f7-block v-if="ready && !transformations.length" class="block-narrow">
       <empty-state-placeholder icon="arrow_2_squarepath" title="transformations.title" text="transformations.text" />
       <f7-row v-if="$f7.width < 1280" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" external :href="documentationLink" target="_blank" v-t="'home.overview.button.documentation'" />
+        <f7-button large fill color="blue" external :href="`${this.$store.state.websiteUrl}/link/transformations`" target="_blank" v-t="'home.overview.button.documentation'" />
       </f7-row>
     </f7-block>
 
@@ -135,9 +135,6 @@ export default {
     }
   },
   computed: {
-    documentationLink () {
-      return `https://${this.$store.state.runtimeInfo.buildString === 'Release Build' ? 'www' : 'next'}.openhab.org/link/transformations`
-    },
     indexedTransformations () {
       if (this.groupBy === 'alphabetical') {
         return this.transformations.reduce((prev, transformation, i, transformations) => {


### PR DESCRIPTION
- Improve doc link logic and use Vuex store for the openHAB website url.
- Channel info: Fix clear buttons displayed even if not editable.
- Persistence edit: Fix styling issues.