### PR TITLE
Don't subscribe to Item events to reload model

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/sse-events-mixin.js
@@ -12,11 +12,10 @@ export default {
   },
   methods: {
     startEventSource () {
-      const topicItems = 'openhab/items/*/added,openhab/items/*/removed,openhab/items/*/updated'
       const topicAudio = 'openhab/webaudio/playurl'
       const commandItem = localStorage.getItem('openhab.ui:commandItem')
       const topicCommand = `openhab/items/${commandItem || ''}/command`
-      let topics = topicItems
+      let topics = null
       if (localStorage.getItem('openhab.ui:webaudio.enable') === 'enabled') {
         topics = topicAudio
       }
@@ -40,11 +39,6 @@ export default {
             this.handleCommand(payload.value)
             break
           default:
-            if (event.topic.startsWith('openhab/items/')) {
-              console.info('Item SSE event received, reloading semantic model ...')
-              this.$store.dispatch('loadSemanticModel')
-              break
-            }
             console.warn('Unhandled SSE event: ' + JSON.stringify(event))
         }
       })


### PR DESCRIPTION
Related to #2584 and https://github.com/openhab/openhab-core/issues/4466.

This avoids that the global SSE connection is always established, and therefore reduces problems with the max parallel HTTP connections limitation. The global SSE connection is now only established if the web audio sink or the command Item are enabled.

Whilst this change potentially makes the UI not reload the model automatically on change, practically the now removed mechanism might haven't been really useful at all because the model is already reloaded on Main UI start, and if SSE was not connected the moment an Item changed the mechanism did not trigger.