### PR TITLE
Settings pages: Fix double scrollbars by hiding y-overflow in block-narrow

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -187,7 +187,7 @@ html
 
 .block-narrow
   z-index auto
-  overflow-x hidden !important
+  overflow hidden !important
 
 @media (min-width 1024px)
     .block-narrow


### PR DESCRIPTION
Fixes #2788.