### PR TITLE
Link add/edit: Fix profile selection

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -83,7 +83,7 @@
         </f7-block-footer>
         <f7-list class="profile-list">
           <f7-list-item radio v-for="profileType in profileTypes" class="profile-item"
-                        :checked="(!currentProfileType && profileType.uid === 'system:default' && !itemTypeNotChannelType) || (currentProfileType && profileType.uid === currentProfileType.uid)"
+                        :checked="(!currentProfileType && profileType.uid === 'system:default' && !itemTypeIsNotChannelType(channel, currentItem)) || (currentProfileType && profileType.uid === currentProfileType.uid)"
                         :disabled="!compatibleProfileTypes.includes(profileType)"
                         :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
                         @change="onProfileTypeChange(profileType.uid)"
@@ -131,11 +131,11 @@ import Item from '@/components/item/item.vue'
 
 import * as Types from '@/assets/item-types.js'
 import ItemMixin from '@/components/item/item-mixin'
-
 import uomMixin from '@/components/item/uom-mixin'
+import LinkMixin from '@/pages/settings/things/link/link-mixin'
 
 export default {
-  mixins: [ItemMixin, uomMixin],
+  mixins: [ItemMixin, uomMixin, LinkMixin],
   components: {
     ConfigSheet,
     ItemPicker,
@@ -181,21 +181,7 @@ export default {
       return this.item ? this.item : (this.createMode ? this.newItem : (this.items ? this.items.find(item => item.name === this.selectedItemName) : null))
     },
     compatibleProfileTypes () {
-      let currentItemType = this.currentItem && this.currentItem.type ? this.currentItem.type : ''
-      let profileTypes = this.profileTypes
-        .filter(p => !p.supportedItemTypes || p.supportedItemTypes.length === 0 || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
-      if (this.itemTypeNotChannelType) {
-        profileTypes = profileTypes.filter(p => p.uid !== 'system:default' && p.uid !== 'system:follow')
-      }
-      return profileTypes
-    },
-    itemTypeNotChannelType () {
-      if (!this.channel || !this.channel.itemType) return false
-      if (!this.currentItem || !this.currentItem.type) return false
-      if (this.channel.itemType.startsWith('Number')) {
-        return !this.currentItem.type.startsWith('Number')
-      }
-      return this.channel.itemType !== this.currentItem.type
+      return this.profileTypes.filter(p => this.isProfileTypeCompatible(this.channel, p, this.currentItem))
     }
   },
   methods: {
@@ -226,8 +212,7 @@ export default {
     loadProfileTypes (channel) {
       this.ready = false
       this.selectedChannel = channel
-      const getProfileTypes = this.$oh.api.get('/rest/profile-types?channelTypeUID=' + channel.channelTypeUID)
-      getProfileTypes.then((data) => {
+      this.$oh.api.get('/rest/profile-types?channelTypeUID=' + channel.channelTypeUID).then((data) => {
         this.profileTypes = data
         this.profileTypes.unshift(data.splice(data.findIndex(p => p.uid === 'system:default'), 1)[0]) // move default to be first
         this.ready = true
@@ -310,7 +295,7 @@ export default {
           return
         }
       }
-      if (this.itemTypeNotChannelType && (!this.currentProfileType || !this.compatibleProfileTypes.includes(this.currentProfileType))) {
+      if (this.itemTypeIsNotChannelType(this.channel, this.currentItem) && (!this.currentProfileType || !this.compatibleProfileTypes.includes(this.currentProfileType))) {
         this.$f7.dialog.alert('Please configure a valid profile')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -83,7 +83,7 @@
         </f7-block-footer>
         <f7-list class="profile-list">
           <f7-list-item radio v-for="profileType in profileTypes" class="profile-item"
-                        :checked="(!currentProfileType && profileType.uid === 'system:default' && !itemTypeIsNotChannelType(channel, currentItem)) || (currentProfileType && profileType.uid === currentProfileType.uid)"
+                        :checked="(!currentProfileType && profileType.uid === 'system:default' && itemTypeIsChannelType(currentItem, channel)) || (currentProfileType && profileType.uid === currentProfileType.uid)"
                         :disabled="!compatibleProfileTypes.includes(profileType)"
                         :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
                         @change="onProfileTypeChange(profileType.uid)"
@@ -295,7 +295,7 @@ export default {
           return
         }
       }
-      if (this.itemTypeIsNotChannelType(this.channel, this.currentItem) && (!this.currentProfileType || !this.compatibleProfileTypes.includes(this.currentProfileType))) {
+      if (!this.itemTypeIsChannelType(this.currentItem, this.channel) && (!this.currentProfileType || !this.compatibleProfileTypes.includes(this.currentProfileType))) {
         this.$f7.dialog.alert('Please configure a valid profile')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -81,9 +81,9 @@
             Learn more about profiles.
           </f7-link>
         </f7-block-footer>
-        <f7-list class="profile-list profile-disabled">
+        <f7-list class="profile-list">
           <f7-list-item radio v-for="profileType in profileTypes" class="profile-item"
-                        :checked="(!currentProfileType && profileType.uid === 'system:default' && !isNumberChannelButNoNumberItem) || (currentProfileType && profileType.uid === currentProfileType.uid)"
+                        :checked="(!currentProfileType && profileType.uid === 'system:default' && !itemTypeNotChannelType) || (currentProfileType && profileType.uid === currentProfileType.uid)"
                         :disabled="!compatibleProfileTypes.includes(profileType)"
                         :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
                         @change="onProfileTypeChange(profileType.uid)"
@@ -182,14 +182,20 @@ export default {
     },
     compatibleProfileTypes () {
       let currentItemType = this.currentItem && this.currentItem.type ? this.currentItem.type : ''
-      return this.profileTypes
-        .filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
-        .filter(p => this.isNumberChannelButNoNumberItem && (p.uid !== 'system:default' && p.uid !== 'system:follow'))
+      let profileTypes = this.profileTypes
+        .filter(p => !p.supportedItemTypes || p.supportedItemTypes.length === 0 || p.supportedItemTypes.includes(currentItemType.split(':', 1)[0]))
+      if (this.itemTypeNotChannelType) {
+        profileTypes = profileTypes.filter(p => p.uid !== 'system:default' && p.uid !== 'system:follow')
+      }
+      return profileTypes
     },
-    isNumberChannelButNoNumberItem () {
+    itemTypeNotChannelType () {
       if (!this.channel || !this.channel.itemType) return false
       if (!this.currentItem || !this.currentItem.type) return false
-      return this.channel.itemType.startsWith('Number') && !this.currentItem.type.startsWith('Number')
+      if (this.channel.itemType.startsWith('Number')) {
+        return !this.currentItem.type.startsWith('Number')
+      }
+      return this.channel.itemType !== this.currentItem.type
     }
   },
   methods: {
@@ -304,7 +310,7 @@ export default {
           return
         }
       }
-      if (this.isNumberChannelButNoNumberItem && (!this.currentProfileType || !this.compatibleProfileTypes.includes(this.currentProfileType))) {
+      if (this.itemTypeNotChannelType && (!this.currentProfileType || !this.compatibleProfileTypes.includes(this.currentProfileType))) {
         this.$f7.dialog.alert('Please configure a valid profile')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -93,9 +93,10 @@ import ConfigSheet from '@/components/config/config-sheet.vue'
 import Item from '@/components/item/item.vue'
 import ItemStatePreview from '@/components/item/item-state-preview.vue'
 import ThingStatus from '@/components/thing/thing-status-mixin'
+import LinkMixin from '@/pages/settings/things/link/link-mixin'
 
 export default {
-  mixins: [ThingStatus],
+  mixins: [ThingStatus, LinkMixin],
   components: {
     ConfigSheet,
     Item,
@@ -137,7 +138,7 @@ export default {
       this.$oh.api.get('/rest/profile-types?channelTypeUID=' + this.channel.channelTypeUID + '&itemType=' + itemType).then((data) => {
         this.profileTypes = data
         this.profileTypes.unshift(data.splice(data.findIndex(p => p.uid === 'system:default'), 1)[0]) // move default to be first
-        this.profileTypes = this.profileTypes.filter(p => !p.supportedItemTypes.length || p.supportedItemTypes.includes(this.item.type.split(':', 1)[0])) // only show compatible profile types
+        this.profileTypes = this.profileTypes.filter(p => this.isProfileTypeCompatible(this.channel, p, this.item)) // only show compatible profile types
 
         this.$oh.api.get('/rest/links/' + itemName + '/' + channelUID).then((data2) => {
           this.link = data2

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-mixin.js
@@ -1,18 +1,18 @@
 export default {
   methods: {
     /**
-     * Check whether the type of the given Item does not match the type of the given channel.
-     * @param {object} channel
+     * Check whether the type of the given Item does match the type of the given channel.
      * @param {object} item
+     * @param {object} channel
      * @return {boolean}
      */
-    itemTypeIsNotChannelType (channel, item) {
-      if (!channel || !channel.itemType) return false
-      if (!item || !item.type) return false
+    itemTypeIsChannelType (item, channel) {
+      if (!channel || !channel.itemType) return true
+      if (!item || !item.type) return true
       if (channel.itemType.startsWith('Number')) {
-        return !item.type.startsWith('Number')
+        return item.type.startsWith('Number')
       }
-      return channel.itemType !== item.type
+      return channel.itemType === item.type
     },
     /**
      * Check whether the given profileType is compatible with the given Item for the given channel.
@@ -23,7 +23,7 @@ export default {
      * @return {boolean}
      */
     isProfileTypeCompatible (channel, profileType, item) {
-      if (this.itemTypeIsNotChannelType(channel, item) && (profileType.uid === 'system:default' || profileType.uid === 'system:follow')) return false
+      if (!this.itemTypeIsChannelType(item, channel) && (profileType.uid === 'system:default' || profileType.uid === 'system:follow')) return false
       if (!profileType.supportedItemTypes || profileType.supportedItemTypes.length === 0) return true
       return profileType.supportedItemTypes.includes(item.type.split(':', 1)[0])
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-mixin.js
@@ -1,0 +1,31 @@
+export default {
+  methods: {
+    /**
+     * Check whether the type of the given Item does not match the type of the given channel.
+     * @param {object} channel
+     * @param {object} item
+     * @return {boolean}
+     */
+    itemTypeIsNotChannelType (channel, item) {
+      if (!channel || !channel.itemType) return false
+      if (!item || !item.type) return false
+      if (channel.itemType.startsWith('Number')) {
+        return !item.type.startsWith('Number')
+      }
+      return channel.itemType !== item.type
+    },
+    /**
+     * Check whether the given profileType is compatible with the given Item for the given channel.
+     *
+     * @param {object} channel
+     * @param {object} profileType
+     * @param {object} item
+     * @return {boolean}
+     */
+    isProfileTypeCompatible (channel, profileType, item) {
+      if (this.itemTypeIsNotChannelType(channel, item) && (profileType.uid === 'system:default' || profileType.uid === 'system:follow')) return false
+      if (!profileType.supportedItemTypes || profileType.supportedItemTypes.length === 0) return true
+      return profileType.supportedItemTypes.includes(item.type.split(':', 1)[0])
+    }
+  }
+}


### PR DESCRIPTION
Regression from #2690.

Reported here:
https://community.openhab.org/t/enocean-impossible-to-link-a-rockerswitch-channel-with-an-item-in-main-ui-there-is-no-profile-available-for-the-selected-item/160987

When creating a Thing channel link to an item, the profile selection are disabled. This presents two problems:

- It made linking a trigger channel to an item not possible, because a profile must be selected, but they're disabled.
- Linking a non-trigger channel to a new item is possible, but selecting a profile is not possible at link creation. The user has to create the link without a profile first, then go back to edit the link in order to assign a profile.

When editing a channel link, profile selection was possible for unsupported profiles, e.g. when editing a link between a Switch Item and a Number channel, one could edit the link to use the default or follow profiles.

This PR fixes these problems.

Note this needs to be backported to 4.3.x