### PR TITLE
[BasicUI] Align and optimize available space for switch with mappings

### DIFF
--- a/bundles/org.openhab.ui.basic/snippets-src/buttons.html
+++ b/bundles/org.openhab.ui.basic/snippets-src/buttons.html
@@ -2,7 +2,7 @@
 	<span class="mdl-form__icon">
 		%icon_snippet%
 	</span>
-	<span class="mdl-form__label">
+	<span class="mdl-form__label %label_class%">
 		%label%
 	</span>
 	<span class="mdl-form__value mdl-form__value--group">

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SwitchRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SwitchRenderer.java
@@ -133,9 +133,17 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
 
             snippet = preprocessSnippet(snippet, w);
 
-            snippet = snippet.replaceAll("%height_auto%", multiline ? "mdl-form__row--height-auto" : "");
-            snippet = snippet.replaceAll("%buttons_class%",
-                    multiline ? "mdl-form__buttons-multiline" : "mdl-form__buttons");
+            if (multiline) {
+                snippet = snippet //
+                        .replaceAll("%height_auto%", "mdl-form__row--height-auto")
+                        .replaceAll("%buttons_class%", "mdl-form__buttons-multiline")
+                        .replaceAll("%label_class%", "mdl-form__label-multiline");
+            } else {
+                snippet = snippet //
+                        .replaceAll("%height_auto%", "") //
+                        .replaceAll("%buttons_class%", "mdl-form__buttons") //
+                        .replaceAll("%label_class%", "");
+            }
 
             StringBuilder buttons = new StringBuilder();
             if (s.getMappings().isEmpty() && item != null) {

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -233,7 +233,7 @@
 		}
 	}
 	&__label-multiline {
-		min-width: 5em;
+		min-width: 3em;
 	}
 	&__control {
 		padding-right: $form-row-desktop-padding;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -517,7 +517,7 @@
 		gap: 4px;
 		html.ui-layout-condensed & {
 			margin: 0;
-			gap: 2px;
+			gap: 3px;
 		}
 		padding-top: 2px;
 		padding-bottom: 2px;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -225,13 +225,15 @@
 		@include flex-shrink(0);
 		@include flex-grow(2);
 		@include flex-2011(2 2 auto);
-		min-width: 5em;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		html.ui-bigger-font & {
 			font-size: 18px;
 		}
+	}
+	&__label-multiline {
+		min-width: 5em;
 	}
 	&__control {
 		padding-right: $form-row-desktop-padding;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -281,6 +281,7 @@
 			box-shadow: none;
 			-webkit-box-shadow: none;
 			text-transform: unset;
+			min-width: 54px;
 			html.ui-layout-condensed & {
 				min-width: 40px;
 				padding-left: 4px;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -514,6 +514,7 @@
 	}
 	&__buttons-multiline {
 		margin: 6px 0;
+		gap: 4px;
 		html.ui-layout-condensed & {
 			margin: 0;
 			gap: 2px;
@@ -523,7 +524,6 @@
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: end;
-		gap: 4px;
 	}
 	&__buttongrid {
 		padding: 0;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -237,9 +237,13 @@
 		padding-left: 4px;
 		html.ui-layout-condensed & {
 			padding-left: 0;
+			padding-right: $form-row-desktop-padding-condensed;
 		}
 		@media screen and (max-width: $layout-tablet-size-threshold) {
 			padding-right: $form-row-mobile-padding;
+			html.ui-layout-condensed & {
+				padding-right: $form-row-mobile-padding-condensed;
+			}
 		}
 		font-weight: 700;
 		html.ui-capitalize-values & {
@@ -503,7 +507,8 @@
 		width: 100%;
 	}
 	&__buttons {
-		padding: 2px;
+		padding-top: 2px;
+		padding-bottom: 2px;
 	}
 	&__buttons-multiline {
 		margin: 6px 0;
@@ -511,7 +516,8 @@
 			margin: 0;
 			gap: 2px;
 		}
-		padding: 2px;
+		padding-top: 2px;
+		padding-bottom: 2px;
 		max-width: 70%;
 		display: flex;
 		flex-wrap: wrap;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -225,6 +225,7 @@
 		@include flex-shrink(0);
 		@include flex-grow(2);
 		@include flex-2011(2 2 auto);
+		min-width: 5em;
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -518,7 +519,6 @@
 		}
 		padding-top: 2px;
 		padding-bottom: 2px;
-		max-width: 70%;
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: end;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -168,7 +168,7 @@
 		@media screen and (max-width: $layout-tablet-size-threshold) {
 			padding-left: $form-row-mobile-padding;
 			html.ui-layout-condensed & {
-				padding-left: $form-row-mobile-padding-condensed;
+				padding-left: 0; // there's already padding in .mdl-form__row
 			}
 		}
 		html:not(.ui-icons-enabled) & {
@@ -212,15 +212,15 @@
 		}
 	}
 	&__label {
+		padding-left: $form-row-desktop-padding;
+		html.ui-layout-condensed & {
+			padding-left: $form-row-desktop-padding-condensed;
+		}
 		@media screen and (max-width: $layout-tablet-size-threshold) {
 			padding-left: $form-row-mobile-padding;
 			html.ui-layout-condensed & {
 				padding-left: $form-row-mobile-padding-condensed;
 			}
-		}
-		padding-left: $form-row-desktop-padding;
-		html.ui-layout-condensed & {
-			padding-left: $form-row-desktop-padding-condensed;
 		}
 		@include flex-shrink(0);
 		@include flex-grow(2);
@@ -233,16 +233,13 @@
 		}
 	}
 	&__control {
-		@media screen and (max-width: $layout-tablet-size-threshold) {
-			padding-right: $form-row-mobile-padding;
-			html.ui-layout-condensed & {
-				padding-left: $form-row-mobile-padding-condensed;
-			}
-		}
 		padding-right: $form-row-desktop-padding;
 		padding-left: 4px;
 		html.ui-layout-condensed & {
-			padding-left: $form-row-desktop-padding-condensed;
+			padding-left: 0;
+		}
+		@media screen and (max-width: $layout-tablet-size-threshold) {
+			padding-right: $form-row-mobile-padding;
 		}
 		font-weight: 700;
 		html.ui-capitalize-values & {
@@ -270,7 +267,7 @@
 		.buttongrid-cell {
 			height: 36px;
 			.buttongrid-button {
-				min-width: 100%;
+				min-width: 100% !important;
 				text-transform: none;
 			}
 		}
@@ -279,6 +276,11 @@
 			box-shadow: none;
 			-webkit-box-shadow: none;
 			text-transform: unset;
+			html.ui-layout-condensed & {
+				min-width: 40px;
+				padding-left: 4px;
+				padding-right: 4px;
+			}
 		}
 		.mdl-button-text {
 			html.ui-bigger-font & {
@@ -501,16 +503,19 @@
 		width: 100%;
 	}
 	&__buttons {
-		padding-top: 2px;
+		padding: 2px;
 	}
 	&__buttons-multiline {
 		margin: 6px 0;
 		html.ui-layout-condensed & {
 			margin: 0;
+			gap: 2px;
 		}
-		max-width: 60%;
+		padding: 2px;
+		max-width: 70%;
 		display: flex;
 		flex-wrap: wrap;
+		justify-content: end;
 		gap: 4px;
 	}
 	&__buttongrid {

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1349,7 +1349,14 @@
 			_t.minimizeWidth = function() {
 				var labelLength = _t.label.textContent.trim().length;
 				_t.label.style.paddingLeft = labelLength === 0 ? 0 : null; // null reverts it to the css
-				_t.label.style.minWidth = labelLength < 6 ? "min-content" : null;
+
+				var labelWidth = _t.label.offsetWidth;
+				// Try and see if min-content could make the label narrower.
+				// If not, undo it so it uses the fixed min-width set in the css.
+				_t.label.style.minWidth = "min-content";
+				if (labelWidth <= _t.label.offsetWidth) {
+					_t.label.style.removeProperty("minWidth");
+				}
 
 				// Minimize the width taken by the buttons without adding extra rows.
 				// Start from the maximum width (limited by `mdl-form__buttons-multiline.max-width`),

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1347,13 +1347,14 @@
 
 		if (_t.buttons.length > 1 && _t.parentNode.classList.contains(o.buttonsMultilineClass)) {
 			_t.minimizeWidth = function() {
+				var labelLength = _t.label.textContent.trim().length;
+				_t.label.style.paddingLeft = labelLength === 0 ? 0 : null; // null reverts it to the css
+				_t.label.style.minWidth = labelLength < 6 ? "min-content" : null;
+
 				// Minimize the width taken by the buttons without adding extra rows.
 				// Start from the maximum width (limited by `mdl-form__buttons-multiline.max-width`),
 				// then shrink it down to the minimum without causing additional wrapping.
 				var buttons = _t.parentNode;
-				if (_t.label.textContent.trim() === "") {
-					buttons.style.maxWidth = "100%";
-				}
 				var width = buttons.parentElement.offsetWidth + 100; // start wider than max-width allows
 				buttons.style.width = width + "px";
 				var height = buttons.offsetHeight;

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1384,7 +1384,8 @@
 				buttons.style.width = (width+1) + "px";
 			};
 
-			_t.minimizeWidth();
+			// Wait until after all the icons are loaded before running minimizeWidth()
+			window.addEventListener("load", _t.minimizeWidth);
 			window.addEventListener("resize", _t.minimizeWidth);
 		} else {
 			_t.minimizeWidth = function() {};
@@ -1412,6 +1413,7 @@
 				}
 			});
 			componentHandler.downgradeElements(_t.buttons);
+			window.removeEventListener("load", _t.minimizeWidth);
 			window.removeEventListener("resize", _t.minimizeWidth);
 		};
 

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1403,6 +1403,7 @@
 				buttons.style.width = (width+1) + "px";
 			};
 
+			_t.minimizeWidth();
 			// Wait until after all the icons are loaded before running minimizeWidth()
 			window.addEventListener("load", _t.minimizeWidth);
 			window.addEventListener("resize", _t.minimizeWidth);

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1177,6 +1177,7 @@
 		Control.call(this, parentNode);
 
 		var
+			maxButtonWidth = 0,
 			_t = this;
 
 		_t.ignoreState = _t.parentNode.getAttribute("data-ignore-state") === "true";
@@ -1239,6 +1240,7 @@
 			) {
 				_t.valueMap[itemState].classList.add(o.buttonActiveClass);
 			}
+			_t.minimizeWidth();
 		};
 
 		_t.setValueColor = function(color) {
@@ -1337,7 +1339,35 @@
 				icon.addEventListener("load", _t.convertToInlineSVG);
 				icon.addEventListener("error", _t.replaceImageWithNone);
 			}
+
+			if (maxButtonWidth < button.offsetWidth) {
+				maxButtonWidth = button.offsetWidth;
+			}
 		});
+
+		if (_t.buttons.length > 1 && _t.parentNode.classList.contains(o.buttonsMultilineClass)) {
+			_t.minimizeWidth = function() {
+				// Minimize the width taken by the buttons without adding extra rows.
+				// Start from the maximum width (limited by `mdl-form__buttons-multiline.max-width`),
+				// then shrink it down to the minimum without causing additional wrapping.
+				var buttons = _t.parentNode;
+				if (_t.label.textContent.trim() === "") {
+					buttons.style.maxWidth = "100%";
+				}
+				var width = buttons.parentElement.offsetWidth + 100; // start wider than max-width allows
+				buttons.style.width = width + "px";
+				var height = buttons.offsetHeight;
+				while (buttons.offsetHeight === height && width >= maxButtonWidth) {
+					buttons.style.width = --width + "px";
+				}
+				buttons.style.width = (width+1) + "px";
+			};
+
+			_t.minimizeWidth();
+			window.addEventListener("resize", _t.minimizeWidth);
+		} else {
+			_t.minimizeWidth = function() {};
+		}
 
 		_t.destroy = function() {
 			_t.buttons.forEach(function(button) {
@@ -1361,6 +1391,7 @@
 				}
 			});
 			componentHandler.downgradeElements(_t.buttons);
+			window.removeEventListener("resize", _t.minimizeWidth);
 		};
 
 		_t.setValueColor(_t.valueColor);
@@ -3936,6 +3967,7 @@
 	buttonTextClass: "mdl-button-text",
 	buttonIconText: ".mdl-button-icon-text",
 	buttonIconTextClass: "mdl-button-icon-text",
+	buttonsMultilineClass: "mdl-form__buttons-multiline",
 	modal: ".mdl-modal",
 	modalContainer: ".mdl-modal__content",
 	selectionRows: ".mdl-form__selection-rows",

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1375,8 +1375,8 @@
 				// Start from the maximum width (limited by `mdl-form__buttons-multiline.max-width`),
 				// then shrink it down to the minimum without causing additional wrapping.
 				var buttons = _t.parentNode;
-				var width = buttons.parentElement.offsetWidth + 100; // start wider than max-width allows
-				buttons.style.width = width + "px";
+				buttons.style.width = "100%";
+				var width = buttons.offsetWidth;
 				var height = buttons.offsetHeight;
 				while (buttons.offsetHeight === height && width >= maxButtonWidth) {
 					buttons.style.width = --width + "px";

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -168,6 +168,12 @@
 		});
 	}
 
+	function getElementWidth(element) {
+		var style = getComputedStyle(element);
+		return element.offsetWidth + parseFloat(style.marginLeft) + parseFloat(style.marginRight) +
+			parseFloat(style.paddingLeft) + parseFloat(style.paddingRight);
+	}
+
 	function EventMapper() {
 		var
 			_t = this;
@@ -1346,6 +1352,7 @@
 		});
 
 		if (_t.buttons.length > 1 && _t.parentNode.classList.contains(o.buttonsMultilineClass)) {
+			var labelMinWidth = 0;
 			if (_t.label.textContent.trim().length === 0) {
 				_t.label.style.paddingLeft = 0;
 				_t.label.style.minWidth = 0;
@@ -1367,16 +1374,28 @@
 				var minContentWidth = _t.label.offsetWidth;
 				if (minContentWidth > defaultMinWidth) {
 					_t.label.style.removeProperty("min-width");
+					labelMinWidth = defaultMinWidth;
+				} else {
+					labelMinWidth = minContentWidth;
 				}
 			}
 
 			_t.minimizeWidth = function() {
 				// Minimize the width taken by the buttons without adding extra rows.
-				// Start from the maximum width (limited by `mdl-form__buttons-multiline.max-width`),
+				// Start from the maximum width the buttons can take,
 				// then shrink it down to the minimum without causing additional wrapping.
 				var buttons = _t.parentNode;
-				buttons.style.width = "100%";
-				var width = buttons.offsetWidth;
+				var buttonsStyle = getComputedStyle(buttons);
+				var labelStyle = getComputedStyle(_t.label);
+				// Calculate the maximum width the buttons can take
+				var width = buttons.parentElement.offsetWidth -
+					parseFloat(buttonsStyle.paddingLeft) - parseFloat(buttonsStyle.paddingRight) -
+					getElementWidth(_t.iconContainer) - getElementWidth(_t.value);
+				if (labelMinWidth) {
+					width -= labelMinWidth + parseFloat(labelStyle.paddingLeft) + parseFloat(labelStyle.paddingRight);
+				}
+				buttons.style.width = width + "px";
+				width = buttons.offsetWidth;
 				var height = buttons.offsetHeight;
 				while (buttons.offsetHeight === height && width >= maxButtonWidth) {
 					buttons.style.width = --width + "px";

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1346,18 +1346,31 @@
 		});
 
 		if (_t.buttons.length > 1 && _t.parentNode.classList.contains(o.buttonsMultilineClass)) {
-			_t.minimizeWidth = function() {
-				var labelLength = _t.label.textContent.trim().length;
-				_t.label.style.paddingLeft = labelLength === 0 ? 0 : null; // null reverts it to the css
+			if (_t.label.textContent.trim().length === 0) {
+				_t.label.style.paddingLeft = 0;
+				_t.label.style.minWidth = 0;
+			} else {
+				// Try to see if setting min-width: min-content would result in a narrower min-width
+				// than the one set in _layout.scss, e.g. when the label is short.
+				// If it does make it narrower, it frees up more space for the buttons.
+				// If it is not narrower, un-set it, so that the min-width from _layout.scss can take effect.
 
-				var labelWidth = _t.label.offsetWidth;
-				// Try and see if min-content could make the label narrower.
-				// If not, undo it so it uses the fixed min-width set in the css.
+				// To measure the min-width using offsetWidth,
+				// we need to make the neighbouring element (buttons) as wide as possible
+				// to force the label to shrink to its min-width
+				// Note that _t.parentNode.style.width will get readjusted inside minimizeWidth()
+				// so setting it to 100% here wouldn't affect the final layout.
+				_t.parentNode.style.width = "100%";
+
+				var defaultMinWidth = parseFloat(getComputedStyle(_t.label).minWidth);
 				_t.label.style.minWidth = "min-content";
-				if (labelWidth <= _t.label.offsetWidth) {
-					_t.label.style.removeProperty("minWidth");
+				var minContentWidth = _t.label.offsetWidth;
+				if (minContentWidth > defaultMinWidth) {
+					_t.label.style.removeProperty("min-width");
 				}
+			}
 
+			_t.minimizeWidth = function() {
 				// Minimize the width taken by the buttons without adding extra rows.
 				// Start from the maximum width (limited by `mdl-form__buttons-multiline.max-width`),
 				// then shrink it down to the minimum without causing additional wrapping.


### PR DESCRIPTION
- Should only affect switch with mappings, not player control
- Utilise the wasted space instead of wrapping the buttons into multiple rows, if possible.
- Right align the buttons. This makes it look _much_ neater.
- Instead of limiting the width of the buttons, reserve a minimum width for the label
- However if the label is shorter than 6 characters (including blank labels), reduce the label's minimum width to just what's actually taken up by the shorter label. This gives more space for the buttons with shorter labels.
- When buttons wrap to multiple rows, make sure that each row contains almost the same number of buttons, instead of having the first row filling up the horizontal space, move the buttons down. By doing this, there is more space for the label to occupy.
- Squeeze extra space for more buttons in "condensed layout" by reducing padding, inter-button gaps, min-width, etc.
- The reduced padding in condensed layout also affects buttons in buttongrid.

Before:
<img width="1130" alt="image" src="https://github.com/user-attachments/assets/6bb010b7-d8e3-42bf-a3ae-0236e3ca3601">



After:

<img width="1127" alt="image" src="https://github.com/user-attachments/assets/395b2440-532b-41f1-8369-c9963ebe84b7">
