### PR TITLE
Item edit: Check for type change & Fix dimension/unit change checks

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -111,8 +111,9 @@ export default {
       unitAutocomplete: null,
       categoryAutocomplete: null,
       nameErrorMessage: '',
+      oldItemType: !this.createMode ? this.item.type.split(':')[0] : '',
       oldItemDimension: (!this.createMode && this.item.type.split(':').length > 1) ? this.item.type.split(':')[1] : '',
-      oldItemUnit: !this.createMode ? (this.unit || '') : ''
+      oldItemUnit: !this.createMode ? (this.item.unitSymbol || '') : ''
     }
   },
   watch: {
@@ -132,9 +133,6 @@ export default {
         return this.item.type.split(':')[0]
       },
       set (newType) {
-        if (!this.createMode) {
-          this.oldItemDimension = this.itemDimension
-        }
         this.$set(this.item, 'type', newType)
       }
     },
@@ -144,9 +142,6 @@ export default {
         return parts.length > 1 ? parts[1] : ''
       },
       set (newDimension) {
-        if (!this.createMode) {
-          this.oldItemDimension = this.itemDimension
-        }
         if (!newDimension) {
           this.$set(this.item, 'type', 'Number')
           return
@@ -162,9 +157,6 @@ export default {
         return this.unit
       },
       set (newUnit) {
-        if (!this.createMode) {
-          this.oldItemUnit = this.unit
-        }
         this.$set(this.item, 'unit', newUnit)
       }
     },
@@ -178,6 +170,11 @@ export default {
     }
   },
   methods: {
+    typeChanged () {
+      if (this.$refs.groupForm && this.$refs.groupForm.typeChanged()) return true
+      if (!this.oldItemType) return false
+      return this.oldItemType !== this.itemType
+    },
     dimensionChanged () {
       if (this.$refs.groupForm && this.$refs.groupForm.dimensionChanged()) return true
       if (!this.oldItemDimension) return false
@@ -187,16 +184,16 @@ export default {
       if (this.$refs.groupForm && this.$refs.groupForm.unitChanged()) return true
       return this.oldItemUnit && this.item.unit && this.oldItemUnit !== this.item.unit
     },
-    revertDimensionChange () {
+    revertChange () {
       if (this.itemType === 'Group') {
-        this.$refs.groupForm.revertDimensionChange()
+        this.$refs.groupForm.revertChange()
         return
       }
       if (!this.oldItemDimension) {
-        this.$set(this.item, 'type', 'Number')
+        this.$set(this.item, 'type', this.oldItemType)
         this.$set(this.item, 'unit', '')
       } else {
-        this.$set(this.item, 'type', 'Number:' + this.oldItemDimension)
+        this.$set(this.item, 'type', this.oldItemType + ':' + this.oldItemDimension)
         this.$set(this.item, 'unit', this.oldItemUnit)
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -179,16 +179,17 @@ export default {
       if (this.validateItemName(this.item.name) !== '') return this.$f7.dialog.alert('Please give the Item a valid name: ' + this.validateItemName(this.item.name)).open()
       if (!this.item.type || !this.types.ItemTypes.includes(this.item.type.split(':')[0])) return this.$f7.dialog.alert('Please give Item a valid type').open()
 
+      const typeChange = this.$refs.itemForm.typeChanged()
       const dimensionChange = this.$refs.itemForm.dimensionChanged()
       const unitChange = this.$refs.itemForm.unitChanged()
-      if (dimensionChange || unitChange) {
-        const title = 'WARNING: ' + (dimensionChange ? 'Dimension' : 'Unit') + ' Changed'
-        const text = dimensionChange ? 'Existing links to channels with dimension may no longer be valid!' : 'Changing the internal unit can corrupt your persisted data and affect rules!'
+      if (typeChange || dimensionChange || unitChange) {
+        const title = 'WARNING: ' + (typeChange ? 'Type' : (dimensionChange ? 'Dimension' : 'Unit')) + ' Changed'
+        const text = (typeChange || dimensionChange) ? `Existing links to channels ${dimensionChange ? 'with dimensions ' : ''}may no longer be valid!` : 'Changing the internal unit can corrupt your persisted data and affect rules!'
         return this.$f7.dialog.create({
           title: title,
           text: text,
           buttons: [
-            { text: 'Cancel', color: 'gray', close: true, onClick: () => this.$refs.itemForm.revertDimensionChange() },
+            { text: 'Cancel', color: 'gray', close: true, onClick: () => this.$refs.itemForm.revertChange() },
             { text: 'Save Anyway', color: 'red', close: true, onClick: () => this.doSave() }
           ],
           destroyOnClose: true


### PR DESCRIPTION
- When editing an Item, also check for Item type change and display a warning when changing the Item type.
- The dimension/unit change checks were not comparing against the saved Item, but instead against the last changes. Fix this.