### PR TITLE
Pages list: Don't allow selecting overview page for removal

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -90,7 +90,7 @@
               :key="index"
               media-item
               class="pagelist-item"
-              :checkbox="showCheckboxes"
+              :checkbox="showCheckboxes && page.uid !== 'overview'"
               :checked="isChecked(((page.component === 'Sitemap') ? 'system:sitemap:' : 'ui:page:') + page.uid)"
               :disabled="showCheckboxes && page.uid === 'overview'"
               @click.ctrl="(e) => ctrlClick(e, page)"


### PR DESCRIPTION
The overview page cannot be removed, so do not allow to select it for removal.