### PR TITLE
[cometvisu] Upgrade openapi generator to 7.0.1

### DIFF
--- a/bundles/org.openhab.ui.cometvisu/pom.xml
+++ b/bundles/org.openhab.ui.cometvisu/pom.xml
@@ -123,7 +123,7 @@
         <groupId>org.openapitools</groupId>
         <artifactId>openapi-generator-maven-plugin</artifactId>
         <!-- RELEASE_VERSION -->
-        <version>4.3.0</version>
+        <version>7.0.1</version>
         <!-- /RELEASE_VERSION -->
         <executions>
           <execution>
@@ -141,6 +141,7 @@
               <modelPackage>org.openhab.ui.cometvisu.internal.backend.model.rest</modelPackage>
               <generateAliasAsModel>true</generateAliasAsModel>
               <generateSupportingFiles>false</generateSupportingFiles>
+              <openapiNormalizer>REF_AS_PARENT_IN_ALLOF=true</openapiNormalizer>
               <configOptions>
                 <sourceFolder>src-gen</sourceFolder>
                 <interfaceOnly>true</interfaceOnly>

--- a/bundles/org.openhab.ui.cometvisu/src/main/resources/openapi.yaml
+++ b/bundles/org.openhab.ui.cometvisu/src/main/resources/openapi.yaml
@@ -238,7 +238,7 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
+                allOf:
                   - $ref: '#/components/schemas/HiddenConfig'
                   - $ref: '#/components/schemas/ConfigSection'
                   - $ref: '#/components/schemas/ConfigOptionValue'
@@ -477,7 +477,7 @@ components:
       additionalProperties:
         type: string
     ReadResponse:
-      oneOf:
+      allOf:
         - $ref: '#/components/schemas/DirContent'
     DirContent:
       type: array

--- a/bundles/org.openhab.ui.cometvisu/src/main/resources/openapi.yaml
+++ b/bundles/org.openhab.ui.cometvisu/src/main/resources/openapi.yaml
@@ -238,7 +238,7 @@ paths:
           content:
             application/json:
               schema:
-                allOf:
+                oneOf:
                   - $ref: '#/components/schemas/HiddenConfig'
                   - $ref: '#/components/schemas/ConfigSection'
                   - $ref: '#/components/schemas/ConfigOptionValue'


### PR DESCRIPTION
* Upgrade openapi-generator-maven-plugin from 4.3.0 to 7.0.1

This is a bit complicated, since the code generator changed.
Our yaml file did no longer work, as genrated classes in `src-gen` did no longer extend from the proper base classes.

With the tweaks it seems to generate as expected, the output looks very similar (though not identical).
Hopefully, this does not break anything.

btw: Could not go beyond 7.0.1 due to OpenAPITools/openapi-generator#18596. Did not find out how to circumvent this problem.