### PR TITLE
Rules list: Improve performance of rule status tracking

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/rule/rule-status-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-status-mixin.js
@@ -3,6 +3,7 @@ import RuleStatusLabels from '@/assets/i18n/rule-status/en'
 export default {
   methods: {
     ruleStatusBadgeColor (statusInfo) {
+      if (statusInfo.status === 'IDLE') return 'green'
       if (statusInfo.statusDetail === 'DISABLED') return 'gray'
       if (statusInfo.status === 'UNINITIALIZED') return 'red'
       if (statusInfo.status === 'INITIALIZING') return 'yellow'
@@ -10,6 +11,7 @@ export default {
       return 'green'
     },
     ruleStatusBadgeText (statusInfo) {
+      if (statusInfo.status === 'IDLE') return 'IDLE'
       if (statusInfo.statusDetail !== 'NONE') return RuleStatusLabels[statusInfo.statusDetail]
       return statusInfo.status
     }


### PR DESCRIPTION
Fixes #2621.
Fixes #2593.

This improves performance of the SSE event source event processing for rule status changes by using a separate object for the rule statuses (allows O(1) modification) instead of finding the rule in the rules array (O(n) for linear search) and ignoring RUNNING status.
The RUNNING status can be ignored IMO because rules tend to run such a short time that you don't see the state shown as RUNNING, so we can use this "trick" to reduce the amount of processed events.
The rule-status-mixin was updated with short circuit evaluations for the IDLE status, which is very likely the most processed status, and therefore reducing the amount of comparisons done.