### PR TITLE
Fix value mapped to NULL not shown in list label item

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-label-item.vue
@@ -1,6 +1,6 @@
 <template>
   <oh-list-item :context="context">
-    <div slot="after" v-if="(config.after === undefined) && (context.store[config.item].state !== 'NULL')">
+    <div slot="after" v-if="(config.after === undefined) && (context.store[config.item].displayState || (context.store[config.item].state !== 'NULL'))">
       {{ context.store[config.item].displayState || context.store[config.item].state }}
     </div>
   </oh-list-item>


### PR DESCRIPTION
Signed-off-by: Mark Herwege <mark.herwege@telenet.be>

See description in https://github.com/openhab/openhab-core/pull/4203#issuecomment-2095792756

If a mapping is used to map a value to NULL, it is currently not shown in an oh_label_item.