### PR TITLE
Downgrade pkce-challenge to 3.x

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -40,7 +40,7 @@
         "moo": "^0.5.2",
         "nearley": "^2.20.1",
         "path-browserify": "^1.0.1",
-        "pkce-challenge": "^4.1.0",
+        "pkce-challenge": "^3.1.0",
         "qrcode": "^1.5.3",
         "scope-css": "^1.2.1",
         "stream-browserify": "^3.0.0",
@@ -6833,6 +6833,11 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/crypto-random-string": {
       "version": "2.0.0",
@@ -16102,11 +16107,11 @@
       }
     },
     "node_modules/pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ==",
-      "engines": {
-        "node": ">=16.20.0"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-3.1.0.tgz",
+      "integrity": "sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==",
+      "dependencies": {
+        "crypto-js": "^4.1.1"
       }
     },
     "node_modules/pkcs7": {
@@ -26741,6 +26746,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
+    },
     "crypto-random-string": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
@@ -33611,9 +33621,12 @@
       "dev": true
     },
     "pkce-challenge": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-4.1.0.tgz",
-      "integrity": "sha512-ZBmhE1C9LcPoH9XZSdwiPtbPHZROwAnMy+kIFQVrnMCxY4Cudlz3gBOpzilgc0jOgRaiT3sIWfpMomW2ar2orQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-3.1.0.tgz",
+      "integrity": "sha512-bQ/0XPZZ7eX+cdAkd61uYWpfMhakH3NeteUF1R8GNa+LMqX8QFAkbCLqq+AYAns1/ueACBu/BMWhrlKGrdvGZg==",
+      "requires": {
+        "crypto-js": "^4.1.1"
+      }
     },
     "pkcs7": {
       "version": "1.0.4",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -78,7 +78,7 @@
     "moo": "^0.5.2",
     "nearley": "^2.20.1",
     "path-browserify": "^1.0.1",
-    "pkce-challenge": "^4.1.0",
+    "pkce-challenge": "^3.1.0",
     "qrcode": "^1.5.3",
     "scope-css": "^1.2.1",
     "stream-browserify": "^3.0.0",

--- a/bundles/org.openhab.ui/web/src/js/openhab/auth.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/auth.js
@@ -30,21 +30,20 @@ if (document.cookie.indexOf('X-OPENHAB-AUTH-HEADER') >= 0) tokenInCustomHeader =
 
 export function authorize (setup) {
   import('pkce-challenge').then((PkceChallenge) => {
-    PkceChallenge.default().then((challenge) => {
-      const authState = (setup ? 'setup-' : '') + Framework7.utils.id()
+    const pkceChallenge = PkceChallenge.default()
+    const authState = (setup ? 'setup-' : '') + Framework7.utils.id()
 
-      sessionStorage.setItem('openhab.ui:codeVerifier', challenge.code_verifier)
-      sessionStorage.setItem('openhab.ui:authState', authState)
+    sessionStorage.setItem('openhab.ui:codeVerifier', pkceChallenge.code_verifier)
+    sessionStorage.setItem('openhab.ui:authState', authState)
 
-      window.location = '/auth' +
-        '?response_type=code' +
-        '&client_id=' + encodeURIComponent(window.location.origin) +
-        '&redirect_uri=' + encodeURIComponent(window.location.origin) +
-        '&scope=admin' +
-        '&code_challenge_method=S256' +
-        '&code_challenge=' + encodeURIComponent(challenge.code_challenge) +
-        '&state=' + authState
-    })
+    window.location = '/auth' +
+      '?response_type=code' +
+      '&client_id=' + encodeURIComponent(window.location.origin) +
+      '&redirect_uri=' + encodeURIComponent(window.location.origin) +
+      '&scope=admin' +
+      '&code_challenge_method=S256' +
+      '&code_challenge=' + encodeURIComponent(pkceChallenge.code_challenge) +
+      '&state=' + authState
   })
 }
 


### PR DESCRIPTION
Version 4.x of pkce-challenge uses the Web Crypto API, which is only available in secure contexts (https) in most browsers. See https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API.