### PR TITLE
CODEOWNERS: Add Blockly maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,3 +11,7 @@
 /bundles/org.openhab.ui.cometvisu/ @peuter
 /bundles/org.openhab.ui.habot/ @ghys
 /bundles/org.openhab.ui.habpanel/ @ghys
+
+# Blockly maintainers:
+/bundles/org.openhab.ui/web/src/assets/definitions/blockly/ @stefan-hoehn @ghys @florian-h05
+/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue @stefan-hoehn @ghys @florian-h05


### PR DESCRIPTION
Add @stefan-hoehn as Blockly CODEOWNER so he is automatically requested for review in his role as Blockly maintainer.