### PR TITLE
Only set API auth headers if requesting the REST API

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/openhab/api.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/api.js
@@ -12,7 +12,7 @@ function wrapPromise (f7promise) {
 Framework7.request.setup({
   xhrFields: { withCredentials: true },
   beforeSend (xhr) {
-    if (getAccessToken() && xhr.requestParameters.method !== 'HEAD') {
+    if (getAccessToken() && xhr.requestParameters.method !== 'HEAD' && xhr.requestParameters.url.startsWith('/rest/')) {
       if (getTokenInCustomHeader()) {
         xhr.setRequestHeader('X-OPENHAB-TOKEN', getAccessToken())
       } else {


### PR DESCRIPTION
This should avoid leaking the user's access token to third-parties in case a UI component uses `this.$oh.api.` to request external resources.
This is currently not the case, but IMO we should add this check anyway as a component might make such a request with a future code change.