### PR TITLE
[BasicUI] Remove a useless call to function reloadIcon (slider widget)

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -2459,7 +2459,6 @@
 				_t.valueNode.innerHTML = value;
 			}
 			if (_t.locked) {
-				_t.reloadIcon(itemState);
 				return;
 			}
 			if (value.indexOf(" ") > 0) {


### PR DESCRIPTION
Follow up #2535

The function reloadIcon is already called by the function setValue at line 636 just before calling setValuePrivate.

The icon continues being refreshed while moving the slider except if releaseOnly parameter is set.

Signed-off-by: Laurent Garnier <lg.hc@free.fr>