### PR TITLE
Fix safe area styling issues with card and card contents

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-card.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-card :no-border="config.noBorder" :no-shadow="config.noShadow" :outline="config.outline" :style="config.style" :class="config.class">
+  <f7-card :no-border="config.noBorder" :no-shadow="config.noShadow" :outline="config.outline" :style="config.style" :class="['oh-card', ...(Array.isArray(config.class) ? config.class : [])]">
     <slot name="header">
       <f7-card-header v-if="config.title" :style="config.headerStyle" :class="config.headerClass">
         <div>{{ config.title }}</div>
@@ -22,6 +22,17 @@
     </slot>
   </f7-card>
 </template>
+
+<style lang="stylus">
+// Fix safe-area issues where oh-card is used inside a block or masonry layout, where the safe areas are already respected by the parent block
+.oh-col >
+.oh-masonry-item >
+  .oh-card
+    --f7-safe-area-left 0px
+    --f7-safe-area-right 0px
+    --f7-safe-area-top 0px
+    --f7-safe-area-bottom 0px
+</style>
 
 <script>
 import mixin from '../widget-mixin'

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -309,3 +309,11 @@ html
       padding 0
       margin-left 8px
       color var(--f7-input-text-color)
+
+// Fix safe area issues inside f7-card components, where safe areas are already respected by the f7-card itself
+.card >
+  div
+    --f7-safe-area-left 0px
+    --f7-safe-area-right 0px
+    --f7-safe-area-top 0px
+    --f7-safe-area-bottom 0px


### PR DESCRIPTION
This fixes ugly styling issues with too large margin/padding on iOS devices due to safe areas getting applied to children of f7-card, even though f7-card already respects the safe areas.

This removes the space marked in the following screenshots:

![image](https://github.com/user-attachments/assets/ea7c32ac-2678-4c33-b123-fe89dde00fab)
![image](https://github.com/user-attachments/assets/96798156-80ee-4592-b30f-d15533ace3e8)