### PR TITLE
Rule/Scene/Script edit: Block addition of reserved tags

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -53,6 +53,13 @@ export default {
       if (tag === 'Scene') return true
     },
     addTag () {
+      // Block adding of Scene or Script tags in the wrong editor
+      // Adding them would otherwise lead to a situation where the rule/scene/script is not visible in the UI
+      if ((!this.inScriptEditor && this.pendingTag === 'Script') ||
+        (!this.inSceneEditor && this.pendingTag === 'Scene')) {
+        this.pendingTag = ''
+        return
+      }
       if (this.pendingTag && this.item.tags.indexOf(this.pendingTag) === -1) {
         this.item.tags.push(this.pendingTag)
       }


### PR DESCRIPTION
Do NOT allow the addition of the scene tag outside the scene editor and addition of the script tag outside the script editor.