### PR TITLE
Chart calendar axis: Don't override user-defined dayLabel and monthName settings

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -272,13 +272,11 @@ export default {
     skeletonCalendarOptions (calendar, calendarIdx) {
       let options = {}
       let calendarOptions = Object.assign({}, calendar.config)
-      calendarOptions.dayLabel = {
-        firstDay: 1,
-        margin: 5
-      }
-      calendarOptions.monthName = {
-        margin: 5
-      }
+      if (!calendarOptions.dayLabel) calendarOptions.dayLabel = {}
+      if (calendarOptions.dayLabel.firstDay === undefined) calendarOptions.dayLabel.firstDay = 1
+      if (calendarOptions.dayLabel.margin === undefined) calendarOptions.dayLabel.margin = 5
+      if (!calendarOptions.monthName) calendarOptions.monthName = {}
+      if (calendarOptions.monthName.margin === undefined) calendarOptions.monthName.margin = 5
 
       // calculate range based on chart type and/or initial period
       const chartType = this.context.component.config.chartType

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-calendar-axis.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-calendar-axis.js
@@ -5,13 +5,11 @@ export default {
     let calendar = chartWidget.evaluateExpression(ComponentId.get(component), component.config)
     calendar.range = [startTime.toDate(), endTime.subtract(1, 'day').toDate()]
     if (orient) calendar.orient = orient
-    calendar.dayLabel = {
-      firstDay: 1,
-      margin: 5
-    }
-    calendar.monthName = {
-      margin: 5
-    }
+    if (!calendar.dayLabel) calendar.dayLabel = {}
+    if (calendar.dayLabel.firstDay === undefined) calendar.dayLabel.firstDay = 1
+    if (calendar.dayLabel.margin === undefined) calendar.dayLabel.margin = 5
+    if (!calendar.monthName) calendar.monthName = {}
+    if (calendar.monthName.margin === undefined) calendar.monthName.margin = 5
 
     if (!calendar.top) calendar.top = 100
     if (!calendar.bottom) calendar.bottom = 50


### PR DESCRIPTION
This e.g. allows to set dayLabel.nameMap (https://echarts.apache.org/en/option.html#calendar.dayLabel.nameMap).