### PR TITLE
oh-sipclient: Add call status Item to report call status to server

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-sipclient-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-sipclient-card.md
@@ -128,6 +128,11 @@ Usage is explained at the [`oh-sipclient` component docs](/docs/ui/components/oh
     Automatically dial the SIP address when loaded
   </PropDescription>
 </PropBlock>
+<PropBlock type="TEXT" name="stateItem" label="State Item" context="item">
+  <PropDescription>
+    String Item to publish the current SIP connection state to the openHAB server and make it accessible from rules etc.
+  </PropDescription>
+</PropBlock>
 <PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP Debug">
   <PropDescription>
     Enable SIP debugging to the browser console (dev tools)

--- a/bundles/org.openhab.ui/doc/components/oh-sipclient.md
+++ b/bundles/org.openhab.ui/doc/components/oh-sipclient.md
@@ -59,6 +59,27 @@ This can be achieved by configuring the widget as usual, but setting SIP usernam
 1. Insert your SIP account credentials, they are used instead of those stored on the openHAB server.
 1. Insert the SIP address/phone number of your SIP account, it is used to hide your local identity from the call dial.
 
+## SIP Connection State Item
+
+The advanced `sipStateItem` property allows to define a String Item to publish the current SIP connection state to the openHAB server.
+
+There are the following basic states:
+
+- `connected`: The SIP client has connected to the SIP server and ready to make outgoing calls.
+- `registered`: The SIP client has registered at the SIP server and ready to receive calls.
+- `disconnected`: The SIP client has disconnected from the SIP server.
+
+In addition, there are the following call states, which provide the caller ID of the remote party, e.g. `**620@fritz.box` after a colon:
+
+- `incoming`: An incoming call is received, e.g. `incoming:**620@fritz.box`.
+- `incoming-accepted`: An incoming call has been accepted and is now active, e.g. `incoming-accepted:**620@fritz.box`.
+- `outgoing`: An outgoing call is started.
+- `outgoing-accepted`: An outgoing call has been accepted and is now active.
+- `ended`: The call has been ended.
+- `failed`: The call has failed.
+
+The `sipStateItem` is useful to track the SIP connection state on the openHAB server and work with it, e.g. in rules.
+
 ## Configuration
 
 <!-- DO NOT REMOVE the following comments -->
@@ -130,6 +151,11 @@ This can be achieved by configuring the widget as usual, but setting SIP usernam
 <PropBlock type="TEXT" name="autoDial" label="Auto Dial">
   <PropDescription>
     Automatically dial the SIP address when loaded
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="stateItem" label="State Item" context="item">
+  <PropDescription>
+    String Item to publish the current SIP connection state to the openHAB server and make it accessible from rules etc.
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="enableSIPDebug" label="Enable SIP Debug">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
@@ -16,6 +16,6 @@ export default () => [
   pb('disableRegister', 'Disable REGISTER', 'SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.').a(),
   pt('autoAnswer', 'Auto Answer', 'Automatically answer an incoming call from one of the comma delimited SIP addresses (<code>userInfo@hostname</code>, <code>userInfo</code>, ...) or use * for all incoming calls.').a(),
   pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded').a(),
-  pi('callStateItem', 'Call State Item', 'String Item to publish the current call state to the openHAB server and make it accessible from rules etc.').a(),
+  pi('sipStateItem', 'SIP State Item', 'String Item to publish the current SIP connection state to the openHAB server and make it accessible from rules etc.').a(),
   pb('enableSIPDebug', 'Enable SIP Debug', 'Enable SIP debugging to the browser console (dev tools)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/sipclient.js
@@ -1,4 +1,4 @@
-import { pt, pn, pb } from '../helpers.js'
+import { pt, pn, pb, pi } from '../helpers.js'
 
 export default () => [
   pn('iconSize', 'Icon Size', 'Size of the icon(s) in px'),
@@ -16,5 +16,6 @@ export default () => [
   pb('disableRegister', 'Disable REGISTER', 'SIP registration can be disabled in case you only want to initiate calls, but not receive calls with the SIP widgets.').a(),
   pt('autoAnswer', 'Auto Answer', 'Automatically answer an incoming call from one of the comma delimited SIP addresses (<code>userInfo@hostname</code>, <code>userInfo</code>, ...) or use * for all incoming calls.').a(),
   pt('autoDial', 'Auto Dial', 'Automatically dial the SIP address when loaded').a(),
+  pi('callStateItem', 'Call State Item', 'String Item to publish the current call state to the openHAB server and make it accessible from rules etc.').a(),
   pb('enableSIPDebug', 'Enable SIP Debug', 'Enable SIP debugging to the browser console (dev tools)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -322,7 +322,7 @@ export default {
               pt('password', 'Local SIP Password', 'Used instead of the password from the widget settings and stored on the openHAB server.'),
               pt('ownSipAddress', 'Local SIP Address', 'SIP Address (phone number) of this local client. Used by the client to remove itself from the dial ' +
                 'popup, which is configured with the phonebook option in the widget settings.'),
-              pi('callStateItem', 'Call State Item', 'Used instead of the call state Item from the widget settings and stored on the openHAB server.').a()
+              pi('sipStateItem', 'State Item', 'Used instead of the SIP connection state Item from the widget settings and stored on the openHAB server.').a()
             ])
         }
       })
@@ -369,8 +369,8 @@ export default {
       }
     },
     updateStatusItem (newStatus) {
-      if (!this.config.callStateItem) return
-      this.$store.dispatch('sendCommand', { itemName: this.config.callStateItem, cmd: newStatus })
+      if (!this.config.sipStateItem) return
+      this.$store.dispatch('sendCommand', { itemName: this.config.sipStateItem, cmd: newStatus })
     }
   },
   created () {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -150,16 +150,19 @@ export default {
         // Update connected status on connection changes
         this.phone.on('connected', () => {
           this.connected = true
+          this.updateStatusItem('connected')
+          console.info(this.LOGGER_PREFIX + ': Connected to SIP server')
           if (this.config.autoDial && this.config.disableRegister === true) {
             this.autoDial()
           }
-          console.info(this.LOGGER_PREFIX + ': Connected to SIP server')
         })
         this.phone.on('disconnected', () => {
           this.connected = false
+          this.updateStatusItem('disconnected')
           console.info(this.LOGGER_PREFIX + ': Disconnected from SIP server')
         })
         this.phone.on('registered', () => {
+          this.updateStatusItem('registered')
           console.info(this.LOGGER_PREFIX + ': SIP registration successful')
           if (this.config.autoDial) {
             // give a little time to account for an incoming call after registration before calling
@@ -209,14 +212,14 @@ export default {
           // Handle ended call
           this.session.on('ended', () => {
             this.stopMedia()
-            this.updateStatusItem('ended')
+            this.updateStatusItem('ended:' + remotePartyWithHost)
             console.info(this.LOGGER_PREFIX + ': Call ended')
           })
           // Handle failed call
           this.session.on('failed', (event) => {
             this.stopTones()
             this.stopMedia()
-            this.updateStatusItem('failed')
+            this.updateStatusItem('failed:' + remotePartyWithHost)
             console.info(this.LOGGER_PREFIX + ': Call failed. Reason: ' + event.cause)
           })
         })

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -54,7 +54,7 @@ import { OhSIPClientDefinition } from '@/assets/definitions/widgets/system'
 import foregroundService from '../widget-foreground-service'
 import { actionsMixin } from '../widget-actions'
 import WidgetConfigPopup from '@/components/pagedesigner/widget-config-popup.vue'
-import { WidgetDefinition, pg, pt } from '@/assets/definitions/widgets/helpers.js'
+import { WidgetDefinition, pg, pt, pi } from '@/assets/definitions/widgets/helpers.js'
 
 // Thanks to Joseph Sardin, https://bigsoundbank.com
 // ringFile source: https://bigsoundbank.com/detail-0375-phone-ring-5.html
@@ -318,7 +318,8 @@ export default {
               pt('username', 'Local SIP Username', 'Used instead of the username from widget settings and stored on the openHAB server.'),
               pt('password', 'Local SIP Password', 'Used instead of the password from the widget settings and stored on the openHAB server.'),
               pt('ownSipAddress', 'Local SIP Address', 'SIP Address (phone number) of this local client. Used by the client to remove itself from the dial ' +
-                'popup, which is configured with the phonebook option in the widget settings.')
+                'popup, which is configured with the phonebook option in the widget settings.'),
+              pi('callStateItem', 'Call State Item', 'Used instead of the call state Item from the widget settings and stored on the openHAB server.').a()
             ])
         }
       })

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -150,7 +150,7 @@ export default {
         // Update connected status on connection changes
         this.phone.on('connected', () => {
           this.connected = true
-          this.updateStatusItem('connected')
+          this.updateStateItem('connected')
           console.info(this.LOGGER_PREFIX + ': Connected to SIP server')
           if (this.config.autoDial && this.config.disableRegister === true) {
             this.autoDial()
@@ -158,11 +158,11 @@ export default {
         })
         this.phone.on('disconnected', () => {
           this.connected = false
-          this.updateStatusItem('disconnected')
+          this.updateStateItem('disconnected')
           console.info(this.LOGGER_PREFIX + ': Disconnected from SIP server')
         })
         this.phone.on('registered', () => {
-          this.updateStatusItem('registered')
+          this.updateStateItem('registered')
           console.info(this.LOGGER_PREFIX + ': SIP registration successful')
           if (this.config.autoDial) {
             // give a little time to account for an incoming call after registration before calling
@@ -179,20 +179,20 @@ export default {
           this.remoteParty = (this.phonebook.size > 0) ? this.phonebook.get(this.session.remote_identity.uri.user) : this.session.remote_identity.uri.user
 
           if (this.session.direction === 'outgoing') {
-            this.updateStatusItem('outgoing:' + remotePartyWithHost)
+            this.updateStateItem('outgoing:' + remotePartyWithHost)
             // Handle accepted call
             this.session.on('accepted', () => {
               this.stopTones()
-              this.updateStatusItem('outgoing-accepted:' + remotePartyWithHost)
+              this.updateStateItem('outgoing-accepted:' + remotePartyWithHost)
               console.info(this.LOGGER_PREFIX + ': Outgoing call in progress')
             })
           } else if (this.session.direction === 'incoming') {
             console.info(this.LOGGER_PREFIX + ': Incoming call from ' + this.remoteParty)
             this.playTone(ringFile)
-            this.updateStatusItem('incoming:' + remotePartyWithHost)
+            this.updateStateItem('incoming:' + remotePartyWithHost)
             // Handle accepted call
             this.session.on('accepted', () => {
-              this.updateStatusItem('incoming-accepted:' + remotePartyWithHost)
+              this.updateStateItem('incoming-accepted:' + remotePartyWithHost)
               console.info(this.LOGGER_PREFIX + ': Incoming call in progress')
             })
             if (this.config.autoAnswer) {
@@ -212,14 +212,14 @@ export default {
           // Handle ended call
           this.session.on('ended', () => {
             this.stopMedia()
-            this.updateStatusItem('ended:' + remotePartyWithHost)
+            this.updateStateItem('ended:' + remotePartyWithHost)
             console.info(this.LOGGER_PREFIX + ': Call ended')
           })
           // Handle failed call
           this.session.on('failed', (event) => {
             this.stopTones()
             this.stopMedia()
-            this.updateStatusItem('failed:' + remotePartyWithHost)
+            this.updateStateItem('failed:' + remotePartyWithHost)
             console.info(this.LOGGER_PREFIX + ': Call failed. Reason: ' + event.cause)
           })
         })
@@ -368,7 +368,7 @@ export default {
         this.call(this.config.autoDial.toString())
       }
     },
-    updateStatusItem (newStatus) {
+    updateStateItem (newStatus) {
       if (!this.config.sipStateItem) return
       this.$store.dispatch('sendCommand', { itemName: this.config.sipStateItem, cmd: newStatus })
     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -170,24 +170,26 @@ export default {
         // Register event for new incoming or outgoing call event
         this.phone.on('newRTCSession', (data) => {
           this.session = data.session
+          const remoteParty = this.session.remote_identity.uri.user
+          const remotePartyWithHost = `${this.session.remote_identity.uri.user}@${this.session.remote_identity.uri.host}`
 
           this.remoteParty = (this.phonebook.size > 0) ? this.phonebook.get(this.session.remote_identity.uri.user) : this.session.remote_identity.uri.user
 
           if (this.session.direction === 'outgoing') {
-            this.updateStatusItem('outgoing')
+            this.updateStatusItem('outgoing:' + remotePartyWithHost)
             // Handle accepted call
             this.session.on('accepted', () => {
               this.stopTones()
-              this.updateStatusItem('outgoing-accepted')
+              this.updateStatusItem('outgoing-accepted:' + remotePartyWithHost)
               console.info(this.LOGGER_PREFIX + ': Outgoing call in progress')
             })
           } else if (this.session.direction === 'incoming') {
             console.info(this.LOGGER_PREFIX + ': Incoming call from ' + this.remoteParty)
             this.playTone(ringFile)
-            this.updateStatusItem('incoming')
+            this.updateStatusItem('incoming:' + remotePartyWithHost)
             // Handle accepted call
             this.session.on('accepted', () => {
-              this.updateStatusItem('incoming-accepted')
+              this.updateStatusItem('incoming-accepted:' + remotePartyWithHost)
               console.info(this.LOGGER_PREFIX + ': Incoming call in progress')
             })
             if (this.config.autoAnswer) {
@@ -195,11 +197,9 @@ export default {
               if (autoAnswer.trim() === '*') {
                 this.answer()
               } else {
-                const userInfo = this.session.remote_identity.uri.user
-                const userInfoHost = `${this.session.remote_identity.uri.user}@${this.session.remote_identity.uri.host}`
                 const parts = autoAnswer.split(',')
                 parts.forEach(part => {
-                  if ((part.indexOf('@') > 0 && part === userInfoHost) || part === userInfo) {
+                  if ((part.indexOf('@') > 0 && part === remotePartyWithHost) || part === remoteParty) {
                     this.answer()
                   }
                 })

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -174,16 +174,20 @@ export default {
           this.remoteParty = (this.phonebook.size > 0) ? this.phonebook.get(this.session.remote_identity.uri.user) : this.session.remote_identity.uri.user
 
           if (this.session.direction === 'outgoing') {
+            this.updateStatusItem('outgoing')
             // Handle accepted call
             this.session.on('accepted', () => {
               this.stopTones()
+              this.updateStatusItem('outgoing-accepted')
               console.info(this.LOGGER_PREFIX + ': Outgoing call in progress')
             })
           } else if (this.session.direction === 'incoming') {
             console.info(this.LOGGER_PREFIX + ': Incoming call from ' + this.remoteParty)
             this.playTone(ringFile)
+            this.updateStatusItem('incoming')
             // Handle accepted call
             this.session.on('accepted', () => {
+              this.updateStatusItem('incoming-accepted')
               console.info(this.LOGGER_PREFIX + ': Incoming call in progress')
             })
             if (this.config.autoAnswer) {
@@ -205,12 +209,14 @@ export default {
           // Handle ended call
           this.session.on('ended', () => {
             this.stopMedia()
+            this.updateStatusItem('ended')
             console.info(this.LOGGER_PREFIX + ': Call ended')
           })
           // Handle failed call
           this.session.on('failed', (event) => {
             this.stopTones()
             this.stopMedia()
+            this.updateStatusItem('failed')
             console.info(this.LOGGER_PREFIX + ': Call failed. Reason: ' + event.cause)
           })
         })
@@ -357,6 +363,10 @@ export default {
       if (!session || !(session.isInProgress() || session.isEstablished())) {
         this.call(this.config.autoDial.toString())
       }
+    },
+    updateStatusItem (newStatus) {
+      if (!this.config.callStateItem) return
+      this.$store.dispatch('sendCommand', { itemName: this.config.callStateItem, cmd: newStatus })
     }
   },
   created () {


### PR DESCRIPTION
This adds the option to specify a String Item, to which the call status is sent.
This allows to track the usage of oh-sipclient from rules and scripts.