### PR TITLE
[BasicUI] Make button text not uppercased

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -278,6 +278,7 @@
 		.mdl-button:focus {
 			box-shadow: none;
 			-webkit-box-shadow: none;
+			text-transform: unset;
 		}
 		.mdl-button-text {
 			html.ui-bigger-font & {


### PR DESCRIPTION
The buttons on iOS and Android apps don't uppercase the text, so this PR makes BasicUI behave the same way.

Related discussion:
https://github.com/openhab/openhab-webui/pull/2388#issuecomment-2270883776
https://github.com/openhab/openhab-webui/pull/2388#issuecomment-2272304430
