### PR TITLE
Analyzer: Fix silent failure if no items are set

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
@@ -246,7 +246,7 @@ prev: /docs/ui/components/
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-button.md
+++ b/bundles/org.openhab.ui/doc/components/oh-button.md
@@ -226,7 +226,7 @@ Button performing an action
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>
@@ -385,7 +385,7 @@ Button performing an action
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="taphold_actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="taphold_actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
@@ -163,7 +163,7 @@ prev: /docs/ui/components/
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
@@ -208,7 +208,7 @@ prev: /docs/ui/components/
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -176,7 +176,7 @@ A regular or expandable cell
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-clock-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-clock-card.md
@@ -231,7 +231,7 @@ Display a digital clock in a card
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -205,7 +205,7 @@ A cell expanding to a color picker
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-data-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-data-series.md
@@ -149,7 +149,7 @@ prev: /docs/ui/components/
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
@@ -267,7 +267,7 @@ Display a read-only gauge in a card to visualize a quantifiable item
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-icon.md
+++ b/bundles/org.openhab.ui/doc/components/oh-icon.md
@@ -185,7 +185,7 @@ Display an openHAB icon
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-image-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image-card.md
@@ -197,7 +197,7 @@ Display an image (URL or Image item ) in a card
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-image.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image.md
@@ -165,7 +165,7 @@ Displays an image from a URL or an item
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -328,7 +328,7 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-label-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-card.md
@@ -166,7 +166,7 @@ Display the state of an item in a card
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>
@@ -325,7 +325,7 @@ Display the state of an item in a card
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="taphold_actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="taphold_actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -192,7 +192,7 @@ A cell with a big label to show a short item state value
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-label-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-item.md
@@ -182,7 +182,7 @@ Display the state of an item in a list
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-link.md
+++ b/bundles/org.openhab.ui/doc/components/oh-link.md
@@ -200,7 +200,7 @@ Link performing an action
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-list-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-list-item.md
@@ -171,7 +171,7 @@ A list item
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
@@ -184,7 +184,7 @@ A circle on a map, to represent a radius
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-map-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-marker.md
@@ -168,7 +168,7 @@ An icon on a map
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -276,7 +276,7 @@ A marker on a floor plan
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
@@ -237,7 +237,7 @@ A cell expanding to rollershutter controls
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -252,7 +252,7 @@ A cell expanding to a big vertical slider
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-time-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-time-series.md
@@ -200,7 +200,7 @@ prev: /docs/ui/components/
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/doc/components/oh-video.md
+++ b/bundles/org.openhab.ui/doc/components/oh-video.md
@@ -189,7 +189,7 @@ Displays a video player from a URL or an item
     Group Item whose members to show in a popup
   </PropDescription>
 </PropBlock>
-<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" context="item">
+<PropBlock type="TEXT" name="actionAnalyzerItems" label="Item(s) to Analyze" required="true" context="item">
   <PropDescription>
     Start analyzing with the specified (set of) Item(s)
   </PropDescription>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
@@ -97,7 +97,7 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['group'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
-    pi(paramPrefix + 'actionAnalyzerItems', 'Item(s) to Analyze', 'Start analyzing with the specified (set of) Item(s)').m()
+    pi(paramPrefix + 'actionAnalyzerItems', 'Item(s) to Analyze', 'Start analyzing with the specified (set of) Item(s)').m().r()
       .v((value, configuration, configDescription, parameters) => {
         return ['analyzer'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),

--- a/bundles/org.openhab.ui/web/src/assets/i18n/analyzer/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/analyzer/en.json
@@ -66,5 +66,7 @@
   "analyzer.dialogs.save.replace.message": "A page with the ID {uid} already exists, would you like to overwrite it?",
   "analyzer.dialogs.save.replace.title": "Page already exists",
   "analyzer.page.updated": "Chart page updated",
-  "analyzer.page.created": "Chart page created"
+  "analyzer.page.created": "Chart page created",
+  "analyzer.invalid-configuration.title": "Invalid configuration",
+  "analyzer.invalid-configuration.text": "Please make sure all required query parameters are passed/the configuration is valid."
 }

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -18,7 +18,7 @@
     </f7-toolbar>
 
     <oh-chart-page v-if="showChart" class="analyzer-chart" :class="{ 'sheet-opened': controlsOpened }" :key="chartKey" :context="context" />
-    <empty-state-placeholder v-else-if="configurationInvalid" icon="exclamationmark" :title="$t('analyzer.invalid-configuration.title')" :text="$t('analyzer.invalid-configuration.text')" />
+    <empty-state-placeholder v-else-if="invalidConfiguration" icon="exclamationmark" :title="$t('analyzer.invalid-configuration.title')" :text="$t('analyzer.invalid-configuration.text')" />
 
     <!-- analyzer controls -->
     <f7-sheet class="analyzer-controls" :backdrop="false" :close-on-escape="true" :opened="controlsOpened" @sheet:closed="controlsOpened = false">
@@ -262,7 +262,7 @@ export default {
   data () {
     return {
       showChart: false,
-      configurationInvalid: false,
+      invalidConfiguration: false,
       itemNames: [],
       items: null,
       seriesOptions: {},
@@ -330,7 +330,7 @@ export default {
     initChart () {
       if (this.$f7route.query.period) this.period = this.$f7route.query.period
       if (this.$f7route.query.items === '') {
-        this.configurationInvalid = true
+        this.invalidConfiguration = true
         return
       }
       this.updateItems(this.$f7route.query.items.split(',')).then(() => {

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -18,6 +18,7 @@
     </f7-toolbar>
 
     <oh-chart-page v-if="showChart" class="analyzer-chart" :class="{ 'sheet-opened': controlsOpened }" :key="chartKey" :context="context" />
+    <empty-state-placeholder v-else-if="configurationInvalid" icon="exclamationmark" :title="$t('analyzer.invalid-configuration.title')" :text="$t('analyzer.invalid-configuration.text')" />
 
     <!-- analyzer controls -->
     <f7-sheet class="analyzer-controls" :backdrop="false" :close-on-escape="true" :opened="controlsOpened" @sheet:closed="controlsOpened = false">
@@ -246,6 +247,7 @@
 
 <script>
 import ItemPicker from '@/components/config/controls/item-picker.vue'
+import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
 import ChartTime from './chart-time'
 import ChartAggregate from './chart-aggregate'
 import ChartCalendar from './chart-calendar'
@@ -254,11 +256,13 @@ import { loadLocaleMessages } from '@/js/i18n'
 export default {
   components: {
     'oh-chart-page': () => import(/* webpackChunkName: "chart-page" */ '../../components/widgets/chart/oh-chart-page.vue'),
-    ItemPicker
+    ItemPicker,
+    EmptyStatePlaceholder
   },
   data () {
     return {
       showChart: false,
+      configurationInvalid: false,
       itemNames: [],
       items: null,
       seriesOptions: {},
@@ -325,6 +329,10 @@ export default {
     },
     initChart () {
       if (this.$f7route.query.period) this.period = this.$f7route.query.period
+      if (this.$f7route.query.items === '') {
+        this.configurationInvalid = true
+        return
+      }
       this.updateItems(this.$f7route.query.items.split(',')).then(() => {
         if (this.$f7route.query.chartType) this.changeChartType(this.$f7route.query.chartType)
         if (this.$f7route.query.coordSystem) this.changeCoordSystem(this.$f7route.query.coordSystem)


### PR DESCRIPTION
Fixes #910.

This fixes a silent failure of the analyzer if no items are passed as query params. In this case, the empty-state-placeholder will be used to display a "Invalid configuration" banner.