### PR TITLE
[blockly] Fix bracketing in context block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -281,11 +281,12 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
     const type = block.getFieldValue('asType')
     if (contextInfo === 'eventAvailable') return ['(event !== undefined)', javascriptGenerator.ORDER_ATOMIC]
     if (contextInfo === 'ruleUID') return ['ctx.ruleUID', javascriptGenerator.ORDER_ATOMIC]
+
     if (contextInfo === 'itemState' || contextInfo === 'oldItemState' || contextInfo === 'itemCommand') {
       if (type === 'asNumber') {
-        return [`event.${contextInfo} !== undefined ? parseFloat(event.${contextInfo}.toString()) : undefined`, javascriptGenerator.ORDER_ATOMIC]
+        return [`((event.${contextInfo} !== undefined) ? parseFloat(event.${contextInfo}.toString()) : undefined)`, javascriptGenerator.ORDER_ATOMIC]
       } else if (type === 'asQuantity') {
-        return [`event.${contextInfo} !== undefined ? Quantity(event.${contextInfo}.toString()) : undefined`, javascriptGenerator.ORDER_ATOMIC]
+        return [`((event.${contextInfo} !== undefined) ? Quantity(event.${contextInfo}.toString()) : undefined)`, javascriptGenerator.ORDER_ATOMIC]
       } else {
         return [`event.${contextInfo}?.toString()`, javascriptGenerator.ORDER_ATOMIC]
       }


### PR DESCRIPTION
Fixes what was mentioned in https://community.openhab.org/t/issue-with-contextual-info-block-after-upgrading-to-4-2/157321