### PR TITLE
[blockly] Adjust persistence blocks to breaking changes

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -166,7 +166,7 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
         persistenceNameInput.setShadowDom(Blockly.utils.xml.textToDom('<shadow type="oh_persistence_dropdown" />'))
       }
       this.appendValueInput('dayInfo')
-        .appendField(new Blockly.FieldDropdown([['has changed since', 'changedSince'], ['has been updated since', 'updatedSince']]), 'methodName')
+        .appendField(new Blockly.FieldDropdown([['has changed since', 'changedSince'], ['will have changed until', 'changedUntil'], ['has been updated since', 'updatedSince'], ['will have been updated until', 'updatedUntil']]), 'methodName')
         .setAlign(Blockly.ALIGN_RIGHT)
         .setCheck(['ZonedDateTime'])
 
@@ -179,7 +179,9 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
         let methodName = thisBlock.getFieldValue('methodName')
         let TIP = {
           'changedSince': 'Checks if the State of the Item has (ever) changed since a certain point in time',
-          'updatedSince': 'Checks if the State of the Item has been updated since a certain point in time'
+          'changedUntil': 'Checks if the State of the Item will have (ever) changed until a certain point in time',
+          'updatedSince': 'Checks if the State of the Item has been updated since a certain point in time',
+          'updatedUntil': 'Checks if the State of the Item will have been updated until a certain point in time'
         }
         return TIP[methodName]
       })
@@ -194,19 +196,17 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
   */
   javascriptGenerator.forBlock['oh_persist_changed'] = function (block) {
     const itemName = javascriptGenerator.valueToCode(block, 'itemName', javascriptGenerator.ORDER_ATOMIC)
-
     const inputType = blockGetCheckedInputType(block, 'itemName')
-
-    let itemCode = generateItemCode(itemName, inputType)
 
     const methodName = block.getFieldValue('methodName')
     const dayInfo = javascriptGenerator.valueToCode(block, 'dayInfo', javascriptGenerator.ORDER_NONE)
-
     const persistenceName = javascriptGenerator.valueToCode(block, 'persistenceName', javascriptGenerator.ORDER_NONE)
     const persistenceExtension = (persistenceName === '\'default\'') ? '' : `, ${persistenceName}`
 
+    let itemCode = generateItemCode(itemName, inputType)
+
     if (isGraalJs) {
-      return [`${itemCode}.history.${methodName}(${dayInfo}${persistenceExtension})`, javascriptGenerator.ORDER_NONE]
+      return [`${itemCode}.persistence.${methodName}(${dayInfo}${persistenceExtension})`, javascriptGenerator.ORDER_NONE]
     } else {
       const { dtf, zdt, getZonedDatetime } = addDateSupport()
       const persistence = addPersistence()

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -143,7 +143,6 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
       case 'maximumUntil':
       case 'minimumSince':
       case 'minimumUntil':
-      case 'historicState':
       case 'persistedState':
         dayInfo = javascriptGenerator.valueToCode(block, 'dayInfo', javascriptGenerator.ORDER_NONE)
         code = (isGraalJs) ? `${itemCode}.persistence.${methodName}(${dayInfo}${persistenceExtension})?.state` : `${persistence}.${methodName}(${itemCode}, ${dayInfo}${persistenceExtension}).getState()`

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -221,7 +221,11 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
   Blockly.Blocks['oh_get_persistence_lastupdate'] = {
     init: function () {
       this.appendDummyInput()
-        .appendField('last updated date of')
+        .appendField(new Blockly.FieldDropdown([
+          ['last', 'lastUpdate'], ['next', 'nextUpdate']
+        ]), 'methodName')
+      this.appendDummyInput()
+        .appendField(' updated date of')
       this.appendValueInput('itemName')
         .setCheck(['String', 'oh_item', 'oh_itemtype'])
       const persistenceNameInput = this.appendValueInput('persistenceName')
@@ -234,8 +238,16 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
       this.setInputsInline(true)
       this.setOutput(true, 'ZonedDateTime')
       this.setColour(0)
-      this.setTooltip('Get the last update time of the provided item')
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-persistence.html#provide-last-updated-date-of-an-item')
+
+      this.setTooltip(() => {
+        const methodName = this.getFieldValue('methodName')
+        const TIP = {
+          'lastUpdate': 'Get the last update time of the provided item',
+          'nextUpdate': 'Get the next update time of the provided item'
+        }
+        return TIP[methodName]
+      })
     }
   }
 
@@ -244,6 +256,7 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
   * Code part
   */
   javascriptGenerator.forBlock['oh_get_persistence_lastupdate'] = function (block) {
+    const methodName = block.getFieldValue('methodName')
     const itemName = javascriptGenerator.valueToCode(block, 'itemName', javascriptGenerator.ORDER_ATOMIC)
     const inputType = blockGetCheckedInputType(block, 'itemName')
     const persistenceName = javascriptGenerator.valueToCode(block, 'persistenceName', javascriptGenerator.ORDER_NONE)
@@ -252,11 +265,11 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
     let itemCode = generateItemCode(itemName, inputType)
 
     if (isGraalJs) {
-      return [`${itemCode}.history.lastUpdate(${persistenceExtension})`, 0]
+      return [`${itemCode}.persistence.${methodName}(${persistenceExtension})`, 0]
     } else {
       const { dtf, zdt, getZonedDatetime } = addDateSupport()
       const persistence = addPersistence()
-      let code = `${persistence}.lastUpdate(${itemCode}${persistenceExtension})`
+      let code = `${persistence}.${methodName}(${itemCode}${persistenceExtension})`
       return [code, 0]
     }
   }


### PR DESCRIPTION
This adjusts the persistence blocks for the **breaking** changes of `org.openhab.core.persistence.extensions.PersistenceExtensions`.

For NashornJS, see https://github.com/openhab/openhab-core/pull/3736 for the changes.
For GraalJS, see https://next.openhab.org/addons/automation/jsscripting/#itempersistence for the current API docs and https://github.com/openhab/openhab-js/pull/331 for the changes.

In a follow-up PR, Blockly should be extended to make use of the new capabilities provided by the changed return type of variance, deviation, average, sum & delta.