### PR TITLE
Fix issues with unchangeable page after cancelled dirty warning

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/dirty-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/dirty-mixin.js
@@ -12,11 +12,11 @@ export default {
           'Changes have not been saved',
           function () { resolve() },
           function () {
-            const { pushStateRoot = '', pushStateSeparator } = router.params
-            let url = routeFrom.url
-            history.pushState({ 'view_main': { 'url': url } }, '', pushStateRoot + pushStateSeparator + url)
+            //const { pushStateRoot = '', pushStateSeparator } = router.params
+            //let url = routeFrom.url
+            //history.pushState({ 'view_main': { 'url': url } }, '', pushStateRoot + pushStateSeparator + url)
             reject()
-            router.allowPageChange = true
+            //router.allowPageChange = true
           }
         )
       } else {


### PR DESCRIPTION
/cc @jimtng 
This seems to fix the issue, however now the browser history behaves different.