### PR TITLE
Accept double click to pick a model in model picker popup

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -88,6 +88,7 @@ export default {
       includeItemTags: false,
       expanded: false,
       doubleClickStarted: null,
+      doubleClickItem: null,
       items: [],
       links: [],
       locations: [],
@@ -278,10 +279,11 @@ export default {
     selectItem (item) {
       if (!this.multiple) {
         this.selectedItem = item
-        if (this.doubleClickStarted) {
+        if (this.doubleClickStarted && this.doubleClickItem === item) {
           this.pickItems()
         } else {
           this.doubleClickStarted = setTimeout(() => { this.doubleClickStarted = null }, 500)
+          this.doubleClickItem = item
         }
       } else if (item.children && item.opened !== undefined) {
         item.opened = !item.opened

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -87,6 +87,7 @@ export default {
       includeItemName: false,
       includeItemTags: false,
       expanded: false,
+      doubleClickStarted: null,
       items: [],
       links: [],
       locations: [],
@@ -277,6 +278,11 @@ export default {
     selectItem (item) {
       if (!this.multiple) {
         this.selectedItem = item
+        if (this.doubleClickStarted) {
+          this.pickItems()
+        } else {
+          this.doubleClickStarted = setTimeout(() => { this.doubleClickStarted = null }, 500)
+        }
       } else if (item.children && item.opened !== undefined) {
         item.opened = !item.opened
       }


### PR DESCRIPTION
Allow double clicking to select an item here, without having to click "Pick" at the top right corner

<img width="640" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/a486d4a4-9ad8-47d2-80ec-50ef416356fd">
