### PR TITLE
[BasicUI] Remove a call to window.console

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1179,7 +1179,6 @@
 		};
 
 		function emitEvent(value) {
-			window.console.log("send " + value);
 			_t.parentNode.dispatchEvent(createEvent(
 				"control-change", {
 					item: _t.item,


### PR DESCRIPTION
Was added when implementing #2536 for test purpose and I forgot to remove it.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>