### PR TITLE
[blockly] Make HTTP block method name dropdown labels less technical

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-http.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-http.js
@@ -30,14 +30,12 @@ export default function (f7, isGraalJs) {
         .appendField(imageTimeoutField, 'imgTimeout')
         .appendField(imageHeaderField, 'imgHeader')
         .appendField(imageQueryField, 'imgQuery')
-        .appendField('send', 'methodField')
         .appendField(new Blockly.FieldDropdown([
-          ['HttpGetRequest', 'HttpGetRequest'],
-          ['HttpPostRequest', 'HttpPostRequest'],
-          ['HttpPutRequest', 'HttpPutRequest'],
-          ['HttpDeleteRequest', 'HttpDeleteRequest']
+          ['send HTTP GET request to', 'HttpGetRequest'],
+          ['send HTTP POST request to', 'HttpPostRequest'],
+          ['send HTTP PUT request to', 'HttpPutRequest'],
+          ['send HTTP DELETE request to', 'HttpDeleteRequest']
         ], this.handleRequestTypeSelection.bind(this)), 'requestType')
-        .appendField('to')
 
       this.setInputsInline(false)
       this.setOutput(true, null)

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-http.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-http.js
@@ -31,10 +31,10 @@ export default function (f7, isGraalJs) {
         .appendField(imageHeaderField, 'imgHeader')
         .appendField(imageQueryField, 'imgQuery')
         .appendField(new Blockly.FieldDropdown([
-          ['send HTTP GET request to', 'HttpGetRequest'],
-          ['send HTTP POST request to', 'HttpPostRequest'],
-          ['send HTTP PUT request to', 'HttpPutRequest'],
-          ['send HTTP DELETE request to', 'HttpDeleteRequest']
+          ['send HTTP GET to', 'HttpGetRequest'],
+          ['send HTTP POST to', 'HttpPostRequest'],
+          ['send HTTP PUT to', 'HttpPutRequest'],
+          ['send HTTP DELETE to', 'HttpDeleteRequest']
         ], this.handleRequestTypeSelection.bind(this)), 'requestType')
 
       this.setInputsInline(false)


### PR DESCRIPTION
See https://github.com/openhab/openhab-webui/pull/2607#issuecomment-2322954012

@ysc @stefan-hoehn For your evaluation.

It looks like it does not create backward compatibility issues, so this change should be fine. If this is accepted, I will change the screenshots again in https://github.com/openhab/openhab-docs/pull/2359