### PR TITLE
fix blockly multilineedit rendering issue

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -306,3 +306,6 @@ html
       padding 0
       margin-left 8px
       color var(--f7-input-text-color)
+
+textarea.blocklyHtmlTextAreaInput
+  background #fff


### PR DESCRIPTION
Finally the long awaited fix for the dreaded blockly multilineedit rendering issue like the following

<img width="380" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/9fa7ba14-bd00-4043-91e0-f3057db1cc25">

more info can be found at: https://github.com/google/blockly-samples/issues/2235 

The solution is to make sure that the hidden textarea style neither has a background of none or transparent.