### PR TITLE
Save stateDescriptionPattern from channel type for UoM Items & Save UoM metadata when adding from model

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -107,7 +107,7 @@ export default {
         const dimension = this.dimensions.find((d) => d.name === newDimension)
         this.$set(this.item, 'groupType', 'Number:' + dimension.name)
         this.groupUnit = this.getUnitHint(dimension.name)
-        this.$set(this.item, 'stateDescriptionPattern', this.getStateDescription())
+        this.$set(this.item, 'stateDescriptionPattern', this.stateDescriptionPattern)
       }
     },
     groupUnit: {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -277,7 +277,7 @@ export default {
     if (this.createMode && this.stateDescription && (this.stateDescription !== this.item.stateDescriptionPattern)) {
       // If there is a state description from the channel type that is different from the default,
       // set it as the item state description
-      this.$set(this, 'item.stateDescriptionPattern', this.stateDescription)
+      this.item.stateDescriptionPattern = this.stateDescription
     }
   },
   beforeDestroy () {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -274,6 +274,11 @@ export default {
     if (!this.item) return
     this.initializeAutocompleteCategory()
     if (this.dimensionsReady) this.initializeAutocompleteUnit()
+    if (this.createMode && this.stateDescription && (this.stateDescription !== this.item.stateDescriptionPattern)) {
+      // If there is a state description from the channel type that is different from the default,
+      // set it as the item state description
+      this.$set(this, 'item.stateDescriptionPattern', this.stateDescription)
+    }
   },
   beforeDestroy () {
     if (this.unitAutocomplete) {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -40,11 +40,11 @@
         <f7-list-input v-show="itemDimension"
                        label="State Description Pattern"
                        type="text"
-                       :info="(createMode) ? 'Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value.' : ''"
-                       :disabled="!editable"
+                       :info="(createMode) ? 'Pattern or transformation applied to the state for display purposes. Only saved if you change the pre-filled default value.' : 'Pattern can only be changed from the state description metadata page after Item creation!'"
+                       :disabled="!createMode"
                        :value="stateDescriptionPattern"
                        @input="stateDescriptionPattern = $event.target.value"
-                       :clear-button="editable" />
+                       :clear-button="createMode" />
 
         <!-- Group Item Form -->
         <group-form ref="groupForm" v-if="itemType === 'Group'" :item="item" :createMode="createMode" />

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -98,7 +98,7 @@ import uomMixin from '@/components/item/uom-mixin'
 
 export default {
   mixins: [ItemMixin, uomMixin],
-  props: ['item', 'items', 'createMode', 'hideCategory', 'hideType', 'hideSemantics', 'forceSemantics', 'unitHint'],
+  props: ['item', 'items', 'createMode', 'hideCategory', 'hideType', 'hideSemantics', 'forceSemantics', 'unitHint', 'stateDescription'],
   components: {
     SemanticsPicker,
     ItemPicker,
@@ -149,7 +149,6 @@ export default {
         const dimension = this.dimensions.find((d) => d.name === newDimension)
         this.$set(this.item, 'type', 'Number:' + dimension.name)
         this.itemUnit = (this.unitHint ? this.unitHint : this.getUnitHint(dimension.name))
-        this.$set(this.item, 'stateDescription', this.getStateDescription())
       }
     },
     itemUnit: {
@@ -171,7 +170,7 @@ export default {
     stateDescriptionPattern: {
       get () {
         if (this.item.stateDescriptionPattern) return this.item.stateDescriptionPattern
-        return this.item.metadata?.stateDescription?.config.pattern || '%.0f %unit%'
+        return this.item.metadata?.stateDescription?.config.pattern || this.stateDescription || (this.createMode ? '%.0f %unit%' : '')
       },
       set (newPattern) {
         this.$set(this.item, 'stateDescriptionPattern', newPattern)

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -77,17 +77,15 @@ export default {
           return Promise.resolve()
         }
       }).then(() => {
-        // Save state description if Item is an UoM Item and if state description changed from the default value
+        // Save state description if Item is an UoM Item
         if ((item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && stateDescriptionPattern) {
-          if (stateDescriptionPattern !== '%.0f %unit%') {
-            const metadata = {
-              value: ' ',
-              config: {
-                pattern: stateDescriptionPattern
-              }
+          const metadata = {
+            value: ' ',
+            config: {
+              pattern: stateDescriptionPattern
             }
-            return this.$oh.api.put('/rest/items/' + item.name + '/metadata/stateDescription', metadata)
           }
+          return this.$oh.api.put('/rest/items/' + item.name + '/metadata/stateDescription', metadata)
         } else {
           return Promise.resolve()
         }

--- a/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/item-mixin.js
@@ -64,34 +64,42 @@ export default {
       const stateDescriptionPattern = item.stateDescriptionPattern
       delete item.stateDescriptionPattern
 
-      // TODO: Add support for saving metadata
       return this.$oh.api.put('/rest/items/' + item.name, item).then(() => {
-        // Save unit metadata if Item is an UoM Item
-        if ((item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && unit) {
-          const metadata = {
-            value: unit,
-            config: {}
-          }
-          return this.$oh.api.put('/rest/items/' + item.name + '/metadata/unit', metadata)
-        } else {
-          return Promise.resolve()
-        }
+        return this.saveUnit(item, unit)
       }).then(() => {
-        // Save state description if Item is an UoM Item
-        if ((item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && stateDescriptionPattern) {
-          const metadata = {
-            value: ' ',
-            config: {
-              pattern: stateDescriptionPattern
-            }
-          }
-          return this.$oh.api.put('/rest/items/' + item.name + '/metadata/stateDescription', metadata)
-        } else {
-          return Promise.resolve()
-        }
+        return this.saveStateDescription(item, stateDescriptionPattern)
       }).catch((err) => {
         return Promise.reject(err)
       })
+    },
+    saveUnit (item, unit) {
+      // Save unit metadata if Item is an UoM Item
+      if ((item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && unit) {
+        const metadata = {
+          value: unit,
+          config: {}
+        }
+        return this.saveMetaData(item, 'unit', metadata)
+      } else {
+        return Promise.resolve()
+      }
+    },
+    saveStateDescription (item, stateDescriptionPattern) {
+      // Save state description if Item is an UoM Item
+      if ((item.type.startsWith('Number:') || item.groupType?.startsWith('Number:')) && stateDescriptionPattern) {
+        const metadata = {
+          value: ' ',
+          config: {
+            pattern: stateDescriptionPattern
+          }
+        }
+        return this.saveMetaData(item, 'stateDescription', metadata)
+      } else {
+        return Promise.resolve()
+      }
+    },
+    saveMetaData (item, value, metadata) {
+      return this.$oh.api.put('/rest/items/' + item.name + '/metadata/' + value, metadata)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -207,6 +207,7 @@ export default {
           category: (channelType) ? channelType.category : '',
           type: channel.itemType,
           unit: this.channelUnit(channel, channelType),
+          stateDescriptionPattern: '',
           tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
         }
         this.newItems.push(newItem)

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -48,7 +48,14 @@
                               @channel-updated="(e) => $emit('channels-updated', e)" />
               </template>
               <template #default="{ channelType, channel }" v-else-if="multipleLinksMode">
-                <item-form v-if="isChecked(channel)" :item="newItem(channel)" :items="items" :createMode="true" :channel="channel" :checked="isChecked(channel)" :unitHint="getUnitHint(channel, channelType)" />
+                <item-form v-if="isChecked(channel)"
+                           :item="newItem(channel)"
+                           :items="items"
+                           :createMode="true"
+                           :channel="channel"
+                           :checked="isChecked(channel)"
+                           :unitHint="getUnitHint(channel, channelType)"
+                           :stateDescription="stateDescription(channelType)" />
               </template>
               <!-- <channel-link #default="{ channelId }" /> -->
             </channel-group>
@@ -208,6 +215,9 @@ export default {
     channelUnit (channel, channelType) {
       const dimension = channel.itemType.startsWith('Number:') ? channel.itemType.split(':')[1] : ''
       return dimension ? this.getUnitHint(dimension, channelType) : ''
+    },
+    stateDescription (channelType) {
+      return channelType?.stateDescription?.pattern
     },
     toggleAllChecks (checked) {
       this.thing.channels.forEach((c) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -191,6 +191,8 @@ export default {
         let copy = Object.assign({}, p)
         delete (copy.channel)
         delete (copy.channelType)
+        delete (copy.unit)
+        delete (copy.stateDescriptionPattern)
         return copy
       })]
       if (this.createEquipment) payload.unshift(this.newEquipmentItem)

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -43,7 +43,7 @@
 
         <!-- Create new item -->
         <f7-col v-else>
-          <item-form ref="itemForm" :item="newItem" :items="items" :createMode="true" :unitHint="linkUnit()" />
+          <item-form ref="itemForm" :item="newItem" :items="items" :createMode="true" :unitHint="linkUnit()" :stateDescription="stateDescription()" />
         </f7-col>
       </template>
 
@@ -206,6 +206,9 @@ export default {
     linkUnit () {
       const dimension = this.channel.itemType.startsWith('Number:') ? this.channel.itemType.split(':')[1] : ''
       return dimension ? this.getUnitHint(dimension, this.channelType) : ''
+    },
+    stateDescription () {
+      return this.channelType?.stateDescription?.pattern
     },
     loadProfileTypes (channel) {
       this.ready = false


### PR DESCRIPTION
When creating a new Number with Dimension item from a channel link, the stateDescriptionPattern does not propose the state description pattern from the channel type as the default.

This PR introduces this.

It only saves this state description pattern from the channel type to metadata of the item if it is not the default state description pattern for a Number type.

Subsequent edits of the item will present a blank state description if none has been saved explicitely. Reasons are:
- a channel stateDescription can contain more than a pattern. Saving only the pattern would override the rest of the stateDescription.
- an item can be linked to multiple channels with (possibly conflicting) stateDescription. The only solution would be for the user the set it on the item and override the channel stateDescriptions. If that is not done, nothing is shown and it is left to core to take one when presenting the formatted state.

See https://github.com/openhab/openhab-addons/pull/16531#discussion_r1530394678

This PR also now saves the unit (and state description pattern) when creating equipment or point from a thing.
See discussion https://community.openhab.org/t/units-are-not-propagated-when-creating-items/154748.
So far, changes were only saved when editing or creating items directly or from thing channels, not when creating from things in the model. 