### PR TITLE
Update plugins

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -169,7 +169,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.1</version>
         <executions>
           <execution>
             <id>unpack-eea</id>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <karaf.version>4.4.5</karaf.version>
     <ohc.version>4.2.0-SNAPSHOT</ohc.version>
     <sat.version>0.16.0</sat.version>
-    <spotless.version>2.38.0</spotless.version>
+    <spotless.version>2.43.0</spotless.version>
     <!-- Eclipse Java formatter version 4.26+ does not check test files -->
     <spotless.eclipse.version>4.25</spotless.eclipse.version>
     <spotless.eclipse.wtp.version>4.21.0</spotless.eclipse.wtp.version>
@@ -235,7 +235,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.1</version>
+          <version>3.3.2</version>
         </plugin>
 
         <plugin>
@@ -272,7 +272,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.4.1</version>
         </plugin>
 
         <plugin>
@@ -284,30 +284,22 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.2.0</version>
+          <version>3.6.3</version>
           <configuration>
             <failOnError>!${quality.skip}</failOnError>
           </configuration>
-          <dependencies>
-            <!-- This newer version fixes issues with resolving tech.units:indriya packages -->
-            <dependency>
-              <groupId>org.codehaus.plexus</groupId>
-              <artifactId>plexus-java</artifactId>
-              <version>1.0.7</version>
-            </dependency>
-          </dependencies>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-plugin-plugin</artifactId>
-          <version>3.9.0</version>
+          <version>3.12.0</version>
         </plugin>
 
         <plugin>
@@ -334,13 +326,13 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.1.2</version>
+          <version>3.2.5</version>
           <configuration>
             <argLine>
               --add-opens java.base/java.net=ALL-UNNAMED
@@ -355,13 +347,13 @@ Import-Package: \\
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.2</version>
+          <version>4.3</version>
           <configuration>
             <basedir>${basedir}</basedir>
             <quiet>false</quiet>
@@ -436,7 +428,7 @@ Import-Package: \\
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.4.1</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -549,7 +541,7 @@ Import-Package: \\
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.13.4</version>
+          <version>1.15.0</version>
         </plugin>
 
       </plugins>
@@ -589,6 +581,9 @@ Import-Package: \\
             </goals>
             <configuration>
               <rules>
+                <requireMavenVersion>
+                  <version>3.6.3</version>
+                </requireMavenVersion>
                 <requireJavaVersion>
                   <version>[17.0,18.0),[21.0,22.0)</version>
                 </requireJavaVersion>


### PR DESCRIPTION
Update nearly all plugins listed by
mvn versions:display-plugin-updates -nsu  -B -Dversions.outputLineWidth=120 | grep -- '->' | sort -u
(except the ones related to Karaf 4.4.6 update and milestone/snapshot releases, openapi-generator, jaxb2 (as this one has another provider as in core, tbc))

* set minimum Maven version to 3.6.3
* build-helper-maven-plugin, 3.4.0 to 3.5.0, see https://github.com/mojohaus/build-helper-maven-plugin/releases/tag/3.5.0
* frontend-maven-plugin, 1.13.4 to 1.15.0, see https://github.com/eirslett/frontend-maven-plugin/blob/master/CHANGELOG.md
* license-maven-plugin, 4.2 to 4.3
* maven-clean-plugin, 3.3.1 to 3.3.2, see https://github.com/apache/maven-clean-plugin/releases
* maven-dependency-plugin, 3.6.0 to 3.6.1, see https://github.com/apache/maven-dependency-plugin/releases/tag/maven-dependency-plugin-3.6.1
* maven-enforcer-plugin, 3.4.0 to 3.4.1
* maven-jar-plugin, 3.3.0 to 3.4.1, see https://github.com/apache/maven-jar-plugin/releases
* maven-javadoc-plugin, 3.2.0 to 3.6.3, see https://github.com/apache/maven-javadoc-plugin/releases
* maven-plugin-plugin, 3.9.0 to 3.12.0, see https://github.com/apache/maven-plugin-tools/releases/tag/maven-plugin-tools-3.12.0
* maven-site-plugin, 3.12.1 to 4.0.0-M13
* maven-source-plugin, 3.3.0 to 3.3.1
* maven-surefire-plugin, 3.1.2 to 3.2.5, see https://github.com/apache/maven-surefire/releases
* sortpom-maven-plugin, 3.3.0 to 3.4.1
* spotless-maven-plugin, 2.38.0 to 2.43.0, see https://github.com/diffplug/spotless/blob/main/plugin-maven/CHANGES.md