### PR TITLE
Widget actions: Add a HTTP action to perform HTTP requests

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
@@ -157,18 +157,35 @@ prev: /docs/ui/components/
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-button.md
+++ b/bundles/org.openhab.ui/doc/components/oh-button.md
@@ -137,18 +137,35 @@ Button performing an action
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">
@@ -296,18 +313,35 @@ Button performing an action
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="taphold_actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="taphold_actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="taphold_actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-axis.md
@@ -74,18 +74,35 @@ prev: /docs/ui/components/
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
@@ -119,18 +119,35 @@ prev: /docs/ui/components/
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-cell.md
@@ -87,18 +87,35 @@ A regular or expandable cell
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-clock-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-clock-card.md
@@ -142,18 +142,35 @@ Display a digital clock in a card
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-colorpicker-cell.md
@@ -116,18 +116,35 @@ A cell expanding to a color picker
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-data-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-data-series.md
@@ -60,18 +60,35 @@ prev: /docs/ui/components/
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-gauge-card.md
@@ -178,18 +178,35 @@ Display a read-only gauge in a card to visualize a quantifiable item
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-icon.md
+++ b/bundles/org.openhab.ui/doc/components/oh-icon.md
@@ -96,18 +96,35 @@ Display an openHAB icon
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-image-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image-card.md
@@ -108,18 +108,35 @@ Display an image (URL or Image item ) in a card
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-image.md
+++ b/bundles/org.openhab.ui/doc/components/oh-image.md
@@ -76,18 +76,35 @@ Displays an image from a URL or an item
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-knob-cell.md
@@ -239,18 +239,35 @@ Use the advanced properties to change the appearance from a knob to a rounded sl
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-label-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-card.md
@@ -77,18 +77,35 @@ Display the state of an item in a card
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">
@@ -236,18 +253,35 @@ Display the state of an item in a card
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="taphold_actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="taphold_actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="taphold_actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="taphold_actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-label-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-cell.md
@@ -103,18 +103,35 @@ A cell with a big label to show a short item state value
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-label-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-label-item.md
@@ -93,18 +93,35 @@ Display the state of an item in a list
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-link.md
+++ b/bundles/org.openhab.ui/doc/components/oh-link.md
@@ -111,18 +111,35 @@ Link performing an action
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-list-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-list-item.md
@@ -82,18 +82,35 @@ A list item
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-circle-marker.md
@@ -95,18 +95,35 @@ A circle on a map, to represent a radius
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-map-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-map-marker.md
@@ -79,18 +79,35 @@ An icon on a map
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
+++ b/bundles/org.openhab.ui/doc/components/oh-plan-marker.md
@@ -187,18 +187,35 @@ A marker on a floor plan
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-rollershutter-cell.md
@@ -148,18 +148,35 @@ A cell expanding to rollershutter controls
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-cell.md
@@ -163,18 +163,35 @@ A cell expanding to a big vertical slider
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-time-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-time-series.md
@@ -111,18 +111,35 @@ prev: /docs/ui/components/
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/doc/components/oh-video.md
+++ b/bundles/org.openhab.ui/doc/components/oh-video.md
@@ -100,18 +100,35 @@ Displays a video player from a URL or an item
     <PropOption value="photos" label="Open photo browser" />
     <PropOption value="group" label="Group details" />
     <PropOption value="analyzer" label="Analyze item(s)" />
-    <PropOption value="url" label="External URL" />
+    <PropOption value="url" label="Navigate to external URL" />
+    <PropOption value="http" label="Send HTTP request" />
     <PropOption value="variable" label="Set Variable" />
   </PropOptions>
 </PropBlock>
 <PropBlock type="TEXT" name="actionUrl" label="Action URL" context="url">
   <PropDescription>
-    URL to navigate to
+    URL to navigate to or to send HTTP request to
   </PropDescription>
 </PropBlock>
 <PropBlock type="BOOLEAN" name="actionUrlSameWindow" label="Open in same tab/window">
   <PropDescription>
     Open the URL in the same tab/window instead of a new one. This will exit the app.
+  </PropDescription>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpMethod" label="HTTP Method">
+  <PropDescription>
+    HTTP method to use for the request
+  </PropDescription>
+  <PropOptions>
+    <PropOption value="GET" label="GET" />
+    <PropOption value="POST" label="POST" />
+    <PropOption value="PUT" label="PUT" />
+    <PropOption value="DELETE" label="DELETE" />
+  </PropOptions>
+</PropBlock>
+<PropBlock type="TEXT" name="actionHttpBody" label="HTTP Body">
+  <PropDescription>
+    Body to send with the request
   </PropDescription>
 </PropBlock>
 <PropBlock type="TEXT" name="actionItem" label="Action Item" context="item">

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
@@ -26,16 +26,30 @@ export const actionParams = (groupName, paramPrefix) => {
       { value: 'photos', label: 'Open photo browser' },
       { value: 'group', label: 'Group details' },
       { value: 'analyzer', label: 'Analyze item(s)' },
-      { value: 'url', label: 'External URL' },
+      { value: 'url', label: 'Navigate to external URL' },
+      { value: 'http', label: 'Send HTTP request' },
       { value: 'variable', label: 'Set Variable' }
     ]),
-    pt(paramPrefix + 'actionUrl', 'Action URL', 'URL to navigate to').c('url')
+    pt(paramPrefix + 'actionUrl', 'Action URL', 'URL to navigate to or to send HTTP request to').c('url')
       .v((value, configuration, configDescription, parameters) => {
-        return ['url'].indexOf(configuration[paramPrefix + 'action']) >= 0
+        return ['url', 'http'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
     pb(paramPrefix + 'actionUrlSameWindow', 'Open in same tab/window', 'Open the URL in the same tab/window instead of a new one. This will exit the app.')
       .v((value, configuration, configDescription, parameters) => {
         return ['url'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
+    po(paramPrefix + 'actionHttpMethod', 'HTTP Method', 'HTTP method to use for the request', [
+      { value: 'GET', label: 'GET' },
+      { value: 'POST', label: 'POST' },
+      { value: 'PUT', label: 'PUT' },
+      { value: 'DELETE', label: 'DELETE' }
+    ])
+      .v((value, configuration, configDescription, parameters) => {
+        return ['http'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
+    pt(paramPrefix + 'actionHttpBody', 'HTTP Body', 'Body to send with the request')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['http'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
     pi(paramPrefix + 'actionItem', 'Action Item', 'Item to perform the action on')
       .v((value, configuration, configDescription, parameters) => {
@@ -119,7 +133,7 @@ export const actionParams = (groupName, paramPrefix) => {
     }),
     pt(paramPrefix + 'actionFeedback', 'Action feedback', 'Shows a toast popup when the action has been executed. Can either be a text to show or a JSON object including some of the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/toast.html#toast-parameters">supported parameters</a>').a()
       .v((value, configuration, configDescription, parameters) => {
-        return ['command', 'toggle', 'options', 'rule'].indexOf(configuration[paramPrefix + 'action']) >= 0
+        return ['command', 'toggle', 'options', 'rule', 'http'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
     pt(paramPrefix + 'actionVariable', 'Variable', 'The variable name to set')
       .v((value, configuration, configDescription, parameters) => {

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -267,6 +267,17 @@ export const actionsMixin = {
           const actionUrlSameWindow = actionConfig[prefix + 'actionUrlSameWindow']
           window.open(actionUrl, (actionUrlSameWindow) ? '_top' : '_blank')
           break
+        case 'http':
+          const actionHttpUrl = actionConfig[prefix + 'actionUrl']
+          const actionHttpMethod = actionConfig[prefix + 'actionHttpMethod'] || 'GET'
+          const actionHttpBody = actionConfig[prefix + 'actionHttpBody']
+          fetch(actionHttpUrl, {
+            mode: 'no-cors',
+            method: actionHttpMethod,
+            body: actionHttpBody
+          }).then(() => this.showActionFeedback(prefix, actionConfig))
+            .catch((e) => this.showActionFeedback(prefix, actionConfig, `Failed to perform HTTP request: ${e.message}`))
+          break
         case 'variable':
           const actionVariable = actionConfig[prefix + 'actionVariable']
           let actionVariableValue = actionConfig[prefix + 'actionVariableValue']


### PR DESCRIPTION
This allows to perform HTTP requests from inside widget actions.
The use case might be limited, but for example this can be used to allow access to local only ressources/smart devices that should not be made available via remote access and hence cannot be integrated as Items into openHAB for security purpose.