### PR TITLE
Developer sidebar: Fix script and scene "unpin all" links

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -108,7 +108,7 @@
           <f7-block-title class="padding-horizontal display-flex">
             <span>Pinned Scenes</span>
             <span style="margin-left:auto">
-              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('rules')" />
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('scenes')" />
             </span>
           </f7-block-title>
           <f7-list media-list>
@@ -136,7 +136,7 @@
           <f7-block-title class="padding-horizontal display-flex">
             <span>Pinned Scripts</span>
             <span style="margin-left:auto">
-              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('rules')" />
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('scripts')" />
             </span>
           </f7-block-title>
           <f7-list media-list>


### PR DESCRIPTION
The links to unpin scenes and scripts in the dev toolbar were set to 'rules' instead of the correct specifics, and so, didn't work.