### PR TITLE
Show lock icon in the item details members list

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -6,8 +6,7 @@
           <item
             v-for="member in groupItem.members" :key="member.name"
             :item="member" :link="'/settings/items/' + member.name"
-            :context="context"
-            :ignore-editable="true" />
+            :context="context" />
           <!-- <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" /> -->
         </ul>
         <item-picker v-if="editMembers" :multiple="true" name="groupMembers" :value="memberNames" title="Members" :editableOnly="true" @input="(members) => memberNames = members" />

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -10,7 +10,7 @@
     v-on="$listeners">
     <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" :state="(noState) ? null : (context && context.store) ? context.store[item.name].state : item.state" height="32" width="32" />
     <span v-else-if="!noIcon" slot="media" class="item-initial">{{ item.name[0] }}</span>
-    <f7-icon v-if="!item.editable && !ignoreEditable" slot="after-title" f7="lock_fill" size="1rem" color="gray" />
+    <f7-icon v-if="!item.editable" slot="after-title" f7="lock_fill" size="1rem" color="gray" />
     <slot name="footer" #footer />
     <div v-if="!noTags" slot="subtitle">
       <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
@@ -25,7 +25,7 @@ import ItemMixin from '@/components/item/item-mixin'
 
 export default {
   mixins: [ItemMixin],
-  props: ['item', 'context', 'ignoreEditable', 'noState', 'noType', 'noIcon', 'noTags', 'link'],
+  props: ['item', 'context', 'noState', 'noType', 'noIcon', 'noTags', 'link'],
   computed: {
     state () {
       if (this.noState) return


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/4118.

@ghys could you comment on the purpose of `ignoreEditable` here? It's preventing the lock icon from showing up.