### PR TITLE
[MainUI] exposes navigation commands to native wrappers

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -633,11 +633,19 @@ export default {
 
     // special treatment for this option because it's needed to configure the app initialization
     this.themeOptions.pageTransitionAnimation = localStorage.getItem('openhab.ui:theme.pagetransition') || 'default'
-    // tell the app to go fullscreen (if the OHApp is supported)
-    if (window.OHApp && typeof window.OHApp.goFullscreen === 'function') {
-      try {
-        window.OHApp.goFullscreen()
-      } catch {}
+
+    // load 2-way communication for native wrappers
+    if (window.OHApp) {
+      // tell the app to go fullscreen (if the OHApp is supported)
+      if (typeof window.OHApp.goFullscreen === 'function') {
+        try {
+          window.OHApp.goFullscreen()
+        } catch {}
+        // expose navigation controls
+        window.MainUI = {
+          navigate: this.navigate
+        }
+      }
     }
 
     const refreshToken = this.getRefreshToken()

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -643,7 +643,7 @@ export default {
         } catch {}
         // expose navigation controls
         window.MainUI = {
-          navigate: this.navigate
+          handleCommand: this.handleCommand
         }
       }
     }

--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -641,7 +641,7 @@ export default {
         try {
           window.OHApp.goFullscreen()
         } catch {}
-        // expose navigation controls
+        // expose external calls
         window.MainUI = {
           handleCommand: this.handleCommand
         }

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -36,7 +36,7 @@ export default {
             break
           case topicCommand:
             const payload = JSON.parse(event.payload)
-            this.navigate(payload)
+            this.navigate(payload.value)
             break
         }
       })

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -36,7 +36,7 @@ export default {
             break
           case topicCommand:
             const payload = JSON.parse(event.payload)
-            this.navigate(payload.value)
+            this.handleCommand(payload.value)
             break
         }
       })
@@ -104,9 +104,9 @@ export default {
         this.$f7.sheet.close(sheetEl)
       }
     },
-    navigate (navigationString) {
-      console.log('Navigating: ' + navigationString)
-      const [command, ...segments] = navigationString.trim().split(':') // NOT use a RegEx lookbehind assertions here, because they are unsupported on Safari < 16.4, i.e. iOS 15.x
+    handleCommand (commandString) {
+      console.log('Navigating: ' + commandString)
+      const [command, ...segments] = commandString.trim().split(':') // NOT use a RegEx lookbehind assertions here, because they are unsupported on Safari < 16.4, i.e. iOS 15.x
       const combined = segments.join(':')
       switch (command) {
         case 'navigate':

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -105,7 +105,7 @@ export default {
       }
     },
     handleCommand (commandString) {
-      console.log('Navigating: ' + commandString)
+      console.log('Handling command: ' + commandString)
       const [command, ...segments] = commandString.trim().split(':') // NOT use a RegEx lookbehind assertions here, because they are unsupported on Safari < 16.4, i.e. iOS 15.x
       const combined = segments.join(':')
       switch (command) {

--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -36,68 +36,7 @@ export default {
             break
           case topicCommand:
             const payload = JSON.parse(event.payload)
-            const [command, ...segments] = payload.value.trim().split(':') // NOT use a RegEx lookbehind assertions here, because they are unsupported on Safari < 16.4, i.e. iOS 15.x
-            const combined = segments.join(':')
-            switch (command) {
-              case 'navigate':
-                this.$f7.views.main.router.navigate(combined)
-                break
-              case 'popup':
-              case 'popover':
-              case 'sheet':
-                if (combined.indexOf('page:') !== 0 && combined.indexOf('widget:') !== 0 && combined.indexOf('oh-') !== 0) {
-                  console.error('Action target is not of the format page:uid or widget:uid or oh-')
-                  return
-                }
-                console.debug(`Opening ${combined} in ${command} modal`)
-                let modalRoute = {
-                  url: combined + '/' + command,
-                  route: {
-                  }
-                }
-                if (command === 'popup') modalRoute.route.popup = { component: OhPopup }
-                if (command === 'popover') modalRoute.route.popup = { component: OhPopover }
-                if (command === 'sheet') modalRoute.route.popup = { component: OhSheet }
-                let modalProps = {
-                  props: {
-                    uid: combined,
-                    modalParams: {}
-                  }
-                }
-                this.closePopups()
-                this.$f7.views.main.router.navigate(modalRoute, modalProps)
-                break
-              case 'close':
-                this.closePopups()
-                break
-              case 'back':
-                this.$f7.views.main.router.back()
-                break
-              case 'reload':
-                window.location.reload()
-                break
-              case 'notification':
-                const payload = {
-                  text: segments[0],
-                  closeButton: true,
-                  swipeToClose: true,
-                  closeTimeout: 5000
-                }
-                if (segments.length > 1) {
-                  payload.title = segments[1]
-                }
-                if (segments.length > 2) {
-                  payload.subtitle = segments[2]
-                }
-                if (segments.length > 3) {
-                  payload.titleRightText = segments[3]
-                }
-                if (segments.length > 4) {
-                  payload.closeTimeout = parseInt(segments[4])
-                }
-                this.$f7.notification.create(payload).open()
-                break
-            }
+            this.navigate(payload)
             break
         }
       })
@@ -163,6 +102,71 @@ export default {
       const sheetEl = this.$el.querySelector('.sheet-modal')
       if (sheetEl) {
         this.$f7.sheet.close(sheetEl)
+      }
+    },
+    navigate (navigationString) {
+      console.log('Navigating: ' + navigationString)
+      const [command, ...segments] = navigationString.trim().split(':') // NOT use a RegEx lookbehind assertions here, because they are unsupported on Safari < 16.4, i.e. iOS 15.x
+      const combined = segments.join(':')
+      switch (command) {
+        case 'navigate':
+          this.$f7.views.main.router.navigate(combined)
+          break
+        case 'popup':
+        case 'popover':
+        case 'sheet':
+          if (combined.indexOf('page:') !== 0 && combined.indexOf('widget:') !== 0 && combined.indexOf('oh-') !== 0) {
+            console.error('Action target is not of the format page:uid or widget:uid or oh-')
+            return
+          }
+          console.debug(`Opening ${combined} in ${command} modal`)
+          const modalRoute = {
+            url: combined + '/' + command,
+            route: {
+            }
+          }
+          if (command === 'popup') modalRoute.route.popup = { component: OhPopup }
+          if (command === 'popover') modalRoute.route.popup = { component: OhPopover }
+          if (command === 'sheet') modalRoute.route.popup = { component: OhSheet }
+          const modalProps = {
+            props: {
+              uid: combined,
+              modalParams: {}
+            }
+          }
+          this.closePopups()
+          this.$f7.views.main.router.navigate(modalRoute, modalProps)
+          break
+        case 'close':
+          this.closePopups()
+          break
+        case 'back':
+          this.$f7.views.main.router.back()
+          break
+        case 'reload':
+          window.location.reload()
+          break
+        case 'notification':
+          const payload = {
+            text: segments[0],
+            closeButton: true,
+            swipeToClose: true,
+            closeTimeout: 5000
+          }
+          if (segments.length > 1) {
+            payload.title = segments[1]
+          }
+          if (segments.length > 2) {
+            payload.subtitle = segments[2]
+          }
+          if (segments.length > 3) {
+            payload.titleRightText = segments[3]
+          }
+          if (segments.length > 4) {
+            payload.closeTimeout = parseInt(segments[4])
+          }
+          this.$f7.notification.create(payload).open()
+          break
       }
     }
   }


### PR DESCRIPTION
This exposes the command item logic to native wrappers, like our IOS and Android clients, so they can control navigation of the app when receiving push notifications.

See https://github.com/openhab/openhab-android/issues/3193