### PR TITLE
Add bottom padding below advanced checkbox in config sheet

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-block v-if="parameters" class="config-sheet no-margin" ref="sheet">
-    <div style="text-align:right" class="padding-right" v-if="hasAdvanced">
+    <div style="text-align:right" class="padding-right padding-bottom" v-if="hasAdvanced">
       <label @click="toggleAdvanced" class="advanced-label">Show advanced</label> <f7-checkbox :checked="showAdvanced" @change="toggleAdvanced" />
     </div>
     <f7-col>


### PR DESCRIPTION
A pet peeve of mine for some time:

![image](https://github.com/user-attachments/assets/57d07186-ef47-4eaa-ba30-044552c8916b)

![image](https://github.com/user-attachments/assets/dc379a79-4e7d-4ebb-95f4-9ecd7aa8a6d3)
