### PR TITLE
[blockly] Small improvements to blocks

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -139,6 +139,10 @@ export default function defineOHBlocks_Persistence (f7, isGraalJs, persistenceSe
             .appendField('skip same ')
             .setAlign(Blockly.ALIGN_RIGHT)
             .setCheck(['Boolean'])
+          this.getInput('skipPrevious').setShadowDom(
+            Blockly.utils.xml.textToDom(`<shadow type="logic_boolean">
+              <field name="BOOL">FALSE</field>
+            </shadow>`))
         }
       } else {
         if (this.getInput('skipPrevious')) {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -143,14 +143,10 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, transformationSer
   }
 
   function transformationOptions () {
-    let options = []
     if (transformationServices && transformationServices.length > 0) {
-      for (let key in transformationServices) {
-        let transformationOption = transformationServices[key]
-        options.push([transformationOption, transformationOption])
-      }
+      return transformationServices.map((service) => [service, service])
     }
-    return options.length > 0 ? options : [['', '']]
+    return [['', '']]
   }
 
   /*

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -9,7 +9,7 @@ import Blockly from 'blockly'
 import { javascriptGenerator } from 'blockly/javascript.js'
 import { addOSGiService } from './utils.js'
 
-export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
+export default function defineOHBlocks_Scripts (f7, isGraalJs, transformationServices, scripts) {
   /*
   * Calls a script that is provided in openHABs scripts folder
   * Blockly part
@@ -111,8 +111,9 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
         .appendField('transform')
       this.appendValueInput('function')
         .appendField('apply')
-        .appendField(new Blockly.FieldTextInput('MAP'), 'type')
+        .appendField(new Blockly.FieldDropdown(transformationOptions()), 'type')
         .appendField('with')
+        .setCheck(null)
 
       this.setInputsInline(false)
       this.setOutput(true, null)
@@ -122,12 +123,14 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
       this.setTooltip(function () {
         const type = thisBlock.getFieldValue('type')
         switch (type) {
+          case '':
+            return 'select from the installed transformations. The list is empty if no transformation addons have been installed.'
           case 'MAP':
-            return 'transforms an input via a map file. Specify the file as the function.\nREGEX and JSONPATH are also valid.'
+            return 'transforms an input via a map file. Specify the file as the function.'
           case 'REGEX':
-            return 'transforms / filters an input by applying the provided regular expression.\nMAP and JSONPATH are also valid.'
+            return 'transforms / filters an input by applying the provided regular expression.'
           case 'JSONPATH':
-            return 'transforms / filters a JSON input by executing the provided JSONPath query.\nMAP and REGEX are also valid.'
+            return 'transforms / filters a JSON input by executing the provided JSONPath query.'
           default:
             return 'transforms the input with the ' + type + ' transformation.'
         }
@@ -137,6 +140,17 @@ export default function defineOHBlocks_Scripts (f7, isGraalJs, scripts) {
         return 'https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#transform-values-via-map-regex-or-jsonpath-and-others' + type.toLowerCase() + '/'
       })
     }
+  }
+
+  function transformationOptions () {
+    let options = []
+    if (transformationServices && transformationServices.length > 0) {
+      for (let key in transformationServices) {
+        let transformationOption = transformationServices[key]
+        options.push([transformationOption, transformationOption])
+      }
+    }
+    return options.length > 0 ? options : [['', '']]
   }
 
   /*

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-timers.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-timers.js
@@ -62,6 +62,9 @@ export default function defineOHBlocks_Timers (f7, isGraalJs) {
           .appendField('timer')
         this.appendValueInput('context')
           .appendField('with context')
+        this.getInput('context').setShadowDom(
+          Blockly.utils.xml.textToDom(`<shadow type="oh_logic_undefined">
+          </shadow>`))
       } else {
         tn.appendField('do with timer')
       }
@@ -152,6 +155,9 @@ export default function defineOHBlocks_Timers (f7, isGraalJs) {
           .appendField('timer')
         this.appendValueInput('context')
           .appendField('with context')
+        this.getInput('context').setShadowDom(
+          Blockly.utils.xml.textToDom(`<shadow type="oh_logic_undefined">
+          </shadow>`))
       } else {
         tn.appendField('do with timer')
       }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/index.js
@@ -36,7 +36,7 @@ export default function (f7, libraryDefinitions, data, isGraalJs) {
   defineTimerBlocks(f7, isGraalJs)
   defineValueStorageBlocks(f7, isGraalJs)
   defineEphemerisBlocks(f7, isGraalJs)
-  defineScriptsBlocks(f7, isGraalJs)
+  defineScriptsBlocks(f7, isGraalJs, data.transformationServices)
   definePersistenceBlocks(f7, isGraalJs, data.persistenceServices)
   defineColorBlocks(f7, isGraalJs)
   defineTextBlocks(f7, isGraalJs)

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1072,9 +1072,9 @@
               </shadow>
             </value>
             <value name="parameters">
-              <block type="dicts_create_with">
+              <shadow type="dicts_create_with">
                 <mutation items="0" />
-              </block>
+              </shadow>
             </value>
           </block>
           <sep gap="48" />

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1200,6 +1200,7 @@ export default {
       scripts: [],
       rules: [],
       persistenceServices: [],
+      transformationServices: [],
       loading: true,
       ready: false
     }
@@ -1229,7 +1230,8 @@ export default {
         this.$oh.api.get('/rest/audio/sinks'),
         this.$oh.api.get('/rest/voice/voices'),
         this.libraryDefinitions ? Promise.resolve(this.libraryDefinitions) : this.$oh.api.get('/rest/ui/components/ui:blocks'),
-        this.$oh.api.get('/rest/persistence')
+        this.$oh.api.get('/rest/persistence'),
+        this.$oh.api.get('/rest/transformations/services')
       ]
       Promise.all(dataPromises)
         .then((data) => {
@@ -1266,6 +1268,12 @@ export default {
             return labelA.localeCompare(labelB)
           })
 
+          this.transformationServices = data[5].sort((a, b) => {
+            const labelA = a
+            const labelB = b
+            return labelA.localeCompare(labelB)
+          })
+
           this.initBlockly(this.blockLibraries)
         })
         .catch((err, status) => {
@@ -1276,7 +1284,8 @@ export default {
       defineOHBlocks(this.$f7, libraryDefinitions, {
         sinks: this.sinks,
         voices: this.voices,
-        persistenceServices: this.persistenceServices
+        persistenceServices: this.persistenceServices,
+        transformationServices: this.transformationServices
       }, this.isGraalJs)
       this.addLibraryToToolbox(libraryDefinitions || [])
 


### PR DESCRIPTION
When going through the available blocks, I saw potential for a few small improvements, which I collected in this PR:

- Persistence `previous...State` and `next...State` blocks: add boolean shadow block for skip same, default false
- Named `timer` blocks: add a `undefined` shadow block for `context`.
- `run rule or script` block: make the parameter dictionnary input a shadow block

The above does not change functionality, but I find it cleaner to always a default attached to the input, even if it is not required for the code. It avoids users thinking they need to put something in. Having a default indicates the default will work unless they need something specific.

In addition to that, for the `transform` block, I made the transformation dropdown dependent on the installed transformations.