### PR TITLE
Things list: Reload on ThingUpdatedEvent

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -380,6 +380,7 @@ export default {
               break
             case 'added':
             case 'removed':
+            case 'updated':
               this.load()
               break
           }


### PR DESCRIPTION
This change makes the SSE event tracking handle ThingUpdatedEvents and reloads the Things list when such an event is received.