### PR TITLE
[blockly] Add multi-select feature

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -18,6 +18,7 @@
         "@jsep-plugin/object": "^1.2.1",
         "@jsep-plugin/regex": "^1.0.3",
         "@jsep-plugin/template": "^1.0.2",
+        "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.11",
         "blockly": "^10.4.2",
         "cronstrue": "^1.100.0",
         "crypto-browserify": "^3.12.0",
@@ -2766,6 +2767,20 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
+    },
+    "node_modules/@mit-app-inventor/blockly-plugin-workspace-multiselect": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@mit-app-inventor/blockly-plugin-workspace-multiselect/-/blockly-plugin-workspace-multiselect-0.1.11.tgz",
+      "integrity": "sha512-SEuyHi43qY7hOfSBzBFzeK8lUWtqnMtfxAe4xSrdelYRSZBoBX6ihFSkexLb8x3OtOubSTfe6cKHOV/0hKiz8A==",
+      "dependencies": {
+        "dragselect": "^2.7.4"
+      },
+      "engines": {
+        "node": ">=8.17.0"
+      },
+      "peerDependencies": {
+        "blockly": "^10.2.0"
+      }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
@@ -8436,6 +8451,11 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
+    },
+    "node_modules/dragselect": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/dragselect/-/dragselect-2.7.4.tgz",
+      "integrity": "sha512-j0qFl4xvsyImlSTn9erDCCT4SSPUMssgKAYuKqhsPr8WPphLghHfjDd4WR2jLjL91fTQQlbbIJ/7T2qwD2hghQ=="
     },
     "node_modules/duplexer": {
       "version": "0.1.2",
@@ -24259,6 +24279,14 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "@mit-app-inventor/blockly-plugin-workspace-multiselect": {
+      "version": "0.1.11",
+      "resolved": "https://registry.npmjs.org/@mit-app-inventor/blockly-plugin-workspace-multiselect/-/blockly-plugin-workspace-multiselect-0.1.11.tgz",
+      "integrity": "sha512-SEuyHi43qY7hOfSBzBFzeK8lUWtqnMtfxAe4xSrdelYRSZBoBX6ihFSkexLb8x3OtOubSTfe6cKHOV/0hKiz8A==",
+      "requires": {
+        "dragselect": "^2.7.4"
+      }
+    },
     "@nicolo-ribaudo/eslint-scope-5-internals": {
       "version": "5.1.1-v1",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/eslint-scope-5-internals/-/eslint-scope-5-internals-5.1.1-v1.tgz",
@@ -28727,6 +28755,11 @@
           "dev": true
         }
       }
+    },
+    "dragselect": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/dragselect/-/dragselect-2.7.4.tgz",
+      "integrity": "sha512-j0qFl4xvsyImlSTn9erDCCT4SSPUMssgKAYuKqhsPr8WPphLghHfjDd4WR2jLjL91fTQQlbbIJ/7T2qwD2hghQ=="
     },
     "duplexer": {
       "version": "0.1.2",

--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -10,7 +10,6 @@
       "license": "EPL-2.0",
       "dependencies": {
         "@blockly/field-slider": "^6.1.4",
-        "@blockly/plugin-cross-tab-copy-paste": "^5.0.5",
         "@blockly/plugin-workspace-search": "^8.1.2",
         "@blockly/shadow-block-converter": "^5.0.0",
         "@blockly/theme-dark": "^6.0.5",
@@ -1975,17 +1974,6 @@
       },
       "peerDependencies": {
         "blockly": "^10.0.0"
-      }
-    },
-    "node_modules/@blockly/plugin-cross-tab-copy-paste": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/plugin-cross-tab-copy-paste/-/plugin-cross-tab-copy-paste-5.0.5.tgz",
-      "integrity": "sha512-fI+jffxuougKtSPxd0vR5GR6xlEshxHKiYEWe0SO+AYGqGh5CFbK3x/mRhCzLQddZ0JhWnrALQjh8R3i2e/Apw==",
-      "engines": {
-        "node": ">=8.17.0"
-      },
-      "peerDependencies": {
-        "blockly": "^10.2.0"
       }
     },
     "node_modules/@blockly/plugin-workspace-search": {
@@ -23622,12 +23610,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@blockly/field-slider/-/field-slider-6.1.4.tgz",
       "integrity": "sha512-aa+jqMeXUpnckTjUv870OtEP+IppDFoVoEFzUPUH7mhMyFElRR/0ZHvbSI17TzIGd8Vdf7+WWzwYsjV4rbv2+A==",
-      "requires": {}
-    },
-    "@blockly/plugin-cross-tab-copy-paste": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@blockly/plugin-cross-tab-copy-paste/-/plugin-cross-tab-copy-paste-5.0.5.tgz",
-      "integrity": "sha512-fI+jffxuougKtSPxd0vR5GR6xlEshxHKiYEWe0SO+AYGqGh5CFbK3x/mRhCzLQddZ0JhWnrALQjh8R3i2e/Apw==",
       "requires": {}
     },
     "@blockly/plugin-workspace-search": {

--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -18,7 +18,7 @@
         "@jsep-plugin/object": "^1.2.1",
         "@jsep-plugin/regex": "^1.0.3",
         "@jsep-plugin/template": "^1.0.2",
-        "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.11",
+        "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.12",
         "blockly": "^10.4.2",
         "cronstrue": "^1.100.0",
         "crypto-browserify": "^3.12.0",
@@ -2769,9 +2769,9 @@
       "dev": true
     },
     "node_modules/@mit-app-inventor/blockly-plugin-workspace-multiselect": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@mit-app-inventor/blockly-plugin-workspace-multiselect/-/blockly-plugin-workspace-multiselect-0.1.11.tgz",
-      "integrity": "sha512-SEuyHi43qY7hOfSBzBFzeK8lUWtqnMtfxAe4xSrdelYRSZBoBX6ihFSkexLb8x3OtOubSTfe6cKHOV/0hKiz8A==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@mit-app-inventor/blockly-plugin-workspace-multiselect/-/blockly-plugin-workspace-multiselect-0.1.12.tgz",
+      "integrity": "sha512-RMT6Wgdo+yOe1L6iRQI2D+EAnhDNI80MMHRNPcUyOCWnF6WCLpleLc3Gjtw3UAoR4arS5JqmO9Z1HLMgCtjY+A==",
       "dependencies": {
         "dragselect": "^2.7.4"
       },
@@ -2779,7 +2779,7 @@
         "node": ">=8.17.0"
       },
       "peerDependencies": {
-        "blockly": "^10.2.0"
+        "blockly": ">=10.4.0 <= 11"
       }
     },
     "node_modules/@nicolo-ribaudo/eslint-scope-5-internals": {
@@ -24280,9 +24280,9 @@
       "dev": true
     },
     "@mit-app-inventor/blockly-plugin-workspace-multiselect": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@mit-app-inventor/blockly-plugin-workspace-multiselect/-/blockly-plugin-workspace-multiselect-0.1.11.tgz",
-      "integrity": "sha512-SEuyHi43qY7hOfSBzBFzeK8lUWtqnMtfxAe4xSrdelYRSZBoBX6ihFSkexLb8x3OtOubSTfe6cKHOV/0hKiz8A==",
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@mit-app-inventor/blockly-plugin-workspace-multiselect/-/blockly-plugin-workspace-multiselect-0.1.12.tgz",
+      "integrity": "sha512-RMT6Wgdo+yOe1L6iRQI2D+EAnhDNI80MMHRNPcUyOCWnF6WCLpleLc3Gjtw3UAoR4arS5JqmO9Z1HLMgCtjY+A==",
       "requires": {
         "dragselect": "^2.7.4"
       }

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -67,7 +67,7 @@
     "@blockly/shadow-block-converter": "^5.0.0",
     "@blockly/theme-dark": "^6.0.5",
     "@blockly/zoom-to-fit": "^5.0.11",
-    "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.11",
+    "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.12",
     "@jsep-plugin/arrow": "^1.0.5",
     "@jsep-plugin/object": "^1.2.1",
     "@jsep-plugin/regex": "^1.0.3",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -67,6 +67,7 @@
     "@blockly/shadow-block-converter": "^5.0.0",
     "@blockly/theme-dark": "^6.0.5",
     "@blockly/zoom-to-fit": "^5.0.11",
+    "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.11",
     "@jsep-plugin/arrow": "^1.0.5",
     "@jsep-plugin/object": "^1.2.1",
     "@jsep-plugin/regex": "^1.0.3",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -63,7 +63,6 @@
   ],
   "dependencies": {
     "@blockly/field-slider": "^6.1.4",
-    "@blockly/plugin-cross-tab-copy-paste": "^5.0.5",
     "@blockly/plugin-workspace-search": "^8.1.2",
     "@blockly/shadow-block-converter": "^5.0.0",
     "@blockly/theme-dark": "^6.0.5",

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1079,6 +1079,7 @@ import { javascriptGenerator } from 'blockly/javascript.js'
 import DarkTheme from '@blockly/theme-dark'
 import { ZoomToFitControl } from '@blockly/zoom-to-fit'
 import { shadowBlockConversionChangeListener } from '@blockly/shadow-block-converter'
+import { Multiselect, MultiselectBlockDragger } from '@mit-app-inventor/blockly-plugin-workspace-multiselect'
 
 import Vue from 'vue'
 
@@ -1186,8 +1187,11 @@ export default {
       }, this.isGraalJs)
       this.addLibraryToToolbox(libraryDefinitions || [])
 
-      this.workspace = Blockly.inject(this.$refs.blocklyEditor, {
+      const options = {
         toolbox: this.$refs.toolbox,
+        plugins: {
+          'blockDragger': MultiselectBlockDragger
+        },
         horizontalLayout: !this.$device.desktop,
         theme: this.$f7.data.themeOptions.dark === 'dark' ? DarkTheme : undefined,
         zoom: {
@@ -1205,8 +1209,20 @@ export default {
         },
         trashcan: false,
         showLabels: false,
+
+        // Multi-select-options
+        multiselectCopyPaste: {
+          crossTab: true,
+          menu: true
+        },
+        multiselectIcon: {
+          hideIcon: true // hide it because it doesn't work in v0.1.11
+        },
+        multiFieldUpdate: true,
+
         renderer: this.getCurrentRenderer()
-      })
+      }
+      this.workspace = Blockly.inject(this.$refs.blocklyEditor, options)
       this.workspace.addChangeListener(shadowBlockConversionChangeListener)
       const workspaceSearch = new WorkspaceSearch(this.workspace)
       workspaceSearch.init()
@@ -1216,6 +1232,9 @@ export default {
 
       const zoomToFit = new ZoomToFitControl(this.workspace)
       zoomToFit.init()
+
+      const multiselectPlugin = new Multiselect(this.workspace)
+      multiselectPlugin.init(options)
 
       this.registerLibraryCallbacks(libraryDefinitions)
       const xml = Blockly.utils.xml.textToDom(this.blocks)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1077,7 +1077,6 @@ import Blockly from 'blockly'
 import { WorkspaceSearch } from '@blockly/plugin-workspace-search'
 import { javascriptGenerator } from 'blockly/javascript.js'
 import DarkTheme from '@blockly/theme-dark'
-import { CrossTabCopyPaste } from '@blockly/plugin-cross-tab-copy-paste'
 import { ZoomToFitControl } from '@blockly/zoom-to-fit'
 import { shadowBlockConversionChangeListener } from '@blockly/shadow-block-converter'
 
@@ -1214,20 +1213,6 @@ export default {
 
       const zoomToFit = new ZoomToFitControl(this.workspace)
       zoomToFit.init()
-
-      if (!Blockly.ContextMenuRegistry.registry.getItem('blockCopyToStorage')) {
-        const copyAndPasteOptions = {
-          contextMenu: true,
-          shortcut: true
-        }
-        const copyAndPastePlugin = new CrossTabCopyPaste()
-        copyAndPastePlugin.init(copyAndPasteOptions, () => {
-          console.log('There has been a block type error during copying and pasting')
-        })
-
-        Blockly.Msg['CROSS_TAB_COPY'] = 'Cross-Rule-Copy'
-        Blockly.Msg['CROSS_TAB_PASTE'] = 'Cross-Rule-Paste'
-      }
 
       this.registerLibraryCallbacks(libraryDefinitions)
       const xml = Blockly.utils.xml.textToDom(this.blocks)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1190,16 +1190,19 @@ export default {
         toolbox: this.$refs.toolbox,
         horizontalLayout: !this.$device.desktop,
         theme: this.$f7.data.themeOptions.dark === 'dark' ? DarkTheme : undefined,
-        zoom:
-          {
-            controls: true,
-            wheel: true,
-            startScale: 1.0,
-            maxScale: 3,
-            minScale: 0.3,
-            scaleSpeed: 1.2,
-            pinch: true
-          },
+        zoom: {
+          controls: true,
+          wheel: true,
+          startScale: 1.0,
+          maxScale: 3,
+          minScale: 0.3,
+          scaleSpeed: 1.2,
+          pinch: true
+        },
+        move: {
+          drag: true,
+          wheel: true
+        },
         trashcan: false,
         showLabels: false,
         renderer: this.getCurrentRenderer()


### PR DESCRIPTION
- Shift + Click to select multiple blocks
- Also shift + mouse drag to multi-select
- Currently multiselect doesn't work on mobile (AFAIK) but copy/pasting even across different scripts works
- Provides cross tab copy/paste, including copy/pasting multiple selected blocks.

The multi-select plugin conflicts with the cross-tab-copy-paste plugin and makes it redundant, so it is removed in this PR

Also in this PR, make two fingers do panning instead of zooming.

These have been split into three commits for granularity so please don't squash them.

Resolve #2417 