### PR TITLE
Rule edit: Generate suggested trigger title only when none is available

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -303,7 +303,7 @@ export default {
           let triggerDescriptionComments = `${commentChar} Triggers:\n`
           for (const trigger of this.rule.triggers) {
             const triggerModuleType = this.moduleTypes.triggers.find((t) => t.uid === trigger.type)
-            let description = this.suggestedModuleTitle(trigger, triggerModuleType, 'trigger')
+            let description = trigger.label || this.suggestedModuleTitle(trigger, triggerModuleType, 'trigger')
             if (triggerModuleType.uid === 'timer.GenericCronTrigger') {
               description = description.charAt(0).toUpperCase() + description.slice(1)
             } else {


### PR DESCRIPTION
This lets the helper library provide a more accurate label for custom triggers

Related: https://github.com/openhab/openhab-jruby/pull/254

<img width="605" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/7805449c-e488-47b3-8a50-6d1a556272ef">
