### PR TITLE
Fix deprecation warning in unit test

### DIFF
--- a/bundles/org.openhab.ui/web/test/jest/__tests__/config-parameter.test.js
+++ b/bundles/org.openhab.ui/web/test/jest/__tests__/config-parameter.test.js
@@ -21,9 +21,6 @@ describe('ConfigParameter', () => {
     }
   })
 
-  it('is a Vue instance', () => {
-    expect(wrapper.isVueInstance()).toBeTruthy()
-  })
   it('is an option control', () => {
     expect(wrapper.vm.control).toBeDefined()
     console.log(wrapper.vm.control.data())


### PR DESCRIPTION
See https://v1.test-utils.vuejs.org/api/wrapper/isvueinstance.html#isvueinstance.