### PR TITLE
Enable additional chart types for `oh-data-series`

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-data-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-data-series.md
@@ -33,6 +33,10 @@ prev: /docs/ui/components/
     The type of the series.<br/><em>Note: <code>heatmap</code> needs a configured visual map or uses the default and is not supported for time series!</em>
   </PropDescription>
   <PropOptions>
+    <PropOption value="line" label="Line" />
+    <PropOption value="bar" label="Bar" />
+    <PropOption value="heatmap" label="Heatmap" />
+    <PropOption value="scatter" label="Scatter" />
     <PropOption value="gauge" label="Gauge" />
     <PropOption value="pie" label="Pie" />
   </PropOptions>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -286,7 +286,7 @@ export default {
     props: {
       parameterGroups: [actionGroup()],
       parameters: [
-        seriesTypeParameter('gauge', 'pie'),
+        seriesTypeParameter('line', 'bar', 'heatmap', 'scatter', 'gauge', 'pie'),
         ...actionParams()
       ]
     }


### PR DESCRIPTION
This enables the use of all imported ECharts in (custom) widgets using  `oh-data-series`.