### PR TITLE
Fix webpack asset filename

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -180,7 +180,7 @@ module.exports = {
           }
         },
         generator: {
-          filename: 'images/[name].[ext]'
+          filename: 'images/[name][ext]'
         }
       },
       {
@@ -192,7 +192,7 @@ module.exports = {
           }
         },
         generator: {
-          filename: 'media/[name].[ext]'
+          filename: 'media/[name][ext]'
         }
       },
       {
@@ -204,7 +204,7 @@ module.exports = {
           }
         },
         generator: {
-          filename: 'fonts/[name].[ext]'
+          filename: 'fonts/[name][ext]'
         }
       },
       {


### PR DESCRIPTION
Resolves https://github.com/openhab/openhab-webui/issues/2483

The webpack [ext] template string already includes a leading . (https://webpack.js.org/configuration/output/#template-strings). This PR removes the the extra dot that was added.