### PR TITLE
Metadata: Add `link_to_more` as well-known namespace

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -12,5 +12,6 @@ export default [
   { name: 'voiceSystem', label: 'Voice System' },
   { name: 'alexa', label: 'Amazon Alexa' },
   { name: 'homekit', label: 'Apple HomeKit' },
-  { name: 'ga', label: 'Google Assistant' }
+  { name: 'ga', label: 'Google Assistant' },
+  { name: 'link_to_more', label: 'Android App: Link to More' }
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/namespaces.js
@@ -13,5 +13,5 @@ export default [
   { name: 'alexa', label: 'Amazon Alexa' },
   { name: 'homekit', label: 'Apple HomeKit' },
   { name: 'ga', label: 'Google Assistant' },
-  { name: 'link_to_more', label: 'Android App: Link to More' }
+  { name: 'link_to_more', label: 'Android App: Device Controls' }
 ]

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -1,0 +1,30 @@
+<template>
+  <div>
+    <f7-list>
+      <f7-list-input
+        label="Android App: Link To More"
+        name="value"
+        ref="value"
+        type="text"
+        :value="metadata.value"
+        @input="updateValue" />
+      <f7-block-footer class="param-description" slot="after-list">
+        <small>
+          Enter a valid URL, e.g. <code>https://www.openhab.org</code> or <code>/locations</code>, to open when you long-press of an Item on the openHAB Android app.
+          <f7-link external color="blue" target="_blank" :href="$store.state.websiteUrl + '/docs/apps/android.html#quick-access-device-controls'">Read the docs.</f7-link>
+        </small>
+      </f7-block-footer>
+    </f7-list>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['itemName', 'metadata', 'namespace'],
+  methods: {
+    updateValue (ev) {
+      this.metadata.value = ev.target.value
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -2,7 +2,7 @@
   <div>
     <f7-list>
       <f7-list-input
-        label="Android App: Link To More"
+        label="Android App: Device Controls"
         name="value"
         ref="value"
         type="text"
@@ -10,8 +10,8 @@
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>
-          Enter a valid URL, e.g. <code>https://www.openhab.org</code> or <code>/locations</code>, to open when you long-press of an Item on the openHAB Android app.
-          <f7-link external color="blue" target="_blank" :href="$store.state.websiteUrl + '/docs/apps/android.html#quick-access-device-controls'">Read the docs.</f7-link>
+          Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press of a tile in Android Device Control.
+          <f7-link external color="blue" target="_blank" :href="$store.state.websiteUrl + '/docs/apps/android.html#device-controls'">Read the docs.</f7-link>
         </small>
       </f7-block-footer>
     </f7-list>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -10,7 +10,7 @@
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>
-          Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press of a tile in Android Device Control.
+          Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press a tile in Android Device Control.
           <f7-link external color="blue" target="_blank" :href="$store.state.websiteUrl + '/docs/apps/android.html#device-controls'">Read the docs.</f7-link>
         </small>
       </f7-block-footer>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -72,10 +72,11 @@ import ItemMetadataWidget from '@/components/item/metadata/item-metadata-widget.
 import ItemMetadataWidgetOrder from '@/components/item/metadata/item-metadata-widgetorder.vue'
 import ItemMetadataAutoUpdate from '@/components/item/metadata/item-metadata-autoupdate.vue'
 import ItemMetadataExpire from '@/components/item/metadata/item-metadata-expire.vue'
+import ItemMetadataVoiceSystem from '@/components/item/metadata/item-metadata-voicesystem.vue'
 import ItemMetadataAlexa from '@/components/item/metadata/item-metadata-alexa.vue'
 import ItemMetadataHomeKit from '@/components/item/metadata/item-metadata-homekit.vue'
 import ItemMetadataGa from '@/components/item/metadata/item-metadata-ga.vue'
-import ItemMetadataVoiceSystem from '@/components/item/metadata/item-metadata-voicesystem.vue'
+import ItemMetadataLinktomore from '@/components/item/metadata/item-metadata-linktomore.vue'
 import DirtyMixin from '../../dirty-mixin'
 
 export default {
@@ -125,14 +126,16 @@ export default {
           return ItemMetadataAutoUpdate
         case 'expire':
           return ItemMetadataExpire
+        case 'voiceSystem':
+          return ItemMetadataVoiceSystem
         case 'alexa':
           return ItemMetadataAlexa
         case 'homekit':
           return ItemMetadataHomeKit
-        case 'voiceSystem':
-          return ItemMetadataVoiceSystem
         case 'ga':
           return ItemMetadataGa
+        case 'link_to_more':
+          return ItemMetadataLinktomore
         default:
           return null
       }


### PR DESCRIPTION
Closes #2382.
Refs https://github.com/openhab/openhab-android/issues/3140.

Adds Android app's link_to_more metadata to the well-known namespaces, therefore also adds an editing page for it.

<details>
<summary>Screenshots</summary>

![image](https://github.com/openhab/openhab-webui/assets/73423173/1545e754-b891-4fb9-8f58-e501b14d4eef)

![image](https://github.com/openhab/openhab-webui/assets/73423173/c06ac1bb-4bbc-467c-b82a-d76835af89ee)

</details>