### PR TITLE
Upgrade plugins

### DIFF
--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -169,7 +169,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.6.1</version>
+        <version>3.8.1</version>
         <executions>
           <execution>
             <id>unpack-eea</id>

--- a/pom.xml
+++ b/pom.xml
@@ -235,7 +235,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-clean-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>3.4.0</version>
         </plugin>
 
         <plugin>
@@ -264,7 +264,7 @@ Import-Package: \\
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.36.0</version>
+              <version>3.39.0</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -272,25 +272,25 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.3</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-jar-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.4.2</version>
         </plugin>
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.6.3</version>
+          <version>3.11.2</version>
           <configuration>
             <failOnError>!${quality.skip}</failOnError>
           </configuration>
@@ -305,7 +305,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.1</version>
           <configuration>
             <preparationGoals>clean install</preparationGoals>
           </configuration>
@@ -320,7 +320,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.12.1</version>
+          <version>3.21.0</version>
         </plugin>
 
         <plugin>
@@ -332,7 +332,7 @@ Import-Package: \\
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.2.5</version>
+          <version>3.5.2</version>
           <configuration>
             <argLine>
               --add-opens java.base/java.net=ALL-UNNAMED
@@ -347,13 +347,13 @@ Import-Package: \\
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>build-helper-maven-plugin</artifactId>
-          <version>3.5.0</version>
+          <version>3.6.0</version>
         </plugin>
 
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.3</version>
+          <version>4.6</version>
           <configuration>
             <basedir>${basedir}</basedir>
             <quiet>false</quiet>
@@ -428,7 +428,7 @@ Import-Package: \\
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>4.0.0</version>
           <configuration>
             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
             <createBackupFile>false</createBackupFile>
@@ -541,7 +541,7 @@ Import-Package: \\
         <plugin>
           <groupId>com.github.eirslett</groupId>
           <artifactId>frontend-maven-plugin</artifactId>
-          <version>1.15.0</version>
+          <version>1.15.1</version>
         </plugin>
 
       </plugins>


### PR DESCRIPTION
* frontend-maven-plugin to 1.15.1
* sortpom-maven-plugin to 4.0.0 (breaking change) https://github.com/Ekryd/sortpom?tab=readme-ov-file#news
* license-maven-plugin to 4.6 https://github.com/mathieucarbou/license-maven-plugin/releases
* maven-clean-plugin to 3.4.0 https://github.com/apache/maven-clean-plugin/releases/tag/maven-clean-plugin-3.4.0
* maven-dependency-plugin to 3.8.1
* maven-enforcer-plugin to 3.5.0 https://github.com/apache/maven-enforcer/releases
* maven-install-plugin to 3.1.3 https://github.com/apache/maven-install-plugin/releases
* maven-jar-plugin to 3.4.2 https://github.com/apache/maven-jar-plugin/releases/tag/maven-jar-plugin-3.4.2
* maven-javadoc-plugin to 3.11.2
* maven-release-plugin to 3.1.1
* maven-site-plugin to 3.21.0
* maven-surefire-plugin to 3.5.2
* build-helper-maven-plugin to 3.6.0 https://github.com/mojohaus/build-helper-maven-plugin/releases/tag/3.6.0


leaving out the remaining
```
[INFO]   org.codehaus.mojo:jaxb2-maven-plugin ....................................................... 2.5.0 -> 3.2.0
[INFO]   org.openapitools:openapi-generator-maven-plugin ........................................... 4.3.0 -> 7.10.0
```
for now....