### PR TITLE
Fix meta tag apple-mobile-web-app-capable deprecation warning

### DIFF
--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -33,7 +33,7 @@
   <meta name="msapplication-tap-highlight" content="no">
   <title>openHAB</title>
   <% if (process.env.TARGET === 'web') { %>
-  <meta name="apple-mobile-web-app-capable" content="yes">
+  <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <link rel="apple-touch-icon" href="/res/icons/apple-touch-icon.png" type="image/png" sizes="180x180" crossorigin="use-credentials">
   <link rel="icon" href="/res/icons/favicon.svg" type="image/svg+xml" sizes="any" crossorigin="use-credentials">


### PR DESCRIPTION
Chromium issued the following deprecation warning:

```
<meta name="apple-mobile-web-app-capable" content="yes"> is deprecated. Please include <meta name="mobile-web-app-capable" content="yes">
```