### PR TITLE
Add support for SVG add-on logos

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -25,11 +25,7 @@
           <addon-stats-line :addon="addon" :iconSize="15" />
         </div>
       </div>
-      <div class="logo-square">
-        <f7-icon v-show="!logoLoaded" size="150" color="gray" :f7="addonIcon" class="card-default-icon" />
-        <img v-if="!logoError" class="lazy logo" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo"
-             :data-src="imageUrl">
-      </div>
+      <addon-logo class="logo-square" :addon="addon" :size="150" />
     </div>
   </f7-link>
 </template>
@@ -96,9 +92,6 @@
     background #fff
     width 100%
     margin-top 5px
-    // height 220px
-    // border 1px solid var(--f7-list-item-border-color)
-    // border-radius 5px
     display flex
     justify-content center
     align-items center
@@ -106,33 +99,24 @@
       content ' '
       display block
       padding-bottom 100%
-  .card-default-icon
-    opacity 0.2
-    position absolute
-  .logo
-    position absolute
-    top 3px
-    left 3px
-    width calc(100% - 6px)
-    height calc(100% - 6px)
-    object-fit contain
+    .logo
+      position absolute
+      top 3px
+      left 3px
+      width calc(100% - 6px)
+      height calc(100% - 6px)
+      object-fit contain
 </style>
 
 <script>
-import { AddonIcons } from '@/assets/addon-store'
 import AddonStatsLine from './addon-stats-line.vue'
+import AddonLogo from '@/components/addons/addon-logo.vue'
 
 export default {
   props: ['addon', 'headline', 'installActionText'],
   components: {
+    AddonLogo,
     AddonStatsLine
-  },
-  data () {
-    return {
-      logoLoaded: false,
-      logoError: false,
-      addonIcon: null
-    }
   },
   computed: {
     autoHeadline () {
@@ -141,25 +125,10 @@ export default {
       if (this.addon.properties && this.addon.properties.posts_count && this.addon.properties.posts_count >= 15) return 'Hot'
       return ''
     },
-    imageUrl () {
-      if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
-      let docsBranch = 'final'
-      if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
-      return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
-    },
     showInstallActions () {
       let splitted = this.addon.uid.split(':')
       return splitted.length < 2 || splitted[0] !== 'eclipse'
     }
-  },
-  mounted () {
-    this.addonIcon = AddonIcons[this.addon.type]
-    this.$$(this.$refs.logo).once('lazy:loaded', (e) => {
-      this.logoLoaded = true
-    })
-    this.$$(this.$refs.logo).once('lazy:error', (e) => {
-      this.logoError = true
-    })
   },
   methods: {
     buttonClicked () {

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -11,10 +11,7 @@
     <div v-else-if="addon.properties && addon.properties.views" slot="subtitle">
       <addon-stats-line :addon="addon" :iconSize="15" />
     </div>
-    <f7-icon v-show="!logoLoaded" slot="media" size="64" color="gray" :f7="addonIcon" class="item-default-icon" />
-    <div class="item-logo" slot="media">
-      <img v-if="!logoError" class="lazy" :style="{ visibility: logoLoaded ? 'visible': 'hidden' }" ref="logo" width="54" :data-src="imageUrl">
-    </div>
+    <addon-logo slot="media" class="logo-square" :addon="addon" size="64" logo-width="54" />
     <div v-if="showInstallActions" slot="after">
       <f7-preloader v-if="addon.pending" color="blue" />
       <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />
@@ -28,20 +25,18 @@
   --f7-list-item-subtitle-text-color var(--f7-list-item-after-text-color)
   .item-inner
     padding-right 3px !important
-  .item-logo
+  .logo-square
+    background white
+    border-radius 5px
+    width 64px
+    height 64px
+    margin-left 3px
     display flex
     justify-content center
     align-items center
-    margin-left 3px
-    width 64px
-    height 64px
-    background white
-    border-radius 5px
-    img
+    .logo
+      margin-left 0
       max-height 54px
-  .item-default-icon
-    opacity 0.2
-    position absolute
   .item-media i
     padding-left 3px
   .item-after
@@ -57,41 +52,20 @@
 </style>
 
 <script>
-import { AddonIcons } from '@/assets/addon-store'
 import AddonStatsLine from './addon-stats-line.vue'
+import AddonLogo from '@/components/addons/addon-logo.vue'
 
 export default {
   props: ['addon', 'installActionText'],
   components: {
+    AddonLogo,
     AddonStatsLine
   },
-  data () {
-    return {
-      logoLoaded: false,
-      logoError: false,
-      addonIcon: null
-    }
-  },
   computed: {
-    imageUrl () {
-      if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
-      let docsBranch = 'final'
-      if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
-      return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.png`
-    },
     showInstallActions () {
       let splitted = this.addon.uid.split(':')
       return splitted.length < 2 || splitted[0] !== 'eclipse'
     }
-  },
-  mounted () {
-    this.addonIcon = AddonIcons[this.addon.type]
-    this.$$(this.$refs.logo).once('lazy:loaded', (e) => {
-      this.logoLoaded = true
-    })
-    this.$$(this.$refs.logo).once('lazy:error', (e) => {
-      this.logoError = true
-    })
   },
   methods: {
     buttonClicked () {

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-logo.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-logo.vue
@@ -1,0 +1,48 @@
+<template>
+  <div>
+    <f7-icon v-show="!logoLoaded" :size="size" color="gray" :f7="addonIcon" class="default-icon" style="padding-left: 0; opacity: 0.2; position: absolute" />
+    <img v-if="!svgLogoError" class="lazy logo" :style="imgStyle" :width="logoWidth" ref="svgLogo"
+         :data-src="imageUrl('svg')">
+    <img v-else-if="!pngLogoError" class="logo" :style="imgStyle" ref="pngLogo"
+         :src="imageUrl('png')" :width="logoWidth" @load="logoLoaded = true" @error="pngLogoError = true">
+  </div>
+</template>
+
+<script>
+import { AddonIcons } from '@/assets/addon-store'
+
+export default {
+  props: ['addon', 'size', 'logoWidth'],
+  data () {
+    return {
+      addonIcon: AddonIcons[this.addon.type],
+      logoLoaded: false,
+      svgLogoError: false,
+      pngLogoError: false
+    }
+  },
+  computed: {
+    imgStyle () {
+      return {
+        visibility: this.logoLoaded ? 'visible' : 'hidden'
+      }
+    }
+  },
+  methods: {
+    imageUrl (type) {
+      if (this.addon.imageLink) return this.addon.imageLink.replace(/^\/\//, 'https://')
+      let docsBranch = 'final'
+      if (this.$store.state.runtimeInfo.buildString === 'Release Build') docsBranch = 'final-stable'
+      return `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/images/addons/${this.addon.id.substring(this.addon.id.indexOf('-') + 1)}.${type}`
+    }
+  },
+  mounted () {
+    this.$$(this.$refs.svgLogo).once('lazy:loaded', (e) => {
+      this.logoLoaded = true
+    })
+    this.$$(this.$refs.svgLogo).once('lazy:error', (e) => {
+      this.svgLogoError = true
+    })
+  }
+}
+</script>


### PR DESCRIPTION
Currently, Main UI attempts to load all add-on logos as PNG (the add-on logo url is generated using the add-on name and expecting a PNG).

This PR adds support for SVG add-on logos, which means: 
The UI will now attempt to load a SVG logo, 
if that fails, it will attempt to load a PNG, 
and if that fails, fall back to the add-on‘s default logo (which is dependent on the add-on type).