### PR TITLE
Add-on logo component: Make lazy loading optional

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -25,7 +25,7 @@
           <addon-stats-line :addon="addon" :iconSize="15" />
         </div>
       </div>
-      <addon-logo class="logo-square" :addon="addon" :size="150" />
+      <addon-logo class="logo-square" :lazy="true" :addon="addon" :size="150" />
     </div>
   </f7-link>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -11,7 +11,7 @@
     <div v-else-if="addon.properties && addon.properties.views" slot="subtitle">
       <addon-stats-line :addon="addon" :iconSize="15" />
     </div>
-    <addon-logo slot="media" class="logo-square" :addon="addon" size="64" />
+    <addon-logo slot="media" class="logo-square" :lazy="true" :addon="addon" size="64" />
     <div v-if="showInstallActions" slot="after">
       <f7-preloader v-if="addon.pending" color="blue" />
       <f7-button v-else-if="addon.installed" class="install-button prevent-active-state-propagation" text="Remove" color="red" round small @click="buttonClicked" />

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-logo.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-logo.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <f7-icon v-show="!logoLoaded" :size="size" color="gray" :f7="addonIcon" class="default-icon" style="padding-left: 0; opacity: 0.2; position: absolute" />
-    <img v-if="!svgLogoError" class="lazy logo" :style="imgStyle" ref="svgLogo"
-         :data-src="imageUrl('svg')">
+    <img v-if="!svgLogoError" :class="lazy ? 'lazy logo' : 'logo'" :style="imgStyle" ref="svgLogo"
+         :src="imageUrl('svg')" :data-src="imageUrl('svg')">
     <img v-else-if="!pngLogoError" class="logo" :style="imgStyle" ref="pngLogo"
          :src="imageUrl('png')" @load="logoLoaded = true" @error="pngLogoError = true">
   </div>
@@ -12,7 +12,7 @@
 import { AddonIcons } from '@/assets/addon-store'
 
 export default {
-  props: ['addon', 'size'],
+  props: ['addon', 'size', 'lazy'],
   data () {
     return {
       addonIcon: AddonIcons[this.addon.type],
@@ -37,10 +37,10 @@ export default {
     }
   },
   mounted () {
-    this.$$(this.$refs.svgLogo).once('lazy:loaded', (e) => {
+    this.$$(this.$refs.svgLogo).once(this.lazy ? 'lazy:loaded' : 'load', (e) => {
       this.logoLoaded = true
     })
-    this.$$(this.$refs.svgLogo).once('lazy:error', (e) => {
+    this.$$(this.$refs.svgLogo).once(this.lazy ? 'lazy:error' : 'error', (e) => {
       this.svgLogoError = true
     })
   }


### PR DESCRIPTION
This makes the lazy loading of the add-on logo optional (can be enabled using a config property) in preparation to use the add-on logo component inside the setup-wizard.