### PR TITLE
Main UI: Allow use of eval() in CSP

### DIFF
--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -15,14 +15,14 @@
         * Enable eval(): add 'unsafe-eval' to default-src
   -->
   <!-- Explanation:
-    * allow loading resources from the same origin, inline scripts and styles
+    * allow loading resources from the same origin, inline scripts (required for inline event listeners) and styles, and the use of eval() (required by ECharts)
     * allow loading fonts from the same origin, and data: URIs
     * allow loading images from any source, and data: URIs
     * allow loading media from any source, and data:, blob: and media: URIs
     * allow connecting (through fetch(), XMLHttpRequest, WebSocket etc.) to the same origin, raw.githubusercontent.com (add-on logos etc.), Iconify icon sources, and any source
   -->
-  <% if (process.env.NODE_ENV !== 'development') { %>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; connect-src 'self' raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *;">
+  <% if (process.env.NODE_ENV === 'production') { %>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; connect-src 'self' raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *;">
   <% } %>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
 


### PR DESCRIPTION
Regression from #2714.

eval() seems to be required by ECharts: When opening a chart, an CSP error is thrown that traces back to ECharts, but the chart still renders.