### PR TITLE
Item edit: Fix dirty warning for not-editable Items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -174,8 +174,6 @@ export default {
   },
   mounted () {
     if (!this.item) return
-    if (!this.item.category) this.$set(this.item, 'category', '')
-    if (!this.item.groupNames) this.$set(this.item, 'groupNames', [])
     const categoryControl = this.$refs.category
     if (!categoryControl || !categoryControl.$el) return
     const inputElement = this.$$(categoryControl.$el).find('input')

--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -66,7 +66,6 @@ export default {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }
-      this.load()
     },
     onPageBeforeOut () {
       if (window) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -104,7 +104,9 @@ export default {
     item: {
       handler: function () {
         if (!this.loading) { // ignore changes during loading
-          this.dirty = !fastDeepEqual(this.item, this.savedItem)
+          const itemClone = cloneDeep(this.item)
+          delete itemClone.functionKey
+          this.dirty = !fastDeepEqual(itemClone, this.savedItem)
         }
       },
       deep: true


### PR DESCRIPTION
Follow-up for one of the previous PRs.

Fix Item dirty warning for:
- Item not editable, but warning still displayed
- editable group Item