### PR TITLE
Overview tab: Fix javascript error

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -65,10 +65,14 @@ export default {
     },
     overviewPage () {
       const page = this.$store.getters.page('overview')
-      if (!page) return null
-      if (page.component !== 'oh-layout-page') return null
-      if (!page.slots || (!page.slots.default.length && !page.slots.masonry && !page.slots.canvas && !page.slots.grid)) return null
-      return page
+      if (page) {
+        if (page.component === 'oh-layout-page') return page
+        if (page.slots) {
+          if (page.slots.default && page.slots.default.length) return page
+          if (page.slots.masonry || page.slots.canvas || page.slots.grid) return page
+        }
+      }
+      return null
     },
     overviewPageContext () {
       return {


### PR DESCRIPTION
The error:
```
app.30bb9074a7a632ce30a5.js:2 TypeError: Cannot read properties of undefined (reading 'length')
    at i.overviewPage (app.30bb9074a7a632ce30a5.js:2:1827039)
    at kn.get (app.30bb9074a7a632ce30a5.js:2:1405688)
    at kn.evaluate (app.30bb9074a7a632ce30a5.js:2:1406838)
    at i.overviewPage (app.30bb9074a7a632ce30a5.js:2:1408704)
    at i.pageStyle (app.30bb9074a7a632ce30a5.js:2:1827241)
    at kn.get (app.30bb9074a7a632ce30a5.js:2:1405688)
    at kn.evaluate (app.30bb9074a7a632ce30a5.js:2:1406838)
    at i.pageStyle (app.30bb9074a7a632ce30a5.js:2:1408704)
    at i.<anonymous> (app.30bb9074a7a632ce30a5.js:2:1827489)
    at e._render (app.30bb9074a7a632ce30a5.js:2:1414330)
```

Refactor overviewPage method to be easier to read.