### PR TITLE
Widget action taphold: Hide context menu in desktop browser

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-actions.js
@@ -331,9 +331,10 @@ export const actionsMixin = {
       this.performAction(event, 'taphold')
     },
     onContextMenu (event) {
-      if (this.performAction(event, 'taphold')) {
-        event.preventDefault()
+      if (this.config.taphold_action) {
         event.stopPropagation()
+        event.preventDefault()
+        this.performAction(event, 'taphold')
       }
       // System contextual menu will be displayed
     }


### PR DESCRIPTION
Fixes #2808.