### PR TITLE
Script Editor: Fix script loading

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -248,8 +248,6 @@ export default {
     // handle script action module type, label, description ect.
     currentModule: {
       handler: function () {
-        console.log('Running')
-
         if (this.savedCurrentModule && !this.loading) { // ignore changes during loading
           this.currentModuleDirty = !fastDeepEqual(this.currentModule, this.savedCurrentModule)
         }
@@ -386,11 +384,7 @@ export default {
         if (this.moduleId) {
           this.$set(this, 'currentModule', this.rule.actions.concat(this.rule.conditions).find((m) => m.id === this.moduleId))
         } else {
-          let mod = this.rule.actions.find((m) => m.id === 'script')
-          if (!this.currentModule) {
-            mod = this.rule.actions.find((m) => m.configuration.script)
-          }
-          this.$set(this, 'currentModule', mod)
+          this.$set(this, 'currentModule', this.rule.actions.find((m) => m.id === 'script' || m.configuration.script))
           this.isScriptRule = true
         }
 


### PR DESCRIPTION
Regression from #2374

The problem is when I clicked on a file-based script in the UI, the content of the script didn't load. 

Before:
<img width="601" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/b3351f27-8ae6-4463-91ee-583fce0cf873">


After:
<img width="670" alt="image" src="https://github.com/openhab/openhab-webui/assets/2554958/596629cb-459d-43c0-992e-7221e2a505dd">
