### PR TITLE
Model editor: Add drag & drop

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -8,7 +8,7 @@
     :subtitle="noType ? '' : getItemTypeAndMetaLabel(item)"
     :after="state"
     v-on="$listeners">
-    <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" :state="(noState || item.type === 'Image') ? null : (context.store[item.name].state || item.state)" height="32" width="32" />
+    <oh-icon v-if="!noIcon && item.category" slot="media" :icon="item.category" :state="(noState || item.type === 'Image') ? null : (context?.store[item.name]?.state || item.state)" height="32" width="32" />
     <span v-else-if="!noIcon" slot="media" class="item-initial">{{ item.name[0] }}</span>
     <f7-icon v-if="!item.editable" slot="after-title" f7="lock_fill" size="1rem" color="gray" />
     <slot name="footer" #footer />

--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -66,7 +66,7 @@
       <f7-block strong class="no-padding" v-if="ready">
         <model-treeview class="model-picker-treeview" :root-nodes="rootNodes"
                         :includeItemName="includeItemName" :includeItemTags="includeItemTags"
-                        :selected-item="selectedItem" @selected="selectItem" @checked="checkItem" />
+                        :selected="selectedItem" @selected="selectItem" @checked="checkItem" />
       </f7-block>
       <f7-block v-else-if="!ready" class="text-align-center">
         <f7-preloader />
@@ -178,7 +178,7 @@ export default {
       this.loadModel().then(() => {
         this.$nextTick(() => {
           this.initSearchbar = true
-          this.applyExpandedOption()
+          this.restoreExpanded()
         })
       })
     },

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,6 +1,7 @@
 <template>
   <f7-treeview class="model-treeview">
-    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" delay="400" swapThreshold="0.6"
+    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index" :model="node" :parentNode="model"

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -4,9 +4,10 @@
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="node in children"
                            :key="node.item.name" :model="node" :parentNode="model"
-                           :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="canDragDrop" :moveState="localMoveState"
+                           :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="canDragDrop" :moveState="moveState"
                            @selected="nodeSelected" :selected="selected"
-                           @checked="(item, check) => $emit('checked', item, check)" />
+                           @checked="(item, check) => $emit('checked', item, check)"
+                           @reload="$emit('reload')" />
     </draggable>
   </f7-treeview>
 </template>
@@ -31,9 +32,15 @@ import Draggable from 'vuedraggable'
 export default {
   mixins: [ModelDragDropMixin],
   props: ['rootNodes', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop'],
+  emits: ['reload'],
   components: {
     Draggable,
     ModelTreeviewItem
+  },
+  data () {
+    return {
+      moveState: {}
+    }
   },
   computed: {
     model: {

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -2,8 +2,8 @@
   <f7-treeview class="model-treeview">
     <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
-      <model-treeview-item v-for="node in children"
-                           :key="node.item.name" :model="node" :parentNode="model"
+      <model-treeview-item v-for="(node, index) in children"
+                           :key="node.item.name + '_' + index" :model="node" :parentNode="model"
                            :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="canDragDrop" :moveState="moveState"
                            @selected="nodeSelected" :selected="selected"
                            @checked="(item, check) => $emit('checked', item, check)"

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-treeview class="model-treeview">
-    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" swapThreshold="0.6"
+    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" delay="400" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index" :model="node" :parentNode="model"

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -38,11 +38,6 @@ export default {
     Draggable,
     ModelTreeviewItem
   },
-  data () {
-    return {
-      moveState: {}
-    }
-  },
   computed: {
     model: {
       get: function () {

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-treeview class="model-treeview">
-    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true" swapThreshold="0.6"
+    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index" :model="node" :parentNode="model"

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-treeview class="model-treeview">
-    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150"
+    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -15,8 +15,9 @@
                            :selected="selected"
                            :includeItemName="includeItemName" :includeItemTags="includeItemTags"
                            :canDragDrop="canDragDrop"
-                           :moveState="localMoveState"
-                           @checked="(item, check) => $emit('checked', item, check)" />
+                           :moveState="moveState"
+                           @checked="(item, check) => $emit('checked', item, check)"
+                           @reload="$emit('reload')" />
     </draggable>
     <div slot="label" class="semantic-class">
       {{ className() }}
@@ -45,6 +46,7 @@ export default {
   name: 'model-treeview-item',
   mixins: [ItemMixin, ModelDragDropMixin],
   props: ['model', 'parentNode', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop', 'moveState'],
+  emits: ['reload'],
   components: {
     Draggable,
     ModelTreeviewItem: 'model-treeview-item'

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -6,7 +6,7 @@
                     :opened="model.opened" :toggle="canHaveChildren"
                     @click="select">
     <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true" swapThreshold="0.6"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index"
@@ -75,6 +75,7 @@ export default {
     },
     select (event) {
       let self = this
+      if (self.dragDropActive) return       // avoid opening item properties during drag drop
       let $ = self.$$
       if ($(event.target).is('.treeview-toggle')) return
       if ($(event.target).is('.checkbox') || $(event.target).is('.icon-checkbox') || $(event.target).is('input')) return

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -75,7 +75,7 @@ export default {
     },
     select (event) {
       let self = this
-      if (self.dragDropActive) return       // avoid opening item properties during drag drop
+      if (self.dragDropActive) return // avoid opening item properties during drag drop
       let $ = self.$$
       if ($(event.target).is('.treeview-toggle')) return
       if ($(event.target).is('.checkbox') || $(event.target).is('.icon-checkbox') || $(event.target).is('input')) return

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -5,7 +5,8 @@
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
                     @click="select">
-    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" delay="400" swapThreshold="0.6"
+    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -7,8 +7,8 @@
                     @click="select">
     <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
-      <model-treeview-item v-for="node in children"
-                           :key="node.item.name"
+      <model-treeview-item v-for="(node, index) in children"
+                           :key="node.item.name + '_' + index"
                            :model="node"
                            :parentNode="model"
                            @selected="(event) => $emit('selected', event)"
@@ -16,8 +16,7 @@
                            :includeItemName="includeItemName" :includeItemTags="includeItemTags"
                            :canDragDrop="canDragDrop"
                            :moveState="moveState"
-                           @checked="(item, check) => $emit('checked', item, check)"
-                           @reload="$emit('reload')" />
+                           @checked="(item, check) => $emit('checked', item, check)" />
     </draggable>
     <div slot="label" class="semantic-class">
       {{ className() }}

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -4,7 +4,7 @@
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
-                    @click="select" >
+                    @click="select">
     <draggable :disabled="!canDragDrop && !dropAllowed(model)" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -17,7 +17,8 @@
                            :includeItemName="includeItemName" :includeItemTags="includeItemTags"
                            :canDragDrop="canDragDrop"
                            :moveState="moveState"
-                           @checked="(item, check) => $emit('checked', item, check)" />
+                           @checked="(item, check) => $emit('checked', item, check)"
+                           @reload="$emit('reload')" />
     </draggable>
     <div slot="label" class="semantic-class">
       {{ className() }}

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -4,7 +4,7 @@
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
-                    @click="select">
+                    @treeview:open="model.opened = true" @treeview:close="model.opened = false" @click="select">
     <draggable :disabled="!canDragDrop && !dropAllowed(model)" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -6,7 +6,7 @@
                     :opened="model.opened" :toggle="canHaveChildren"
                     @click="select">
     <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" swapThreshold="0.6"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -5,7 +5,7 @@
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="model.item.type === 'Group'"
                     @click="select">
-    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" swapThreshold="0.6"
+    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" delay="400" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -5,7 +5,7 @@
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
                     @click="select">
-    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150"
+    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -4,8 +4,8 @@
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
-                    @click="select">
-    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
+                    @click="select" >
+    <draggable :disabled="!canDragDrop && !dropAllowed(model)" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -3,17 +3,21 @@
                     :icon-ios="icon('ios')" :icon-aurora="icon('aurora')" :icon-md="icon('md')"
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
-                    :opened="model.opened"
+                    :opened="model.opened" :toggle="model.item.type === 'Group'"
                     @click="select">
-    <model-treeview-item v-for="node in [model.children.locations,
-                                         model.children.equipment, model.children.points,
-                                         model.children.groups, model.children.items].flat()"
-                         :key="node.item.name"
-                         :model="node"
-                         @selected="(event) => $emit('selected', event)"
-                         :selected="selected"
-                         :includeItemName="includeItemName" :includeItemTags="includeItemTags"
-                         @checked="(item, check) => $emit('checked', item, check)" />
+    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" swapThreshold="0.6"
+               @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
+      <model-treeview-item v-for="node in children"
+                           :key="node.item.name"
+                           :model="node"
+                           :parentNode="model"
+                           @selected="(event) => $emit('selected', event)"
+                           :selected="selected"
+                           :includeItemName="includeItemName" :includeItemTags="includeItemTags"
+                           :canDragDrop="canDragDrop"
+                           :moveState="localMoveState"
+                           @checked="(item, check) => $emit('checked', item, check)" />
+    </draggable>
     <div slot="label" class="semantic-class">
       {{ className() }}
       <template v-if="includeItemTags">
@@ -34,31 +38,24 @@
 
 <script>
 import ItemMixin from '@/components/item/item-mixin'
+import ModelDragDropMixin from '@/pages/settings/model/model-dragdrop-mixin'
+import Draggable from 'vuedraggable'
 
 export default {
   name: 'model-treeview-item',
-  mixins: [ItemMixin],
-  props: ['model', 'selected', 'includeItemName', 'includeItemTags'],
+  mixins: [ItemMixin, ModelDragDropMixin],
+  props: ['model', 'parentNode', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop', 'moveState'],
   components: {
+    Draggable,
     ModelTreeviewItem: 'model-treeview-item'
-  },
-  computed: {
-    children () {
-      return [this.model.children.locations,
-        this.model.children.equipment, this.model.children.points,
-        this.model.children.groups, this.model.children.items].flat()
-    },
-    iconColor () {
-      return (this.model.item.metadata && this.model.item.metadata.semantics) ? '' : 'gray'
-    }
   },
   methods: {
     icon (theme) {
-      if (this.model.class.indexOf('Location') === 0) {
+      if (this.model.class?.indexOf('Location') === 0) {
         return (theme === 'md') ? 'material:place' : 'f7:placemark'
-      } else if (this.model.class.indexOf('Equipment') === 0) {
+      } else if (this.model.class?.indexOf('Equipment') === 0) {
         return (theme === 'md') ? 'material:payments' : 'f7:cube_box'
-      } else if (this.model.class.indexOf('Point') === 0) {
+      } else if (this.model.class?.indexOf('Point') === 0) {
         return (theme === 'md') ? 'material:flash_on' : 'f7:bolt_fill'
       } else if (this.model.item.type === 'Group') {
         return (theme === 'md') ? 'material:folder' : 'f7:folder'

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -5,8 +5,8 @@
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
                     @click="select">
-    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true" swapThreshold="0.6"
+    <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="(node, index) in children"
                            :key="node.item.name + '_' + index"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -3,7 +3,7 @@
                     :icon-ios="icon('ios')" :icon-aurora="icon('aurora')" :icon-md="icon('md')"
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
-                    :opened="model.opened" :toggle="model.item.type === 'Group'"
+                    :opened="model.opened" :toggle="canHaveChildren"
                     @click="select">
     <draggable :disabled="!canDragDrop || !model.item.editable" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" forceFallback="true" scrollSensitivity="200" delay="400" swapThreshold="0.6"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -46,7 +46,7 @@ import Draggable from 'vuedraggable'
 export default {
   name: 'model-treeview-item',
   mixins: [ItemMixin, ModelDragDropMixin],
-  props: ['model', 'parentNode', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop', 'moveState'],
+  props: ['model', 'parentNode', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop'],
   emits: ['reload'],
   components: {
     Draggable,

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -43,7 +43,7 @@
           </f7-block-footer>
           <f7-block class="semantic-tree">
             <model-treeview class="model-picker-treeview" :rootNodes="rootLocations"
-                            :selected-item="selectedItem" @selected="selectItem" @checked="checkItem" />
+                            :selected="selectedItem" @selected="selectItem" @checked="checkItem" />
           </f7-block>
         </f7-block>
       </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -32,7 +32,7 @@ export default {
         newChildren.equipment = nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Equipment'))
         newChildren.points = nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Point'))
         newChildren.groups = nodeList.filter(n => !n.item.metadata?.semantics && n.item.type === 'Group')
-        newChildren.items =  nodeList.filter(n => !n.item.metadata?.semantics && n.item.type !== 'Group')
+        newChildren.items = nodeList.filter(n => !n.item.metadata?.semantics && n.item.type !== 'Group')
         this.$set(this.model, 'children', newChildren)
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -101,6 +101,11 @@ export default {
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
       const oldParentNode = this.moveState.oldParent
+      if (node.item.name === parentNode.item.name) {
+        // This should not be possible, but just to make sure to avoid infinite loop
+        this.restoreModelUpdate()
+        return
+      }
       if (parentNode.item && node.item.groupNames?.includes(parentNode.item.name)) {
         const message = 'Group "' + this.itemLabel(parentNode.item) +
           '" already contains item "' + this.itemLabel(node.item) + '"'
@@ -501,6 +506,7 @@ export default {
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'adding', false)
       this.$set(this.moveState, 'removing', false)
+      this.$set(this.moveState, 'saving', false)
       this.$emit('reload')
     },
     itemLabel (item) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -627,7 +627,7 @@ export default {
       if (!node.children) return []
       return [node.children.locations, node.children.equipment, node.children.points, node.children.groups, node.children.items].flat()
     },
-    keyDownHandler (event) {     
+    keyDownHandler (event) {
       if (!event.repeat && event.keyCode === 27) {
         console.debug('escape pressed')
         console.debug('runtime escape', Date.now() - this.moveState.dragStartTimestamp)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -504,7 +504,7 @@ export default {
         // moving into root, so remove from source
         // issue: it will only remove from the current parent, not all
         this.remove(node, parentNode, oldIndex)
-      } else if (parentNode.class !== '' && newParentNode.class !== '') {
+      } else if (node.class.startsWith('Point') && parentNode.class !== '' && newParentNode.class !== '') {
         // special rule: a point can be part of a location and equipment at the same time, e.g. central HVAC equipment with controls by room
         if (parentNode.class.startsWith('Equipment') && newParentNode.class.startsWith('Location') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -67,6 +67,7 @@ export default {
       this.$set(this.moveState, 'moveConfirmed', false)
       this.$set(this.moveState, 'node', this.children[event.oldIndex])
       this.$set(this.moveState, 'nodesToUpdate', [])
+      this.$set(this.moveState, 'dragStartTimestamp', Date.now())
       console.debug('Drag start - moveState:', cloneDeep(this.moveState))
     },
     onDragChange (event) {
@@ -102,7 +103,7 @@ export default {
       })
     },
     validateAdd () {
-      const timestamp = Date.now()
+      console.debug('runtime validateAdd start', Date.now() - moveState.dargStartTimestamp)
       this.$set(this.moveState, 'adding', true)
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
@@ -110,15 +111,16 @@ export default {
       if (node.item.name === parentNode?.item?.name) {
         // This should not be possible, but just to make sure to avoid infinite loop
         this.restoreModelUpdate()
+        console.debug('runtime validateAdd end', Date.now() - moveState.dargStartTimestamp)
         return
       }
       if (parentNode.item && node.item.groupNames?.includes(parentNode.item.name)) {
         const message = 'Group "' + this.itemLabel(parentNode.item) +
           '" already contains item "' + this.itemLabel(node.item) + '"'
         console.debug('Add rejected: ' + message)
-        console.debug('runtime validateAdd', Date.now() - timestamp)
         this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
+        console.debug('runtime validateAdd end', Date.now() - moveState.dargStartTimestamp)
         return
       }
       if (node.item.type === 'Group' && node.class === '') {
@@ -128,9 +130,9 @@ export default {
             '" with semantic child "' + this.itemLabel(semanticNode.item) +
             '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
           console.debug('Add rejected: ' + message)
-          console.debug('runtime validateAdd', Date.now() - timestamp)
           this.$f7.dialog.alert(message).open()
           this.restoreModelUpdate()
+          console.debug('runtime validateAdd end', Date.now() - moveState.dargStartTimestamp)
           return
         }
       }
@@ -139,14 +141,14 @@ export default {
           '" from non-semantic group "' + this.itemLabel(oldParentNode.item) +
           '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
         console.debug('Add rejected:' + message)
-        console.debug('runtime validateAdd', Date.now() - timestamp)
         this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
+        console.debug('runtime validateAdd end', Date.now() - moveState.dargStartTimestamp)
         return
       }
       if (!this.isValidGroupType(node, parentNode)) {
-        console.debug('runtime validateAdd', Date.now() - timestamp)
         this.restoreModelUpdate()
+        console.debug('runtime validateAdd end', Date.now() - moveState.dargStartTimestamp)
         return
       }
       if (parentNode.class.startsWith('Location')) {
@@ -160,10 +162,10 @@ export default {
       }
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'adding', false)
-      console.debug('runtime validateAdd end', Date.now() - timestamp)
+      console.debug('runtime validateAdd end', Date.now() - moveState.dargStartTimestamp)
     },
     isValidGroupType (node, parentNode) {
-      const timestamp = Date.now()
+      console.debug('runtime isValidGroupType start', Date.now() - moveState.dargStartTimestamp)
       const groupTypeDef = parentNode.item?.groupType?.split(':')
       const baseType = groupTypeDef ? groupTypeDef[0] : 'None'
       if (baseType === 'None') return true
@@ -179,8 +181,8 @@ export default {
              '" not compatible with "' + (node.item.type === 'Group' ? 'group ' : '') + 'item dimension "' + dimension +
              '" of "' + (node.item.type === 'Group' ? 'group ' : '') + '" item "' + this.itemLabel(node.item) + '"'
           console.debug('Add rejected: ' + message)
-          console.debug('runtime isValidGroupType', Date.now() - timestamp)
           this.$f7.dialog.alert(message).open()
+          console.debug('runtime isValidGroupType end', Date.now() - moveState.dargStartTimestamp)
           return false
         }
         if (dimension) {
@@ -194,8 +196,8 @@ export default {
               '" with dimension "' + childWithDifferentDimension.dimension +
               '" different from group dimension "' + dimension + '"'
             console.debug('Add rejected: ' + message)
-            console.debug('runtime isValidGroupType', Date.now() - timestamp)
             this.$f7.dialog.alert(message).open()
+            console.debug('runtime isValidGroupType end', Date.now() - moveState.dargStartTimestamp)
             return false
           }
         }
@@ -207,11 +209,11 @@ export default {
           '" not compatible with type "' + type +
           '" of item "' + this.itemLabel(node.item) + '"'
         console.debug('Add rejected: ' + message)
-        console.debug('runtime isValidGroupType', Date.now() - timestamp)
-        this.$f7.dialog.alert(message).open()
-        return false
+         this.$f7.dialog.alert(message).open()
+         console.debug('runtime isValidGroupType end', Date.now() - moveState.dargStartTimestamp)
+         return false
       }
-      console.debug('runtime isValidGroupType', Date.now() - timestamp)
+      console.debug('runtime isValidGroupType end', Date.now() - moveState.dargStartTimestamp)
       return true
     },
     aggregationFunctions (type) {
@@ -235,7 +237,7 @@ export default {
       return [...types.CommonFunctions, ...specificAggregationFunctions(type)]
     },
     addIntoLocation (node, parentNode) {
-      const timestamp = Date.now()
+      console.debug('runtime addIntoLocation start', Date.now() - moveState.dargStartTimestamp)
       if (node.class.startsWith('Location')) {
         this.addLocation(node, parentNode)
       } else if (node.class.startsWith('Equipment')) {
@@ -243,7 +245,6 @@ export default {
       } else if (node.class.startsWith('Point')) {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
-        console.debug('runtime addIntoLocation', Date.now() - timestamp)
         this.$set(this.moveState, 'moveConfirmed', true)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -257,7 +258,6 @@ export default {
           ]
         }).open()
       } else {
-        console.debug('runtime addIntoLocation', Date.now() - timestamp)
         this.$set(this.moveState, 'moveConfirmed', true)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -271,12 +271,11 @@ export default {
           ]
         }).open()
       }
-      console.debug('runtime addIntoLocation end', Date.now() - timestamp)
+      console.debug('runtime addIntoLocation end', Date.now() - moveState.dargStartTimestamp)
     },
     addIntoEquipment (node, parentNode) {
-      const timestamp = Date.now()
+      console.debug('runtime addIntoEquipment start', Date.now() - moveState.dargStartTimestamp)
       if (node.class.startsWith('Location')) {
-        console.debug('runtime addIntoEquipment', Date.now() - timestamp)
         this.$f7.dialog.alert(
           'Cannot move Location "' + this.itemLabel(node.item) +
           '" into Equipment "' + this.itemLabel(parentNode.item) + '"'
@@ -290,7 +289,6 @@ export default {
         this.addEquipment(node, parentNode)
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
-        console.debug('runtime addIntoEquipment', Date.now() - timestamp)
         const dialog = this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -303,9 +301,10 @@ export default {
           ]
         }).open()
       }
-      console.debug('runtime addIntoEquipment end', Date.now() - timestamp)
+      console.debug('runtime addIntoEquipment end', Date.now() - moveState.dargStartTimestamp)
     },
     addIntoGroup (node, parentNode) {
+      console.debug('runtime addIntoGroup start', Date.now() - moveState.dargStartTimestamp)
       if (node.class.startsWith('Location')) {
         this.addLocation(node, parentNode)
       } else if (node.class.startsWith('Equipment')) {
@@ -315,9 +314,10 @@ export default {
       } else {
         this.addNonSemantic(node, parentNode)
       }
+      console.debug('runtime addIntoGroup end', Date.now() - moveState.dargStartTimestamp)
     },
     addIntoRoot (node, parentNode) {
-      const timestamp = Date.now()
+      console.debug('runtime addIntoRoot start', Date.now() - moveState.dargStartTimestamp)
       if (node.class.startsWith('Location')) {
         this.addLocation(node, parentNode)
       } else if (node.class.startsWith('Equipment')) {
@@ -326,7 +326,6 @@ export default {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
-        console.debug('runtime addIntoRoot', Date.now() - timestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -341,7 +340,6 @@ export default {
         }).open()
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
-        console.debug('runtime addIntoRoot', Date.now() - timestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -355,10 +353,10 @@ export default {
           ]
         }).open()
       }
-      console.debug('runtime addIntoRoot end', Date.now() - timestamp)
+      console.debug('runtime addIntoRoot end', Date.now() - moveState.dargStartTimestamp)
     },
     addLocation (node, parentNode) {
-      const timestamp = Date.now()
+      console.debug('runtime addLocation start', Date.now() - moveState.dargStartTimestamp)
       const semantics = { config: {} }
       semantics.value = node.item?.metadata?.semantics?.value || 'Location'
       if (parentNode.class.startsWith('Location')) {
@@ -368,11 +366,11 @@ export default {
       node.class = semantics.value
       const nodeChildren = this.nodeChildren(node)
       nodeChildren.filter((n) => !n.class).forEach((n) => this.addIntoLocation(n, node))
-      console.debug('runtime addLocation end', Date.now() - timestamp)
       this.updateAfterAdd(node, parentNode, semantics)
+      console.debug('runtime addLocation end', Date.now() - moveState.dargStartTimestamp)
     },
     addEquipment (node, parentNode) {
-      const timestamp = Date.now()
+      console.debug('runtime addEquipment start', Date.now() - moveState.dargStartTimestamp)
       const semantics = { config: {} }
       semantics.value = node.item?.metadata?.semantics?.value || 'Equipment'
       if (parentNode.class.startsWith('Location')) {
@@ -384,12 +382,12 @@ export default {
       node.class = semantics.value
       const nodeChildren = this.nodeChildren(node)
       nodeChildren.filter((n) => !n.class).forEach((n) => this.addIntoEquipment(n, node))
-      console.debug('runtime addEquipment end', Date.now() - timestamp)
       this.updateAfterAdd(node, parentNode, semantics)
+      console.debug('runtime addEquipment end', Date.now() - moveState.dargStartTimestamp)
     },
     addPoint (node, parentNode) {
-      const timestamp = Date.now()
-      const semantics = { config: {} }
+      console.debug('runtime addPoint start', Date.now() - moveState.dargStartTimestamp)
+       const semantics = { config: {} }
       semantics.value = node.item?.metadata?.semantics?.value || 'Point'
       if (parentNode.class.startsWith('Location')) {
         semantics.config.hasLocation = parentNode.item.name
@@ -398,16 +396,18 @@ export default {
       }
       if (!node.item.tags.includes(semantics.value)) node.item.tags.push(semantics.value)
       node.class = semantics.value
-      console.debug('runtime addPoint end', Date.now() - timestamp)
       this.updateAfterAdd(node, parentNode, semantics)
+      console.debug('runtime addPoint end', Date.now() - moveState.dargStartTimestamp)
     },
     addNonSemantic (node, parentNode) {
+      console.debug('runtime addNonSemantic start', Date.now() - moveState.dargStartTimestamp)
       node.class = ''
       this.updateAfterAdd(node, parentNode, null)
+      console.debug('runtime addNonSemantic end', Date.now() - moveState.dargStartTimestamp)
     },
     updateAfterAdd (node, parentNode, semantics) {
-      const timestamp = Date.now()
-      let updateRequired = false
+      console.debug('runtime updateAfterAdd start', Date.now() - moveState.dargStartTimestamp)
+     let updateRequired = false
       if (semantics === null) {
         if (node.item.metadata?.semantics) {
           node.item.metadata.semantics = null
@@ -439,25 +439,46 @@ export default {
         this.$set(this.moveState, 'nodesToUpdate', nodesToUpdate)
       }
       console.debug('Add - finished, new moveState:', cloneDeep(this.moveState))
-      console.debug('runtime updateAfterAdd', Date.now() - timestamp)
+      console.debug('runtime updateAfterAdd end', Date.now() - moveState.dargStartTimestamp)
     },
     validateRemove () {
-      const timestamp = Date.now()
+      console.debug('runtime validateRemove start', Date.now() - moveState.dargStartTimestamp)
       this.$set(this.moveState, 'removing', true)
       const node = this.moveState.node
+      const newParentNode = this.moveSate.newParent
       const parentNode = this.moveState.oldParent
       const oldIndex = this.moveState.oldIndex
       console.debug('Remove - new moveState:', cloneDeep(this.moveState))
-      if (parentNode.class !== '' && this.moveState.newParent.class !== '') {
-        // special rule: a point can be part of a location and equipment at the same time, e.g. central HVAC equipment with controls by room
-        if (parentNode.class.startsWith('Equipment') && this.moveState.newParent.class.startsWith('Location') &&
-            this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
+      if (newParentNode.item === '') {
+        if (node.class.startsWith('Equipment') || node.class.startsWith('Point')) {
           this.$set(this.moveState, 'moveConfirmed', true)
-          console.debug('runtime validateRemove', Date.now() - timestamp)
+          this.$f7.dialog.create({
+            text: 'Node "' + this.itemLabel(node.item) +
+              '" dragged from  "' + this.itemLabel(parentNode.item) +
+              '" into root, remove from model?',
+            buttons: [
+              { text: 'Cancel', color: 'gray', keycodes: [27], onClick: () => this.restoreModelUpdate() },
+              { text: 'Yes', keycodes: [13], onClick: () => {
+                  node.item.metadata.semantics = null
+                  this.remove(node, parentNode, oldIndex)
+                }
+              }
+            ]
+          }).open()          
+        } else {
+          // moving into root, so remove from source
+          // issue: it will only remove from the current parent, not all
+          this.remove(node, parentNode, oldIndex)
+        }
+      } else if (parentNode.class !== '' && newParentNode.class !== '') {
+        // special rule: a point can be part of a location and equipment at the same time, e.g. central HVAC equipment with controls by room
+        if (parentNode.class.startsWith('Equipment') && newParentNode.class.startsWith('Location') &&
+            this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {
+          this.$set(this.moveState, 'moveConfirmed', true)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
               '" dragged from Equipment "' + this.itemLabel(parentNode.item) +
-              '" into Location "' + this.itemLabel(this.moveState.newParent.item) +
+              '" into Location "' + this.itemLabel(newParentNode.item) +
               '", should Point still be in Equipment as well?',
             buttons: [
               { text: 'Cancel', color: 'gray', keycodes: [27], onClick: () => this.restoreModelUpdate() },
@@ -465,14 +486,13 @@ export default {
               { text: 'No', strong: true, onClick: () => this.remove(node, parentNode, oldIndex) }
             ]
           }).open()
-        } else if (parentNode.class.startsWith('Location') && this.moveState.newParent.class.startsWith('Equipment') &&
-            this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
+        } else if (parentNode.class.startsWith('Location') && newParentNode.class.startsWith('Equipment') &&
+            this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {
           this.$set(this.moveState, 'moveConfirmed', true)
-          console.debug('runtime validateRemove', Date.now() - timestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
               '" dragged from Location "' + this.itemLabel(parentNode.item) +
-              '" into Equipment "' + this.itemLabel(this.moveState.newParent.item) +
+              '" into Equipment "' + this.itemLabel(newParentNode.item) +
               '", should Point still be in Location as well?',
             buttons: [
               { text: 'Cancel', color: 'gray', keycodes: [27], onClick: () => this.restoreModelUpdate() },
@@ -489,11 +509,10 @@ export default {
         this.remove(node, parentNode, oldIndex)
       } else if (parentNode.item?.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
-        console.debug('runtime validateRemove', Date.now() - timestamp)
         this.$f7.dialog.create({
           text: 'Item "' + this.itemLabel(node.item) +
             '" dragged from group "' + this.itemLabel(parentNode.item) +
-            '" into "' + this.itemLabel(this.moveState.newParent.item) +
+            '" into "' + this.itemLabel(newParentNode.item) +
             '", keep original?',
           buttons: [
             { text: 'Cancel', color: 'gray', keycodes: [27], onClick: () => this.restoreModelUpdate() },
@@ -504,10 +523,10 @@ export default {
       } else {
         this.updateAfterRemove()
       }
-      console.debug('runtime validateRemove end', Date.now() - timestamp)
+      console.debug('runtime validateRemove end', Date.now() - moveState.dargStartTimestamp)
     },
     remove (node, parentNode, oldIndex) {
-      const timestamp = Date.now()
+      console.debug('runtime remove start', Date.now() - moveState.dargStartTimestamp)
       const groupNameIndex = node.item.groupNames.findIndex(g => g === parentNode.item?.name)
       if (groupNameIndex >= 0) {
         node.item.groupNames.splice(groupNameIndex, 1)
@@ -523,14 +542,17 @@ export default {
       }
       this.updateAfterRemove()
       console.debug('Remove - finished, new moveState:', cloneDeep(this.moveState))
-      console.debug('runtime remove', Date.now() - timestamp)
+      console.debug('runtime remove end', Date.now() - moveState.dargStartTimestamp)
     },
     updateAfterRemove () {
+      console.debug('runtime updateAfterRemove start', Date.now() - moveState.dargStartTimestamp)
       this.$set(this.moveState, 'canRemove', false)
       this.$set(this.moveState, 'removing', false)
       this.$set(this.moveState, 'dragFinished', true)
+      console.debug('runtime updateAfterRemove end', Date.now() - moveState.dargStartTimestamp)
     },
     saveUpdate () {
+      console.debug('runtime saveUpdate start', Date.now() - moveState.dargStartTimestamp)
       this.$set(this.moveState, 'saving', true)
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
@@ -543,9 +565,10 @@ export default {
       } else {
         this.saveModelUpdate()
       }
+      console.debug('runtime saveUpdate end', Date.now() - moveState.dargStartTimestamp)
     },
     saveModelUpdate () {
-      const timestamp = Date.now()
+      console.debug('runtime saveModelUpdate start', Date.now() - moveState.dargStartTimestamp)
       this.$set(this.moveState, 'dragFinished', false)
       this.moveState.nodesToUpdate.forEach((n) => {
         const updatedItem = n.item
@@ -554,11 +577,11 @@ export default {
       })
       this.$set(this.moveState, 'saving', false)
       this.$set(this.moveState, 'dragDropActive', false)
-      console.debug('runtime saveModelUpdate', Date.now() - timestamp)
+      console.debug('runtime saveModelUpdate end', Date.now() - moveState.dargStartTimestamp)
     },
     restoreModelUpdate () {
-      const timestamp = Date.now()
       console.debug('Restore model')
+      console.debug('runtime restoreModelUpdate start', Date.now() - moveState.dargStartTimestamp)
       this.$set(this.moveState, 'cancelled', true)
       this.$set(this.moveState, 'canRemove', false)
       this.$set(this.moveState, 'canAdd', false)
@@ -567,7 +590,7 @@ export default {
       this.$set(this.moveState, 'saving', false)
       this.$set(this.moveState, 'dragDropActive', false)
       this.$emit('reload')
-      console.debug('runtime restoreModelUpdate', Date.now() - timestamp)
+      console.debug('runtime restoreModelUpdate end', Date.now() - moveState.dargStartTimestamp)
     },
     itemLabel (item) {
       if (!item) return 'model root'

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -43,11 +43,18 @@ export default {
     },
     canSave () {
       return !this.moveState.cancelled && this.moveState.dragEnd && this.moveState.dragFinished && !this.moveState.canAdd && !this.moveState.canRemove && !this.moveState.saving
+    },
+    canHaveChildren () {
+      console.debug("Node children:", cloneDeep(this.children))
+      console.debug("Node children length:", this.children.length)
+      console.debug("Can have children: ", (this.children.length > 0 || this.moveState.moving) === true)
+      return ((this.model.item.type === 'Group') && (this.children.length > 0 || this.moveState.moving) === true)
     }
   },
   methods: {
     onDragStart (event) {
       console.debug('Drag start - event:', event)
+      this.$set(this.moveState, 'moving', true)
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'canRemove', false)
       this.$set(this.moveState, 'dragEnd', false)
@@ -77,6 +84,7 @@ export default {
       }
     },
     onDragEnd (event) {
+      this.$set(this.moveState, 'moving', false)
       this.$set(this.moveState, 'dragEnd', true)
       console.debug('Drag end - event:', event)
       console.debug('Drag end - moveState:', cloneDeep(this.moveState))

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -10,11 +10,10 @@ export default {
     moveState: {
       type: Object,
       default: () => ({
-        dragDropActive: false,
         moving: false,
         canAdd: false,
         canRemove: false,
-        dragEnd: false,
+        dragEnd: true,
         dragFinished: false,
         saving: false,
         cancelled: false,
@@ -62,7 +61,7 @@ export default {
       return (this.model.item.metadata && this.model.item.metadata.semantics) ? '' : 'gray'
     },
     dragDropActive () {
-      return this.moveState.dragDropActive
+      return !this.moveState.dragEnd
     },
     canAdd () {
       return !this.moveState.cancelled && this.moveState.dragEnd && !this.moveState.dragFinished && this.moveState.canAdd && !this.moveState.adding
@@ -81,7 +80,6 @@ export default {
     onDragStart (event) {
       console.debug('Drag start - event:', event)
       window.addEventListener('keydown', this.keyDownHandler)
-      this.moveState.dragDropActive = true
       this.moveState.moving = true
       this.moveState.canAdd = false
       this.moveState.canRemove = false
@@ -613,7 +611,6 @@ export default {
         this.saveItem(updatedItem)
       })
       this.moveState.saving = false
-      this.moveState.dragDropActive = false
       console.debug('runtime saveModelUpdate end', Date.now() - this.moveState.dragStartTimestamp)
     },
     restoreModelUpdate () {
@@ -625,19 +622,12 @@ export default {
       this.moveState.adding = false
       this.moveState.removing = false
       this.moveState.saving = false
-      this.moveState.dragDropActive = false
       this.$emit('reload')
       console.debug('runtime restoreModelUpdate end', Date.now() - this.moveState.dragStartTimestamp)
     },
     itemLabel (item) {
       if (!item) return 'model root'
       return (item.label ? (this.includeItemName ? item.label + ' (' + item.name + ')' : item.label) : item.name)
-    },
-    nodeLocation (node) {
-      // This check is incomplete. It should walk up the model tree to find the lowest level location at or above the current node,
-      // but the full tree is not easily available here.
-      if (node.class.startsWith('Location')) return node.item.name
-      return node.item.metadata?.semantics?.config?.hasLocation
     },
     nodeChildren (node) {
       if (!node) return this.children

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -229,8 +229,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-            verticalButtons: true,
-            buttons: [
+          verticalButtons: true,
+          buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
             { text: 'Point', onClick: () => this.addPoint(node, parentNode) }
@@ -257,8 +257,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-            verticalButtons: true,
-            buttons: [
+          verticalButtons: true,
+          buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
             { text: 'Point', onClick: () => this.addPoint(node, parentNode) }
@@ -290,8 +290,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-            verticalButtons: true,
-            buttons: [
+          verticalButtons: true,
+          buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Location', onClick: () => this.addLocation(node, parentNode) },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
@@ -304,8 +304,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-            verticalButtons: true,
-            buttons: [
+          verticalButtons: true,
+          buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
             { text: 'Point', onClick: () => this.addPoint(node, parentNode) },
@@ -401,8 +401,8 @@ export default {
             '" dragged from group "' + this.itemLabel(parentNode.item) +
             '" into "' + this.itemLabel(this.moveState.newParent.item) +
             '", keep original?',
-            verticalButtons: true,
-            buttons: [
+          verticalButtons: true,
+          buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Keep', onClick: () => this.updateAfterRemove() },
             { text: 'Remove', onClick: () => this.remove(node, parentNode, oldIndex) }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -27,11 +27,13 @@ export default {
         return [this.model.children.locations, this.model.children.equipment, this.model.children.points, this.model.children.groups, this.model.children.items].flat()
       },
       set: function (nodeList) {
-        this.$set(this.model.children, 'locations', nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Location')))
-        this.$set(this.model.children, 'equipment', nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Equipment')))
-        this.$set(this.model.children, 'points', nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Point')))
-        this.$set(this.model.children, 'groups', nodeList.filter(n => !n.item.metadata?.semantics && n.item.type === 'Group'))
-        this.$set(this.model.children, 'items', nodeList.filter(n => !n.item.metadata?.semantics && n.item.type !== 'Group'))
+        const newChildren = {}
+        newChildren.locations = nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Location'))
+        newChildren.equipment = nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Equipment'))
+        newChildren.points = nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Point'))
+        newChildren.groups = nodeList.filter(n => !n.item.metadata?.semantics && n.item.type === 'Group')
+        newChildren.items =  nodeList.filter(n => !n.item.metadata?.semantics && n.item.type !== 'Group')
+        this.$set(this.model, 'children', newChildren)
       }
     },
     iconColor () {
@@ -616,10 +618,6 @@ export default {
       // This check is incomplete. It should walk up the model tree to find the lowest level location at or above the current node,
       // but the full tree is not easily available here.
       if (node.class.startsWith('Location')) return node.item.name
-      const parentItem = node.item.metadata?.semantics?.config?.isPartOf
-      if (parentItem) {
-        // go up the tree, retrieve the node and call recursively
-      }
       return node.item.metadata?.semantics?.config?.hasLocation
     },
     nodeChildren (node) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -393,8 +393,8 @@ export default {
       console.debug('Remove - new moveState:', cloneDeep(this.moveState))
       if (parentNode.class !== '' && this.moveState.newParent.class !== '') {
         // special rule: a point can be part of a location and equipment at the same time, e.g. central HVAC equipment with controls by room
-        if (parentNode.class.startsWith('Equipment') && this.moveState.newParent.class.startsWith('Location')
-            && this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
+        if (parentNode.class.startsWith('Equipment') && this.moveState.newParent.class.startsWith('Location') &&
+            this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
           this.$set(this.moveState, 'moveConfirmed', true)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
@@ -407,8 +407,8 @@ export default {
               { text: 'No', strong: true, onClick: () => this.remove(node, parentNode, oldIndex) }
             ]
           }).open()
-        } else if (parentNode.class.startsWith('Location') && this.moveState.newParent.class.startsWith('Equipment')
-            && this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
+        } else if (parentNode.class.startsWith('Location') && this.moveState.newParent.class.startsWith('Equipment') &&
+            this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
           this.$set(this.moveState, 'moveConfirmed', true)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -102,7 +102,8 @@ export default {
       console.debug('runtime onDragStart', Date.now() - this.moveState.dragStartTimestamp)
     },
     onDragChange (event) {
-      if (this.moveState.cancelled || !this.moveState.node.item.editable) {
+      const dropAllowed = this.moveState.moveTarget ? this.dropAllowed(this.moveState.moveTarget) : true
+      if (this.moveState.cancelled || !this.moveState.node.item.editable || !dropAllowed) {
         return
       }
       console.debug('runtime onDragChange', Date.now() - this.moveState.dragStartTimestamp)
@@ -123,23 +124,25 @@ export default {
       console.debug('Drag change - moveState:', cloneDeep(this.moveState))
     },
     onDragMove (event) {
+      console.debug('Drag move - event:', event)
       // cancel opening previous group we moved over as we moved away from it
-      const moveTarget = event.relatedContext?.element
-      const movedToSamePlace = moveTarget?.item?.name === this.moveState.moveTarget
+      const movedToSamePlace = event.relatedContext?.element?.item?.name === this.moveState.moveTarget?.item?.name
       if (!movedToSamePlace) {
         clearTimeout(this.moveState.moveDelayedOpen)
         this.moveState.moveDelayedOpen = null
       }
+      this.moveState.moveTarget = event.relatedContext?.element
       // return if we cannot drop here
-      if (this.moveState.cancelled || !this.moveState.node.item.editable || !this.dropAllowed(event?.relatedContext?.element)) {
+      if (this.moveState.cancelled || !this.moveState.node.item.editable || !this.dropAllowed(this.moveState.moveTarget)) {
         return false
       }
       // Open group if not open yet, with a delay so you don't open it if you just drag over it
-      if (!movedToSamePlace && moveTarget?.item?.type === 'Group' && !moveTarget.opened) {
-        this.moveState.moveTarget = moveTarget?.item?.name
+      if (!movedToSamePlace && this.moveState.moveTarget?.item?.type === 'Group' && !this.moveState.moveTarget?.opened) {
+        const element = event.relatedContext.element
         this.moveState.moveDelayedOpen = setTimeout(() => {
-          moveTarget.opened = true
-        }, 1000)
+          // this.$set(element, "opened", true)
+          element.opened = true
+        }, 1000, element)
       }
       return true
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -45,7 +45,7 @@ export default {
       return !this.moveState.cancelled && this.moveState.dragEnd && this.moveState.dragFinished && !this.moveState.canAdd && !this.moveState.canRemove && !this.moveState.saving
     },
     canHaveChildren () {
-      return ((this.model.item.type === 'Group') && (this.children.length > 0 || this.moveState.moving) === true)
+      return ((this.model.item.type === 'Group') && (this.children.length > 0 || this.moveState.moving)) === true
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -1,0 +1,361 @@
+import cloneDeep from 'lodash/cloneDeep'
+import * as types from '@/assets/item-types.js'
+import ItemMixin from '@/components/item/item-mixin'
+import TagMixin from '@/components/tags/tag-mixin'
+
+export default {
+  mixins: [ItemMixin, TagMixin],
+  data () {
+    return {
+      localMoveState: this.moveState ? this.moveState : {}
+    }
+  },
+  watch: {
+    moveState: {
+      handler () {
+        if (this.moveFinished) {
+          this.saveModelUpdate(this.localMoveState)
+          this.$set(this.localMoveState, 'hasMoved', false)
+        }
+      },
+      deep: true
+    }
+  },
+  computed: {
+    children: {
+      get: function () {
+        return this.nodeChildren()
+      },
+      set: function (nodeList) {
+        this.$set(this.model.children, 'locations', nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Location')))
+        this.$set(this.model.children, 'equipment', nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Equipment')))
+        this.$set(this.model.children, 'points', nodeList.filter(n => n.item.metadata?.semantics?.value?.startsWith('Point')))
+        this.$set(this.model.children, 'groups', nodeList.filter(n => !n.item.metadata?.semantics && n.item.type === 'Group'))
+        this.$set(this.model.children, 'items', nodeList.filter(n => !n.item.metadata?.semantics && n.item.type !== 'Group'))
+      }
+    },
+    iconColor () {
+      return (this.model.item.metadata && this.model.item.metadata.semantics) ? '' : 'gray'
+    },
+    moveFinished () {
+      return this.localMoveState.dragFinished && this.localMoveState.addFinished && this.localMoveState.removeFinished && this.localMoveState.hasMoved
+    }
+  },
+  methods: {
+    onDragStart (event) {
+      console.debug('Drag start - event:', event)
+      this.$set(this.localMoveState, 'dragFinished', false)
+      this.$set(this.localMoveState, 'node', this.children[event.oldIndex])
+      console.debug('Drag start - stored moveState:', cloneDeep(this.localMoveState))
+    },
+    onDragChange (event) {
+      console.debug('Drag change - event:', event)
+      console.debug('Drag change - stored moveState:', cloneDeep(this.localMoveState))
+      if (event.added) {
+        this.$set(this.localMoveState, 'addFinished', false)
+        this.validateAdd()
+      }
+      if (event.removed) {
+        this.$set(this.localMoveState, 'removeFinished', false)
+        this.validateRemove(event.removed.oldIndex)
+      }
+    },
+    onDragMove (event) {
+      if (event.relatedContext.element?.item?.type === 'Group' && !event.relatedContext.element.opened) {
+        event.relatedContext.element.opened = true
+      }
+    },
+    onDragEnd (event) {
+      this.$set(this.localMoveState, 'dragFinished', true)
+      console.debug('Drag end - event:', event)
+      console.debug('Drag end - stored moveState:', cloneDeep(this.localMoveState))
+    },
+    nestedNodes (node, nodes) {
+      const children = [...node.children.locations, ...node.children.equipment, ...node.children.points, ...node.children.groups, ...node.children.items]
+      nodes.push(...children)
+      children.forEach((child) => this.nestedNodes(child, nodes))
+      return nodes
+    },
+    validateAdd () {
+      const node = this.localMoveState.node
+      const parentNode = this.model
+      const semantics = {
+        'value': null,
+        'config': {
+          'hasLocation': null,
+          'isPartOf': null,
+          'isPointOf': null
+        }
+      }
+      if (node.item.type === 'Group' && node.class === '' && parentNode?.class) {
+        const semanticNode = this.nestedNodes(node, []).find((n) => n.class !== '')
+        if (semanticNode) {
+          this.$f7.dialog.alert(
+            'Cannot insert non-semantic group ' + this.itemLabel(node.item) +
+            ' with semantic child ' + this.itemLabel(semanticNode.item) +
+            ' into semantic group'
+          ).open()
+          this.$set(this.localMoveState, 'addFinished', true)
+          return
+        }
+      }
+      if (!this.isValidGroupType(node, parentNode)) {
+        this.$set(this.localMoveState, 'addFinished', true)
+        return
+      }
+      if (parentNode?.class === 'Location') {
+        if (node.class === 'Location') {
+          this.addLocation(node, parentNode, semantics)
+        } else if (node.class === 'Equipment') {
+          this.addEquipment(node, parentNode, semantics)
+        } else if (node.class?.startsWith('Point')) {
+          this.addPoint(node, parentNode, semantics)
+        } else if (node.item.type === 'Group') {
+          this.$f7.dialog.create({
+            text: 'Insert ' + this.itemLabel(node.item) + ' as',
+            buttons: [
+              { text: 'Location', onClick: () => this.addLocation(node, parentNode, semantics) },
+              { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode, semantics) }
+            ]
+          }).open()
+        } else {
+          this.$f7.dialog.create({
+            text: 'Insert ' + this.itemLabel(node.item) + ' as',
+            buttons: [
+              { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode, semantics) },
+              { text: 'Point', onClick: () => this.addPoint(node, parentNode, semantics) }
+            ]
+          }).open()
+        }
+      } else if (parentNode?.class === 'Equipment') {
+        if (node.class === 'Location') {
+          this.$f7.dialog.alert('Cannot move Location ' + this.itemLabel(node.item) + ' into Equipment ' + this.itemLabel(parentNode.item)).open()
+          return false
+        } else if (node.class === 'Equipment') {
+          this.addEquipment(node, parentNode, semantics)
+        } else if (node.class?.startsWith('Point')) {
+          this.addPoint(node, parentNode, semantics)
+        } else if (node.item.type === 'Group') {
+          this.addEquipment(node, parentNode, semantics)
+        } else {
+          this.$f7.dialog.create({
+            text: 'Insert ' + this.itemLabel(node.item) + ' as',
+            buttons: [
+              { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode, semantics) },
+              { text: 'Point', onClick: () => this.addPoint(node, parentNode, semantics) }
+            ]
+          }).open()
+        }
+      } else {
+        if (parentNode.item) {
+          this.addNonSemantic(node, parentNode, semantics)
+        } else if (node.class === 'Location') {
+          this.addLocation(node, parentNode, semantics)
+        } else if (node.class === 'Equipment') {
+          this.addEquipment(node, parentNode, semantics)
+        } else if (node.class?.startsWith('Point')) {
+          this.addPoint(node, parentNode, semantics)
+        } else if (node.item.type === 'Group') {
+          this.$f7.dialog.create({
+            text: 'Insert ' + this.itemLabel(node.item) + ' as',
+            buttons: [
+              { text: 'Location', onClick: () => this.addLocation(node, parentNode, semantics) },
+              { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode, semantics) },
+              { text: 'Non Semantic', onClick: () => this.addNonSemantic(node, parentNode, semantics) }
+            ]
+          }).open()
+        } else {
+          this.$f7.dialog.create({
+            text: 'Insert ' + this.itemLabel(node.item) + ' as',
+            buttons: [
+              { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode, semantics) },
+              { text: 'Point', onClick: () => this.addPoint(node, parentNode, semantics) },
+              { text: 'Non Semantic', onClick: () => this.addNonSemantic(node, parentNode, semantics) }
+            ]
+          }).open()
+        }
+      }
+    },
+    isValidGroupType (node, parentNode) {
+      const groupTypeDef = parentNode.item?.groupType?.split(':')
+      const baseType = groupTypeDef ? groupTypeDef[0] : 'None'
+      if (baseType === 'None') return true
+      const baseDimension = groupTypeDef && groupTypeDef.length > 1 ? groupTypeDef[1] : null
+
+      const typeDef = node.item.type !== 'Group' ? node.item.type?.split(':') : node.item.groupType?.split(':')
+      const type = typeDef ? typeDef[0] : 'None'
+      const dimension = typeDef.length > 1 ? typeDef[1] : null
+      if ((type === 'Number' || type === 'None') && baseType === 'Number') {
+        if (baseDimension && dimension && baseDimension !== dimension) {
+          this.$f7.dialog.alert(
+            'Group dimension ' + baseDimension +
+             ' of group ' + this.itemLabel(parentNode.item) +
+             ' not compatible with ' + (node.item.type === 'Group' ? 'group ' : '') + 'item dimension ' + dimension +
+             ' of ' + (node.item.type === 'Group' ? 'group ' : '') + 'item ' + this.itemLabel(node.item)
+          ).open()
+          return false
+        }
+        if (dimension) {
+          const childWithDifferentDimension = parentNode.children.map((child) => {
+            const childTypeDef = child.item.type !== 'Group' ? child.item.type.split(':') : child.item.groupType?.split(':')
+            return childTypeDef.length > 1 ? { item: child.item, dimension: childTypeDef[1] } : null
+          }).find((child) => { return dimension !== child?.dimension })
+          if (childWithDifferentDimension) {
+            this.$f7.dialog.alert(
+              'Group ' + this.itemLabel(parentNode.item) +
+              ' already contains item ' + this.itemLabel(childWithDifferentDimension.item) +
+              ' with dimension ' + childWithDifferentDimension.dimension +
+              ' different from group dimension ' + dimension
+            ).open()
+            return false
+          }
+        }
+      }
+      const aggregationFunction = parentNode.item?.function?.name
+      if (aggregationFunction && !this.aggregationFunctions(type).contains(aggregationFunction)) {
+        this.$f7.dialog.alert(
+          'Group aggreggation function ' + aggregationFunction +
+          ' for group ' + this.itemLabel(parentNode.item) +
+          ' not compatible with type ' + type +
+          ' of item ' + this.itemLabel(node.item)
+        ).open()
+        return false
+      }
+      return true
+    },
+    aggregationFunctions (type) {
+      const specificAggregationFunctions = (type) => {
+        switch (type) {
+          case 'Dimmer':
+          case 'Rollershutter':
+          case 'Number':
+            return types.ArithmeticFunctions
+          case 'Contact':
+            return types.LogicalOpenClosedFunctions
+          case 'Player':
+            return types.LogicalPlayPauseFunctions
+          case 'DateTime':
+            return types.DateTimeFunctions
+          case 'Switch':
+            return types.LogicalOnOffFunctions
+        }
+        return []
+      }
+      return [...types.CommonFunctions, ...specificAggregationFunctions(type)]
+    },
+    addLocation (node, parentNode, semantics) {
+      semantics.value = node.item?.metadata?.semantics?.value || 'Location'
+      if (parentNode.class === 'Location') {
+        semantics.config.isPartOf = parentNode.item.name
+      }
+      if (!this.localMoveState.node.item.tags.includes(semantics.value)) this.localMoveState.node.item.tags.push(semantics.value)
+      this.$set(this.localMoveState.node, 'class', 'Location')
+      this.updateAfterAdd(node, parentNode, semantics)
+    },
+    addEquipment (node, parentNode, semantics) {
+      semantics.value = node.item?.metadata?.semantics?.value || 'Equipment'
+      if (parentNode.class === 'Location') {
+        semantics.config.hasLocation = parentNode.item.name
+      } else if (parentNode.class === 'Equipment') {
+        semantics.config.isPartOf = parentNode.item.name
+      }
+      if (!this.localMoveState.node.item.tags.includes(semantics.value)) this.localMoveState.node.item.tags.push(semantics.value)
+      this.$set(this.localMoveState.node, 'class', 'Equipment')
+      this.updateAfterAdd(node, parentNode, semantics)
+    },
+    addPoint (node, parentNode, semantics) {
+      semantics.value = node.item?.metadata?.semantics?.value || 'Point'
+      if (parentNode.class === 'Location') {
+        semantics.config.hasLocation = parentNode.item.name
+      } else if (parentNode.class === 'Equipment') {
+        semantics.config.isPointOf = parentNode.item.name
+      }
+      if (!this.localMoveState.node.item.tags.includes(semantics.value)) this.localMoveState.node.item.tags.push(semantics.value)
+      this.$set(this.localMoveState.node, 'class', 'Point')
+      this.updateAfterAdd(node, parentNode, semantics)
+    },
+    addNonSemantic (node, parentNode, semantics) {
+      this.$set(this.localMoveState.node, 'class', '')
+      if (node.item.metadata?.semantics) {
+        this.$set(this.localMoveState.node.item.metadata, 'semantics', null)
+      }
+      this.updateAfterAdd(node, parentNode, semantics)
+    },
+    updateAfterAdd (node, parentNode, semantics) {
+      this.$set(this.localMoveState, 'hasMoved', true)
+      if (node.item.metadata) {
+        this.$set(this.localMoveState.node.item.metadata, 'semantics', semantics)
+      } else {
+        this.$set(this.localMoveState.node.item, 'metadata', { semantics })
+      }
+      if (parentNode?.item?.type === 'Group' && !node.item.groupNames.includes(parentNode.item.name)) {
+        node.item.groupNames.push(parentNode.item.name)
+      }
+      console.debug('Add - new moveState:', cloneDeep(this.localMoveState))
+      console.debug('Add - parentNode:', cloneDeep(parentNode))
+      console.debug('Add - children:', cloneDeep(this.children))
+      if (!this.children.find(n => n.item.name === node.item.name)) {
+        // sometimes the list gets updates when dragging, sometimes it is missed so we have to add here
+        this.children.push(node)
+      }
+      const newChildren = this.children
+      this.children = newChildren // force setters to update model
+      console.debug('Add - new children:', cloneDeep(this.children))
+      console.debug('Add - added to parent:', cloneDeep(parentNode))
+      this.$set(this.localMoveState, 'addFinished', true)
+      console.debug('Add - finished, new moveState:', cloneDeep(this.localMoveState))
+    },
+    validateRemove (oldIndex) {
+      const node = this.localMoveState.node
+      const parentNode = this.model
+      console.debug('Remove - new moveState:', cloneDeep(this.localMoveState))
+      console.debug('Remove - parentNode:', cloneDeep(parentNode))
+      console.debug('Remove - children:', cloneDeep(this.children))
+      if (parentNode.class !== '') {
+        // always remove from semantic model groups
+        this.remove(node, parentNode, oldIndex)
+      } else if (!parentNode.item && node.class !== '') {
+        // always remove semantic item from root level when moving into another group
+        this.remove(node, parentNode, oldIndex)
+      } else if (parentNode.item?.type === 'Group') {
+        this.$f7.dialog.create({
+          text: 'Item ' + this.itemLabel(node.item) + ' dragged from group ' + this.itemLabel(parentNode.item) + ': Remove original ?',
+          buttons: [
+            { text: 'Remove', onClick: () => this.remove(node, parentNode, oldIndex) },
+            { text: 'Keep', onClick: () => this.$set(this.moveState, 'removeFinished', true) }
+          ]
+        }).open()
+      } else {
+        this.$set(this.localMoveState, 'removeFinished', true)
+      }
+    },
+    remove (node, parentNode, oldIndex) {
+      const groupNameIndex = node.item.groupNames.findIndex(g => g === parentNode.item?.name)
+      if (groupNameIndex >= 0) {
+        node.item.groupNames.splice(groupNameIndex, 1)
+      }
+      const newChildren = this.nodeChildren(parentNode)
+      newChildren.splice(oldIndex, 1)
+      this.children = newChildren
+      console.debug('Remove - new children:', cloneDeep(this.children))
+      console.debug('Remove - removed from parent:', parentNode)
+      this.$set(this.localMoveState, 'removeFinished', true)
+      console.debug('Remove - finished, new moveState:', cloneDeep(this.localMoveState))
+    },
+    saveModelUpdate (moveState) {
+      const updatedItem = moveState.node.item
+      console.debug('Save - updatedItem: ', cloneDeep(updatedItem))
+      this.saveItem(updatedItem)
+    },
+    itemLabel (item) {
+      return (item.label ? (this.includeItemName ? item.label + ' (' + item.name + ')' : item.label) : item.name)
+    },
+    nodeChildren (node) {
+      const parentNode = node || this.model
+      if (!parentNode.children) return []
+      return [parentNode.children.locations,
+        parentNode.children.equipment, parentNode.children.points,
+        parentNode.children.groups, parentNode.children.items].flat()
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -6,6 +6,28 @@ import fastDeepEqual from 'fast-deep-equal/es6'
 
 export default {
   mixins: [ItemMixin, TagMixin],
+  props: {
+    moveState: {
+      type: Object,
+      default: () => ({
+        dragDropActive: false,
+        moving: false,
+        canAdd: false,
+        canRemove: false,
+        dragEnd: false,
+        dragFinished: false,
+        saving: false,
+        cancelled: false,
+        moveConfirmed: false,
+        node: null,
+        newParent: null,
+        oldParent: null,
+        oldIndex: null,
+        dragStartTimestamp: null,
+        nodesToUpdate: []
+      })
+    }
+  },
   watch: {
     moveState: {
       handler: function () {
@@ -59,18 +81,18 @@ export default {
     onDragStart (event) {
       console.debug('Drag start - event:', event)
       window.addEventListener('keydown', this.keyDownHandler)
-      this.$set(this.moveState, 'dragDropActive', true)
-      this.$set(this.moveState, 'moving', true)
-      this.$set(this.moveState, 'canAdd', false)
-      this.$set(this.moveState, 'canRemove', false)
-      this.$set(this.moveState, 'dragEnd', false)
-      this.$set(this.moveState, 'dragFinished', false)
-      this.$set(this.moveState, 'saving', false)
-      this.$set(this.moveState, 'cancelled', false)
-      this.$set(this.moveState, 'moveConfirmed', false)
-      this.$set(this.moveState, 'node', this.children[event.oldIndex])
-      this.$set(this.moveState, 'nodesToUpdate', [])
-      this.$set(this.moveState, 'dragStartTimestamp', Date.now())
+      this.moveState.dragDropActive = true
+      this.moveState.moving = true
+      this.moveState.canAdd = false
+      this.moveState.canRemove = false
+      this.moveState.dragEnd = false
+      this.moveState.dragFinished = false
+      this.moveState.saving = false
+      this.moveState.cancelled = false
+      this.moveState.moveConfirmed = false
+      this.moveState.node = this.children[event.oldIndex]
+      this.moveState.dragStartTimestamp = Date.now()
+      this.moveState.nodesToUpdate.splice(0)
       console.debug('Drag start - moveState:', cloneDeep(this.moveState))
       console.debug('runtime onDragStart', Date.now() - this.moveState.dragStartTimestamp)
     },
@@ -82,13 +104,13 @@ export default {
         return
       }
       if (event.added) {
-        this.$set(this.moveState, 'newParent', this.model)
-        this.$set(this.moveState, 'canAdd', true)
+        this.moveState.newParent = this.model
+        this.moveState.canAdd = true
       }
       if (event.removed) {
-        this.$set(this.moveState, 'oldParent', this.model)
-        this.$set(this.moveState, 'oldIndex', event.removed.oldIndex)
-        this.$set(this.moveState, 'canRemove', true)
+        this.moveState.oldParent = this.model
+        this.moveState.oldIndex = event.removed.oldIndex
+        this.moveState.canRemove = true
       }
       console.debug('Drag change - moveState:', cloneDeep(this.moveState))
     },
@@ -109,8 +131,8 @@ export default {
         this.restoreModelUpdate()
         return
       }
-      this.$set(this.moveState, 'moving', false)
-      this.$set(this.moveState, 'dragEnd', true)
+      this.moveState.moving = false
+      this.moveState.dragEnd = true
       console.debug('Drag end - moveState:', cloneDeep(this.moveState))
     },
     nestedSemanticNode (node) {
@@ -123,7 +145,7 @@ export default {
     },
     validateAdd () {
       console.debug('runtime validateAdd start', Date.now() - this.moveState.dragStartTimestamp)
-      this.$set(this.moveState, 'adding', true)
+      this.moveState.adding = true
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
       const oldParentNode = this.moveState.oldParent
@@ -182,8 +204,8 @@ export default {
       } else {
         this.addIntoRoot(node, parentNode)
       }
-      this.$set(this.moveState, 'canAdd', false)
-      this.$set(this.moveState, 'adding', false)
+      this.moveState.canAdd = false
+      this.moveState.adding = false
       console.debug('runtime validateAdd end', Date.now() - this.moveState.dragStartTimestamp)
     },
     isValidGroupType (node, parentNode) {
@@ -270,7 +292,7 @@ export default {
       } else if (node.class.startsWith('Point')) {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
-        this.$set(this.moveState, 'moveConfirmed', true)
+        this.moveState.moveConfirmed = true
         console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -284,7 +306,7 @@ export default {
           ]
         }).open()
       } else {
-        this.$set(this.moveState, 'moveConfirmed', true)
+        this.moveState.moveConfirmed = true
         console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -316,7 +338,7 @@ export default {
       } else if (node.item.type === 'Group') {
         this.addEquipment(node, parentNode)
       } else {
-        this.$set(this.moveState, 'moveConfirmed', true)
+        this.moveState.moveConfirmed = true
         console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         const dialog = this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -354,7 +376,7 @@ export default {
       } else if (node.class.startsWith('Point')) {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
-        this.$set(this.moveState, 'moveConfirmed', true)
+        this.moveState.moveConfirmed = true
         console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -369,7 +391,7 @@ export default {
           ]
         }).open()
       } else {
-        this.$set(this.moveState, 'moveConfirmed', true)
+        this.moveState.moveConfirmed = true
         console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -465,16 +487,14 @@ export default {
       const newChildren = this.children
       this.children = newChildren // force setters to update model
       if (updateRequired) {
-        let nodesToUpdate = this.moveState.nodesToUpdate
-        nodesToUpdate.push(node)
-        this.$set(this.moveState, 'nodesToUpdate', nodesToUpdate)
+        this.moveState.nodesToUpdate.push(node)
       }
       console.debug('Add - finished, new moveState:', cloneDeep(this.moveState))
       console.debug('runtime updateAfterAdd end', Date.now() - this.moveState.dragStartTimestamp)
     },
     validateRemove () {
       console.debug('runtime validateRemove start', Date.now() - this.moveState.dragStartTimestamp)
-      this.$set(this.moveState, 'removing', true)
+      this.moveState.removing = true
       const node = this.moveState.node
       const newParentNode = this.moveState.newParent
       const parentNode = this.moveState.oldParent
@@ -488,7 +508,7 @@ export default {
         // special rule: a point can be part of a location and equipment at the same time, e.g. central HVAC equipment with controls by room
         if (parentNode.class.startsWith('Equipment') && newParentNode.class.startsWith('Location') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {
-          this.$set(this.moveState, 'moveConfirmed', true)
+          this.moveState.moveConfirmed = true
           console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
@@ -503,7 +523,7 @@ export default {
           }).open()
         } else if (parentNode.class.startsWith('Location') && newParentNode.class.startsWith('Equipment') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {
-          this.$set(this.moveState, 'moveConfirmed', true)
+          this.moveState.moveConfirmed = true
           console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
@@ -524,7 +544,7 @@ export default {
         // always remove semantic item from root level when moving into another group
         this.remove(node, parentNode, oldIndex)
       } else if (parentNode.item?.type === 'Group') {
-        this.$set(this.moveState, 'moveConfirmed', true)
+        this.moveState.moveConfirmed = true
         console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Item "' + this.itemLabel(node.item) +
@@ -563,14 +583,14 @@ export default {
     },
     updateAfterRemove () {
       console.debug('runtime updateAfterRemove start', Date.now() - this.moveState.dragStartTimestamp)
-      this.$set(this.moveState, 'canRemove', false)
-      this.$set(this.moveState, 'removing', false)
-      this.$set(this.moveState, 'dragFinished', true)
+      this.moveState.canRemove = false
+      this.moveState.removing = false
+      this.moveState.dragFinished = true
       console.debug('runtime updateAfterRemove end', Date.now() - this.moveState.dragStartTimestamp)
     },
     saveUpdate () {
       console.debug('runtime saveUpdate start', Date.now() - this.moveState.dragStartTimestamp)
-      this.$set(this.moveState, 'saving', true)
+      this.moveState.saving = true
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
       if (!this.moveState.moveConfirmed) {
@@ -587,26 +607,26 @@ export default {
     },
     saveModelUpdate () {
       console.debug('runtime saveModelUpdate start', Date.now() - this.moveState.dragStartTimestamp)
-      this.$set(this.moveState, 'dragFinished', false)
+      this.moveState.dragFinished = false
       this.moveState.nodesToUpdate.forEach((n) => {
         const updatedItem = n.item
         console.debug('Save - updatedItem: ', cloneDeep(updatedItem))
         this.saveItem(updatedItem)
       })
-      this.$set(this.moveState, 'saving', false)
-      this.$set(this.moveState, 'dragDropActive', false)
+      this.moveState.saving = false
+      this.moveState.dragDropActive = false
       console.debug('runtime saveModelUpdate end', Date.now() - this.moveState.dragStartTimestamp)
     },
     restoreModelUpdate () {
       console.debug('Restore model')
       console.debug('runtime restoreModelUpdate start', Date.now() - this.moveState.dragStartTimestamp)
-      this.$set(this.moveState, 'cancelled', true)
-      this.$set(this.moveState, 'canRemove', false)
-      this.$set(this.moveState, 'canAdd', false)
-      this.$set(this.moveState, 'adding', false)
-      this.$set(this.moveState, 'removing', false)
-      this.$set(this.moveState, 'saving', false)
-      this.$set(this.moveState, 'dragDropActive', false)
+      this.moveState.cancelled = true
+      this.moveState.canRemove = false
+      this.moveState.canAdd = false
+      this.moveState.adding = false
+      this.moveState.removing = false
+      this.moveState.saving = false
+      this.moveState.dragDropActive = false
       this.$emit('reload')
       console.debug('runtime restoreModelUpdate end', Date.now() - this.moveState.dragStartTimestamp)
     },
@@ -629,7 +649,7 @@ export default {
       if (!event.repeat && event.keyCode === 27) {
         console.debug('escape pressed')
         console.debug('runtime escape', Date.now() - this.moveState.dragStartTimestamp)
-        this.$set(this.moveState, 'cancelled', true)
+        this.moveState.cancelled = true
       }
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -101,6 +101,7 @@ export default {
       })
     },
     validateAdd () {
+      const timestamp = Date.now()
       this.$set(this.moveState, 'adding', true)
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
@@ -114,6 +115,7 @@ export default {
         const message = 'Group "' + this.itemLabel(parentNode.item) +
           '" already contains item "' + this.itemLabel(node.item) + '"'
         console.debug('Add rejected: ' + message)
+        console.debug('runtime validateAdd', Date.now() - timestamp)
         this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
         return
@@ -125,6 +127,7 @@ export default {
             '" with semantic child "' + this.itemLabel(semanticNode.item) +
             '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
           console.debug('Add rejected: ' + message)
+          console.debug('runtime validateAdd', Date.now() - timestamp)
           this.$f7.dialog.alert(message).open()
           this.restoreModelUpdate()
           return
@@ -135,11 +138,13 @@ export default {
           '" from non-semantic group "' + this.itemLabel(oldParentNode.item) +
           '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
         console.debug('Add rejected:' + message)
+        console.debug('runtime validateAdd', Date.now() - timestamp)
         this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
         return
       }
       if (!this.isValidGroupType(node, parentNode)) {
+        console.debug('runtime validateAdd', Date.now() - timestamp)
         this.restoreModelUpdate()
         return
       }
@@ -154,8 +159,10 @@ export default {
       }
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'adding', false)
+      console.debug('runtime validateAdd end', Date.now() - timestamp)
     },
     isValidGroupType (node, parentNode) {
+      const timestamp = Date.now()
       const groupTypeDef = parentNode.item?.groupType?.split(':')
       const baseType = groupTypeDef ? groupTypeDef[0] : 'None'
       if (baseType === 'None') return true
@@ -171,6 +178,7 @@ export default {
              '" not compatible with "' + (node.item.type === 'Group' ? 'group ' : '') + 'item dimension "' + dimension +
              '" of "' + (node.item.type === 'Group' ? 'group ' : '') + '" item "' + this.itemLabel(node.item) + '"'
           console.debug('Add rejected: ' + message)
+          console.debug('runtime isValidGroupType', Date.now() - timestamp)
           this.$f7.dialog.alert(message).open()
           return false
         }
@@ -185,6 +193,7 @@ export default {
               '" with dimension "' + childWithDifferentDimension.dimension +
               '" different from group dimension "' + dimension + '"'
             console.debug('Add rejected: ' + message)
+            console.debug('runtime isValidGroupType', Date.now() - timestamp)
             this.$f7.dialog.alert(message).open()
             return false
           }
@@ -197,9 +206,11 @@ export default {
           '" not compatible with type "' + type +
           '" of item "' + this.itemLabel(node.item) + '"'
         console.debug('Add rejected: ' + message)
+        console.debug('runtime isValidGroupType', Date.now() - timestamp)
         this.$f7.dialog.alert(message).open()
         return false
       }
+      console.debug('runtime isValidGroupType', Date.now() - timestamp)
       return true
     },
     aggregationFunctions (type) {
@@ -223,6 +234,7 @@ export default {
       return [...types.CommonFunctions, ...specificAggregationFunctions(type)]
     },
     addIntoLocation (node, parentNode) {
+      const timestamp = Date.now()
       if (node.class.startsWith('Location')) {
         this.addLocation(node, parentNode)
       } else if (node.class.startsWith('Equipment')) {
@@ -230,6 +242,7 @@ export default {
       } else if (node.class.startsWith('Point')) {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
+        console.debug('runtime addIntoLocation', Date.now() - timestamp)
         this.$set(this.moveState, 'moveConfirmed', true)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -243,6 +256,7 @@ export default {
           ]
         }).open()
       } else {
+        console.debug('runtime addIntoLocation', Date.now() - timestamp)
         this.$set(this.moveState, 'moveConfirmed', true)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
@@ -256,9 +270,12 @@ export default {
           ]
         }).open()
       }
+      console.debug('runtime addIntoLocation end', Date.now() - timestamp)
     },
     addIntoEquipment (node, parentNode) {
+      const timestamp = Date.now()
       if (node.class.startsWith('Location')) {
+        console.debug('runtime addIntoEquipment', Date.now() - timestamp)
         this.$f7.dialog.alert(
           'Cannot move Location "' + this.itemLabel(node.item) +
           '" into Equipment "' + this.itemLabel(parentNode.item) + '"'
@@ -272,6 +289,7 @@ export default {
         this.addEquipment(node, parentNode)
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime addIntoEquipment', Date.now() - timestamp)
         const dialog = this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -284,6 +302,7 @@ export default {
           ]
         }).open()
       }
+      console.debug('runtime addIntoEquipment end', Date.now() - timestamp)
     },
     addIntoGroup (node, parentNode) {
       if (node.class.startsWith('Location')) {
@@ -297,6 +316,7 @@ export default {
       }
     },
     addIntoRoot (node, parentNode) {
+      const timestamp = Date.now()
       if (node.class.startsWith('Location')) {
         this.addLocation(node, parentNode)
       } else if (node.class.startsWith('Equipment')) {
@@ -305,6 +325,7 @@ export default {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime addIntoRoot', Date.now() - timestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -319,6 +340,7 @@ export default {
         }).open()
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime addIntoRoot', Date.now() - timestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -332,8 +354,10 @@ export default {
           ]
         }).open()
       }
+      console.debug('runtime addIntoRoot end', Date.now() - timestamp)
     },
     addLocation (node, parentNode) {
+      const timestamp = Date.now()
       const semantics = { config: {} }
       semantics.value = node.item?.metadata?.semantics?.value || 'Location'
       if (parentNode.class.startsWith('Location')) {
@@ -343,9 +367,11 @@ export default {
       node.class = semantics.value
       const nodeChildren = this.nodeChildren(node)
       nodeChildren.forEach((n) => this.addIntoLocation(n, node))
+      console.debug('runtime addLocation end', Date.now() - timestamp)
       this.updateAfterAdd(node, parentNode, semantics)
     },
     addEquipment (node, parentNode) {
+      const timestamp = Date.now()
       const semantics = { config: {} }
       semantics.value = node.item?.metadata?.semantics?.value || 'Equipment'
       if (parentNode.class.startsWith('Location')) {
@@ -357,9 +383,11 @@ export default {
       node.class = semantics.value
       const nodeChildren = this.nodeChildren(node)
       nodeChildren.forEach((n) => this.addIntoEquipment(n, node))
+      console.debug('runtime addEquipment end', Date.now() - timestamp)
       this.updateAfterAdd(node, parentNode, semantics)
     },
     addPoint (node, parentNode) {
+      const timestamp = Date.now()
       const semantics = { config: {} }
       semantics.value = node.item?.metadata?.semantics?.value || 'Point'
       if (parentNode.class.startsWith('Location')) {
@@ -369,6 +397,7 @@ export default {
       }
       if (!node.item.tags.includes(semantics.value)) node.item.tags.push(semantics.value)
       node.class = semantics.value
+      console.debug('runtime addPoint end', Date.now() - timestamp)
       this.updateAfterAdd(node, parentNode, semantics)
     },
     addNonSemantic (node, parentNode) {
@@ -376,6 +405,7 @@ export default {
       this.updateAfterAdd(node, parentNode, null)
     },
     updateAfterAdd (node, parentNode, semantics) {
+      const timestamp = Date.now()
       if (semantics === null) {
         if (node.item.metadata?.semantics) {
           node.item.metadata.semantics = null
@@ -399,8 +429,10 @@ export default {
       nodesToUpdate.push(node)
       this.$set(this.moveState, 'nodesToUpdate', nodesToUpdate)
       console.debug('Add - finished, new moveState:', cloneDeep(this.moveState))
+      console.debug('runtime updateAfterAdd', Date.now() - timestamp)
     },
     validateRemove () {
+      const timestamp = Date.now()
       this.$set(this.moveState, 'removing', true)
       const node = this.moveState.node
       const parentNode = this.moveState.oldParent
@@ -411,6 +443,7 @@ export default {
         if (parentNode.class.startsWith('Equipment') && this.moveState.newParent.class.startsWith('Location') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
           this.$set(this.moveState, 'moveConfirmed', true)
+          console.debug('runtime validateRemove', Date.now() - timestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
               '" dragged from Equipment "' + this.itemLabel(parentNode.item) +
@@ -425,6 +458,7 @@ export default {
         } else if (parentNode.class.startsWith('Location') && this.moveState.newParent.class.startsWith('Equipment') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(this.moveState.newParent)) {
           this.$set(this.moveState, 'moveConfirmed', true)
+          console.debug('runtime validateRemove', Date.now() - timestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
               '" dragged from Location "' + this.itemLabel(parentNode.item) +
@@ -445,6 +479,7 @@ export default {
         this.remove(node, parentNode, oldIndex)
       } else if (parentNode.item?.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime validateRemove', Date.now() - timestamp)
         this.$f7.dialog.create({
           text: 'Item "' + this.itemLabel(node.item) +
             '" dragged from group "' + this.itemLabel(parentNode.item) +
@@ -459,8 +494,10 @@ export default {
       } else {
         this.updateAfterRemove()
       }
+      console.debug('runtime validateRemove end', Date.now() - timestamp)
     },
     remove (node, parentNode, oldIndex) {
+      const timestamp = Date.now()
       const groupNameIndex = node.item.groupNames.findIndex(g => g === parentNode.item?.name)
       if (groupNameIndex >= 0) {
         node.item.groupNames.splice(groupNameIndex, 1)
@@ -476,6 +513,7 @@ export default {
       }
       this.updateAfterRemove()
       console.debug('Remove - finished, new moveState:', cloneDeep(this.moveState))
+      console.debug('runtime remove', Date.now() - timestamp)
     },
     updateAfterRemove () {
       this.$set(this.moveState, 'canRemove', false)
@@ -497,6 +535,7 @@ export default {
       }
     },
     saveModelUpdate () {
+      const timestamp = Date.now()
       this.$set(this.moveState, 'dragFinished', false)
       this.moveState.nodesToUpdate.forEach((n) => {
         const updatedItem = n.item
@@ -505,8 +544,10 @@ export default {
       })
       this.$set(this.moveState, 'saving', false)
       this.$set(this.moveState, 'dragDropActive', false)
+      console.debug('runtime saveModelUpdate', Date.now() - timestamp)
     },
     restoreModelUpdate () {
+      const timestamp = Date.now()
       console.debug('Restore model')
       this.$set(this.moveState, 'cancelled', true)
       this.$set(this.moveState, 'canRemove', false)
@@ -516,6 +557,7 @@ export default {
       this.$set(this.moveState, 'saving', false)
       this.$set(this.moveState, 'dragDropActive', false)
       this.$emit('reload')
+      console.debug('runtime restoreModelUpdate', Date.now() - timestamp)
     },
     itemLabel (item) {
       if (!item) return 'model root'

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -10,10 +10,8 @@ export default {
       handler: function () {
         // console.debug('Watch - moveState:', cloneDeep(this.moveState))
         if (this.canSave) {
-          this.$set(this.moveState, 'canSave', false)
           this.saveModelUpdate()
         } else if (this.canRemove) {
-          this.$set(this.moveState, 'canRemove', false)
           this.validateRemove()
         } else if (this.canAdd) {
           this.validateAdd()
@@ -39,13 +37,13 @@ export default {
       return (this.model.item.metadata && this.model.item.metadata.semantics) ? '' : 'gray'
     },
     canAdd () {
-      return !this.moveState.dragFinished && this.moveState.dragEnd && this.moveState.canAdd
+      return this.moveState.dragEnd && !this.moveState.dragFinished && this.moveState.canAdd && !this.moveState.adding
     },
     canRemove () {
-      return !this.moveState.dragFinished && this.moveState.dragEnd && !this.moveState.canAdd && this.moveState.canRemove
+      return this.moveState.dragEnd && !this.moveState.dragFinished && !this.moveState.canAdd && this.moveState.canRemove && !this.moveState.removing
     },
     canSave () {
-      return this.moveState.dragFinished && this.moveState.dragEnd && !this.moveState.canAdd && !this.moveState.canRemove && this.moveState.canSave
+      return this.moveState.dragEnd && this.moveState.dragFinished && !this.moveState.canAdd && !this.moveState.canRemove && !this.moveState.saving
     }
   },
   methods: {
@@ -53,7 +51,6 @@ export default {
       console.debug('Drag start - event:', event)
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'canRemove', false)
-      this.$set(this.moveState, 'canSave', false)
       this.$set(this.moveState, 'dragEnd', false)
       this.$set(this.moveState, 'dragFinished', false)
       this.$set(this.moveState, 'node', this.children[event.oldIndex])
@@ -89,6 +86,7 @@ export default {
       return nodes
     },
     validateAdd () {
+      this.$set(this.moveState, 'adding', true)
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
       const oldParentNode = this.moveState.oldParent
@@ -326,9 +324,11 @@ export default {
       console.debug('Add - new children:', cloneDeep(this.children))
       console.debug('Add - added to parent:', cloneDeep(parentNode))
       this.$set(this.moveState, 'canAdd', false)
+      this.$set(this.moveState, 'adding', false)
       console.debug('Add - finished, new moveState:', cloneDeep(this.moveState))
     },
     validateRemove () {
+      this.$set(this.moveState, 'removing', true)
       const node = this.moveState.node
       const parentNode = this.moveState.oldParent
       const oldIndex = this.moveState.oldIndex
@@ -371,13 +371,16 @@ export default {
     },
     updateAfterRemove () {
       this.$set(this.moveState, 'canRemove', false)
+      this.$set(this.moveState, 'removing', false)
       this.$set(this.moveState, 'dragFinished', true)
-      this.$set(this.moveState, 'canSave', true)
     },
     saveModelUpdate () {
+      this.$set(this.moveState, 'saving', true)
+      this.$set(this.moveState, 'dragFinished', false)
       const updatedItem = this.moveState.node.item
       console.debug('Save - updatedItem: ', cloneDeep(updatedItem))
       this.saveItem(updatedItem)
+      this.$set(this.moveState, 'saving', false)
     },
     restoreModelUpdate() {
       this.$set(this.moveState, 'canRemove', false)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -45,9 +45,6 @@ export default {
       return !this.moveState.cancelled && this.moveState.dragEnd && this.moveState.dragFinished && !this.moveState.canAdd && !this.moveState.canRemove && !this.moveState.saving
     },
     canHaveChildren () {
-      console.debug("Node children:", cloneDeep(this.children))
-      console.debug("Node children length:", this.children.length)
-      console.debug("Can have children: ", (this.children.length > 0 || this.moveState.moving) === true)
       return ((this.model.item.type === 'Group') && (this.children.length > 0 || this.moveState.moving) === true)
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -35,6 +35,9 @@ export default {
     iconColor () {
       return (this.model.item.metadata && this.model.item.metadata.semantics) ? '' : 'gray'
     },
+    dragDropActive () {
+      return this.moveState.moving || this.moveState.adding || this.moveState.removing || this.moveState.saving
+    },
     canAdd () {
       return !this.moveState.cancelled && this.moveState.dragEnd && !this.moveState.dragFinished && this.moveState.canAdd && !this.moveState.adding
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -94,31 +94,31 @@ export default {
       const parentNode = this.moveState.newParent
       const oldParentNode = this.moveState.oldParent
       if (parentNode.item && node.item.groupNames?.includes(parentNode.item.name)) {
-        this.$f7.dialog.alert(
-          'Group "' + this.itemLabel(parentNode.item) +
+        const message = 'Group "' + this.itemLabel(parentNode.item) +
           '" already contains item "' + this.itemLabel(node.item) + '"'
-        ).open()
+        console.debug('Add rejected: ' + message)
+        this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
         return
       }
       if (node.item.type === 'Group' && node.class === '') {
         const semanticNode = this.nestedNodes(node).find((n) => n.class !== '')
         if (semanticNode) {
-          this.$f7.dialog.alert(
-            'Cannot insert non-semantic group "' + this.itemLabel(node.item) +
+          const message = 'Cannot insert non-semantic group "' + this.itemLabel(node.item) +
             '" with semantic child "' + this.itemLabel(semanticNode.item) +
             '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
-          ).open()
+          console.debug('Add rejected: ' + message)
+          this.$f7.dialog.alert(message).open()
           this.restoreModelUpdate()
           return
         }
       }
       if (node.class !== '' && parentNode.class !== '' && oldParentNode?.class === '') {
-        this.$f7.dialog.alert(
-          'Cannot move semantic item "' + this.itemLabel(node.item) +
+        const message = 'Cannot move semantic item "' + this.itemLabel(node.item) +
           '" from non-semantic group "' + this.itemLabel(oldParentNode.item) +
           '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
-        ).open()
+        console.debug('Add rejected:' + message)
+        this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
         return
       }
@@ -147,12 +147,12 @@ export default {
       const dimension = typeDef.length > 1 ? typeDef[1] : null
       if ((type === 'Number' || type === 'None') && baseType === 'Number') {
         if (baseDimension && dimension && baseDimension !== dimension) {
-          this.$f7.dialog.alert(
-            'Group dimension "' + baseDimension +
+          const message = 'Group dimension "' + baseDimension +
              '" of group "' + this.itemLabel(parentNode.item) +
              '" not compatible with "' + (node.item.type === 'Group' ? 'group ' : '') + 'item dimension "' + dimension +
              '" of "' + (node.item.type === 'Group' ? 'group ' : '') + '" item "' + this.itemLabel(node.item) + '"'
-          ).open()
+          console.debug('Add rejected: ' + message)
+          this.$f7.dialog.alert(message).open()
           return false
         }
         if (dimension) {
@@ -161,24 +161,24 @@ export default {
             return childTypeDef.length > 1 ? { item: child.item, dimension: childTypeDef[1] } : null
           }).find((child) => { return dimension !== child?.dimension })
           if (childWithDifferentDimension) {
-            this.$f7.dialog.alert(
-              'Group "' + this.itemLabel(parentNode.item) +
+            const message = 'Group "' + this.itemLabel(parentNode.item) +
               '" already contains item "' + this.itemLabel(childWithDifferentDimension.item) +
               '" with dimension "' + childWithDifferentDimension.dimension +
               '" different from group dimension "' + dimension + '"'
-            ).open()
+            console.debug('Add rejected: ' + message)
+            this.$f7.dialog.alert(message).open()
             return false
           }
         }
       }
       const aggregationFunction = parentNode.item?.function?.name
       if (aggregationFunction && !this.aggregationFunctions(type).includes(aggregationFunction)) {
-        this.$f7.dialog.alert(
-          'Group aggreggation function "' + aggregationFunction +
+        const message = 'Group aggreggation function "' + aggregationFunction +
           '" for group "' + this.itemLabel(parentNode.item) +
           '" not compatible with type "' + type +
           '" of item "' + this.itemLabel(node.item) + '"'
-        ).open()
+        console.debug('Add rejected: ' + message)
+        this.$f7.dialog.alert(message).open()
         return false
       }
       return true
@@ -376,8 +376,6 @@ export default {
       }
       const newChildren = this.children
       this.children = newChildren // force setters to update model
-      console.debug('Add - new children:', cloneDeep(this.children))
-      console.debug('Add - added to parent:', cloneDeep(parentNode))
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'adding', false)
       console.debug('Add - finished, new moveState:', cloneDeep(this.moveState))
@@ -426,8 +424,6 @@ export default {
           node.item.metadata.semantics = null
         }
       }
-      console.debug('Remove - new children:', cloneDeep(this.children))
-      console.debug('Remove - removed from parent:', parentNode)
       this.updateAfterRemove()
       console.debug('Remove - finished, new moveState:', cloneDeep(this.moveState))
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -101,7 +101,7 @@ export default {
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
       const oldParentNode = this.moveState.oldParent
-      if (node.item.name === parentNode.item.name) {
+      if (node.item.name === parentNode?.item?.name) {
         // This should not be possible, but just to make sure to avoid infinite loop
         this.restoreModelUpdate()
         return
@@ -502,6 +502,7 @@ export default {
     },
     restoreModelUpdate () {
       console.debug('Restore model')
+      this.$set(this.moveState, 'cancelled', true)
       this.$set(this.moveState, 'canRemove', false)
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'adding', false)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -56,10 +56,6 @@ export default {
   methods: {
     onDragStart (event) {
       console.debug('Drag start - event:', event)
-      if (window) {
-        // Allow escape during drag
-        window.addEventListener('keyDown', this.keyDown)
-      }
       this.$set(this.moveState, 'dragDropActive', true)
       this.$set(this.moveState, 'moving', true)
       this.$set(this.moveState, 'canAdd', false)
@@ -97,12 +93,8 @@ export default {
     onDragEnd (event) {
       console.debug('runtime onDragEnd', Date.now() - this.moveState.dragStartTimestamp)
       console.debug('Drag end - event:', event)
-      if (window) {
-        window.removeEventListener('keyDown', this.keyDown)
-      }
       this.$set(this.moveState, 'moving', false)
       this.$set(this.moveState, 'dragEnd', true)
-      console.debug('Drag end - event:', event)
       console.debug('Drag end - moveState:', cloneDeep(this.moveState))
     },
     nestedSemanticNode (node) {
@@ -129,6 +121,7 @@ export default {
         const message = 'Group "' + this.itemLabel(parentNode.item) +
           '" already contains item "' + this.itemLabel(node.item) + '"'
         console.debug('Add rejected: ' + message)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
         console.debug('runtime validateAdd end', Date.now() - this.moveState.dragStartTimestamp)
@@ -141,6 +134,7 @@ export default {
             '" with semantic child "' + this.itemLabel(semanticNode.item) +
             '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
           console.debug('Add rejected: ' + message)
+          console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
           this.$f7.dialog.alert(message).open()
           this.restoreModelUpdate()
           console.debug('runtime validateAdd end', Date.now() - this.moveState.dragStartTimestamp)
@@ -152,6 +146,7 @@ export default {
           '" from non-semantic group "' + this.itemLabel(oldParentNode.item) +
           '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
         console.debug('Add rejected:' + message)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.alert(message).open()
         this.restoreModelUpdate()
         console.debug('runtime validateAdd end', Date.now() - this.moveState.dragStartTimestamp)
@@ -192,6 +187,7 @@ export default {
              '" not compatible with "' + (node.item.type === 'Group' ? 'group ' : '') + 'item dimension "' + dimension +
              '" of "' + (node.item.type === 'Group' ? 'group ' : '') + '" item "' + this.itemLabel(node.item) + '"'
           console.debug('Add rejected: ' + message)
+          console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
           this.$f7.dialog.alert(message).open()
           console.debug('runtime isValidGroupType end', Date.now() - this.moveState.dragStartTimestamp)
           return false
@@ -207,6 +203,7 @@ export default {
               '" with dimension "' + childWithDifferentDimension.dimension +
               '" different from group dimension "' + dimension + '"'
             console.debug('Add rejected: ' + message)
+            console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
             this.$f7.dialog.alert(message).open()
             console.debug('runtime isValidGroupType end', Date.now() - this.moveState.dragStartTimestamp)
             return false
@@ -220,6 +217,7 @@ export default {
           '" not compatible with type "' + type +
           '" of item "' + this.itemLabel(node.item) + '"'
         console.debug('Add rejected: ' + message)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.alert(message).open()
         console.debug('runtime isValidGroupType end', Date.now() - this.moveState.dragStartTimestamp)
         return false
@@ -257,6 +255,7 @@ export default {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -270,6 +269,7 @@ export default {
         }).open()
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -287,6 +287,7 @@ export default {
     addIntoEquipment (node, parentNode) {
       console.debug('runtime addIntoEquipment start', Date.now() - this.moveState.dragStartTimestamp)
       if (node.class.startsWith('Location')) {
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.alert(
           'Cannot move Location "' + this.itemLabel(node.item) +
           '" into Equipment "' + this.itemLabel(parentNode.item) + '"'
@@ -300,6 +301,7 @@ export default {
         this.addEquipment(node, parentNode)
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         const dialog = this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -337,6 +339,7 @@ export default {
         this.addPoint(node, parentNode)
       } else if (node.item.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -351,6 +354,7 @@ export default {
         }).open()
       } else {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
@@ -469,6 +473,7 @@ export default {
         if (parentNode.class.startsWith('Equipment') && newParentNode.class.startsWith('Location') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {
           this.$set(this.moveState, 'moveConfirmed', true)
+          console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
               '" dragged from Equipment "' + this.itemLabel(parentNode.item) +
@@ -483,6 +488,7 @@ export default {
         } else if (parentNode.class.startsWith('Location') && newParentNode.class.startsWith('Equipment') &&
             this.nodeLocation(parentNode) !== this.nodeLocation(newParentNode)) {
           this.$set(this.moveState, 'moveConfirmed', true)
+          console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
           this.$f7.dialog.create({
             text: 'Point "' + this.itemLabel(node.item) +
               '" dragged from Location "' + this.itemLabel(parentNode.item) +
@@ -503,6 +509,7 @@ export default {
         this.remove(node, parentNode, oldIndex)
       } else if (parentNode.item?.type === 'Group') {
         this.$set(this.moveState, 'moveConfirmed', true)
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.create({
           text: 'Item "' + this.itemLabel(node.item) +
             '" dragged from group "' + this.itemLabel(parentNode.item) +
@@ -551,6 +558,7 @@ export default {
       const node = this.moveState.node
       const parentNode = this.moveState.newParent
       if (!this.moveState.moveConfirmed) {
+        console.debug('runtime dialog open', Date.now() - this.moveState.dragStartTimestamp)
         this.$f7.dialog.confirm(
           'Move "' + this.itemLabel(node.item) + '" into "' + this.itemLabel(parentNode.item) + '"?',
           () => this.saveModelUpdate(),

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -123,7 +123,7 @@ export default {
         this.$f7.dialog.alert(
           'Cannot move semantic item "' + this.itemLabel(node.item) +
           '" from non-semantic group "' + this.itemLabel(oldParentNode.item) +
-          '" into semantic group "' + this.itemLabel(parentNode.item) + "'"
+          '" into semantic group "' + this.itemLabel(parentNode.item) + '"'
         ).open()
         this.restoreModelUpdate()
         return
@@ -160,7 +160,6 @@ export default {
         if (node.class.startsWith('Location')) {
           this.$f7.dialog.alert('Cannot move Location "' + this.itemLabel(node.item) + '" into Equipment "' + this.itemLabel(parentNode.item) + '"').open()
           this.restoreModelUpdate()
-          return
         } else if (node.class.startsWith('Equipment')) {
           this.addEquipment(node, parentNode, semantics)
         } else if (node.class.startsWith('Point')) {
@@ -221,7 +220,7 @@ export default {
             'Group dimension "' + baseDimension +
              '" of group "' + this.itemLabel(parentNode.item) +
              '" not compatible with "' + (node.item.type === 'Group' ? 'group ' : '') + 'item dimension "' + dimension +
-             '" of "' + (node.item.type === 'Group' ? 'group ' : '') + '" item "' + this.itemLabel(node.item) +'"'
+             '" of "' + (node.item.type === 'Group' ? 'group ' : '') + '" item "' + this.itemLabel(node.item) + '"'
           ).open()
           return false
         }
@@ -355,10 +354,7 @@ export default {
           text: 'Item "' + this.itemLabel(node.item) + '" dragged from group "' + this.itemLabel(parentNode.item) + '", remove original?',
           buttons: [
             { text: 'Remove', onClick: () => this.remove(node, parentNode, oldIndex) },
-            { text: 'Keep', onClick: () => {
-                this.updateAfterRemove()
-              }
-          }
+            { text: 'Keep', onClick: () => this.updateAfterRemove() }
           ]
         }).open()
       } else {
@@ -397,7 +393,7 @@ export default {
       this.saveItem(updatedItem)
       this.$set(this.moveState, 'saving', false)
     },
-    restoreModelUpdate() {
+    restoreModelUpdate () {
       this.$set(this.moveState, 'canRemove', false)
       this.$set(this.moveState, 'canAdd', false)
       this.$set(this.moveState, 'adding', false)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -118,7 +118,7 @@ export default {
           return
         }
       }
-      if (node.class !== '' && parentNode.class !== '' && oldParentNode?.class === '') {
+      if (node.class !== '' && parentNode.class !== '' && (oldParentNode.item && oldParentNode?.class === '')) {
         const message = 'Cannot move semantic item "' + this.itemLabel(node.item) +
           '" from non-semantic group "' + this.itemLabel(oldParentNode.item) +
           '" into semantic group "' + this.itemLabel(parentNode.item) + '"'

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -216,6 +216,7 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
+          verticalButtons: true,
           buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Location', onClick: () => this.addLocation(node, parentNode) },
@@ -228,7 +229,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-          buttons: [
+            verticalButtons: true,
+            buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
             { text: 'Point', onClick: () => this.addPoint(node, parentNode) }
@@ -255,7 +257,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-          buttons: [
+            verticalButtons: true,
+            buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
             { text: 'Point', onClick: () => this.addPoint(node, parentNode) }
@@ -287,7 +290,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-          buttons: [
+            verticalButtons: true,
+            buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Location', onClick: () => this.addLocation(node, parentNode) },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
@@ -300,7 +304,8 @@ export default {
           text: 'Insert "' + this.itemLabel(node.item) +
             '" into "' + this.itemLabel(parentNode.item) +
             '" as',
-          buttons: [
+            verticalButtons: true,
+            buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Equipment', onClick: () => this.addEquipment(node, parentNode) },
             { text: 'Point', onClick: () => this.addPoint(node, parentNode) },
@@ -396,7 +401,8 @@ export default {
             '" dragged from group "' + this.itemLabel(parentNode.item) +
             '" into "' + this.itemLabel(this.moveState.newParent.item) +
             '", keep original?',
-          buttons: [
+            verticalButtons: true,
+            buttons: [
             { text: 'Cancel', color: 'gray', onClick: () => this.restoreModelUpdate() },
             { text: 'Keep', onClick: () => this.updateAfterRemove() },
             { text: 'Remove', onClick: () => this.remove(node, parentNode, oldIndex) }

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
@@ -1,4 +1,5 @@
 import { compareItems } from '@/components/widgets/widget-order'
+import cloneDeep from 'lodash/cloneDeep'
 
 function compareModelItems (o1, o2) {
   return compareItems(o1.item || o1, o2.item || o2)
@@ -22,11 +23,13 @@ export default {
       links: [],
       locations: [],
       rootLocations: [],
-      equipment: {},
+      equipment: [],
       rootEquipment: [],
       rootPoints: [],
       rootGroups: [],
       rootItems: [],
+
+      expandedTreeviewItems: [],
 
       previousSelection: null,
       selectedItem: null
@@ -39,8 +42,10 @@ export default {
      * @returns {Promise<void>}
      */
     loadModel () {
-      if (this.loading) return
+      if (this.loading) return Promise.resolve()
       this.loading = true
+
+      this.saveExpanded()
 
       const items = this.$oh.api.get('/rest/items?staticDataOnly=true&metadata=.+')
       const links = this.$oh.api.get('/rest/links')
@@ -152,6 +157,20 @@ export default {
             item.classList.add('treeview-item-opened')
           } else {
             item.classList.remove('treeview-item-opened')
+          }
+        }
+      })
+    },
+    saveExpanded () {
+      this.expandedTreeviewItems = [...document.querySelectorAll('.treeview-item-opened')]
+    },
+    restoreExpanded () {
+      const treeviewItems = document.querySelectorAll('.treeview-item')
+
+      treeviewItems.forEach(item => {
+        if (item.classList.contains('treeview-item')) {
+          if (this.expanded || this.expandedTreeviewItems.includes(item)) {
+            item.classList.add('treeview-item-opened')
           }
         }
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
@@ -130,7 +130,7 @@ export default {
 
       if (this.includeNonSemantic) {
         parent.children.groups = this.items
-          .filter((i) => i.type === 'Group' && (!i.metadata || (i.metadata && !i.metadata.semantics)) && i.groupNames.indexOf(parent.item.name) >= 0)
+          .filter((i) => i.type === 'Group' && !(parent.item.metadata && parent.item.metadata.semantics) && i.groupNames.indexOf(parent.item.name) >= 0)
           .map(this.modelItem).sort(compareModelItems)
         parent.children.groups.forEach(this.getChildren)
         if (parent.item.metadata && parent.item.metadata.semantics) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
@@ -1,12 +1,11 @@
 import { compareItems } from '@/components/widgets/widget-order'
-import cloneDeep from 'lodash/cloneDeep'
 
 function compareModelItems (o1, o2) {
   return compareItems(o1.item || o1, o2.item || o2)
 }
 
 /**
- * Mixin for model page and model picker popup.
+ * Mixin for the model page and model picker popup.
  *
  * The component using this mixin has to provide the following methods:
  * - `selectItem(item)`: Called when an item is selected.

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -73,7 +73,7 @@
           <f7-block v-show="!empty" strong class="semantic-tree" no-gap @click.native="clearSelection">
             <model-treeview :rootNodes="[rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
                             :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="true"
-                            @selected="selectItem" :selected="selectedItem" @reload="load"/>
+                            @selected="selectItem" :selected="selectedItem" @reload="load" />
           </f7-block>
         </f7-col>
         <f7-col width="100" medium="50" class="details-pane">

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -73,7 +73,7 @@
           <f7-block v-show="!empty" strong class="semantic-tree" no-gap @click.native="clearSelection">
             <model-treeview :rootNodes="[rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
                             :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="true"
-                            @selected="selectItem" :selected="selectedItem" />
+                            @selected="selectItem" :selected="selectedItem" @reload="load"/>
           </f7-block>
         </f7-col>
         <f7-col width="100" medium="50" class="details-pane">
@@ -378,6 +378,7 @@ export default {
     clearSelection (ev) {
       if (ev.target && ev.currentTarget && ev.target === ev.currentTarget) {
         this.selectedItem = null
+        this.detailsOpened = false
       }
     },
     toggleNonSemantic () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -71,13 +71,9 @@
           </f7-block>
 
           <f7-block v-show="!empty" strong class="semantic-tree" no-gap @click.native="clearSelection">
-            <!-- <empty-state-placeholder v-if="empty" icon="list_bullet_indent" title="model.title" text="model.text" /> -->
-            <f7-treeview>
-              <model-treeview-item v-for="node in [rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
-                                   :key="node.item.name" :model="node"
-                                   :includeItemName="includeItemName" :includeItemTags="includeItemTags"
-                                   @selected="selectItem" :selected="selectedItem" />
-            </f7-treeview>
+            <model-treeview :rootNodes="[rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
+                            :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="true"
+                            @selected="selectItem" :selected="selectedItem" />
           </f7-block>
         </f7-col>
         <f7-col width="100" medium="50" class="details-pane">
@@ -177,15 +173,6 @@
 .semantic-tree
   padding 0
   border-right 1px solid var(--f7-block-strong-border-color)
-  .treeview
-    --f7-treeview-item-height 40px
-    .treeview-item-label
-      font-size 10pt
-      white-space nowrap
-      overflow-x hidden
-    .semantic-class
-      font-size 8pt
-      color var(--f7-list-item-footer-text-color)
 .model-details-sheet
   .toolbar
     --f7-theme-color var(--f7-color-blue)
@@ -234,6 +221,7 @@
 
 <script>
 import ModelDetailsPane from '@/components/model/details-pane.vue'
+import ModelTreeview from '@/components/model/model-treeview.vue'
 import AddFromThing from './add-from-thing.vue'
 import AddFromTemplate from './add-from-template.vue'
 
@@ -241,7 +229,6 @@ import ItemStatePreview from '@/components/item/item-state-preview.vue'
 import ItemDetails from '@/components/model/item-details.vue'
 import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 import LinkDetails from '@/components/model/link-details.vue'
-import ModelTreeviewItem from '@/components/model/treeview-item.vue'
 
 import ModelMixin from '@/pages/settings/model/model-mixin'
 
@@ -250,11 +237,11 @@ export default {
   components: {
     'empty-state-placeholder': () => import('@/components/empty-state-placeholder.vue'),
     ModelDetailsPane,
+    ModelTreeview,
     ItemStatePreview,
     ItemDetails,
     MetadataMenu,
-    LinkDetails,
-    ModelTreeviewItem
+    LinkDetails
   },
   data () {
     if (!this.$f7.data.model) this.$f7.data.model = {}
@@ -336,7 +323,7 @@ export default {
             this.$refs.searchbar.f7Searchbar.$inputEl[0].focus()
           }
           this.$refs.searchbar?.f7Searchbar.search(this.$f7.data.lastModelSearchQuery || '')
-          this.applyExpandedOption()
+          this.restoreExpanded()
         })
         if (!this.eventSource) this.startEventSource()
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -35,7 +35,7 @@
       </div>
       <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
     </f7-toolbar>
-    <f7-toolbar v-else bottom class="toolbar-details" style="height: calc(50px + var(--f7-safe-area-bottom))">
+    <f7-toolbar v-else bottom class="toolbar-details">
       <f7-link :disabled="selectedItem != null" class="left" @click="selectedItem = null">
         Clear
       </f7-link>
@@ -169,7 +169,15 @@
 <style lang="stylus">
 .semantic-tree-wrapper
   padding 0
-  margin 0 !important
+  .row
+    height 100%
+    .col-100
+      height 100%
+      overflow auto
+      .semantic-tree
+        min-height 100%
+        margin 0
+        height auto
 .semantic-tree
   margin 0 !important
   border-right 1px solid var(--f7-block-strong-border-color)
@@ -183,16 +191,8 @@
 
 @media (min-width: 768px)
   .semantic-tree-wrapper
-    height calc(100% - var(--f7-navbar-height))
+    height calc(100% - var(--f7-toolbar-height))
     .row
-      height 100%
-      .col-100
-        height 100%
-        overflow auto
-        .semantic-tree
-          min-height 100%
-          margin 0
-          height auto
       .details-pane
         padding-top 0
         .block
@@ -204,12 +204,22 @@
     visibility hidden !important
 
 @media (max-width: 767px)
+  .semantic-tree-wrapper.block:first-child
+    margin-top 5px
+  .semantic-tree-wrapper
+    height calc(100% - 20px)
+    margin-bottom 5px
   .details-pane
     display none
   .semantic-tree-wrapper.sheet-opened
-    margin-bottom var(--f7-sheet-height)
-  .details-sheet
-    height calc(1.4*var(--f7-sheet-height))
+    height calc(100% - 5px - var(--f7-sheet-height) + var(--f7-page-toolbar-bottom-offset, 0px) + var(--f7-page-content-extra-padding-bottom, 0px))
+    margin-bottom calc(var(--f7-sheet-height) - var(--f7-page-toolbar-bottom-offset, 0px) - var(--f7-page-content-extra-padding-bottom, 0px))
+  .toolbar-details.toolbar.toolbar-bottom
+    height  calc( 50px + var(--f7-safe-area-bottom))
+  .model-details-sheet.sheet-modal.sheet-modal-bottom .block
+    margin-top 0px
+    padding-left 0px
+    padding-right 0px
 
 .expand-button
   margin-right 8px

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -71,7 +71,7 @@
           </f7-block>
 
           <f7-block v-show="!empty" strong class="semantic-tree" no-gap @click.native="clearSelection">
-            <model-treeview :rootNodes="[rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()"
+            <model-treeview :rootNodes="[rootLocations, rootEquipment, rootPoints, rootGroups, rootItems].flat()" :items="items"
                             :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="true"
                             @selected="selectItem" :selected="selectedItem" @reload="load" />
           </f7-block>
@@ -243,6 +243,7 @@ import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 import LinkDetails from '@/components/model/link-details.vue'
 
 import ModelMixin from '@/pages/settings/model/model-mixin'
+import ItemsAddFromTextualDefinition from '../items/parser/items-add-from-textual-definition.vue'
 
 export default {
   mixins: [ModelMixin],

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -168,6 +168,7 @@
 
 <style lang="stylus">
 .semantic-tree-wrapper
+  user-select: none
   padding 0
   .row
     height 100%
@@ -179,6 +180,7 @@
         margin 0
         height auto
 .semantic-tree
+  user-select: none
   margin 0 !important
   border-right 1px solid var(--f7-block-strong-border-color)
 .model-details-sheet

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -169,9 +169,9 @@
 <style lang="stylus">
 .semantic-tree-wrapper
   padding 0
-  margin-bottom 0
+  margin 0 !important
 .semantic-tree
-  padding 0
+  margin 0 !important
   border-right 1px solid var(--f7-block-strong-border-color)
 .model-details-sheet
   .toolbar


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/2728
Closes https://github.com/openhab/openhab-webui/issues/969

Allow drag and drop in the model view:

1. Drag and drop inside the semantic model
2. Move items into the semantic model
3. Move between non-semantic groups (and duplicate)
4. Ask for creation of location, equipment or point if item does not have a semantic class yet when moving into the semantic model

This PR requires further testing, but I do want to already provide it for others to start evaluating, as there is a fair amount of change. I probably have missed some boundary cases of changes in the model that are or are not possible.

Edit: I have tested this on different devices, and from my perspective, it works well. But again, I may have missed something. Therefore I would appreciate others to test.
I have put extensive debug logging into the code to be able to debug potential issues.

Here are a few gifs of what it looks like:

![ModelMove1](https://github.com/user-attachments/assets/e7b71748-901d-421b-adec-afd233c781f2)

![ModelMove2](https://github.com/user-attachments/assets/03ec2316-c3f2-4817-87a2-78f99187ea8e)

