### PR TITLE
Widget expressions: Fix handling of Item name being `undefined` & Align behaviour for @ and @@ shorthands in that case

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-expression-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-expression-mixin.js
@@ -16,12 +16,12 @@ import jsepTemplate from '@jsep-plugin/template'
 expr.jsep.plugins.register(jsepRegex, jsepArrow, jsepObject, jsepTemplate)
 
 expr.addUnaryOp('@', (itemName) => {
-  if (itemName === undefined) return undefined
+  if (itemName === undefined) return '-'
   const item = store.getters.trackedItems[itemName]
   return (item.displayState !== undefined) ? item.displayState : item.state
 })
 expr.addUnaryOp('@@', (itemName) => {
-  if (itemName === undefined) return undefined
+  if (itemName === undefined) return '-'
   return store.getters.trackedItems[itemName].state
 })
 expr.addUnaryOp('#', (itemName) => {

--- a/bundles/org.openhab.ui/web/src/js/store/modules/states.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/states.js
@@ -23,6 +23,7 @@ const handler = (context) => {
       if (typeof prop !== 'string') return {}
 
       const itemName = prop
+      if (itemName === 'undefined') return { state: '-' }
       if (!context.getters.isItemTracked(itemName)) {
         context.commit('addToTrackingList', itemName.toString())
 


### PR DESCRIPTION
Fixes #2956.
This fix creates the limitation that an Item must not be named `undefined` - for an Item with this name, state tracking won't work.