### PR TITLE
[blockly] Riemann sum persistence extension and js tern definitions

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -311,7 +311,7 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
     skipPrevious = (skipPrevious === 'undefined') ? false : skipPrevious
 
     let riemannType = block.getFieldValue('riemannType')
-    riemannType = (riemannType === 'undefined') ? '' : (', ' + riemannType)
+    riemannType = (riemannType === 'undefined') ? '' : `, ${itemCode}.persistence.${riemannType}`
 
     const persistenceExtension = (persistenceName === '\'default\'') ? '' : `, ${persistenceName}`
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -25,6 +25,7 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
           ['historic evolution rate', 'evolutionRateSince'], ['future evolution rate', 'evolutionRateUntil'], ['state evolution rate between', 'evolutionRateBetween'],
           ['historic state minimum', 'minimumSince'], ['future state minimum', 'minimumUntil'], ['state minimum between', 'minimumBetween'],
           ['historic state maximum', 'maximumSince'], ['future state maximum', 'maximumUntil'], ['state maximum between', 'maximumBetween'],
+          ['historic state Riemann sum', 'riemannSumSince'], ['future state Riemann sum', 'riemannSumUntil'], ['state Riemann sum between', 'riemannSumBetween'],
           ['historic state sum', 'sumSince'], ['future state sum', 'sumUntil'], ['state sum between', 'sumBetween'],
           ['historic state updates count', 'countSince'], ['future state updates count', 'countUntil'], ['state updates count between', 'countBetween'],
           ['historic state changes count', 'countStateChangesSince'], ['future state changes count', 'countStateChangesUntil'], ['state changes count between', 'countStateChangesBetween'],
@@ -74,6 +75,9 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
           'maximumSince': 'Gets the maximum value of the State of the Item since a certain point in time',
           'maximumUntil': 'Gets the maximum value of the State of the Item until a certain point in time',
           'maximumBetween': 'Gets the maximum value of the State of the Item between two points in time',
+          'riemannSumSince': 'Gets the Riemann sum (integral) of the previous States of the Item since a certain point in time',
+          'riemannSumUntil': 'Gets the Riemann sum (integral) of the future States of the Item until a certain point in time',
+          'riemannSumBetween': 'Gets the Riemann sum (integral) of the States of the Item between two points in time',
           'sumSince': 'Gets the sum of the previous States of the Item since a certain point in time',
           'sumUntil': 'Gets the sum of the future States of the Item until a certain point in time',
           'sumBetween': 'Gets the sum of the States of the Item between two points in time',
@@ -129,12 +133,16 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
 
       let hasSinceField = this.methodName.endsWith('Since') || this.methodName.endsWith('Between') || (this.methodName === 'persistedState')
       let hasUntilField = this.methodName.endsWith('Until') || this.methodName.endsWith('Between')
+      let hasRiemannTypeField = this.methodName.startsWith('riemannSum') || this.methodName.startsWith('average') || this.methodName.startsWith('deviation') || this.methodName.startsWith('variance')
 
       if (this.getInput('dayInfoSince') && !hasSinceField) {
         this.removeInput('dayInfoSince')
       }
       if (this.getInput('dayInfoUntil') && !hasUntilField) {
         this.removeInput('dayInfoUntil')
+      }
+      if (this.getInput('riemannTypeInput') && !hasRiemannTypeField) {
+        this.removeInput('riemannTypeInput')
       }
 
       if (['previousState', 'nextState', 'previousNumericState', 'nextNumericState', 'previousStateTime', 'nextStateTime'].includes(this.methodName)) {
@@ -207,6 +215,19 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
             }
           }
         }
+
+        if (hasRiemannTypeField && !this.getInput('riemannTypeInput')) {
+          this.appendDummyInput('riemannTypeInput')
+            .appendField('using Riemann')
+            .appendField(new Blockly.FieldDropdown([
+              ['left', 'RiemannType.LEFT'],
+              ['right', 'RiemannType.RIGHT'],
+              ['trapezoidal', 'RiemannType.TRAPEZOIDAL'],
+              ['midpoint', 'RiemannType.MIDPOINT']
+            ]), 'riemannType')
+            .appendField('approximation')
+          this.moveInputBefore('riemannTypeInput', 'itemName')
+        }
       }
     },
     returnTypeNames: function () {
@@ -240,6 +261,9 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
         case 'deviationSince':
         case 'deviationUntil':
         case 'deviationBetween':
+        case 'riemannSumSince':
+        case 'riemannSumUntil':
+        case 'riemannSumBetween':
         case 'sumSince':
         case 'sumUntil':
         case 'sumBetween':
@@ -282,9 +306,12 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
     let code = ''
     const dayInfoSince = javascriptGenerator.valueToCode(block, 'dayInfoSince', javascriptGenerator.ORDER_NONE)
     const dayInfoUntil = javascriptGenerator.valueToCode(block, 'dayInfoUntil', javascriptGenerator.ORDER_NONE)
-    const dayInfo = dayInfoSince + ((dayInfoSince && dayInfoUntil) ? ' ,' : '') + dayInfoUntil
+    const dayInfo = dayInfoSince + ((dayInfoSince && dayInfoUntil) ? ', ' : '') + dayInfoUntil
     let skipPrevious = javascriptGenerator.valueToCode(block, 'skipPrevious', javascriptGenerator.ORDER_NONE)
-    skipPrevious = ((skipPrevious === 'undefined') ? false : skipPrevious)
+    skipPrevious = (skipPrevious === 'undefined') ? false : skipPrevious
+
+    let riemannType = block.getFieldValue('riemannType')
+    riemannType = (riemannType === 'undefined') ? '' : (', ' + riemannType)
 
     const persistenceExtension = (persistenceName === '\'default\'') ? '' : `, ${persistenceName}`
 
@@ -332,13 +359,16 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
       case 'deviationSince':
       case 'deviationUntil':
       case 'deviationBetween':
+      case 'riemannSumSince':
+      case 'riemannSumUntil':
+      case 'riemannSumBetween':
       case 'sumSince':
       case 'sumUntil':
       case 'sumBetween':
       case 'varianceSince':
       case 'varianceUntil':
       case 'varianceBetween':
-        code = `${itemCode}.persistence.${methodName}(${dayInfo}${persistenceExtension})?.${returnTypeName}`
+        code = `${itemCode}.persistence.${methodName}(${dayInfo}${riemannType}${persistenceExtension})?.${returnTypeName}`
         break
 
       // Returning JS Array of timestamp and state pairs, whereby PersistedState is mapped to return type (GraalJS) or org.openhab.core.persistence.HistoricItem

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -311,7 +311,7 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
     skipPrevious = (skipPrevious === 'undefined') ? false : skipPrevious
 
     let riemannType = block.getFieldValue('riemannType')
-    riemannType = (riemannType === 'undefined') ? '' : `, ${itemCode}.persistence.${riemannType}`
+    riemannType = (riemannType === 'undefined') ? '' : `, items.${riemannType}`
 
     const persistenceExtension = (persistenceName === '\'default\'') ? '' : `, ${persistenceName}`
 

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -109,19 +109,19 @@
         },
         "ItemPersistence": {
             "averageBetween": {
-              "!doc": "Gets the average value of the state of a given Item between two certain points in time.",
-              "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
+              "!doc": "Gets the average value of the state of a given Item between two points in time.",
+              "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedState|null"
             },
             "averageSince": {
                 "!doc": "Gets the average value of the state of a given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedState|null"
             },
             "averageUntil": {
                 "!doc": "Gets the average value of the state of a given Item until a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedState|null"
             },
             "changedBetween": {
-                "!doc": "Checks if the state of a given Item has changed between two certain points in time.",
+                "!doc": "Checks if the state of a given Item has changed between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
             "changedSince": {
@@ -133,7 +133,7 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
             "countBetween": {
-                "!doc": "Gets the number of available persisted data points of a given Item between two certain points in time.",
+                "!doc": "Gets the number of available persisted data points of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number"
             },
             "countSince": {
@@ -145,7 +145,7 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
             },
             "countStateChangesBetween": {
-                "!doc": "Gets the number of changes in persisted data points of a given Item between two certain points in time.",
+                "!doc": "Gets the number of changes in persisted data points of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number"
             },
             "countStateChangesSince": {
@@ -153,11 +153,11 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
             },
             "countStateChangesUntil": {
-                "!doc": "Gets the number of changes in future data points of a given Item since a certain point in time.",
+                "!doc": "Gets the number of changes in future data points of a given Item until a certain point in time.",
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number"
             },
             "deltaBetween": {
-                "!doc": "Gets the difference value of the state of a given Item between two certain points in time.",
+                "!doc": "Gets the difference value of the state of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
             },
             "deltaSince": {
@@ -169,19 +169,19 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
             },
             "deviationBetween": {
-                "!doc": "Gets the standard deviation of the state of the given Item between two certain points in time.",
-                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
+                "!doc": "Gets the standard deviation of the state of the given Item between two points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedState|null"
             },
             "deviationSince": {
                 "!doc": "Gets the standard deviation of the state of the given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedState|null"
             },
             "deviationUntil": {
                 "!doc": "Gets the standard deviation of the state of the given Item until a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedState|null"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedState|null"
             },
             "evolutionRateBetween": {
-                "!doc": "Gets the evolution rate of the state of a given Item between two certain points in time.",
+                "!doc": "Gets the evolution rate of the state of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "evolutionRateSince": {
@@ -193,7 +193,7 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> number|null"
             },
             "getAllStatesBetween": {
-                "!doc": "Retrieves persisted data for a given Item between two certain points in time.",
+                "!doc": "Retrieves persisted data for a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> [PersistedItem]"
             },
             "getAllStatesSince": {
@@ -221,7 +221,7 @@
               "!type": "fn(serviceId?: string) -> ZonedDateTime|null"
             },
             "maximumBetween": {
-                "!doc": "Gets the maximum value of the persisted states of a given Item between two certain points in time.",
+                "!doc": "Gets the maximum value of the persisted states of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
             },
             "maximumSince": {
@@ -233,7 +233,7 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
             },
             "minimumBetween": {
-                "!doc": "Gets the minimum value of the persisted states of a given Item between two certain points in time.",
+                "!doc": "Gets the minimum value of the persisted states of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem"
             },
             "minimumSince": {
@@ -256,8 +256,20 @@
                 "!doc": "Returns the next state of a given item.",
                 "!type": "fn(skipEqual?: boolean, serviceId?: string) -> PersistedItem"
             },
+            "riemannSumBetween": {
+                "!doc": "Gets the Riemannsum of the state of the given Item between two points in time, time calculated in seconds.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedItem|null"
+            },
+            "riemannSumSince": {
+                "!doc": "Gets the Riemannsum of of the state of the given Item since a certain point in time, time calculated in seconds.",
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedItem|null"
+            },
+            "riemannSumUntil": {
+                "!doc": "Gets the Riemannsum of of the state of the given Item until a certain point in time, time calculated in seconds.",
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedItem|null"
+            },
             "sumBetween": {
-                "!doc": "Gets the sum of the states of a given Item between two certain points in time.",
+                "!doc": "Gets the sum of the states of a given Item between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
             },
             "sumSince": {
@@ -269,7 +281,7 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
             },
             "updatedBetween": {
-                "!doc": "Checks if the state of a given Item has been updated between two certain points in time.",
+                "!doc": "Checks if the state of a given Item has been updated between two points in time.",
                 "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
             "updatedSince": {
@@ -281,16 +293,16 @@
                 "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> boolean"
             },
             "varianceBetween": {
-                "!doc": "Gets the variance of the state of the given Item between two certain points in time.",
-                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
+                "!doc": "Gets the variance of the state of the given Item between two points in time.",
+                "!type": "fn(begin: +Date|+ZonedDateTime, end: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedItem|null"
             },
             "varianceSince": {
                 "!doc": "Gets the variance of the state of the given Item since a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedItem|null"
             },
             "varianceUntil": {
                 "!doc": "Gets the variance of the state of the given Item until a certain point in time.",
-                "!type": "fn(timestamp: +Date|+ZonedDateTime, serviceId?: string) -> PersistedItem|null"
+                "!type": "fn(timestamp: +Date|+ZonedDateTime, riemannType?: RiemannType, serviceId?: string) -> PersistedItem|null"
             }
         },
         "PersistedItem": {

--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -443,6 +443,24 @@
                 "!type": "object"
             }
         },
+        "RiemannType": {
+            "LEFT": {
+                "!doc": "Left riemann sum: takes the persisted value at the start of the bucket to represent the value for the whole bucket",
+                "!type": "string"
+            },
+            "RIGHT": {
+                "!doc": "Right riemann sum: takes the persisted value at the end of the bucket to represent the value for the whole bucket",
+                "!type": "string"
+            },
+            "TRAPEZOIDAL": {
+                "!doc": "Trapezoidal riemann sum: takes the average of the persisted value at the start end the end of the bucket, effectively making a linear interpolation to fit the curve",
+                "!type": "string"
+            },
+            "MIDPOINT": {
+                "!doc": "Midpoint riemann sum: uses 3 persisted values and uses the middle of the values as an approximation for the value halfway in the interval between the middle of point 1 and 2 and the middle of point 2 and 3",
+                "!type": "string"
+            }
+        },
         "ItemsNamespace": {
             "getItem": {
                 "!doc": "Gets an Item.",
@@ -478,6 +496,10 @@
                 "!doc":  "A TimeSeries is used to transport a set of states together with their timestamp.",
                 "!type": "fn(policy: string)",
                 "prototype": "TimeSeries"
+            },
+            "RiemannType": {
+                "!doc": "The type of approximation to use for calculating the Riemann sum.",
+                "!type": "RiemannType"
             },
             "NAME": {
                 "!doc": "Gets an Item using it's name on the items namespace, e.g. items.Hallway_Light",


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-js/pull/401
Depends on https://github.com/openhab/openhab-core/pull/4461

This will also require a new js scripting library release.

This PR extends the Blockly block getting a statistical value from persistence to be aligned with core and js scripting extensions.
The added statistical function is Riemann sum. This is an approximation of the integral value and can e.g. be used to calculate an approximation for energy consumption (in kWh) when the instantanous power (in W) is persisted.
The existing sum method calculates a naive sum, ignoring the time dimension and is not applicable for this. It could be used only if the persistence interval is constant by using the sum and multiplying with the interval duration.

There are multiple types of Riemann sum calculations depending on which value is used as an approximation in each bucket. The ones implemented in core (and js scripting) are: left, right, trapezoidal and midpoint. If the Riemann sum statistical method block is selected in the block, a parameter for this will also be shown, defaulting to left.

As average, variance and deviation statistical methods are based on Riemann sum calculations (the current average calculation assumes Riemann sums of type left), these methods now also have this extra type input parameter (defaulting to left).

Note that in most cases, the trapezoidal (or midpoint) methods would result in better accuracy. However, for backward compatibility reasons, the default has been kept on left.