### PR TITLE
Things (inbox) list: Improve condition for reversed checkbox style

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -48,7 +48,7 @@
       <f7-col>
         <f7-block-title>
           <span v-if="ready">{{ inboxCount }} entries</span>
-          <div v-if="!$device.desktop" style="text-align:right; color:var(--f7-block-text-color); font-weight: normal" class="float-right">
+          <div v-if="!$device.desktop && $f7.width < 1024" style="text-align:right; color:var(--f7-block-text-color); font-weight: normal" class="float-right">
             <f7-checkbox :checked="showIgnored" @change="toggleIgnored" /> <label @click="toggleIgnored" style="cursor:pointer">Show ignored</label>
           </div>
           <div v-else style="text-align:right; color:var(--f7-block-text-color); font-weight: normal" class="float-right">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -72,7 +72,7 @@
         <f7-block-title class="searchbar-hide-on-search">
           <span>{{ thingsCount }} Things</span>
           <template v-if="groupBy === 'location'">
-            <div v-if="!$device.desktop" style="text-align:right; color:var(--f7-block-text-color); font-weight: normal" class="float-right">
+            <div v-if="!$device.desktop && $f7.width < 1024" style="text-align:right; color:var(--f7-block-text-color); font-weight: normal" class="float-right">
               <f7-checkbox :checked="showNoLocation" @change="toggleShowNoLocation" /> <label @click="toggleShowNoLocation" style="cursor:pointer">Show no location</label>
             </div>
             <div v-else style="text-align:right; color:var(--f7-block-text-color); font-weight: normal" class="float-right">


### PR DESCRIPTION
Follow-up for #2472.

Improve the condition to only show the reversed order where really required.