### PR TITLE
Allow custom css UI file

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -632,6 +632,15 @@ export default {
       this.updateThemeOptions()
       this.$f7.data.themeOptions = this.themeOptions
 
+      fetch('/static/theme.css').then(resp => {
+        if (resp.ok) {
+          const themeLink = document.createElement('link')
+          themeLink.rel = 'stylesheet'
+          themeLink.href = '/static/theme.css'
+          document.head.appendChild(themeLink)
+        }
+      })
+
       if (!this.user) {
         this.tryExchangeAuthorizationCode().then((user) => {
           this.loggedIn = true


### PR DESCRIPTION
This PR checks for a `theme.css` file served from, OH_CONF/html. If that file exits it links it to the MainUI page after f7 css calculations have been made so that user directives are not over-riden by any f7 settings.

The ability to set MainUI site-wide css has come up several times in forum questions and requests. I think I remember at some point @ghys had some hesitancy with regards to enabling a site-wide css file like this, but I don't remember what the objection was and I can't find where I thought this comes from anymore so I may be misremembering. Either way, this small change just enables an advanced user to create a single css file.

However, if this starts to get a lot of use, I can see refactoring many of the current styles to use a series of `--oh-` specific css variables which would allow for easy creation and sharing of different MainUI themes (something that has just come up again in the most recent wishlist thread on the forums).