### PR TITLE
Fix code editor overflow in sitemap editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -97,7 +97,7 @@
 </template>
 
 <style lang="stylus">
-.sitemap-editor-tabs
+.layout-editor-tabs
   --f7-grid-gap 0px
   height calc(100% - var(--f7-toolbar-height))
   .tab


### PR DESCRIPTION
This was caused by a wrong class name in layout-edit.vue, that overwrote a Framework7 CSS var used by the sitemap editor.

Reported on the community https://community.openhab.org/t/openhab-4-2-release-discussion/157076/8.