### PR TITLE
Items List: Remove Add item from textual

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -109,17 +109,8 @@
     <f7-fab v-show="!showCheckboxes" position="center-bottom" text="Refresh" slot="fixed" color="blue" @click="load()">
       <f7-icon ios="f7:arrow_clockwise" md="material:refresh" aurora="f7:arrow_clockwise" />
     </f7-fab>
-    <f7-fab v-show="!showCheckboxes" position="right-bottom" slot="fixed" color="blue">
+    <f7-fab v-show="!showCheckboxes" position="right-bottom" slot="fixed" color="blue" href="add">
       <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
-      <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
-      <f7-fab-buttons position="top">
-        <f7-fab-button fab-close label="Add Item" href="add">
-          <f7-icon ios="material:label_outline" md="material:label_outline" aurora="material:label_outline" />
-        </f7-fab-button>
-        <f7-fab-button fab-close label="Add Items from Textual Definition" href="add-from-textual-definition">
-          <f7-icon ios="f7:document_text" md="material:assignment" aurora="f7:text_badge_plus" />
-        </f7-fab-button>
-      </f7-fab-buttons>
     </f7-fab>
   </f7-page>
 </template>


### PR DESCRIPTION
Make the + Icon in the items list go straight into adding a new item. This makes the most common operation quicker.

Adding from textual definition can still be done through Developer Tool, as it's not a common task.