### PR TITLE
Persistence edit: Support excluding items or groups

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -36,12 +36,12 @@
           </f7-list>
           <f7-list>
             <item-picker :key="'exclude-groups-' + excludeGroupItems.length" title="Select groups" name="excludeGroupItems" multiple="true" filterType="Group"
-                         :value="excludeGroupItems" @input="excludeGroupItems = $event" />
+                         :disabled="!anySelected" :value="excludeGroupItems" @input="excludeGroupItems = $event" />
             <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
           </f7-list>
           <f7-list>
             <item-picker :key="'exclude-items-' + excludeItems.length" title="Select Items" name="excludeItems" multiple="true"
-                         :value="excludeItems" @input="excludeItems = $event" />
+                         :disabled="!anySelected" :value="excludeItems" @input="excludeItems = $event" />
             <f7-list-item>... to be excluded from persistence.</f7-list-item>
           </f7-list>
         </f7-col>
@@ -126,6 +126,11 @@ export default {
       set (newAllItemsSelected) {
         this.$set(this.currentConfiguration, 'items',  itemConfig(newAllItemsSelected, this.groupItems, this.items, this.excludeGroupItems, this.excludeItems))
       }
+    },
+    anySelected: {
+      get () {
+        return this.allItemsSelected || (this.groupItems.length > 0) || (this.items.length > 0)
+      }
     }
   },
   methods: {
@@ -133,7 +138,7 @@ export default {
       return (allItemsSelected ? ['*'] : []).concat(groupItems.map((i) => i + '*')).concat(items).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
     },
     updateModuleConfig () {
-      if (!this.allItemsSelected && this.groupItems.length === 0 && this.items.length === 0) {
+      if (!this.anySelected) {
         this.$f7.dialog.alert('Please select Items')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -130,14 +130,14 @@ export default {
   },
   methods: {
     itemConfig(allItemsSelected, groupItems, items, excludeGroupItems, excludeItems) {
-      return (allItemsSelected ? ['*'] : groupItems.map((i) => i + '*').concat(items)).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
+      return (allItemsSelected ? ['*'] : []).concat(groupItems.map((i) => i + '*')).concat(items).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
     },
     updateModuleConfig () {
-      if (this.currentConfiguration.items.length === 0) {
+      if (!this.allItemsSelected && this.groupItems.length === 0 && this.items.length === 0) {
         this.$f7.dialog.alert('Please select Items')
         return
       }
-      this.$f7.emit('configurationUpdate', this.currentConfiguration)
+      this.$f7.emit('configurationUpdate', itemConfig(this.allItemsSelected, this.allItemsSelected ? [] : this.groupItems, this.allItemsSelected ? [] : this.items, this.excludeGroupItems, this.excludeItems))
       this.$refs.modulePopup.close()
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -124,7 +124,7 @@ export default {
         return this.currentConfiguration.items.filter((i) => i === '*').length > 0
       },
       set (newAllItemsSelected) {
-        this.$set(this.currentConfiguration, 'items',  this.itemConfig(newAllItemsSelected, this.groupItems, this.items, this.excludeGroupItems, this.excludeItems))
+        this.$set(this.currentConfiguration, 'items', this.itemConfig(newAllItemsSelected, this.groupItems, this.items, this.excludeGroupItems, this.excludeItems))
       }
     },
     anySelected: {
@@ -134,7 +134,7 @@ export default {
     }
   },
   methods: {
-    itemConfig(allItemsSelected, groupItems, items, excludeGroupItems, excludeItems) {
+    itemConfig (allItemsSelected, groupItems, items, excludeGroupItems, excludeItems) {
       return (allItemsSelected ? ['*'] : []).concat(groupItems.map((i) => i + '*')).concat(items).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
     },
     updateModuleConfig () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -89,7 +89,7 @@ export default {
   computed: {
     groupItems: {
       get () {
-        return this.allItemsSelected ? [] : this.currentConfiguration.items.filter((i) => i.length > 1 && !i.startsWith('!') && i.endsWith('*')).map((i) => i.slice(0, -1))
+        return this.currentConfiguration.items.filter((i) => i.length > 1 && !i.startsWith('!') && i.endsWith('*')).map((i) => i.slice(0, -1))
       },
       set (newGroupItems) {
         this.$set(this.currentConfiguration, 'items', itemConfig(this.allItemsSelected, newGroupItems.sort((a, b) => a.localeCompare(b)), this.items, this.excludeGroupItems, this.excludeItems))
@@ -97,7 +97,7 @@ export default {
     },
     items: {
       get () {
-        return this.allItemsSelected ? [] : this.currentConfiguration.items.filter((i) => !i.startsWith('!') && !i.endsWith('*'))
+        return this.currentConfiguration.items.filter((i) => !i.startsWith('!') && !i.endsWith('*'))
       },
       set (newItems) {
         this.$set(this.currentConfiguration, 'items', itemConfig(this.allItemsSelected, this.groupItems, newItems.sort((a, b) => a.localeCompare(b)), this.excludeGroupItems, this.excludeItems))
@@ -130,7 +130,7 @@ export default {
   },
   methods: {
     itemConfig(allItemsSelected, groupItems, items, excludeGroupItems, excludeItems) {
-      return (allItemsSelected ? ['*'] : []).concat(groupItems.map((i) => i + '*')).concat(items).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
+      return (allItemsSelected ? ['*'] : groupItems.map((i) => i + '*').concat(items)).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
     },
     updateModuleConfig () {
       if (this.currentConfiguration.items.length === 0) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -35,12 +35,12 @@
             <f7-list-item>... to be persisted.</f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker :key="'exclude-groups-' + excludeGroupItems.length" title="Select groups" name="excludeGroupItems" multiple="true" filterType="Group"
+            <item-picker :key="'exclude-groups-' + excludeGroupItems.length" title="Select exclude groups" name="excludeGroupItems" multiple="true" filterType="Group"
                          :disabled="!anySelected" :value="excludeGroupItems" @input="excludeGroupItems = $event" />
             <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker :key="'exclude-items-' + excludeItems.length" title="Select Items" name="excludeItems" multiple="true"
+            <item-picker :key="'exclude-items-' + excludeItems.length" title="Select exclude Items" name="excludeItems" multiple="true"
                          :disabled="!anySelected" :value="excludeItems" @input="excludeItems = $event" />
             <f7-list-item>... to be excluded from persistence.</f7-list-item>
           </f7-list>
@@ -92,7 +92,7 @@ export default {
         return this.currentConfiguration.items.filter((i) => i.length > 1 && !i.startsWith('!') && i.endsWith('*')).map((i) => i.slice(0, -1))
       },
       set (newGroupItems) {
-        this.$set(this.currentConfiguration, 'items', itemConfig(this.allItemsSelected, newGroupItems.sort((a, b) => a.localeCompare(b)), this.items, this.excludeGroupItems, this.excludeItems))
+        this.$set(this.currentConfiguration, 'items', this.itemConfig(this.allItemsSelected, newGroupItems.sort((a, b) => a.localeCompare(b)), this.items, this.excludeGroupItems, this.excludeItems))
       }
     },
     items: {
@@ -100,7 +100,7 @@ export default {
         return this.currentConfiguration.items.filter((i) => !i.startsWith('!') && !i.endsWith('*'))
       },
       set (newItems) {
-        this.$set(this.currentConfiguration, 'items', itemConfig(this.allItemsSelected, this.groupItems, newItems.sort((a, b) => a.localeCompare(b)), this.excludeGroupItems, this.excludeItems))
+        this.$set(this.currentConfiguration, 'items', this.itemConfig(this.allItemsSelected, this.groupItems, newItems.sort((a, b) => a.localeCompare(b)), this.excludeGroupItems, this.excludeItems))
       }
     },
     excludeGroupItems: {
@@ -108,7 +108,7 @@ export default {
         return this.currentConfiguration.items.filter((i) => i.startsWith('!') && i.endsWith('*')).map((i) => i.slice(1, -1))
       },
       set (newExcludeGroupItems) {
-        this.$set(this.currentConfiguration, 'items', itemConfig(this.allItemsSelected, this.groupItems, this.items, newExcludeGroupItems.sort((a, b) => a.localeCompare(b)), this.excludeItems))
+        this.$set(this.currentConfiguration, 'items', this.itemConfig(this.allItemsSelected, this.groupItems, this.items, newExcludeGroupItems.sort((a, b) => a.localeCompare(b)), this.excludeItems))
       }
     },
     excludeItems: {
@@ -116,7 +116,7 @@ export default {
         return this.currentConfiguration.items.filter((i) => i.startsWith('!') && !i.endsWith('*')).map((i) => i.slice(1))
       },
       set (newExcludeItems) {
-        this.$set(this.currentConfiguration, 'items', itemConfig(this.allItemsSelected, this.groupItems, this.items, this.excludeGroupItems, newExcludeItems.sort((a, b) => a.localeCompare(b))))
+        this.$set(this.currentConfiguration, 'items', this.itemConfig(this.allItemsSelected, this.groupItems, this.items, this.excludeGroupItems, newExcludeItems.sort((a, b) => a.localeCompare(b))))
       }
     },
     allItemsSelected: {
@@ -124,7 +124,7 @@ export default {
         return this.currentConfiguration.items.filter((i) => i === '*').length > 0
       },
       set (newAllItemsSelected) {
-        this.$set(this.currentConfiguration, 'items',  itemConfig(newAllItemsSelected, this.groupItems, this.items, this.excludeGroupItems, this.excludeItems))
+        this.$set(this.currentConfiguration, 'items',  this.itemConfig(newAllItemsSelected, this.groupItems, this.items, this.excludeGroupItems, this.excludeItems))
       }
     },
     anySelected: {
@@ -142,7 +142,8 @@ export default {
         this.$f7.dialog.alert('Please select Items')
         return
       }
-      this.$f7.emit('configurationUpdate', itemConfig(this.allItemsSelected, this.allItemsSelected ? [] : this.groupItems, this.allItemsSelected ? [] : this.items, this.excludeGroupItems, this.excludeItems))
+      this.$set(this.currentConfiguration, 'items', this.itemConfig(this.allItemsSelected, this.allItemsSelected ? [] : this.groupItems, this.allItemsSelected ? [] : this.items, this.excludeGroupItems, this.excludeItems))
+      this.$f7.emit('configurationUpdate', this.currentConfiguration)
       this.$refs.modulePopup.close()
     }
   }


### PR DESCRIPTION
Ability to exclude items or groups from persistence configurations.

Requires https://github.com/openhab/openhab-core/pull/4468