### PR TITLE
Help sidebar docs: Fix external anchors & Script editor RegEx

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/help-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help-sidebar.vue
@@ -73,7 +73,7 @@
         </f7-block>
 
         <!-- script editor docs -->
-        <context v-if="/\/settings\/(scripts\/|rules\/[A-z0-9]+\/script)/.test($store.state.pagePath)" path="/settings/script-editor" />
+        <context v-if="/\/settings\/(scripts\/[A-z0-9]+|rules\/[A-z0-9]+\/script)/.test($store.state.pagePath)" path="/settings/script-editor" />
         <!-- /settings/* docs -->
         <context v-else-if="($store.state.pagePath) === '/settings/'" path="/settings/index" />
         <context v-else-if="/\/settings\/[A-z]+/.test($store.state.pagePath)" :path="/(\/[A-z]+\/[A-z]+)/.exec($store.state.pagePath)[0]" />

--- a/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
@@ -91,6 +91,8 @@ export default {
             body = body.replace(/<a href="(%7B%7Bbase%7D%7D|\/docs)/gm, `<a class="external" target="_blank" href="${this.$store.state.websiteUrl}/docs`)
             // Fix local folder anchor href: Rewrite folder to /folder/
             body = body.replace(/(<a href=")([A-z]+)(")/gm, '$1' + this.localUrl + '$2/$3')
+            // Fix external anchor href
+            body = body.replace(/<a href="http/gm, '<a class="external" target="_blank" href="http')
 
             // Allow embedding framework7 icons by using <!--F7(:blue|:green) ICON_NAME --> comments
             body = body.replace(/<!--F7 ([A-z]*) -->/gm, '<i class="f7-icons size-22">$1</i>')


### PR DESCRIPTION
- Fixes an issue reported in https://github.com/openhab/openhab-webui/pull/2322#issuecomment-1948875309 where external anchor hrefs did not work.
- Fixes an issue where the script editor docs were shown on the `/settings/scripts/` page.