### PR TITLE
Page designers: Fix dirty handling for code tab

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -168,6 +168,7 @@ export default {
         slots: {
           default: [],
           grid: [],
+          masonry: [],
           canvas: []
         }
       },
@@ -344,10 +345,11 @@ export default {
     toYaml () {
       this.pageYaml = YAML.stringify({
         config: this.page.config,
-        blocks: this.page.slots.default,
-        masonry: this.page.slots.masonry,
-        grid: this.page.slots.grid,
-        canvas: this.page.slots.canvas
+        // make sure array is available for existing pages, where the prop might be undefined, by falling back to empty array
+        blocks: this.page.slots.default || [],
+        masonry: this.page.slots.masonry || [],
+        grid: this.page.slots.grid || [],
+        canvas: this.page.slots.canvas || []
       })
     },
     fromYaml () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -167,8 +167,8 @@ export default {
         tags: [],
         slots: {
           default: [],
-          grid: [],
           masonry: [],
+          grid: [],
           canvas: []
         }
       },


### PR DESCRIPTION
This fixes an issue, where the usage of the code tab of a page marked it as dirty, even if no change to the page was made.
Please note that for the layout page desinger, the fix however does not apply on the first time when the code tab of an existing page is opened.