### PR TITLE
[BasicUI] Remove reading of frequency parameter of colorpicker element

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
@@ -62,9 +62,6 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
 
         String snippet = getSnippet("colorpicker");
 
-        // set the default send-update frequency to 200ms
-        String frequency = cp.getFrequency() == 0 ? "200" : Integer.toString(cp.getFrequency());
-
         // get RGB hex value
         State state = itemUIRegistry.getState(cp);
         String hexValue = getRGBHexCodeFromItemState(state);
@@ -84,7 +81,6 @@ public class ColorpickerRenderer extends AbstractWidgetRenderer {
         if (purelabel != null) {
             snippet = snippet.replace("%purelabel%", purelabel);
         }
-        snippet = snippet.replace("%frequency%", frequency);
         snippet = snippet.replace("%servletname%", WebAppServlet.SERVLET_PATH);
 
         // Process the color tags


### PR DESCRIPTION
Note that %frequency% does not exist in colorpicker snippet.

Related to openhab/openhab-core#4338

Signed-off-by: Laurent Garnier <lg.hc@free.fr>