### PR TITLE
Canvas layout page: Hide empty background image element to remove white border

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -89,6 +89,7 @@
           : '#444 0px 0px 4px',
       }">
       <div
+        v-if="config.imageUrl || config.imageSrcSet"
         style="
           height: inherit;
           width: inherit;


### PR DESCRIPTION
See https://community.openhab.org/t/remove-border-from-fixed-canvas-layout/137541