### PR TITLE
[BasicUI] Fix frame title's left padding in condensed tablet layout

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -434,19 +434,17 @@
 	&__title {
 		margin: 0;
 		padding-left: $form-row-desktop-padding + $mdl-grid-spacing;
-		html.ui-layout-condensed & {
-			padding-left: $form-row-desktop-padding-condensed + $mdl-grid-spacing;
-		}
 		padding-top: 25px;
 		padding-bottom: 10px;
 		html.ui-layout-condensed & {
+			padding-left: $form-row-desktop-padding-condensed + $mdl-grid-spacing;
 			padding-top: 15px;
 			padding-bottom: 5px;
 		}
 		@media screen and (max-width: $layout-tablet-size-threshold) {
 			padding-left: $form-row-mobile-padding + $mdl-grid-spacing;
 			html.ui-layout-condensed & {
-				padding-left: $form-row-desktop-padding-condensed + $mdl-grid-spacing;
+				padding-left: $form-row-mobile-padding-condensed + $mdl-grid-spacing;
 			}
 		}
 	}


### PR DESCRIPTION
Before:

<img width="328" alt="image" src="https://github.com/user-attachments/assets/f8dcad17-a86f-4a19-8c99-7668d755f37d">

After:

<img width="378" alt="image" src="https://github.com/user-attachments/assets/673397dc-af99-4d46-8a9c-845f44033882">
