### PR TITLE
[BasicUI] All buttons forced on one line for a Player item

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SwitchRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/SwitchRenderer.java
@@ -22,6 +22,7 @@ import org.openhab.core.items.GroupItem;
 import org.openhab.core.items.Item;
 import org.openhab.core.items.ItemNotFoundException;
 import org.openhab.core.library.items.NumberItem;
+import org.openhab.core.library.items.PlayerItem;
 import org.openhab.core.library.items.RollershutterItem;
 import org.openhab.core.library.items.SwitchItem;
 import org.openhab.core.library.types.OnOffType;
@@ -79,6 +80,7 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
         String snippetName = null;
         Item item = null;
         int nbButtons = 0;
+        boolean multiline = false;
         try {
             item = itemUIRegistry.getItem(w.getItem());
             if (s.getMappings().isEmpty()) {
@@ -96,6 +98,7 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
                         // Render with buttons only when a max of MAX_BUTTONS options are defined
                         snippetName = "buttons";
                         nbButtons = optsSize;
+                        multiline = true;
                     } else {
                         snippetName = "switch";
                     }
@@ -103,6 +106,7 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
             } else {
                 snippetName = "buttons";
                 nbButtons = s.getMappings().size();
+                multiline = !(item instanceof PlayerItem);
             }
         } catch (ItemNotFoundException e) {
             logger.debug("Failed to retrieve item during widget rendering: {}", e.getMessage());
@@ -121,6 +125,9 @@ public class SwitchRenderer extends AbstractWidgetRenderer {
                 snippet = snippet.replaceAll("%checked%", "");
             }
         } else {
+            snippet = snippet.replaceAll("%height_auto%", multiline ? "mdl-form__row--height-auto" : "");
+            snippet = snippet.replaceAll("%buttons_class%",
+                    multiline ? "mdl-form__buttons-multiline" : "mdl-form__buttons");
             StringBuilder buttons = new StringBuilder();
             if (s.getMappings().isEmpty() && item != null) {
                 final CommandDescription commandDescription = item.getCommandDescription();

--- a/bundles/org.openhab.ui.basic/src/main/resources/snippets/buttons.html
+++ b/bundles/org.openhab.ui.basic/src/main/resources/snippets/buttons.html
@@ -1,4 +1,4 @@
-<div class="mdl-form__row mdl-form__row--height-auto mdl-cell mdl-cell--%cells%-col mdl-cell--%cells_tablet%-col-tablet %visibility_class%">
+<div class="mdl-form__row %height_auto% mdl-cell mdl-cell--%cells%-col mdl-cell--%cells_tablet%-col-tablet %visibility_class%">
 	<span %iconstyle% class="mdl-form__icon">
 		%icon_snippet%
 	</span>
@@ -9,7 +9,7 @@
 		%value%
 	</span>
 	<div
-		class="mdl-form__control mdl-form__buttons"
+		class="mdl-form__control %buttons_class%"
 		data-control-type="buttons"
 		data-item="%item%"
 		data-has-value="%has_value%"

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -489,6 +489,9 @@
 		width: 100%;
 	}
 	&__buttons {
+		padding-top: 2px;
+	}
+	&__buttons-multiline {
 		margin: 6px 0;
 		html.ui-layout-condensed & {
 			margin: 0;


### PR DESCRIPTION
Follow-up #2341
Partial revert to make two exceptions and restore old behaviour (buttons on a unique line) for:
* Control buttons of a Player item
* Buttons in the settings page

Signed-off-by: Laurent Garnier <lg.hc@free.fr>