### PR TITLE
Fix searchbar flickering for model, rules & Things

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -325,7 +325,6 @@ export default {
     },
     load () {
       if (this.initSearchbar) this.$f7.data.lastModelSearchQuery = this.$refs.searchbar?.f7Searchbar.query
-      this.initSearchbar = false
 
       this.loadModel().then(() => {
         this.initSearchbar = true

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -215,7 +215,6 @@ export default {
       this.loading = true
 
       if (this.initSearchbar) this.$f7.data[`last${this.type}SearchQuery`] = this.$refs.searchbar?.f7Searchbar.query
-      this.initSearchbar = false
 
       this.$set(this, 'selectedItems', [])
       this.showCheckboxes = false

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -6,9 +6,9 @@
         <f7-link icon-md="material:done_all" @click="toggleCheck()"
                  :text="(!$theme.md) ? ((showCheckboxes) ? 'Done' : 'Select') : ''" />
       </f7-nav-right>
-      <f7-subnavbar :inner="false" v-show="initSeachbar">
+      <f7-subnavbar :inner="false" v-show="initSearchbar">
         <f7-searchbar
-          v-if="initSeachbar"
+          v-if="initSearchbar"
           ref="searchbar"
           class="searchbar-things"
           search-container=".contacts-list"
@@ -170,7 +170,7 @@ export default {
   data () {
     return {
       ready: false,
-      initSeachbar: false,
+      initSearchbar: false,
       loading: false,
       things: [],
       inbox: [],
@@ -253,12 +253,11 @@ export default {
       if (this.loading) return
       this.loading = true
 
-      if (this.initSeachbar) this.$f7.data.lastThingsSearchQuery = this.$refs.searchbar?.f7Searchbar.query
-      this.initSeachbar = false
+      if (this.initSearchbar) this.$f7.data.lastThingsSearchQuery = this.$refs.searchbar?.f7Searchbar.query
 
       this.$oh.api.get('/rest/things?summary=true').then((data) => {
         this.things = data.sort((a, b) => (a.label || a.UID).localeCompare(b.label || a.UID))
-        this.initSeachbar = true
+        this.initSearchbar = true
         this.loading = false
         this.ready = true
         this.$nextTick(() => {


### PR DESCRIPTION
It seems the searchbar still works even if not re-rendered after update.