### PR TITLE
Charts: Fix initial period wrongly calculated for future charts

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -207,8 +207,8 @@ export default {
         if (chartType) {
           day = fn.apply(day, [1, chartType === 'isoWeek' ? 'week' : chartType])
         } else {
-          const period = this.period || DEFAULT_PERIOD
-          let span = period.match(/^([\d]*)([smhdDwWMQyY])$/)
+          const period = this.period || this.context.component.config.period || DEFAULT_PERIOD
+          const span = period.match(/^([\d]*)([smhdDwWMQyY])$/)
           if (span) {
             day = fn.apply(day, [parseInt(span[1]) || 1, span[2].replace(/[DWY]/, (x) => x.toLowerCase())])
           }


### PR DESCRIPTION
Follow-up fix for #2545.

When the initial period was different from `D`, the period initial endTime calculation was wrong.
This lead to the initial period being calculated wrong: One day was always into the future, the rest of the period to the past.