### PR TITLE
Upgrade Karaf from 4.4.6 to 4.4.7

### DIFF
--- a/bundles/org.openhab.ui.habot/pom.xml
+++ b/bundles/org.openhab.ui.habot/pom.xml
@@ -14,8 +14,8 @@
   <dependencies>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <version>1.69</version>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <version>1.78.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.opennlp</groupId>

--- a/bundles/org.openhab.ui.habot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.ui.habot/src/main/feature/feature.xml
@@ -8,7 +8,7 @@
 		<bundle>mvn:org.openhab.ui.bundles/org.openhab.ui.habot/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.semantics/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest/${project.version}</bundle>
-		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk15on/1.69</bundle>
+		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk18on/1.78.1</bundle>
 		<bundle dependency="true">mvn:org.apache.opennlp/opennlp-tools/1.9.3</bundle>
 		<bundle dependency="true">mvn:org.bitbucket.b_c/jose4j/0.7.9</bundle>
 	</feature>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
 
     <bnd.version>7.1.0</bnd.version>
     <eea.version>2.4.0</eea.version>
-    <jackson.version>2.16.0</jackson.version>
-    <karaf.version>4.4.6</karaf.version>
+    <jackson.version>2.18.2</jackson.version>
+    <karaf.version>4.4.7</karaf.version>
     <ohc.version>5.0.0-SNAPSHOT</ohc.version>
     <sat.version>0.17.0</sat.version>
     <spotless.version>2.43.0</spotless.version>


### PR DESCRIPTION
Depends on Karaf 4.4.7 core upgrade, openhab/openhab-core#4406.
 
BouncyCastle crypto library was still on jdk15on version in habot - I upgraded it to jdk18on 1.78.1 to keep it in sync with core. Hope this does not break something.


* Sync runtime dependencies with Karaf 4.4.7, most notably:
   * BouncyCastle 1.78.1
   * Jackson 2.17.2