### PR TITLE
Fix rule module editor popup for blockly

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -454,6 +454,7 @@ export default {
         }
       }, {
         props: {
+          rule: this.rule,
           currentSection: this.currentSection,
           ruleModule: this.currentModule,
           ruleModuleType: this.currentModuleType,

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -63,12 +63,18 @@
           Configuration
         </f7-block-title>
         <f7-col v-if="ruleModule && currentRuleModuleType && (!ruleModule.new || advancedTypePicker)">
-          <config-sheet :key="currentSection + ruleModule.id"
+          <config-sheet v-if="!(ruleModule.configuration && ruleModule.configuration.blockSource)"
+                        :key="currentSection + ruleModule.id"
                         ref="parameters"
                         :parameterGroups="[]"
                         :parameters="currentRuleModuleType.configDescriptions"
                         :configuration="ruleModule.configuration"
                         @updated="dirty = true" />
+          <f7-block v-else>
+            <f7-button @click="editBlockly" color="blue" outline fill>
+              Edit Blockly
+            </f7-button>
+          </f7-block>
         </f7-col>
       </f7-block>
     </f7-page>
@@ -120,6 +126,10 @@ export default {
       }
       this.$f7.emit('ruleModuleConfigUpdate', this.ruleModule)
       this.$refs.modulePopup.close()
+    },
+    editBlockly () {
+      this.updateModuleConfig()
+      this.$f7.views.main.router.navigate(`/settings/rules/${this.rule.uid}/script/${this.ruleModule.id}`)
     },
     startScripting (language) {
       const contentType = (language === 'blockly') ? 'application/javascript' : language


### PR DESCRIPTION
Currently for Blockly Script Action or Condition, clicking on "Edit module" the pencil icon would open up rule-module-popup, which allows user to edit the raw javascript directly without regard to the blockly's block code. 

<img width="669" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/b51f1099-60fc-4cc7-bcd2-ce8778640a1d">

This PR changed it by replacing the configuration sheet with a button that leads to the blockly editor

<img width="654" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/2f3a803d-0ad6-4096-9e39-513fcda3bd34">
