### PR TITLE
Remove unnecessary !important from block style fixes inside f7-card

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -313,8 +313,8 @@ html
 // Fix safe area issues inside f7-card components, where safe areas are already respected by the f7-card itself
 .card
   .block
-    padding-left var(--f7-block-padding-horizontal) !important
-    padding-right var(--f7-block-padding-horizontal) !important
+    padding-left var(--f7-block-padding-horizontal)
+    padding-right var(--f7-block-padding-horizontal)
   .media-item
     .item-content
       padding-left var(--f7-list-item-padding-horizontal)


### PR DESCRIPTION
Minor regression from #2801.

This fixes difficulties with overwriting that style in widgets.