### PR TITLE
Remove padding in list grouping toolbar

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -70,7 +70,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ pages.length }} pages
         </f7-block-title>
-        <div class="searchbar-found" v-show="!ready || pages.length > 0">
+        <div class="searchbar-found padding-left padding-right" v-show="!ready || pages.length > 0">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical
@@ -147,6 +147,13 @@
     </f7-fab>
   </f7-page>
 </template>
+
+<style lang="stylus">
+.searchbar-found
+  @media (min-width 960px)
+    padding-left 0 !important
+    padding-right 0 !important
+</style>
 
 <script>
 export default {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -70,7 +70,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ pages.length }} pages
         </f7-block-title>
-        <div class="padding-left padding-right searchbar-found" v-show="!ready || pages.length > 0">
+        <div class="searchbar-found" v-show="!ready || pages.length > 0">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -52,7 +52,7 @@
             <label @click="toggleIgnored" style="cursor:pointer">Show ignored</label> <f7-checkbox :checked="showIgnored" @change="toggleIgnored" />
           </div>
         </f7-block-title>
-        <div class="searchbar-found" v-show="!ready || inboxCount > 0">
+        <div class="searchbar-found padding-left padding-right" v-show="!ready || inboxCount > 0">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical
@@ -115,6 +115,13 @@
     </f7-fab>
   </f7-page>
 </template>
+
+<style lang="stylus">
+.searchbar-found
+  @media (min-width 960px)
+    padding-left 0 !important
+    padding-right 0 !important
+</style>
 
 <script>
 export default {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -52,7 +52,7 @@
             <label @click="toggleIgnored" style="cursor:pointer">Show ignored</label> <f7-checkbox :checked="showIgnored" @change="toggleIgnored" />
           </div>
         </f7-block-title>
-        <div class="padding-left padding-right searchbar-found" v-show="!ready || inboxCount > 0">
+        <div class="searchbar-found" v-show="!ready || inboxCount > 0">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -73,7 +73,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ things.length }} Things
         </f7-block-title>
-        <div class="searchbar-found padding-left padding-right">
+        <div class="searchbar-found">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -73,7 +73,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ things.length }} Things
         </f7-block-title>
-        <div class="searchbar-found">
+        <div class="searchbar-found padding-left padding-right">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical
@@ -143,6 +143,11 @@
 <style lang="stylus">
 .things-list
   margin-bottom calc(var(--f7-fab-size) + 2 * calc(var(--f7-fab-margin) + var(--f7-safe-area-bottom)))
+
+.searchbar-found
+  @media (min-width 960px)
+    padding-left 0 !important
+    padding-right 0 !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -66,7 +66,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ transformations.length }} transformations
         </f7-block-title>
-        <div class="padding-left padding-right searchbar-found">
+        <div class="searchbar-found">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -66,7 +66,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           {{ transformations.length }} transformations
         </f7-block-title>
-        <div class="searchbar-found">
+        <div class="searchbar-found padding-left padding-right">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
               Alphabetical
@@ -116,6 +116,13 @@
     </f7-fab>
   </f7-page>
 </template>
+
+<style lang="stylus">
+.searchbar-found
+  @media (min-width 960px)
+    padding-left 0 !important
+    padding-right 0 !important
+</style>
 
 <script>
 


### PR DESCRIPTION
A minor cosmetic change

Before:
![image](https://github.com/openhab/openhab-webui/assets/2554958/693eb16f-db4f-4597-aa41-bec89feefea6)

After:
<img width="1046" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/45bd0a1b-781d-4bf4-a1d0-869b96c9169a">

