### PR TITLE
Things list: Fix broken list index after Thing removal

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -40,6 +40,7 @@
     </f7-toolbar>
 
     <f7-list-index
+      v-if="ready"
       ref="listIndex"
       v-show="groupBy === 'alphabetical' && !$device.desktop"
       list-el=".things-list"


### PR DESCRIPTION
After a Thing has been removed, the list index showed several wrong entries derived from Thing labels.