### PR TITLE
GH Actions: Upgrade relative-ci/agent-upload-artifact-action

### DIFF
--- a/.github/workflows/mainui.yml
+++ b/.github/workflows/mainui.yml
@@ -85,6 +85,6 @@ jobs:
       
       # Upload bundle stats to use on relative-ci.yaml workflow
       - name: Upload webpack stats artifact
-        uses: relative-ci/agent-upload-artifact-action@v1.0.3
+        uses: relative-ci/agent-upload-artifact-action@v2
         with:
           webpackStatsFile: ./bundles/org.openhab.ui/web/stats.json


### PR DESCRIPTION
Fixes Node.js 16 deprecation warning.