### PR TITLE
[MainUI] Do not reload inbox for inboxupdatedevents

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -376,8 +376,10 @@ export default {
     startEventSource () {
       this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/things/*/added,openhab/things/*/removed,openhab/things/*/updated,openhab/things/*/status,openhab/inbox/*', null, (event) => {
         const topicParts = event.topic.split('/')
-        if (topicParts[1] === 'inbox' && event.type !== 'InboxUpdatedEvent') {
-          this.loadInbox()
+        if (topicParts[1] === 'inbox') {
+          if(event.type !== 'InboxUpdatedEvent') {
+            this.loadInbox()
+          }
         } else {
           switch (topicParts[3]) {
             case 'status':

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -376,7 +376,7 @@ export default {
     startEventSource () {
       this.eventSource = this.$oh.sse.connect('/rest/events?topics=openhab/things/*/added,openhab/things/*/removed,openhab/things/*/updated,openhab/things/*/status,openhab/inbox/*', null, (event) => {
         const topicParts = event.topic.split('/')
-        if (topicParts[1] === 'inbox') {
+        if (topicParts[1] === 'inbox' && event.type !== 'InboxUpdatedEvent') {
           this.loadInbox()
         } else {
           switch (topicParts[3]) {


### PR DESCRIPTION
See https://github.com/openhab/openhab-webui/issues/2395

Skip inboxupdatedevents as they do not change the inbox count (which is the only information actually used after loading this potentially very large structure of data)