### PR TITLE
Fix profile selection when linking a channel to an item

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -182,9 +182,12 @@ export default {
     },
     compatibleProfileTypes () {
       let currentItemType = this.currentItem && this.currentItem.type ? this.currentItem.type : ''
-      return this.profileTypes
-        .filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
-        .filter(p => this.isNumberChannelButNoNumberItem && (p.uid !== 'system:default' && p.uid !== 'system:follow'))
+
+      if (this.isNumberChannelButNoNumberItem) {
+        return this.profileTypes.filter(p => p.uid !== 'system:default' && p.uid !== 'system:follow')
+      }
+
+      return this.profileTypes.filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
     },
     isNumberChannelButNoNumberItem () {
       if (!this.channel || !this.channel.itemType) return false


### PR DESCRIPTION
Regression from #2690

Reported here:
https://community.openhab.org/t/enocean-impossible-to-link-a-rockerswitch-channel-with-an-item-in-main-ui-there-is-no-profile-available-for-the-selected-item/160987

When creating a Thing channel link to an item, the profile selection are disabled. This presents two problems:

- It made linking a trigger channel to an item not possible, because a profile must be selected, but they're disabled.
- Linking a non-trigger channel to a new item is possible, but selecting a profile is not possible at link creation. The user has to create the link without a profile first, then go back to edit the link in order to assign a profile.

This PR fixes both these problems.

Note this needs to be backported to 4.3.x