### PR TITLE
Page editors: Encapsulate CSS to avoid polluting global CSS

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -52,24 +52,24 @@
 </template>
 
 <style lang="stylus">
-.page-code-editor.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(100% - 3*var(--f7-navbar-height))
-  width 100%
-.yaml-message
-  display block
-  position absolute
-  top 80%
-  white-space pre-wrap
-.code-editor-docs-link
-  position absolute
-  top calc(80% - var(--f7-navbar-height))
-  width 100%
 .chart-editor
   .oh-chart-page-chart
     top calc(var(--f7-navbar-height) + var(--f7-toolbar-height)) !important
     height calc(100% - var(--f7-navbar-height) - 2 * var(--f7-toolbar-height)) !important
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(100% - 3*var(--f7-navbar-height))
+    width 100%
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
+  .code-editor-docs-link
+    position absolute
+    top calc(80% - var(--f7-navbar-height))
+    width 100%
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -128,20 +128,21 @@
 </template>
 
 <style lang="stylus">
-.page-code-editor.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(100% - 3*var(--f7-navbar-height))
-  width 100%
-.yaml-message
-  display block
-  position absolute
-  top 80%
-  white-space pre-wrap
-.homecards-list
-  .item-link
-    overflow inherit
-    z-index inherit !important
+.home-editor
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(100% - 3*var(--f7-navbar-height))
+    width 100%
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
+  .homecards-list
+    .item-link
+      overflow inherit
+      z-index inherit !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -97,32 +97,32 @@
 </template>
 
 <style lang="stylus">
-.layout-editor-tabs
-  --f7-grid-gap 0px
-  height calc(100% - var(--f7-toolbar-height))
-  .tab
-    height 100%
-.page-code-editor.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(100% - 3*var(--f7-navbar-height))
-  width 100%
-.yaml-message
-  display block
-  position absolute
-  top 80%
-  white-space pre-wrap
-.layout-editor-design-tab
-  .layout-page
-    margin-bottom calc(var(--f7-toolbar-height) + 1rem)
-    .oh-masonry
-      z-index inherit
 .layout-editor
   .page-content
     z-index inherit
   .toolbar-details
     .tab-link-highlight
       display none
+  .layout-editor-tabs
+    --f7-grid-gap 0px
+    height calc(100% - var(--f7-toolbar-height))
+    .tab
+      height 100%
+    .layout-editor-design-tab
+      .layout-page
+        margin-bottom calc(var(--f7-toolbar-height) + 1rem)
+        .oh-masonry
+          z-index inherit
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(100% - 3*var(--f7-navbar-height))
+    width 100%
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -93,24 +93,25 @@
 </template>
 
 <style lang="stylus">
-.page-code-editor.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(100% - 3*var(--f7-navbar-height))
-  width 100%
-.yaml-message
-  display block
-  position absolute
-  top 80%
-  white-space pre-wrap
 .map-editor
-  .oh-map-page-lmap
-    top calc(var(--f7-navbar-height) + var(--f7-toolbar-height)) !important
-    height calc(100% - var(--f7-navbar-height) - 2 * var(--f7-toolbar-height)) !important
-.markers-list
-  .item-link
-    overflow inherit
-    z-index inherit !important
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(100% - 3*var(--f7-navbar-height))
+    width 100%
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
+  .map-editor
+    .oh-map-page-lmap
+      top calc(var(--f7-navbar-height) + var(--f7-toolbar-height)) !important
+      height calc(100% - var(--f7-navbar-height) - 2 * var(--f7-toolbar-height)) !important
+  .markers-list
+    .item-link
+      overflow inherit
+      z-index inherit !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -98,24 +98,25 @@
 </template>
 
 <style lang="stylus">
-.page-code-editor.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(100% - 3*var(--f7-navbar-height))
-  width 100%
-.yaml-message
-  display block
-  position absolute
-  top 80%
-  white-space pre-wrap
 .plan-editor
-  .oh-plan-page-lmap
-    top calc(var(--f7-navbar-height) + var(--f7-toolbar-height)) !important
-    height calc(100% - var(--f7-navbar-height) - 2 * var(--f7-toolbar-height)) !important
-.markers-list
-  .item-link
-    overflow inherit
-    z-index inherit !important
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(100% - 3*var(--f7-navbar-height))
+    width 100%
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
+  .plan-editor
+    .oh-plan-page-lmap
+      top calc(var(--f7-navbar-height) + var(--f7-toolbar-height)) !important
+      height calc(100% - var(--f7-navbar-height) - 2 * var(--f7-toolbar-height)) !important
+  .markers-list
+    .item-link
+      overflow inherit
+      z-index inherit !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -74,20 +74,21 @@
 </template>
 
 <style lang="stylus">
-.page-code-editor.vue-codemirror
-  display block
-  top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
-  height calc(100% - 2*var(--f7-navbar-height))
-  width 100%
-.yaml-message
-  display block
-  position absolute
-  top 80%
-  white-space pre-wrap
-.tabs-list
-  .item-link
-    overflow inherit
-    z-index inherit !important
+.tabs-editor
+  .page-code-editor.vue-codemirror
+    display block
+    top calc(var(--f7-navbar-height) + var(--f7-tabbar-height))
+    height calc(100% - 2*var(--f7-navbar-height))
+    width 100%
+  .tabs-list
+    .item-link
+      overflow inherit
+      z-index inherit !important
+  .yaml-message
+    display block
+    position absolute
+    top 80%
+    white-space pre-wrap
 </style>
 
 <script>


### PR DESCRIPTION
This fixes an issue where the last lines of the layout code editor were not visible.

Reported on the community: https://community.openhab.org/t/openhab-4-2-release-discussion/157076/12