### PR TITLE
Config sheet: Properly handle null as configuration value

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -112,7 +112,7 @@ export default {
       // - a default value is defined and the actual value differs from the default value
       // - no default value is defined and the param has a value
       return finalParameters.filter((p) => !p.advanced ||
-        (p.default !== undefined && this.configuration[p.name] !== undefined ? this.configuration[p.name].toString() !== p.default : this.configuration[p.name] !== undefined))
+        (p.default !== undefined && this.configuration[p.name] !== undefined && this.configuration[p.name] !== null ? this.configuration[p.name].toString() !== p.default : this.configuration[p.name] !== undefined))
     }
   },
   methods: {


### PR DESCRIPTION
This fixes an error that was previously thrown.

```
backend.js:5526 TypeError: Cannot read properties of null (reading 'toString')
    at eval (index.js??vue-loader-options!./src/components/config/config-sheet.vue?vue&type=script&lang=js:57:133)
    at Array.filter (<anonymous>)
    at VueComponent.displayedParameters (index.js??vue-loader-options!./src/components/config/config-sheet.vue?vue&type=script&lang=js:56:30)
    at Watcher.get (vue.esm.js:4223:33)
    at Watcher.evaluate (vue.esm.js:4324:27)
    at VueComponent.computedGetter [as displayedParameters] (vue.esm.js:4547:25)
    at Object.get (vue.esm.js:771:26)
    at Proxy.render (templateLoader.js??ruleSet[1].rules[2]!./node_modules/vue-loader/lib/index.js??vue-loader-options!./src/components/config/config-sheet.vue?vue&type=template&id=23208b3e:34:11)
    at Vue._render (vue.esm.js:2591:28)
    at VueComponent.updateComponent (vue.esm.js:3137:27)
```