### PR TITLE
[BasicUI] Fix build after a method renaming in core framework

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/WebAppServlet.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/WebAppServlet.java
@@ -173,7 +173,7 @@ public class WebAppServlet extends HttpServlet {
                 // we are at the homepage, so we render the children of the sitemap root node
                 if (subscriptionId != null) {
                     if (subscriptions.exists(subscriptionId)) {
-                        subscriptions.setPageId(subscriptionId, sitemap.getName(), sitemapName);
+                        subscriptions.updateSubscriptionLocation(subscriptionId, sitemap.getName(), sitemapName);
                     } else {
                         logger.debug("Basic UI requested a non-existing event subscription id ({})", subscriptionId);
                     }
@@ -185,7 +185,7 @@ public class WebAppServlet extends HttpServlet {
                 // we are on some subpage, so we have to render the children of the widget that has been selected
                 if (subscriptionId != null) {
                     if (subscriptions.exists(subscriptionId)) {
-                        subscriptions.setPageId(subscriptionId, sitemap.getName(), widgetId);
+                        subscriptions.updateSubscriptionLocation(subscriptionId, sitemap.getName(), widgetId);
                     } else {
                         logger.debug("Basic UI requested a non-existing event subscription id ({})", subscriptionId);
                     }


### PR DESCRIPTION
Related to openhab/openhab-core#3652 that renamed method setPageId into updateSubscriptionLocation

Signed-off-by: Laurent Garnier <lg.hc@free.fr>