### PR TITLE
oh-context: Fix rendering failure when not in edit mode

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
@@ -56,6 +56,7 @@ export default {
       }
       this.$set(ctx, 'const', ctxConstants)
 
+      if (typeof ctx.ctxVars !== 'object') this.$set(ctx, 'ctxVars', {})
       this.$set(ctx.ctxVars, this.varScope, this.ctxVars)
 
       return ctx


### PR DESCRIPTION
When not being in edit mode, oh-context did not render at all. Instead, an error was thrown:

```
[Vue warn]: Cannot set reactive property on undefined, null, or primitive value: undefined

found in

---> <OhContext> at src/components/widgets/system/oh-context.vue
```