### PR TITLE
Sitemap editor: Add drag & drop

### DIFF
--- a/bundles/org.openhab.ui/web/.vscode/settings.json
+++ b/bundles/org.openhab.ui/web/.vscode/settings.json
@@ -3,7 +3,7 @@
   "vetur.format.defaultFormatter.html": "js-beautify-html",
   "javascript.format.insertSpaceBeforeFunctionParenthesis": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": false
+    "source.fixAll.eslint": "never"
   },
   "eslint.validate": ["vue", "html", "javascript"]
 }

--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -62,6 +62,7 @@
         "vue-qrcode": "^0.3.5",
         "vue-round-slider": "^1.0.1",
         "vue2-leaflet": "^2.7.1",
+        "vuedraggable": "^2.24.3",
         "vuetrend": "^0.3.4",
         "vuex": "^3.6.2",
         "yaml": "^2.5.0"
@@ -21469,6 +21470,21 @@
         "vue": "^2.5.17"
       }
     },
+    "node_modules/vuedraggable": {
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+      "license": "MIT",
+      "dependencies": {
+        "sortablejs": "1.10.2"
+      }
+    },
+    "node_modules/vuedraggable/node_modules/sortablejs": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+      "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A==",
+      "license": "MIT"
+    },
     "node_modules/vuetrend": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/vuetrend/-/vuetrend-0.3.4.tgz",
@@ -37911,6 +37927,21 @@
       "resolved": "https://registry.npmjs.org/vue2-leaflet/-/vue2-leaflet-2.7.1.tgz",
       "integrity": "sha512-K7HOlzRhjt3Z7+IvTqEavIBRbmCwSZSCVUlz9u4Rc+3xGCLsHKz4TAL4diAmfHElCQdPPVdZdJk8wPUt2fu6WQ==",
       "requires": {}
+    },
+    "vuedraggable": {
+      "version": "2.24.3",
+      "resolved": "https://registry.npmjs.org/vuedraggable/-/vuedraggable-2.24.3.tgz",
+      "integrity": "sha512-6/HDXi92GzB+Hcs9fC6PAAozK1RLt1ewPTLjK0anTYguXLAeySDmcnqE8IC0xa7shvSzRjQXq3/+dsZ7ETGF3g==",
+      "requires": {
+        "sortablejs": "1.10.2"
+      },
+      "dependencies": {
+        "sortablejs": {
+          "version": "1.10.2",
+          "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.10.2.tgz",
+          "integrity": "sha512-YkPGufevysvfwn5rfdlGyrGjt7/CRHwvRPogD/lC+TnvcN29jDpCifKP+rBqf+LRldfXSTh+0CGLcSg0VIxq3A=="
+        }
+      }
     },
     "vuetrend": {
       "version": "0.3.4",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -103,6 +103,7 @@
     "vue-qrcode": "^0.3.5",
     "vue-round-slider": "^1.0.1",
     "vue2-leaflet": "^2.7.1",
+    "vuedraggable": "^2.24.3",
     "vuetrend": "^0.3.4",
     "vuex": "^3.6.2",
     "yaml": "^2.5.0"

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -53,7 +53,7 @@ function writeWidget (widget, indent) {
       }
     }
   }
-  if (widget.slots) {
+  if (widget.slots?.widgets?.length) {
     dsl += ' {\n'
     widget.slots.widgets.forEach((w) => {
       dsl += writeWidget(w, indent + 4)

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-code.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-code.vue
@@ -79,7 +79,6 @@ export default {
         const parser = new Parser(Grammar.fromCompiled(grammar))
         parser.feed(this.sitemapDsl.trim().replace(/\t/g, ' '))
         if (!parser.results.length) return { error: 'Unable to parse, check your input' }
-        // return parser.results[0].map((i) => i.name).join('\n')
         return parser.results[0]
       } catch (e) {
         return { error: e }

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
@@ -84,8 +84,7 @@ export default {
       // Linkable widget types only contain frames or none at all
       if (this.LINKABLE_WIDGET_TYPES.includes(parentWidget.component)) {
         if (parentWidget.slots?.widgets?.length > 0) {
-          const widgetList = parentWidget.slots.widgets.map((w) => ({ ...w }))
-          if (excludeWidgetIndex !== null) widgetList.splice(excludeWidgetIndex, 1)
+          const widgetList = parentWidget.slots.widgets.filter((widget, index) => index !== excludeWidgetIndex)
           if (widgetList.find(w => w.component === 'Frame')) {
             return types.filter(t => t.type === 'Frame')
           } else {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
@@ -74,6 +74,27 @@ export default {
     }
   },
   methods: {
+    allowedWidgetTypes (parentWidget, excludeWidgetIndex) {
+      let types = this.WIDGET_TYPES.filter(w => w.type !== 'Sitemap')
+      // Button only allowed inside Buttongrid
+      if (parentWidget.component === 'Buttongrid') return types.filter(t => t.type === 'Button')
+      types = types.filter(t => t.type !== 'Button')
+      // No frames in frame
+      if (parentWidget.component === 'Frame') return types.filter(t => t.type !== 'Frame')
+      // Linkable widget types only contain frames or none at all
+      if (this.LINKABLE_WIDGET_TYPES.includes(parentWidget.component)) {
+        if (parentWidget.slots?.widgets?.length > 0) {
+          const widgetList = parentWidget.slots.widgets.map((w) => ({...w}))
+          if (excludeWidgetIndex !== null) widgetList.splice(excludeWidgetIndex, 1)
+          if (widgetList.find(w => w.component === 'Frame')) {
+            return types.filter(t => t.type === 'Frame')
+          } else {
+            return types.filter(t => t.type !== 'Frame')
+          }
+        }
+      }
+      return types
+    },
     widgetTypeDef (component) {
       const componentType = component ?? this.widget.component
       return this.WIDGET_TYPES.find(w => w.type === componentType)

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
@@ -84,7 +84,7 @@ export default {
       // Linkable widget types only contain frames or none at all
       if (this.LINKABLE_WIDGET_TYPES.includes(parentWidget.component)) {
         if (parentWidget.slots?.widgets?.length > 0) {
-          const widgetList = parentWidget.slots.widgets.map((w) => ({...w}))
+          const widgetList = parentWidget.slots.widgets.map((w) => ({ ...w }))
           if (excludeWidgetIndex !== null) widgetList.splice(excludeWidgetIndex, 1)
           if (widgetList.find(w => w.component === 'Frame')) {
             return types.filter(t => t.type === 'Frame')

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -66,15 +66,12 @@ export default {
     },
     onStart (event) {
       console.debug('Drag start event:', event)
-      this.$set(this.localMoveState, 'widget', null)
+      this.$set(this.localMoveState, 'widget', this.widget.slots.widgets[event.oldIndex])
       this.$set(this.localMoveState, 'oldList', this.widget.slots.widgets)
       this.$set(this.localMoveState, 'oldIndex', event.oldIndex)
     },
     onChange (event) {
       console.debug('Drag change event:', event)
-      if (!this.localMoveState.widget) {
-        this.$set(this.localMoveState, 'widget', event.added?.element || event.moved?.element || event.removed?.element)
-      }
       if (event.added) {
         this.validateMove(event.added.newIndex)
       }

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -37,7 +37,7 @@
 
 <script>
 import SitemapMixin from '@/components/pagedesigner/sitemap/sitemap-mixin'
-import draggable from 'vuedraggable'
+import Draggable from 'vuedraggable'
 import fastDeepEqual from 'fast-deep-equal/es6'
 
 export default {
@@ -45,7 +45,7 @@ export default {
   mixins: [SitemapMixin],
   props: ['includeItemName', 'widget', 'parentWidget', 'itemsList', 'selected', 'sitemap', 'moveState'],
   components: {
-    draggable,
+    Draggable,
     SitemapTreeviewItem: 'sitemap-treeview-item'
   },
   data () {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -4,14 +4,21 @@
                     :textColor="iconColor" :color="'blue'"
                     :selected="selected && selected === widget"
                     :opened="!widget.closed"
+                    @treeview:open="setWidgetClosed(false)"
+                    @treeview:close="setWidgetClosed(true)"
                     @click="select">
-    <sitemap-treeview-item class="sitemap-treeview-item" v-for="(childwidget, idx) in children"
-                           :key="idx"
-                           :includeItemName="includeItemName"
-                           :widget="childwidget" :parent-widget="widget"
-                           :itemsList="items"
-                           @selected="(event) => $emit('selected', event)"
-                           :selected="selected" />
+    <draggable v-if="canHaveChildren" :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6"
+               @start="onStart" @change="onChange" @end="onEnd">
+      <sitemap-treeview-item class="sitemap-treeview-item" v-for="(childwidget, idx) in children"
+                            :key="idx"
+                            :includeItemName="includeItemName"
+                            :widget="childwidget" :parentWidget="widget"
+                            :itemsList="items"
+                            @selected="(event) => $emit('selected', event)"
+                            :selected="selected"
+                            :sitemap="localSitemap"
+                            :moveState="localMoveState" />
+    </draggable>
     <div slot="label" class="subtitle">
       {{ subtitle() }}
     </div>
@@ -30,13 +37,22 @@
 
 <script>
 import SitemapMixin from '@/components/pagedesigner/sitemap/sitemap-mixin'
+import draggable from 'vuedraggable'
+import fastDeepEqual from 'fast-deep-equal/es6'
 
 export default {
   name: 'sitemap-treeview-item',
   mixins: [SitemapMixin],
-  props: ['includeItemName', 'widget', 'parentWidget', 'itemsList', 'selected'],
+  props: ['includeItemName', 'widget', 'parentWidget', 'itemsList', 'selected', 'sitemap', 'moveState'],
   components: {
+    draggable,
     SitemapTreeviewItem: 'sitemap-treeview-item'
+  },
+  data () {
+    return {
+      localSitemap: this.sitemap ? this.sitemap : this.widget,
+      localMoveState: this.moveState ? this.moveState : {}
+    }
   },
   methods: {
     subtitle () {
@@ -47,6 +63,61 @@ export default {
       let $ = self.$$
       if ($(event.target).is('.treeview-toggle')) return
       this.$emit('selected', [this.widget, this.parentWidget])
+    },
+    onStart (event) {
+      console.debug('Drag start event:', event)
+      this.$set(this.localMoveState, 'widget', null)
+      this.$set(this.localMoveState, 'oldList', this.widget.slots.widgets)
+      this.$set(this.localMoveState, 'oldIndex', event.oldIndex)
+      this.$nextTick()
+    },
+    onChange (event) {
+      console.debug('Drag change event:', event)
+      if (!this.localMoveState.widget) {
+        this.$set(this.localMoveState, 'widget', event.added?.element || event.moved?.element || event.removed?.element)
+        this.$nextTick()
+      }
+      if (event.added) {
+        this.validateMove(event.added.newIndex)
+      }
+    },
+    onEnd (event) {
+      console.debug('Drag end event:', event)
+      this.validateMove(event.newIndex)
+    },
+    validateMove (newIndex) {
+      const widget = this.localMoveState.widget
+      const parentWidget = this.findParent(widget, this.localSitemap)
+      const newList = parentWidget.slots.widgets
+      console.log('New parent:', parentWidget.config.label)
+      if (!this.allowedWidgetTypes(parentWidget, newIndex).map(wt => wt.type).includes(widget.component)) {
+        this.$f7.toast.create({
+          text: 'Move invalid',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        console.debug('Move invalid, restore in original position:', this.localMoveState)
+        newList.splice(newIndex, 1)
+        this.localMoveState.oldList.splice(this.localMoveState.oldIndex, 0, widget)
+      } else {
+        console.debug('Move valid')
+      }
+    },
+    findParent(widget, parentWidget) {
+      if (parentWidget.slots?.widgets) {
+        for (const w of parentWidget.slots.widgets) {
+          if (fastDeepEqual(widget, w)) {
+            return parentWidget
+          } else {
+            parent = this.findParent(widget, w)
+            if (parent != null) return parent
+          }
+        }
+      }
+      return null
+    },
+    setWidgetClosed (closed) {
+      this.$set(this.widget, 'closed', closed)
     }
   },
   computed: {
@@ -54,8 +125,10 @@ export default {
       return ''
     },
     children () {
-      if (!this.widget.slots || !this.widget.slots.widgets) return []
-      return this.widget.slots.widgets
+      return this.widget.slots?.widgets || []
+    },
+    canHaveChildren () {
+      return this.LINKABLE_WIDGET_TYPES.includes(this.widget.component)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -10,14 +10,14 @@
     <draggable v-if="canHaveChildren" :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6"
                @start="onStart" @change="onChange" @end="onEnd">
       <sitemap-treeview-item class="sitemap-treeview-item" v-for="(childwidget, idx) in children"
-                            :key="idx"
-                            :includeItemName="includeItemName"
-                            :widget="childwidget" :parentWidget="widget"
-                            :itemsList="items"
-                            @selected="(event) => $emit('selected', event)"
-                            :selected="selected"
-                            :sitemap="localSitemap"
-                            :moveState="localMoveState" />
+                             :key="idx"
+                             :includeItemName="includeItemName"
+                             :widget="childwidget" :parentWidget="widget"
+                             :itemsList="items"
+                             @selected="(event) => $emit('selected', event)"
+                             :selected="selected"
+                             :sitemap="localSitemap"
+                             :moveState="localMoveState" />
     </draggable>
     <div slot="label" class="subtitle">
       {{ subtitle() }}
@@ -69,13 +69,11 @@ export default {
       this.$set(this.localMoveState, 'widget', null)
       this.$set(this.localMoveState, 'oldList', this.widget.slots.widgets)
       this.$set(this.localMoveState, 'oldIndex', event.oldIndex)
-      this.$nextTick()
     },
     onChange (event) {
       console.debug('Drag change event:', event)
       if (!this.localMoveState.widget) {
         this.$set(this.localMoveState, 'widget', event.added?.element || event.moved?.element || event.removed?.element)
-        this.$nextTick()
       }
       if (event.added) {
         this.validateMove(event.added.newIndex)
@@ -103,13 +101,13 @@ export default {
         console.debug('Move valid')
       }
     },
-    findParent(widget, parentWidget) {
+    findParent (widget, parentWidget) {
       if (parentWidget.slots?.widgets) {
         for (const w of parentWidget.slots.widgets) {
           if (fastDeepEqual(widget, w)) {
             return parentWidget
           } else {
-            parent = this.findParent(widget, w)
+            const parent = this.findParent(widget, w)
             if (parent != null) return parent
           }
         }

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -84,7 +84,7 @@ export default {
       const widget = this.localMoveState.widget
       const parentWidget = this.findParent(widget, this.localSitemap)
       const newList = parentWidget.slots.widgets
-      console.log('New parent:', parentWidget.config.label)
+      console.debug('New parent:', parentWidget)
       if (!this.allowedWidgetTypes(parentWidget, newIndex).map(wt => wt.type).includes(widget.component)) {
         this.$f7.toast.create({
           text: 'Move invalid',

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -38,7 +38,7 @@
             <f7-col>
               <f7-block strong class="sitemap-tree" no-gap @click.native="clearSelection">
                 <f7-treeview>
-                  <sitemap-treeview-item :widget="sitemap" :includeItemName="includeItemName" :itemsList="items" @selected="selectWidget" :selected="selectedWidget" />
+                  <sitemap-treeview-item :widget="sitemap" :includeItemName="includeItemName" :itemsList="items" @selected="selectWidget" :selected="selectedWidget"/>
                 </f7-treeview>
               </f7-block>
             </f7-col>
@@ -338,23 +338,7 @@ export default {
     },
     addableWidgetTypes () {
       if (!this.selectedWidget) return
-      let types = this.WIDGET_TYPES.filter(w => w.type !== 'Sitemap')
-      // Button only allowed inside Buttongrid
-      if (this.selectedWidget.component === 'Buttongrid') return types.filter(w => w.type === 'Button')
-      types = types.filter(w => w.type !== 'Button')
-      // No frames in frame
-      if (this.selectedWidget.component === 'Frame') return types.filter(w => w.type !== 'Frame')
-      // Linkable widget types only contain frames or none at all
-      if (this.LINKABLE_WIDGET_TYPES.includes(this.selectedWidget.component)) {
-        if (this.selectedWidget.slots?.widgets?.length > 0) {
-          if (this.selectedWidget.slots.widgets.find(w => w.component === 'Frame')) {
-            return types.filter(w => w.type === 'Frame')
-          } else {
-            return types.filter(w => w.type !== 'Frame')
-          }
-        }
-      }
-      return types
+      return this.allowedWidgetTypes (this.selectedWidget)
     }
   },
   watch: {
@@ -654,6 +638,7 @@ export default {
       if (widget.component === 'Buttongrid') {
         widget.slots?.widgets?.sort((button1, button2) => ((button1.config?.row ?? 0) - (button2.config?.row ?? 0)) || ((button1.config?.column ?? 0) - (button2.config?.column ?? 0)))
       }
+      this.addEmptySlot(widget)
       widget.slots?.widgets?.forEach(this.cleanConfig)
     },
     preProcessSitemapLoad (sitemap) {
@@ -679,7 +664,19 @@ export default {
           }
         }
       }
+      this.addEmptySlot(widget)
       widget.slots?.widgets?.forEach(this.preProcessWidgetLoad)
+    },
+    addEmptySlot (widget) {
+      // Needed for drag and drop to work into empty slot
+      if (this.LINKABLE_WIDGET_TYPES.includes(widget.component)) {
+        if (!widget.slots) {
+          widget.slots = {}
+        }
+        if (!widget.slots.widgets) {
+          widget.slots.widgets = []
+        }
+      }
     },
     preProcessSitemapSave (sitemap) {
       const processed = JSON.parse(JSON.stringify(sitemap))

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -38,7 +38,7 @@
             <f7-col>
               <f7-block strong class="sitemap-tree" no-gap @click.native="clearSelection">
                 <f7-treeview>
-                  <sitemap-treeview-item :widget="sitemap" :includeItemName="includeItemName" :itemsList="items" @selected="selectWidget" :selected="selectedWidget"/>
+                  <sitemap-treeview-item :widget="sitemap" :includeItemName="includeItemName" :itemsList="items" @selected="selectWidget" :selected="selectedWidget" />
                 </f7-treeview>
               </f7-block>
             </f7-col>
@@ -338,7 +338,7 @@ export default {
     },
     addableWidgetTypes () {
       if (!this.selectedWidget) return
-      return this.allowedWidgetTypes (this.selectedWidget)
+      return this.allowedWidgetTypes(this.selectedWidget)
     }
   },
   watch: {


### PR DESCRIPTION
This PR implements drag and drop in the sitemap tree, to make it easier to graphically rearange sitemaps. To achieve this, I have included [Vue.Draggable](https://github.com/SortableJS/Vue.Draggable), by itself based on SortableJS.

Implementing this for the sitemap editor is only a first step. I think it should be possible to also use this library to implement drag and drop in the model tree, making it a lot easier to reconfigure the model tree. The level of complexity there is higher, so I started with trying it on the sitemap tree.

This PR obviously adds another dependency. Let me know if you believe it is worth the added size before I continue on this.

Here is how it looks like:
![SitemapDragAndDrop](https://github.com/user-attachments/assets/a36386f2-b7d0-45de-a324-6749eedfe58b)

This will also require further testing on different browsers and mobile.