### PR TITLE
HomeKit metadata: Mark Thermostat.CurrentHeatingCoolingMode as optional

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/homekit.js
@@ -243,9 +243,9 @@ export const accessories = {
     { label: 'Name', mandatory: false }
   ],
   'Thermostat': [
-    { label: 'CurrentHeatingCoolingMode', mandatory: true },
     { label: 'CurrentTemperature', mandatory: true },
     { label: 'TargetHeatingCoolingMode', mandatory: true },
+    { label: 'CurrentHeatingCoolingMode', mandatory: false },
     { label: 'TargetTemperature', mandatory: false },
     { label: 'CoolingThresholdTemperature', mandatory: false },
     { label: 'HeatingThresholdTemperature', mandatory: false },


### PR DESCRIPTION
See https://github.com/openhab/openhab-addons/pull/17191