### PR TITLE
oh-sipclient: Add auto answer & auto dial features

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-sipclient-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-sipclient-card.md
@@ -69,7 +69,7 @@ Usage is explained at the [`oh-sipclient` component docs](/docs/ui/components/oh
 </PropBlock>
 <PropBlock type="TEXT" name="websocketUrl" label="Websocket URL" required="true">
   <PropDescription>
-    Full URL of the WebRTC SIP websocket, e.g. 'wss://siphost:8089/ws' or relative path, e.g. '/ws', for Android & iOS, you need wss (WebSocket secured)
+    Full URL of the WebRTC SIP websocket, e.g. <code>wss://siphost:8089/ws</code> or relative path, e.g. <code>/ws</code>, for Android & iOS, you need <code>wss</code> (WebSocket secured)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="domain" label="SIP Domain" required="true">
@@ -85,7 +85,7 @@ Usage is explained at the [`oh-sipclient` component docs](/docs/ui/components/oh
 </PropBlock>
 <PropBlock type="TEXT" name="phonebook" label="Phonebook" required="true">
   <PropDescription>
-    Single SIP Address (phone number) for a single call target or a comma-separated list of 'phoneNumber=name' for multiple call targets. Used as well to display a name instead of the number for incoming calls.
+    Single SIP Address (phone number) for a single call target or a comma-separated list of <code>phoneNumber=name</code> for multiple call targets. Used as well to display a name instead of the number for incoming calls.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="dtmfString" label="DTMF String">
@@ -118,7 +118,20 @@ Usage is explained at the [`oh-sipclient` component docs](/docs/ui/components/oh
     SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.
   </PropDescription>
 </PropBlock>
-<PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP debugging to the browser console (dev tools)">
+<PropBlock type="TEXT" name="autoAnswer" label="Auto Answer">
+  <PropDescription>
+    Automatically answer an incoming call from one of the comma delimited SIP addresses (<code>userInfo@hostname</code>, <code>userInfo</code>, ...) or use * for all incoming calls.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="autoDial" label="Auto Dial">
+  <PropDescription>
+    Automatically dial the SIP address when loaded (requires <code>disableRegister</code> to be enabled)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP Debug">
+  <PropDescription>
+    Enable SIP debugging to the browser console (dev tools)
+  </PropDescription>
 </PropBlock>
 </PropGroup>
 </div>

--- a/bundles/org.openhab.ui/doc/components/oh-sipclient-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-sipclient-card.md
@@ -125,7 +125,7 @@ Usage is explained at the [`oh-sipclient` component docs](/docs/ui/components/oh
 </PropBlock>
 <PropBlock type="TEXT" name="autoDial" label="Auto Dial">
   <PropDescription>
-    Automatically dial the SIP address when loaded (requires <code>disableRegister</code> to be enabled)
+    Automatically dial the SIP address when loaded
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP Debug">

--- a/bundles/org.openhab.ui/doc/components/oh-sipclient.md
+++ b/bundles/org.openhab.ui/doc/components/oh-sipclient.md
@@ -129,7 +129,7 @@ This can be achieved by configuring the widget as usual, but setting SIP usernam
 </PropBlock>
 <PropBlock type="TEXT" name="autoDial" label="Auto Dial">
   <PropDescription>
-    Automatically dial the SIP address when loaded (requires <code>disableRegister</code> to be enabled)
+    Automatically dial the SIP address when loaded
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP Debug">

--- a/bundles/org.openhab.ui/doc/components/oh-sipclient.md
+++ b/bundles/org.openhab.ui/doc/components/oh-sipclient.md
@@ -73,7 +73,7 @@ This can be achieved by configuring the widget as usual, but setting SIP usernam
 </PropBlock>
 <PropBlock type="TEXT" name="websocketUrl" label="Websocket URL" required="true">
   <PropDescription>
-    Full URL of the WebRTC SIP websocket, e.g. 'wss://siphost:8089/ws' or relative path, e.g. '/ws', for Android & iOS, you need wss (WebSocket secured)
+    Full URL of the WebRTC SIP websocket, e.g. <code>wss://siphost:8089/ws</code> or relative path, e.g. <code>/ws</code>, for Android & iOS, you need <code>wss</code> (WebSocket secured)
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="domain" label="SIP Domain" required="true">
@@ -89,7 +89,7 @@ This can be achieved by configuring the widget as usual, but setting SIP usernam
 </PropBlock>
 <PropBlock type="TEXT" name="phonebook" label="Phonebook" required="true">
   <PropDescription>
-    Single SIP Address (phone number) for a single call target or a comma-separated list of 'phoneNumber=name' for multiple call targets. Used as well to display a name instead of the number for incoming calls.
+    Single SIP Address (phone number) for a single call target or a comma-separated list of <code>phoneNumber=name</code> for multiple call targets. Used as well to display a name instead of the number for incoming calls.
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="dtmfString" label="DTMF String">
@@ -122,7 +122,20 @@ This can be achieved by configuring the widget as usual, but setting SIP usernam
     SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.
   </PropDescription>
 </PropBlock>
-<PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP debugging to the browser console (dev tools)">
+<PropBlock type="TEXT" name="autoAnswer" label="Auto Answer">
+  <PropDescription>
+    Automatically answer an incoming call from one of the comma delimited SIP addresses (<code>userInfo@hostname</code>, <code>userInfo</code>, ...) or use * for all incoming calls.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="autoDial" label="Auto Dial">
+  <PropDescription>
+    Automatically dial the SIP address when loaded (requires <code>disableRegister</code> to be enabled)
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP Debug">
+  <PropDescription>
+    Enable SIP debugging to the browser console (dev tools)
+  </PropDescription>
 </PropBlock>
 </PropGroup>
 </div>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
@@ -14,5 +14,7 @@ export default () => [
   pb('enableLocalVideo', 'Enable Local Video View', 'Display the local camera on video calls'),
   pt('defaultVideoAspectRatio', 'Default Aspect Ratio', 'Default video aspect ratio used to size the widget before video is loaded. Defaults to 4/3, 16/9 and 1 are common alternatives.').a(),
   pb('disableRegister', 'Disable REGISTER', 'SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.').a(),
+  pt('autoAnswer', 'Auto Answer', 'Automatically answer an incoming call from one of the comma delimited SIP addresses (userInfo@hostname, userInfo, ...) or use * for all incoming calls.').a(),
+  pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded').a(),
   pb('enableSIPDebug', 'Enable SIP debugging to the browser console (dev tools)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
@@ -2,19 +2,19 @@ import { pt, pn, pb } from '../helpers.js'
 
 export default () => [
   pn('iconSize', 'Icon Size', 'Size of the icon(s) in px'),
-  pt('websocketUrl', 'Websocket URL', 'Full URL of the WebRTC SIP websocket, e.g. \'wss://siphost:8089/ws\' or relative path, e.g. \'/ws\', for Android & iOS, you need wss (WebSocket secured)').r(),
+  pt('websocketUrl', 'Websocket URL', 'Full URL of the WebRTC SIP websocket, e.g. <code>wss://siphost:8089/ws</code> or relative path, e.g. <code>/ws</code>, for Android & iOS, you need <code>wss</code> (WebSocket secured)').r(),
   pt('domain', 'SIP Domain', '').r(),
   pt('username', 'SIP Username', ''),
   pt('password', 'SIP Password', ''),
   pb('enableTones', 'Enable tones', 'Enable ringback and ring tone. Not recommended for mobile browsers, might cause issues. Ring tone might only work after interaction with the webpage.').a(),
-  pt('phonebook', 'Phonebook', 'Single SIP Address (phone number) for a single call target or a comma-separated list of \'phoneNumber=name\' for multiple call targets. Used as well to display a name instead of the number for incoming calls.').r(),
+  pt('phonebook', 'Phonebook', 'Single SIP Address (phone number) for a single call target or a comma-separated list of <code>phoneNumber=name</code> for multiple call targets. Used as well to display a name instead of the number for incoming calls.').r(),
   pt('dtmfString', 'DTMF String', 'Display a button to send a preset DTMF string while in calls for remote doors, gates, etc...'),
   pb('hideCallerId', 'Hide caller id', 'Hides the username of the remote party for incoming calls.'),
   pb('enableVideo', 'Enable Video', 'Enable video calling'),
   pb('enableLocalVideo', 'Enable Local Video View', 'Display the local camera on video calls'),
   pt('defaultVideoAspectRatio', 'Default Aspect Ratio', 'Default video aspect ratio used to size the widget before video is loaded. Defaults to 4/3, 16/9 and 1 are common alternatives.').a(),
   pb('disableRegister', 'Disable REGISTER', 'SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.').a(),
-  pt('autoAnswer', 'Auto Answer', 'Automatically answer an incoming call from one of the comma delimited SIP addresses (userInfo@hostname, userInfo, ...) or use * for all incoming calls.').a(),
-  pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded').a(),
-  pb('enableSIPDebug', 'Enable SIP debugging to the browser console (dev tools)').a()
+  pt('autoAnswer', 'Auto Answer', 'Automatically answer an incoming call from one of the comma delimited SIP addresses (<code>userInfo@hostname</code>, <code>userInfo</code>, ...) or use * for all incoming calls.').a(),
+  pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded (requires <code>disableRegister</code> to be enabled)').a(),
+  pb('enableSIPDebug', 'Enable SIP Debug', 'Enable SIP debugging to the browser console (dev tools)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
@@ -15,6 +15,6 @@ export default () => [
   pt('defaultVideoAspectRatio', 'Default Aspect Ratio', 'Default video aspect ratio used to size the widget before video is loaded. Defaults to 4/3, 16/9 and 1 are common alternatives.').a(),
   pb('disableRegister', 'Disable REGISTER', 'SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.').a(),
   pt('autoAnswer', 'Auto Answer', 'Automatically answer an incoming call from one of the comma delimited SIP addresses (<code>userInfo@hostname</code>, <code>userInfo</code>, ...) or use * for all incoming calls.').a(),
-  pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded (requires <code>disableRegister</code> to be enabled)').a(),
+  pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded').a(),
   pb('enableSIPDebug', 'Enable SIP Debug', 'Enable SIP debugging to the browser console (dev tools)').a()
 ]


### PR DESCRIPTION
Adds two new features:

- Auto accept calls if they match a configured list of numbers (* for all, 'user', or 'user@host` in a comma delimited list).
- Auto dial a pre-configured number when the client finishes registering (or when the client connects if registration is disabled).

Both can be safely used together.
This allows for features like intercoms, as well as widgets that connect when popped up.

---------

Also-by: Florian Hotze <florianh_dev@icloud.com>
Signed-off-by: Dan Cunningham <dan@digitaldan.com>