### PR TITLE
Widget expressions: Add `#` as a shorthand for item.numericState

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -20,12 +20,17 @@ expr.jsep.plugins.register(jsepRegex, jsepArrow, jsepObject, jsepTemplate)
 
 expr.addUnaryOp('@', (itemName) => {
   if (itemName === undefined) return undefined
-  const itemState = store.getters.trackedItems[itemName]
-  return itemState.displayState || itemState.state
+  const item = store.getters.trackedItems[itemName]
+  return item.displayState || item.state
 })
 expr.addUnaryOp('@@', (itemName) => {
   if (itemName === undefined) return undefined
   return store.getters.trackedItems[itemName].state
+})
+expr.addUnaryOp('#', (itemName) => {
+  if (itemName === undefined) return undefined
+  const item = store.getters.trackedItems[itemName]
+  return item.numericState || item.state
 })
 
 dayjs.extend(relativeTime)

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -30,7 +30,7 @@ expr.addUnaryOp('@@', (itemName) => {
 expr.addUnaryOp('#', (itemName) => {
   if (itemName === undefined) return undefined
   const item = store.getters.trackedItems[itemName]
-  return item.numericState || item.state
+  return item.numericState
 })
 
 dayjs.extend(relativeTime)

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -29,8 +29,7 @@ expr.addUnaryOp('@@', (itemName) => {
 })
 expr.addUnaryOp('#', (itemName) => {
   if (itemName === undefined) return undefined
-  const item = store.getters.trackedItems[itemName]
-  return item.numericState
+  return store.getters.trackedItems[itemName].numericState
 })
 
 dayjs.extend(relativeTime)


### PR DESCRIPTION
See: https://github.com/openhab/openhab-core/pull/4123

Add `#` alongside the existing shorthands:
```
@'ItemName' => items.ItemName.state
@@'ItemName' => items.ItemName.displayState
#'ItemName' => items.ItemName.numericState
```

Yes, the docs will be updated if/after this is merged.
