### PR TITLE
`oh-clock-card`: Remove (broken) background property in favour of style config

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-clock-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-clock-card.md
@@ -70,11 +70,6 @@ Display a digital clock in a card
     <PropOption value="HH:mm:ss" label="Current time ('HH:mm:ss')" />
   </PropOptions>
 </PropBlock>
-<PropBlock type="TEXT" name="background" label="Background style">
-  <PropDescription>
-    Background style (in CSS "background" attribute format)
-  </PropDescription>
-</PropBlock>
 <PropBlock type="TEXT" name="timeFontSize" label="Time Font Size">
   <PropDescription>
     Time font size (e.g. "34px")

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
@@ -143,7 +143,6 @@ export const OhClockCardDefinition = () => new WidgetDefinition('oh-clock-card',
       { value: 'LT', label: 'Localized time (\'LT\'. e.g. \'8:02 PM\')' },
       { value: 'HH:mm:ss', label: 'Current time (\'HH:mm:ss\')' }
     ], false),
-    pt('background', 'Background style', 'Background style (in CSS "background" attribute format)'),
     pt('timeFontSize', 'Time Font Size', 'Time font size (e.g. "34px")'),
     pt('timeFontWeight', 'Time Font Weight', 'Time font weight (e.g. "normal" or "bold")'),
     pb('showDate', 'Show the date', 'Show the current date in addition to the time'),


### PR DESCRIPTION
This avoids confusion because `background` is not working anymore.
Use `style: background: ` instead.