### PR TITLE
CSP: Allow embedding any source

### DIFF
--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -19,10 +19,11 @@
     * allow loading fonts from the same origin, and data: URIs
     * allow loading images from any source, and data: URIs
     * allow loading media from any source, and data:, blob: and media: URIs
+    * allow embedding (<iframe>) any source
     * allow connecting (through fetch(), XMLHttpRequest, WebSocket etc.) to the same origin, raw.githubusercontent.com (add-on logos etc.), Iconify icon sources, and any source
   -->
   <% if (process.env.NODE_ENV === 'production') { %>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; connect-src 'self' raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; frame-src *; connect-src 'self' raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *;">
   <% } %>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
 


### PR DESCRIPTION
Regression from #2714.

This updates Main UI‘s CSP to allow embedding any source.

Fixes issues reported on the community, see
https://community.openhab.org/t/openhab-4-3-milestone-discussion/158139/6 and https://community.openhab.org/t/openhab-4-3-milestone-discussion/158139/7.