### PR TITLE
Downgrade vue-fragment as the upgrade broke oh-repeater in some circumstances

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -53,7 +53,7 @@
         "vue-codemirror": "^4.0.6",
         "vue-draggable-resizable": "^2.3.0",
         "vue-echarts": "^6.6.9",
-        "vue-fragment": "^1.6.0",
+        "vue-fragment": "^1.5.1",
         "vue-fullscreen": "^2.6.1",
         "vue-grid-layout": "^2.4.0",
         "vue-i18n": "^8.28.2",
@@ -20133,9 +20133,9 @@
       "dev": true
     },
     "node_modules/vue-fragment": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.6.0.tgz",
-      "integrity": "sha512-a5T8ZZZK/EQzgVShEl374HbobUJ0a7v12BzOzS6Z/wd/5EE/5SffcyHC+7bf9hP3L7Yc0hhY/GhMdwFQ25O/8A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.5.1.tgz",
+      "integrity": "sha512-ig6eES6TcMBbANW71ylB+AJgRN+Zksb3f50AxjGpAk6hMzqmeuD80qeh4LJP0jVw2dMBMjgRUfIkrvxygoRgtQ==",
       "peerDependencies": {
         "vue": "^2.5.16"
       }
@@ -36697,9 +36697,9 @@
       }
     },
     "vue-fragment": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.6.0.tgz",
-      "integrity": "sha512-a5T8ZZZK/EQzgVShEl374HbobUJ0a7v12BzOzS6Z/wd/5EE/5SffcyHC+7bf9hP3L7Yc0hhY/GhMdwFQ25O/8A==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vue-fragment/-/vue-fragment-1.5.1.tgz",
+      "integrity": "sha512-ig6eES6TcMBbANW71ylB+AJgRN+Zksb3f50AxjGpAk6hMzqmeuD80qeh4LJP0jVw2dMBMjgRUfIkrvxygoRgtQ==",
       "requires": {}
     },
     "vue-fullscreen": {

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -91,7 +91,7 @@
     "vue-codemirror": "^4.0.6",
     "vue-draggable-resizable": "^2.3.0",
     "vue-echarts": "^6.6.9",
-    "vue-fragment": "^1.6.0",
+    "vue-fragment": "^1.5.1",
     "vue-fullscreen": "^2.6.1",
     "vue-grid-layout": "^2.4.0",
     "vue-i18n": "^8.28.2",


### PR DESCRIPTION
When we upgrade to Vue 3, we can remove this dependency as Vue 3 has this functionality integrated, see https://api.vueframework.com/guide/migration/fragments.html.