### PR TITLE
Bump maven-compiler-plugin to 3.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.11.0</version>
+          <version>3.13.0</version>
           <configuration>
             <compilerId>eclipse</compilerId>
             <compilerArgs>


### PR DESCRIPTION
Avoid ZipException with ejc >3.30.0.

Refs: openhab/openhab-core#4167