### PR TITLE
[blockly] add more thing blocks

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-things.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-things.js
@@ -6,6 +6,9 @@
 import Blockly from 'blockly'
 import { javascriptGenerator } from 'blockly/javascript.js'
 import { FieldThingPicker } from './fields/thing-field.js'
+import { blockGetCheckedInputType } from './utils.js'
+
+const unavailMsg = 'Advanced Thing blocks aren\'t supported in "application/javascript;version=ECMAScript-5.1"'
 
 export default function defineOHBlocks (f7, isGraalJs) {
   Blockly.Blocks['oh_thing'] = {
@@ -25,6 +28,28 @@ export default function defineOHBlocks (f7, isGraalJs) {
     const thingUid = block.getFieldValue('thingUid')
     let code = `'${thingUid}'`
     return [code, 0]
+  }
+
+  Blockly.Blocks['oh_getthing'] = {
+    init: function () {
+      this.appendValueInput('thingUid')
+        .appendField('get thing')
+        .setCheck(['String', 'oh_thing'])
+      this.setInputsInline(false)
+      this.setOutput(true, 'oh_thingtype')
+      this.setColour(0)
+      this.setTooltip('Get a thing from the thing registry')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-thing')
+    }
+  }
+
+  javascriptGenerator.forBlock['oh_getthing'] = function (block) {
+    const thingUid = javascriptGenerator.valueToCode(block, 'thingUid', javascriptGenerator.ORDER_ATOMIC)
+    if (isGraalJs) {
+      return [`things.getThing(${thingUid})`, 0]
+    } else {
+      throw new Error(unavailMsg)
+    }
   }
 
   Blockly.Blocks['oh_getthing_state'] = {
@@ -49,6 +74,134 @@ export default function defineOHBlocks (f7, isGraalJs) {
         'things',
         ['var ' + javascriptGenerator.FUNCTION_NAME_PLACEHOLDER_ + ' = Java.type("org.openhab.core.model.script.actions.Things")'])
       return [`things.getThingStatusInfo(${thingUid}).getStatus()`, 0]
+    }
+  }
+
+  Blockly.Blocks['oh_things'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('get things')
+      this.setInputsInline(false)
+      this.setOutput(true, 'Array')
+      this.setColour(0)
+      this.setTooltip('Retrieve all things')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-things')
+      this.setOutput(true, null) // Array of Thing objects
+    }
+  }
+
+  javascriptGenerator.forBlock['oh_things'] = function (block) {
+    if (isGraalJs) {
+      return ['things.getThings()', 0]
+    } else {
+      throw new Error(unavailMsg)
+    }
+  }
+
+  Blockly.Blocks['oh_getthing'] = {
+    init: function () {
+      this.appendValueInput('thingUid')
+        .appendField('get thing')
+        .setCheck(['String', 'oh_thing'])
+      this.setInputsInline(false)
+      this.setOutput(true, 'oh_thingtype')
+      this.setColour(0)
+      this.setTooltip('Get a thing from the thing registry')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-thing')
+    }
+  }
+
+  javascriptGenerator.forBlock['oh_getthing'] = function (block) {
+    const thingUid = javascriptGenerator.valueToCode(block, 'thingUid', javascriptGenerator.ORDER_ATOMIC)
+    if (isGraalJs) {
+      return [`things.getThing(${thingUid})`, 0]
+    } else {
+      throw new Error(unavailMsg)
+    }
+  }
+
+  Blockly.Blocks['oh_getthing_attribute'] = {
+    init: function () {
+      const block = this
+      const choices = [['uid', 'Uid'], ['label', 'Label'], ['status', 'Status'], ['status info', 'StatusInfo'], ['location', 'Location'], ['enabled', 'IsEnabled'], ['thing type UID', 'ThingTypeUID'], ['bridge UID', 'BridgeUID']]
+      const dropdown = new Blockly.FieldDropdown(
+        choices,
+        function (newMode) {
+          block._updateType(newMode)
+        })
+      this.appendValueInput('thing')
+        .setCheck(['oh_thingtype', 'oh_thing'])
+        .appendField('get ')
+        .appendField(dropdown, 'attributeName')
+        .appendField('of thing')
+      this.setInputsInline(false)
+
+      this.setOutput(true, 'String')
+      this.setColour(0)
+      this.setTooltip('Retrieve a specific attribute from the thing. Note that groups and tags return a list and should be used with the loops-block \'for each item ... in list\'. ')
+      this.setTooltip(function () {
+        const attributeName = block.getFieldValue('attributeName')
+        let TIP = {
+          'Uid': 'unique id of the Thing (string)',
+          'Label': 'label of the Thing (string)',
+          'Status': 'status of the Thing (string)',
+          'StatusInfo': 'statusInfo of the Thing (string)',
+          'Location': 'location of the Thing (string)',
+          'Enabled': 'is the thing enabled (boolean)',
+          'ThingTypeUID': 'unique id of the Thing\'s type (string)',
+          'BridgeUID': 'unique id of the Thing\'s bridge (string)'
+        }
+        return TIP[attributeName] + ' \n Note: make sure to use "get thing xxx"-Block for the connected block when working with Variables, not "thing xxx"-Block'
+      })
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-items-things.html#get-particular-attributes-of-a-thing')
+    },
+    /**
+     * Modify this block to have the correct output type based on the attribute.
+     */
+    _updateType: function (newAttributeName) {
+      if (['Uid', 'Status', 'StatusInfo', 'Location', 'thingTypeUID', 'bridgeUID'].includes(newAttributeName)) {
+        this.outputConnection.setCheck('String')
+      } else if (newAttributeName === 'Enabled') {
+        this.outputConnection.setCheck('Boolean')
+      } else {
+        this.outputConnection.setCheck('String')
+      }
+    },
+    /**
+     * Create XML to represent the input and output types.
+     * @return {!Element} XML storage element.
+     * @this {Blockly.Block}
+     */
+    mutationToDom: function () {
+      let container = Blockly.utils.xml.createElement('mutation')
+      container.setAttribute('attributeName', this.getFieldValue('attributeName'))
+      return container
+    },
+    /**
+     * Parse XML to restore the input and output types.
+     * @param {!Element} xmlElement XML storage element.
+     * @this {Blockly.Block}
+     */
+    domToMutation: function (xmlElement) {
+      this._updateType(xmlElement.getAttribute('attributeName'))
+    }
+  }
+
+  /*
+* Provides all attributes from a Thing
+* Code part
+*/
+  javascriptGenerator.forBlock['oh_getthing_attribute'] = function (block) {
+    const theThing = javascriptGenerator.valueToCode(block, 'thing', javascriptGenerator.ORDER_ATOMIC)
+    const inputType = blockGetCheckedInputType(block, 'thing')
+    let attributeName = block.getFieldValue('attributeName')
+
+    if (isGraalJs) {
+      attributeName = attributeName.charAt(0).toLowerCase() + attributeName.slice(1)
+      let code = (inputType === 'oh_thing') ? `things.getThing(${theThing}).${attributeName}` : `${theThing}.${attributeName}`
+      return [code, 0]
+    } else {
+      throw new Error(unavailMsg)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -502,6 +502,21 @@
               <shadow type="oh_thing" />
             </value>
           </block>
+          <block type="oh_getthing_attribute">
+            <value name="thing">
+              <shadow type="oh_getthing">
+                <value name="thingUid">
+                  <shadow type="oh_thing" />
+                </value>
+              </shadow>
+            </value>
+          </block>
+          <block type="oh_getthing">
+            <value name="thingUid">
+              <shadow type="oh_thing" />
+            </value>
+          </block>
+          <block type="oh_things" />
           <block type="oh_thing" />
         </category>
 


### PR DESCRIPTION
Add missing blocks to work with a thing or a group of things

- oh_getthing (one particular)
- oh_getthing_state (the state of the string - to be consistent with items)
- oh_things (get all things - can be used to iterate over all things)
- oh_getthing_attribute (retrieve any attribute of a thing)

<img width="810" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/eba370af-fc91-4c40-a974-e2cad2a27fe5">

<img width="414" alt="image" src="https://github.com/openhab/openhab-webui/assets/5937600/8aaf71ec-f761-4e26-b1eb-c733b4c90d14">

