### PR TITLE
Rule & Script editor: Various improvements

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -11,7 +11,7 @@
       </f7-list-group>
       <f7-list-group v-if="itemType && !hideType">
         <!-- Type -->
-        <f7-list-item v-if="itemType && !hideType" title="Type" class="align-popup-list-item" :disabled="!editable" :key="'type-' + itemType" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+        <f7-list-item v-if="itemType && !hideType" title="Type" class="aligned-smart-select" :disabled="!editable" :key="'type-' + itemType" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
           <select name="select-type" @change="item.type = $event.target.value">
             <option v-for="t in types.ItemTypes" :key="t" :value="t" :selected="t === itemType">
               {{ t }}
@@ -19,7 +19,7 @@
           </select>
         </f7-list-item>
         <!-- Dimensions -->
-        <f7-list-item v-if="dimensions.length && !hideType && itemType === 'Number'" title="Dimension" class="align-popup-list-item" :disabled="!editable" :key="'dimension-' + itemDimension" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
+        <f7-list-item v-if="dimensions.length && !hideType && itemType === 'Number'" title="Dimension" class="aligned-smart-select" :disabled="!editable" :key="'dimension-' + itemDimension" smart-select :smart-select-params="{searchbar: true, openIn: 'popup', closeOnSelect: true}">
           <select name="select-dimension" @change="setDimension($event.target.value)">
             <option key="" value="Number" :selected="itemDimension === ''" />
             <option v-for="d in dimensions" :key="d.name" :value="d.name" :selected="d.name === itemDimension">
@@ -83,17 +83,6 @@
     display inherit !important
   .item-title
     font-weight inherit !important
-.align-popup-list-item
-  .item-title
-    // f7-input-item uses 35% for the item-title,
-    // but since their item-inner has less padding (16px vs 31px) on the left side, add those 15px difference
-    min-width calc(35% + 0.35*15px)
-  .item-after
-    width 100%
-    margin 0
-    padding 0
-    margin-left 8px
-    color var(--f7-input-text-color)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -296,3 +296,16 @@ html
 
 .sitemap-validation-dialog
   --f7-dialog-width 80%
+
+// Align smart-select item with f7-list-input fields
+.aligned-smart-select
+  .item-title
+    // f7-input-item uses 35% for the item-title,
+    // but since their item-inner has less padding (16px vs 31px) on the left side, add those 15px difference
+    min-width calc(35% + 0.35*15px)
+  .item-after
+    width 100%
+    margin 0
+    padding 0
+    margin-left 8px
+    color var(--f7-input-text-color)

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -6,19 +6,19 @@
           <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
         </f7-nav-left>
         <f7-nav-title v-if="ruleModule && ruleModule.new">
-          {{ sectionLabels[currentSection][1] }}
+          Add {{ sectionLabels[currentSection][1] }}
         </f7-nav-title>
         <f7-nav-title v-else>
-          Edit module
+          Edit {{ sectionLabels[currentSection][1] }}
         </f7-nav-title>
         <f7-nav-right>
           <f7-link v-show="currentRuleModuleType" @click="updateModuleConfig">
-            Done
+            Save
           </f7-link>
         </f7-nav-right>
       </f7-navbar>
       <f7-block v-if="ruleModule" class="no-margin no-padding">
-        <f7-col v-if="!isSceneModule" class="margin-top">
+        <f7-col v-if="!isSceneModule && currentRuleModuleType" class="margin-top">
           <f7-list inline-labels no-hairlines-md class="no-margin">
             <f7-list-input type="text" :placeholder="moduleTitleSuggestion" :value="ruleModule.label" required
                            @input="ruleModule.label = $event.target.value" clear-button />
@@ -96,9 +96,9 @@ export default {
       currentRuleModuleType: this.ruleModuleType,
       advancedTypePicker: false,
       sectionLabels: {
-        triggers: ['When', 'Add Trigger'],
-        actions: ['Then', 'Add Action'],
-        conditions: ['But only if', 'Add Condition']
+        triggers: ['When', 'Trigger'],
+        actions: ['Then', 'Action'],
+        conditions: ['But only if', 'Condition']
       }
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -86,7 +86,7 @@
           </div>
         </f7-toolbar>
         <f7-block class="block-narrow">
-          <script-general-settings :createMode="newScript" :rule="rule" :isScriptRule="isScriptRule" :mode="mode" :languages="languages" @newLanguage="changeLanguage" />
+          <script-general-settings :createMode="newScript" :rule="rule" :module="currentModule" :module-type="scriptModuleType" :module-types="moduleTypes" :isScriptRule="isScriptRule" :mode="mode" :languages="languages" @newLanguage="changeLanguage" />
           <f7-col v-if="isEditable && isScriptRule">
             <f7-list>
               <f7-list-button color="red" @click="deleteRule">
@@ -153,7 +153,20 @@ export default {
     pageTitle () {
       if (this.newScript) return 'Create Script'
       if (this.isScriptRule) return this.rule.name
-      if (this.currentModule && this.currentModule.label) return this.currentModule.label
+      if (this.currentModule) {
+        let title = 'Edit'
+        switch (this.currentModule.type) {
+          case 'script.ScriptAction':
+          case 'script.ScriptCondition':
+            title += ' ' + this.currentModule.type.slice('script.Script'.length)
+            break
+        }
+        title += ' Script'
+        if (this.currentModule.label) {
+          title += ': ' + this.currentModule.label
+        }
+        return title
+      }
       return 'Edit Script'
     },
     isEditable () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
@@ -3,12 +3,18 @@
     <rule-general-settings v-if="createMode || isScriptRule" :ready="true" :rule="rule" :createMode="createMode" :inScriptEditor="true" />
     <f7-block class="block-narrow">
       <f7-col v-if="!createMode && languages">
-        <f7-block-title>Scripting Language</f7-block-title>
-        <f7-list media-list>
-          <f7-list-item media-item radio radio-icon="start" :disabled="!editable"
-                        :value="mode" :checked="mode === language.contentType" @change="$emit('newLanguage', language.contentType)"
-                        v-for="language in languages" :key="language.contentType"
-                        :title="language.name" :after="language.version" :footer="language.contentType" />
+        <f7-list inline-labels>
+          <template v-if="module && !isScriptRule">
+            <f7-list-input :label="scriptType + ' Title'" type="text" :value="module.label" :placeholder="suggestedModuleTitle(module, moduleType)" @input="module.label = $event.target.value" :disabled="!editable" :clear-button="editable" />
+            <f7-list-input label="Description" type="text" :value="module.description" :placeholder="suggestedModuleDescription(module, moduleType)" @input="module.description = $event.target.value" :disabled="!editable" :clear-button="editable" />
+          </template>
+          <f7-list-item title="Scripting Language" class="aligned-smart-select" :disabled="!editable" :key="mode" smart-select :smart-select-params="{openIn: 'sheet', closeOnSelect: true}">
+            <select @change="$emit('newLanguage', $event.target.value)">
+              <option v-for="language in languages" :key="language.contentType" :value="language.contentType" :selected="language.contentType === mode">
+                {{ language.name }} ({{ language.version }})
+              </option>
+            </select>
+          </f7-list-item>
         </f7-list>
       </f7-col>
     </f7-block>
@@ -17,16 +23,33 @@
 
 <script>
 import RuleGeneralSettings from '@/components/rule/rule-general-settings.vue'
+import ModuleDescriptionSuggestions from '../module-description-suggestions'
 
 export default {
-  props: ['rule', 'createMode', 'isScriptRule', 'languages', 'mode'],
+  mixins: [ModuleDescriptionSuggestions],
+  props: ['rule', 'module', 'moduleType', 'moduleTypes', 'createMode', 'isScriptRule', 'languages', 'mode'],
   emits: ['newLanguage'],
   components: {
     RuleGeneralSettings
   },
   computed: {
     editable () {
+      console.log('module')
+      console.log(this.module)
+      console.log('moduleType')
+      console.log(this.moduleType)
+      console.log('isScriptRule')
+      console.log(this.isScriptRule)
       return this.createMode || (this.rule && this.rule.editable)
+    },
+    scriptType () {
+      switch (this.module.type) {
+        case 'script.ScriptAction':
+        case 'script.ScriptCondition':
+          return this.module.type.slice('script.Script'.length)
+        default:
+          return 'Module'
+      }
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
@@ -34,12 +34,6 @@ export default {
   },
   computed: {
     editable () {
-      console.log('module')
-      console.log(this.module)
-      console.log('moduleType')
-      console.log(this.moduleType)
-      console.log('isScriptRule')
-      console.log(this.isScriptRule)
       return this.createMode || (this.rule && this.rule.editable)
     },
     scriptType () {


### PR DESCRIPTION
Various improvements to the rule editor and script editor

- Remove/hide non-functional title/description input fields in the initial Add Trigger/Action/Condition for the rule editor. These inputs don't do anything. They became functional once a type of module is selected, and they will indeed show up then.
- When editing a rule module, set the popup title to reflect the type of module, i.e. "Edit Trigger", or "Edit Condition"
- Changed the link on the top right corner from `Done` to `Save`
- Removed the pencil icon for consistency. Previously, Cron and Scripts have a pencil icon which goes to the Edit module popup vs clicking directly on the line goes directly to Cron Builder, or Script Editor. Now with the pencil icon gone, cron will go into the Edit module popup, which can lead to the cron builder from there, and Scripts go directly to script editor. Changing the script title/description is possible from within the script editor's bottom area as shown below.

Script Editor:
- Change the title of Script Editor, from "Edit Script" to better clarify what type of script is being edited. So the new title becomes "Edit Action Script: <script title>" or "Edit Condition Script: <script title>" 
- Add the ability to change the script's title and description after they're created.


## Remove the Title/Description input in the Add [Trigger/Action/Condition]
They don't seem to apply to anything

Before:
![image](https://github.com/openhab/openhab-webui/assets/2554958/519a133b-a62a-4e6e-88e9-f015f312e54c)

After:
<img width="653" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/12755cd8-8d23-4634-bc1e-b082579a92f2">

## Change the popup title from `Edit module` to `Edit [Trigger/Action/Condition]`
Before:
![image](https://github.com/openhab/openhab-webui/assets/2554958/e7fbb042-9b68-438a-ade9-21f4bb11fe18)

After:
![image](https://github.com/openhab/openhab-webui/assets/2554958/80612479-b7e2-4f31-bbb5-c0c081d701ca)

## Change the title of script editor
Before:
![image](https://github.com/openhab/openhab-webui/assets/2554958/4f27714a-6c1a-438f-9648-8819d83f797a)

After:
<img width="516" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/39508ba4-3218-4639-9727-71fffa34b2b6">

And when the action has a custom label:
<img width="512" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/ba978e8c-47ef-4e29-bb11-e9065c24b9ed">

So user can see whether it's an action script or a condition script from the editor's title
<img width="569" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/67b7a3d0-b55c-4c1b-8a7a-ff6cfd5f31af">

## Removed pencil icons
Before:
<img width="796" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/fa6ca44b-85f1-4936-ad9c-8652eca283ed">

After:
<img width="786" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/e8651ac5-8fb7-4e86-81dc-888d7ee9a9d6">


## Allow changing the script module's title and description
Before:
Currently it's not possible to do this. There is no input / way to do it
<img width="544" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/bd37aaec-ede2-41fa-847a-4f9d050ed08c">


After:
<img width="561" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/342aa38f-27b2-4ea9-b611-5c169164656a">

Also the "Scripting Language" selection has been changed into a smart-select sheet selection.
<img width="1178" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/7f8989b0-0433-4e1c-9d03-c26b4cb06e04">
