### PR TITLE
oh-cell: Fix headerBadgeColor

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
@@ -23,14 +23,14 @@
               <div slot="header" v-if="header" class="button-header display-flex">
                 <oh-icon class="header-icon" v-if="config.icon" :icon="config.icon" :color="config.iconColor" width="20" height="20" />
                 <span class="header-text">{{ header }}</span>
-                <f7-badge v-if="config.headerBadge" color="config.headerBadgeColor">
+                <f7-badge v-if="config.headerBadge" :color="config.headerBadgeColor">
                   {{ config.headerBadge }}
                 </f7-badge>
               </div>
               <div slot="title" v-if="config.title" class="button-header display-flex">
                 <oh-icon class="header-icon" v-if="!header && config.icon" :icon="config.icon" :color="config.iconColor" width="20" height="20" />
                 <span class="header-text">{{ config.title }}</span>
-                <f7-badge v-if="config.headerBadge" color="config.headerBadgeColor">
+                <f7-badge v-if="config.headerBadge" :color="config.headerBadgeColor">
                   {{ config.headerBadge }}
                 </f7-badge>
               </div>


### PR DESCRIPTION
The color attribute for the header badges in the oh-cell were not dynamic and as a result setting headerBadgeColor in the cell config caused a malformed color class to be added to the badge.