### PR TITLE
oh-player-controls: Hide default tooltip

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-segmented v-bind="config" round outline strong class="player-controls">
+  <f7-segmented v-bind="config" round outline strong class="player-controls" title="">
     <f7-button color="blue" @click.stop="skipPrevious()" large icon-material="skip_previous" icon-size="24" icon-color="gray" />
     <f7-button v-if="this.config.showRewindFFward" color="blue" @click.stop="rewind()" large icon-material="fast_rewind" icon-size="24" icon-color="gray" />
     <f7-button color="blue" @click.stop="playPause()" large round fill :icon-f7="(isPlaying) ? 'pause_fill' : 'play_fill'" icon-size="24" />


### PR DESCRIPTION
Previously, when hovering over a `oh-player-control` component, a tooltip, which shouldn't be there, was shown.
This was caused by the config title being set as the divs title.
It is now fixed by manually setting title to an empy string.