### PR TITLE
Charts: Enable boundary and itemState persistence query params by default

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
@@ -43,6 +43,16 @@ prev: /docs/ui/components/
     The identifier of the persistence service to retrieve the data from. Leave blank to the use the default.
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="noBoundary" label="Don't Include Boundary">
+  <PropDescription>
+    Do not get one value before and after the requested period and move them to the start and end of the period
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="noItemState" label="Don't Include Item State">
+  <PropDescription>
+    Do not add the current Item state into the requested period (the item state will be before or at the end time)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="INTEGER" name="offsetAmount" label="Offset Amount">
   <PropDescription>
     Offset to <em>subtract</em> from the displayed period, use if you want to do period comparisons (see also Offset Unit).

--- a/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-calendar-series.md
@@ -43,6 +43,16 @@ prev: /docs/ui/components/
     The identifier of the persistence service to retrieve the data from. Leave blank to the use the default.
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="noBoundary" label="Don't Include Boundary">
+  <PropDescription>
+    Do not get one value before and after the requested period and move them to the start and end of the period
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="noItemState" label="Don't Include Item State">
+  <PropDescription>
+    Do not add the current Item state into the requested period (the item state will be before or at the end time)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="INTEGER" name="offsetAmount" label="Offset Amount">
   <PropDescription>
     Offset to <em>subtract</em> from the displayed period, use if you want to do period comparisons (see also Offset Unit).

--- a/bundles/org.openhab.ui/doc/components/oh-time-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-time-series.md
@@ -43,6 +43,16 @@ prev: /docs/ui/components/
     The identifier of the persistence service to retrieve the data from. Leave blank to the use the default.
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="noBoundary" label="Don't Include Boundary">
+  <PropDescription>
+    Do not get one value before and after the requested period and move them to the start and end of the period
+  </PropDescription>
+</PropBlock>
+<PropBlock type="BOOLEAN" name="noItemState" label="Don't Include Item State">
+  <PropDescription>
+    Do not add the current Item state into the requested period (the item state will be before or at the end time)
+  </PropDescription>
+</PropBlock>
 <PropBlock type="INTEGER" name="offsetAmount" label="Offset Amount">
   <PropDescription>
     Offset to <em>subtract</em> from the displayed period, use if you want to do period comparisons (see also Offset Unit).

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -62,6 +62,10 @@ const yAxisIndexParameter = pn('yAxisIndex', 'Y Axis Index', 'The index of the Y
 const persistenceServiceParameter = pt('service', 'Persistence Service', 'The identifier of the persistence service to retrieve the data from. Leave blank to the use the default.')
   .c('persistenceService').a()
 
+const boundaryParameter = pb('noBoundary', 'Don\'t Include Boundary', 'Do not get one value before and after the requested period and move them to the start and end of the period').a()
+
+const itemStateParameter = pb('noItemState', 'Don\'t Include Item State', 'Do not add the current Item state into the requested period (the item state will be before or at the end time)').a()
+
 const offsetAmountParameter = pn('offsetAmount', 'Offset Amount', 'Offset to <em>subtract</em> from the displayed period, use if you want to do period comparisons (see also Offset Unit).').a()
 
 const offsetUnitParameter = pt('offsetUnit', 'Offset Unit', 'Offset to <em>subtract</em> from the displayed period, use if you want to do period comparisons (see also Offset Amount).')
@@ -92,6 +96,8 @@ const seriesParameters = [
   nameParameter,
   itemParameter,
   persistenceServiceParameter,
+  boundaryParameter,
+  itemStateParameter,
   offsetAmountParameter,
   offsetUnitParameter
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -153,7 +153,7 @@ export default {
         return Promise.resolve(getter([]))
       }
 
-      let boundary = seriesComponents[component.component].includeBoundary?.(component)
+      const boundary = seriesComponents[component.component].includeBoundary?.(component) || component.config.noBoundary !== true
       const itemPromises = neededItems.map((neededItem) => {
         if (this.items[neededItem]) return Promise.resolve(this.items[neededItem])
         return this.$oh.api.get(`/rest/items/${neededItem}`).then((item) => {
@@ -176,7 +176,7 @@ export default {
           starttime: seriesStartTime.toISOString(),
           endtime: seriesEndTime.subtract(1, 'millisecond').toISOString(),
           boundary,
-          itemState: true
+          itemState: component.config.noItemState !== true
         }
 
         return Promise.all([itemPromises[neededItem], this.$oh.api.get(url, query)])

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -175,7 +175,8 @@ export default {
           serviceId,
           starttime: seriesStartTime.toISOString(),
           endtime: seriesEndTime.subtract(1, 'millisecond').toISOString(),
-          boundary
+          boundary,
+          itemState: true
         }
 
         return Promise.all([itemPromises[neededItem], this.$oh.api.get(url, query)])

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.js
@@ -17,7 +17,7 @@ function dimensionFromDate (d, dimension, invert) {
 }
 
 function includeBoundaryFor (component) {
-  return (!component || !component.config || component.config.aggregationFunction !== 'diff_last') ? undefined : true
+  return (!component || !component.config || component.config.aggregationFunction === 'diff_last') ? true : undefined
 }
 
 export default {


### PR DESCRIPTION
Refs https://github.com/openhab/openhab-core/pull/4394.