### PR TITLE
Fix Main UI dark mode scrollbars in Chrome

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -125,6 +125,9 @@ html
 .md .title-large-text
   font-weight bold !important
 
+:root .theme-dark
+  color-scheme dark
+
 .theme-dark .home-tabs
   --f7-bars-bg-color rgb(32, 32, 33)
   --f7-bars-text-color #fff


### PR DESCRIPTION
This fixes the issue that when using Chrome the scrollbars are still very bright and not dark.

### Before

![Screenshot from 2024-06-15 00-33-01](https://github.com/openhab/openhab-webui/assets/12213581/f43c20a0-fb72-4ea7-92a4-2ea5860961a7)


### After

![Screenshot from 2024-06-15 00-33-22](https://github.com/openhab/openhab-webui/assets/12213581/a92b5cbc-1246-4e9b-afbe-3d5b86e7fdef)
