### PR TITLE
[blockly] Add undefined block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-logic.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-logic.js
@@ -1,0 +1,30 @@
+/*
+* Adds new blocks to the logic section
+*/
+
+import Blockly from 'blockly'
+import { javascriptGenerator } from 'blockly/javascript.js'
+
+export default function (f7, isGraalJs) {
+  /*
+* Add a block returning undefined
+* Blockly part
+*/
+  Blockly.Blocks['oh_logic_undefined'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('undefined')
+      this.setOutput(true, null)
+      this.setColour('%{BKY_LOGIC_HUE}')
+      this.setTooltip('returns undefined as value')
+    }
+  }
+
+  /*
+  * returns undefined
+  * Code part
+  */
+  javascriptGenerator.forBlock['oh_logic_undefined'] = function (block) {
+    return ['undefined', javascriptGenerator.ORDER_ATOMIC]
+  }
+}

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
@@ -18,6 +18,7 @@ import defineUomBlocks from './blocks-uom.js'
 import defineMetaBlocks from './blocks-metadata.js'
 import defineMathBlocks from './blocks-math.js'
 import defineHttpBlocks from './blocks-http.js'
+import defineLogicBlocks from './blocks-logic.js'
 
 import { defineLibraries } from './libraries.js'
 
@@ -44,5 +45,6 @@ export default function (f7, libraryDefinitions, data, isGraalJs) {
   defineMathBlocks(f7, isGraalJs)
   defineMetaBlocks(f7, isGraalJs)
   defineHttpBlocks(f7, isGraalJs)
+  defineLogicBlocks(f7, isGraalJs)
   defineLibraries(libraryDefinitions)
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -10,6 +10,7 @@
         <block type="logic_negate" />
         <block type="logic_boolean" />
         <block type="logic_null" />
+        <block type="oh_logic_undefined" />
         <block type="logic_ternary" />
       </category>
 


### PR DESCRIPTION
Adds the undefined block as discussed at https://community.openhab.org/t/blockly-proposal-to-change-contextual-info-blocks/154403 

<img width="317" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/fd0273f6-4a96-44e9-b606-c25e887e77d5">

creates 

```
var notDefinedVar;


if (notDefinedVar == undefined) {
  console.log('I am undefined');
}
```

Note that the logic block never creates "===" but always "=="