### PR TITLE
Charts config: Add gauge and pie chart types

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -199,7 +199,9 @@ const seriesParameters = [
 const seriesTypesLabels = {
   line: 'Line',
   bar: 'Bar',
+  gauge: 'Gauge',
   heatmap: 'Heatmap',
+  pie: 'Pie',
   scatter: 'Scatter'
 }
 


### PR DESCRIPTION
Those are imported in https://github.com/openhab/openhab-webui/blob/974e28e9babf865d92297980db7e4ff144ffa566/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue#L47 and should therefore work.