### PR TITLE
Setup wizard: Add InMemory persistence to recommended add-ons

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/setup-wizard/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/setup-wizard/en.json
@@ -33,6 +33,8 @@
   "setupwizard.addon.persistence-rrd4j.line2": "Recommended if you want to have charts of the historic state of numerical items.",
   "setupwizard.addon.persistence-mapdb.line1": "Always stores the last state of an item. Allows restoring the state of all items on openHAB startup.",
   "setupwizard.addon.persistence-mapdb.line2": "Recommended if you want openHAB to always remember the last state before shutdown.",
+  "setupwizard.addon.persistence-inmemory.line1": "Stores states in memory only. Limits size and does not persist data on disk.",
+  "setupwizard.addon.persistence-inmemory.line2": "Recommended for temporarily storing forecasts.",
   "setupwizard.persistence.footer": "Other advanced persistence services and configurations are possible and can be configured later.",
   "setupwizard.persistence.install": "Install Selected Persistence Add-ons",
   "setupwizard.persistence.installLater": "Install Persistence Add-ons Later",

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -326,7 +326,7 @@ export default {
       addonSuggestionsReady: false,
       addons: [],
       // all recommended addons, pre-defined
-      recommendedAddons: ['persistence-rrd4j', 'persistence-mapdb', 'automation-jsscripting', 'ui-basic', 'binding-astro'],
+      recommendedAddons: ['persistence-rrd4j', 'persistence-mapdb', 'persistence-inmemory', 'automation-jsscripting', 'ui-basic', 'binding-astro'],
       // addon types that can be selected in wizard before main addon selection step, to be excluded from main selection step, pre-defined
       preSelectingAddonTypes: ['persistence'],
       // addons that can be selected in wizard before main addon selection step, to be excluded from main selection step, pre-defined


### PR DESCRIPTION
With https://github.com/openhab/openhab-addons/pull/16496 merged, we can add InMemory persistence to the recommended add-ons.