### PR TITLE
Rule module popup: Fix margin issue with Configuration block title

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -62,7 +62,7 @@
             </select>
           </f7-list-item>
         </f7-list>
-        <f7-block-title v-if="ruleModule && currentRuleModuleType && (!ruleModule.new || advancedTypePicker)" style="margin-bottom: calc(var(--f7-block-title-margin-bottom) - var(--f7-list-margin-vertical))">
+        <f7-block-title v-if="ruleModule && currentRuleModuleType && (!ruleModule.new || advancedTypePicker)" style="margin-bottom: min(calc(var(--f7-block-title-margin-bottom) - var(--f7-list-margin-vertical)), 0px)">
           Configuration
         </f7-block-title>
         <f7-col v-if="ruleModule && currentRuleModuleType && (!ruleModule.new || advancedTypePicker)">


### PR DESCRIPTION
Fixes margin issue by ensuring that margin is not negative.

![image](https://github.com/openhab/openhab-webui/assets/73423173/dedbbb5e-07d7-4460-bfdd-ffcb27fd1b7f)
