### PR TITLE
Health menu: Remove sidebar and settings entry, instead use FAB

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -39,10 +39,6 @@
           </f7-list-item>
           <li v-if="showSettingsSubmenu">
             <ul class="menu-sublinks">
-              <f7-list-item v-if="$store.getters.apiEndpoint('links')" link="/settings/health/" title="Health checks" view=".view-main" panel-close :animate="false" no-chevron
-                            :class="{ currentsection: currentUrl.indexOf('/settings/health') === 0 }">
-                <f7-icon slot="media" f7="heart" color="gray" />
-              </f7-list-item>
               <f7-list-item v-if="$store.getters.apiEndpoint('things')" link="/settings/things/" title="Things" view=".view-main" panel-close :animate="false" no-chevron
                             :class="{ currentsection: currentUrl.indexOf('/settings/things') === 0 }">
                 <f7-icon slot="media" f7="lightbulb" color="gray" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-orphanlinks.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-orphanlinks.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
-    <f7-navbar title="Orphan links" back-link="Health checks" back-link-url="/settings/health/" back-link-force>
+    <f7-navbar title="Orphan Links" back-link="Health Checks" back-link-url="/settings/health/" back-link-force>
       <f7-nav-right>
         <developer-dock-icon />
       </f7-nav-right>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
-    <f7-navbar title="Health checks" back-link="Settings" back-link-url="/settings/" back-link-force>
+    <f7-navbar title="Health Checks" back-link="Settings" back-link-url="/settings/" back-link-force>
       <f7-nav-right>
         <developer-dock-icon />
       </f7-nav-right>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -24,17 +24,6 @@
           <f7-block-title>Configuration</f7-block-title>
           <f7-list media-list class="search-list">
             <f7-list-item
-              v-if="$store.getters.apiEndpoint('links')"
-              media-item
-              link="health/"
-              title="Health check"
-              :badge="(healthCount > 0) ? healthCount : undefined"
-              :after="(healthCount > 0) ? undefined : 0"
-              badge-color="red"
-              :footer="objectsSubtitles.health">
-              <f7-icon slot="media" f7="heart" color="gray" />
-            </f7-list-item>
-            <f7-list-item
               v-if="$store.getters.apiEndpoint('things')"
               media-item
               link="things/"
@@ -199,6 +188,10 @@
         <small v-t="'admin.notTranslatedYet'" />
       </f7-block-footer>
     </f7-block>
+
+    <f7-fab v-if="healthCount > 0" position="center-bottom" :text="`Health Issues (${healthCount})`" slot="fixed" color="red" href="health/">
+      <f7-icon f7="heart" />
+    </f7-fab>
   </f7-page>
 </template>
 


### PR DESCRIPTION
Closes #2644.

This removes the health check entry from the sidebar and the settings menu and instead uses a floating action button (FAB) to allow access to the health checks page if there are any actual issues.

This is only a minor cosmetic change to a new feature, so it should be fine to merge that for RC2.