### PR TITLE
Cron expression builder: Set day 1 as Sunday

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -21,7 +21,7 @@
         "@jsep-plugin/template": "^1.0.2",
         "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.12",
         "blockly": "^10.4.2",
-        "cronstrue": "^2.48.0",
+        "cronstrue": "^2.50.0",
         "crypto-browserify": "^3.12.0",
         "dayjs": "^1.11.10",
         "diacritic": "^0.0.2",
@@ -6739,9 +6739,9 @@
       }
     },
     "node_modules/cronstrue": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.48.0.tgz",
-      "integrity": "sha512-w+VAWjiBJmKYeeK+i0ur3G47LcKNgFuWwb8LVJTaXSS2ExtQ5zdiIVnuysgB3N457gTaSllme0qTpdsJWK/wIg==",
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.50.0.tgz",
+      "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg==",
       "bin": {
         "cronstrue": "bin/cli.js"
       }
@@ -26699,9 +26699,9 @@
       }
     },
     "cronstrue": {
-      "version": "2.48.0",
-      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.48.0.tgz",
-      "integrity": "sha512-w+VAWjiBJmKYeeK+i0ur3G47LcKNgFuWwb8LVJTaXSS2ExtQ5zdiIVnuysgB3N457gTaSllme0qTpdsJWK/wIg=="
+      "version": "2.50.0",
+      "resolved": "https://registry.npmjs.org/cronstrue/-/cronstrue-2.50.0.tgz",
+      "integrity": "sha512-ULYhWIonJzlScCCQrPUG5uMXzXxSixty4djud9SS37DoNxDdkeRocxzHuAo4ImRBUK+mAuU5X9TSwEDccnnuPg=="
     },
     "cross-env": {
       "version": "7.0.3",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -59,7 +59,7 @@
     "@jsep-plugin/template": "^1.0.2",
     "@mit-app-inventor/blockly-plugin-workspace-multiselect": "^0.1.12",
     "blockly": "^10.4.2",
-    "cronstrue": "^2.48.0",
+    "cronstrue": "^2.50.0",
     "crypto-browserify": "^3.12.0",
     "dayjs": "^1.11.10",
     "diacritic": "^0.0.2",

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -191,7 +191,7 @@
               <f7-list-item radio :checked="day.cronEvery === 8" @change="day.cronEvery = 8">
                 {{ text.Day.lastWeek[0] }}
                 <select size="small" v-model="day.cronLastSpecificDomDay" style="max-width: 150px">
-                  <option v-for="val in 7" :key="val" :label="text.Week[val-1]" :value="val-1" />
+                  <option v-for="val in 7" :key="val" :label="text.Week[val-1]" :value="val" />
                 </select>
                 {{ text.Day.lastWeek[1]||'' }}
               </f7-list-item>
@@ -211,7 +211,7 @@
                 {{ text.Day.someWeekday[0] }}
                 <f7-stepper small :value="week.cronNthDayNth" @stepper:change="(v) => week.cronNthDayNth = v" :min="1" :max="5" />
                 <select size="small" v-model="week.cronNthDayDay" style="max-width: 150px">
-                  <option v-for="val in 7" :key="val" :label="text.Week[val-1]" :value="val-1" />
+                  <option v-for="val in 7" :key="val" :label="text.Week[val-1]" :value="val" />
                 </select>
                 {{ text.Day.someWeekday[1] }}
               </f7-list-item>
@@ -574,7 +574,8 @@ export default {
     },
     translation () {
       return cronstrue.toString(this.cron, {
-        use24HourTimeFormat: true
+        use24HourTimeFormat: true,
+        dayOfWeekStartIndexZero: false
       })
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -140,9 +140,11 @@
           </span>
           <f7-block>
             <f7-list>
+              <!-- Every day -->
               <f7-list-item radio :checked="day.cronEvery === 1" @change="day.cronEvery = 1">
                 {{ text.Day.every }}
               </f7-list-item>
+              <!-- Every 1 day(s) starting on Sunday -->
               <f7-list-item radio :checked="day.cronEvery === 2" @change="day.cronEvery = 2">
                 {{ text.Day.intervalWeek[0] }}
                 <f7-stepper small :value="week.incrementIncrement" @stepper:change="(v) => week.incrementIncrement = v" :min="1" :max="7" />
@@ -153,6 +155,7 @@
                 <!-- <f7-stepper small :value="week.incrementStart" @stepper:change="(v) => week.incrementStart = v" :min="0" :max="23"></f7-stepper> -->
                 {{ text.Day.intervalWeek[2]||'' }}
               </f7-list-item>
+              <!-- Every 1 day(s) starting on the 1 of the month -->
               <f7-list-item radio :checked="day.cronEvery === 3" @change="day.cronEvery = 3">
                 {{ text.Day.intervalDay[0] }}
                 <f7-stepper small :value="day.incrementIncrement" @stepper:change="(v) => day.incrementIncrement = v" :min="1" :max="31" />
@@ -160,6 +163,7 @@
                 <f7-stepper small :value="day.incrementStart" @stepper:change="(v) => day.incrementStart = v" :min="1" :max="31" />
                 {{ text.Day.intervalDay[2]||'' }}
               </f7-list-item>
+              <!-- Specific day of week -->
               <f7-list-item radio ref="specificDayOfWeek" :title="text.Day.specificWeek" smart-select no-chevron :smart-select-params="{ openIn: 'popover', view: $f7.views.main }" :checked="day.cronEvery === 4" @click="day.cronEvery = 4">
                 <select multiple @change="week.specificSpecific = $refs.specificDayOfWeek.f7SmartSelect.getValue()">
                   <option v-for="val in 7" :key="val" :value="['SUN','MON','TUE','WED','THU','FRI','SAT'][val-1]" :selected="week.specificSpecific.indexOf(['SUN','MON','TUE','WED','THU','FRI','SAT'][val-1]) >= 0">
@@ -167,6 +171,7 @@
                   </option>
                 </select>
               </f7-list-item>
+              <!-- Specific day of the month -->
               <f7-list-item radio ref="specificDayOfMonth" :title="text.Day.specificDay" smart-select no-chevron :smart-select-params="{ openIn: 'popover', view: $f7.views.main }" :checked="day.cronEvery === 5" @click="day.cronEvery = 5">
                 <select multiple @change="day.specificSpecific = $refs.specificDayOfMonth.f7SmartSelect.getValue()">
                   <option v-for="val in 31" :key="val" :value="val" :selected="day.specificSpecific.indexOf(val) >= 0">
@@ -174,12 +179,15 @@
                   </option>
                 </select>
               </f7-list-item>
+              <!-- On the last day of the month -->
               <f7-list-item radio :checked="day.cronEvery === 6" @change="day.cronEvery = 6">
                 {{ text.Day.lastDay }}
               </f7-list-item>
+              <!-- On the last weekday of the month -->
               <f7-list-item radio :checked="day.cronEvery === 7" @change="day.cronEvery = 7">
                 {{ text.Day.lastWeekday }}
               </f7-list-item>
+              <!-- On the last Sunday of the month -->
               <f7-list-item radio :checked="day.cronEvery === 8" @change="day.cronEvery = 8">
                 {{ text.Day.lastWeek[0] }}
                 <select size="small" v-model="day.cronLastSpecificDomDay" style="max-width: 150px">
@@ -187,15 +195,18 @@
                 </select>
                 {{ text.Day.lastWeek[1]||'' }}
               </f7-list-item>
+              <!-- 1 day(s) before the end of the month -->
               <f7-list-item radio :checked="day.cronEvery === 9" @change="day.cronEvery = 9">
                 <f7-stepper small :value="day.cronDaysBeforeEomMinus" @stepper:change="(v) => day.cronDaysBeforeEomMinus = v" :min="1" :max="31" />
                 {{ text.Day.beforeEndMonth[0] }}
               </f7-list-item>
+              <!-- Nearest weekday (Monday to Friday) to the 1 of the month -->
               <f7-list-item radio :checked="day.cronEvery === 10" @change="day.cronEvery = 10">
                 {{ text.Day.nearestWeekday[0] }}
                 <f7-stepper small :value="day.cronDaysNearestWeekday" @stepper:change="(v) => day.cronDaysNearestWeekday = v" :min="1" :max="31" />
                 {{ text.Day.nearestWeekday[1] }}
               </f7-list-item>
+              <!-- On the 1 Sunday of the month -->
               <f7-list-item radio :checked="day.cronEvery === 11" @change="day.cronEvery = 11">
                 {{ text.Day.someWeekday[0] }}
                 <f7-stepper small :value="week.cronNthDayNth" @stepper:change="(v) => week.cronNthDayNth = v" :min="1" :max="5" />


### PR DESCRIPTION
Fixes #1371.
Fixes #902.

This sets the UI's cron builder to use day 1 for Sunday, instead of Monday, which is the convention as used by the Quartz scheduler, see https://docs.oracle.com/cd/E12058_01/doc/doc.1014/e12030/cron_expressions.htm and https://freeformatter.com/cron-expression-generator-quartz.html.