### PR TITLE
SSE Item State Tracking: Avoid requesting __ob__ and __v_isRef

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/glance/glance-helpers.js
+++ b/bundles/org.openhab.ui/web/src/components/cards/glance/glance-helpers.js
@@ -24,9 +24,7 @@ export function allEquipmentPoints (equipment) {
  * @param {String} property return only points also related to this property
  */
 export function findPoints (arr, value, partial, property) {
-  console.debug(arr)
   const points = arr.filter((p) => (partial) ? p.metadata.semantics.value.indexOf(value) === 0 : p.metadata.semantics.value === value)
   if (!property) return points
-  console.debug('found1' + points)
   return points.filter((p) => p.metadata.semantics.config.relatesTo === property)
 }

--- a/bundles/org.openhab.ui/web/src/js/store/modules/states.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/states.js
@@ -16,9 +16,10 @@ const handler = (context) => {
   return {
     get (obj, prop) {
       if (prop === '_keys') return Object.keys(context.state.itemStates)
+      if (prop === '__ob__') return obj.__ob__
 
       // to avoid the Vue devtools requesting invalid items in development
-      if (['state', 'getters', '_vm', 'toJSON'].indexOf(prop.toString()) >= 0) return {}
+      if (['state', 'getters', '_vm', 'toJSON', '__v_isRef'].indexOf(prop.toString()) >= 0) return {}
       if (typeof prop !== 'string') return {}
 
       const itemName = prop


### PR DESCRIPTION
Fixes #2530.
Regression from #2489.

I wasn't able to identify the root cause, but this seems to solve the problem.