### PR TITLE
Update openhab-js tern defs

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -204,6 +204,14 @@
                 "!doc": "Query the next update time of a given item.",
                 "!type": "fn(serviceId?: string) -> ZonedDateTime|null"
             },
+            "lastChange": {
+                "!doc": "Query the last change time of a given item.",
+                "!type": "fn(serviceId?: string) -> ZonedDateTime|null"
+            },
+            "nextChange": {
+              "!doc": "Query the next change time of a given item.",
+              "!type": "fn(serviceId?: string) -> ZonedDateTime|null"
+            },
             "maximumBetween": {
                 "!doc": "Gets the maximum value of the persisted states of a given Item between two certain points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
@@ -229,8 +237,8 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem"
             },
             "persist": {
-                "!doc": "Persists the state of a given item",
-                "!type": "fn(serviceId?: string)"
+                "!doc": "Persists the current state of a given item or the given state at a given timestamp or a TimeSeries (see JavaScript Scripting docs/Standard Library/Items)",
+                "!type": "fn(timestamp?: +Date|+ZonedDateTime, state?: ?, timeSeries?: TimeSeries, serviceId?: string)"
             },
             "previousState": {
                 "!doc": "Returns the previous state of a given item.",
@@ -307,6 +315,32 @@
             "quantityState": {
                 "!doc": "Item state as Quantity or null if state is not Quantity-compatible",
                 "!type": "QuantityClass|null"
+            }
+        },
+        "TimeSeries": {
+            "policy": {
+                "!doc": "Policy of the TimeSeries",
+                "!type": "string"
+            },
+            "begin": {
+                "!doc": "Timestamp of the first element in the TimeSeries",
+                "!type": "+Instant"
+            },
+            "end": {
+                "!doc": "Timestamp of the last element in the TimeSeries",
+                "!type": "+Instant"
+            },
+            "size": {
+                "!doc": "Number of elements in the TimeSeries",
+                "!type": "number"
+            },
+            "states": {
+                "!doc": "Array of states in the TimeSeries",
+                "!type": "[?]"
+            },
+            "add": {
+                "!doc": "Adds a new element to the TimeSeries",
+                "!type": "fn(timestamp: ?, state: ?)"
             }
         },
         "ItemSemantics": {
@@ -415,6 +449,11 @@
             "safeItemName": {
                 "!doc": "Helper function to ensure an Item name is valid. All invalid characters are replaced with an underscore.",
                 "!type": "fn(s: string) -> string"
+            },
+            "TimeSeries": {
+                "!doc":  "A TimeSeries is used to transport a set of states together with their timestamp.",
+                "!type": "fn(policy: string)",
+                "prototype": "TimeSeries"
             },
             "NAME": {
                 "!doc": "Gets an Item using it's name on the items namespace, e.g. items.Hallway_Light",


### PR DESCRIPTION
This updates the tern defs used for autocompletion to the current library version included in the add-on (5.2.0). 
See https://github.com/openhab/openhab-js/compare/v5.0.0...v5.2.0 for changes.

Last update was in #2563.