### PR TITLE
Add stale action GHA workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,27 @@
+name: 'Stale issues check'
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    name: Stale issues check
+    permissions:
+      issues: write
+    steps:
+      - name: Stale issues check
+        uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 60
+          days-before-issue-close: 180
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          only-labels: 'awaiting feedback'
+          stale-issue-label: 'stale'
+          exempt-issue-labels: 'pinned,security,PR pending'
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because it has not had recent activity.
+            It will be closed if no further activity occurs. Thank you for your contributions.


### PR DESCRIPTION
This allows for automatically marking issues as stale and closing them.

We use this in the core/add-ons and distro repos.
The "stale" label needs to be added for this to work.