### PR TITLE
Channel edit: Fix regression causing editable channels to be locked

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -2,7 +2,7 @@
   <f7-page @page:afterin="onPageAfterIn" name="channel-edit">
     <f7-navbar :title="channel.label" :subtitle="thing.label" back-link="Cancel">
       <f7-nav-right>
-        <f7-link v-if="!channel.editable" slot="right" icon-f7="lock_fill" icon-only tooltip="Channels of Things defined in a .things file are not editable from this screen" />
+        <f7-link v-if="!thing.editable" slot="right" icon-f7="lock_fill" icon-only tooltip="Channels of Things defined in a .things file are not editable from this screen" />
         <f7-link @click="save()" v-else-if="$theme.md" icon-md="material:save" icon-only />
         <f7-link @click="save()" v-else>
           Done


### PR DESCRIPTION
Regression from #2403.

Channel doesn't have its own `editable` property.