### PR TITLE
Tag Input: Fix automatic add on blur

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -17,11 +17,9 @@
         placeholder="Add tag"
         :value="pendingTag"
         @input="pendingTag = $event.target.value"
-        @blur="addTag()"
-        @keyPressed.native="keyPressed"
         :input="false"
         class="add-tag-input">
-        <input slot="input" type="text" placeholder="Add tag" @keypress="keyPressed">
+        <input slot="input" type="text" placeholder="Add tag" @keyup="keyUp" @blur="addTag">
       </f7-list-input>
     </f7-list>
   </div>
@@ -52,7 +50,7 @@ export default {
       if (this.inSceneEditor !== true) return false
       if (tag === 'Scene') return true
     },
-    addTag () {
+    addTag (evt) {
       const newTag = this.pendingTag
       this.pendingTag = ''
       // Block adding of Scene or Script tags in the wrong editor
@@ -71,13 +69,12 @@ export default {
         }
         this.item.tags.push(newTag)
       }
+      evt.target.value = ''
     },
-    keyPressed (evt) {
+    keyUp (evt) {
       this.pendingTag = evt.target.value
       if (evt.code === 'Enter') {
-        this.addTag()
-        evt.target.value = ''
-        this.pendingTag = ''
+        this.addTag(evt)
       }
     },
     deleteTag (ev) {


### PR DESCRIPTION
User inadvertently losing the entered new tag when they haven't realised that they needed to press Enter. It seems that onblur was originally intended to auto-add the typed tag, e.g. when user immediately clicked "Save" (top right), but it was attached to the wrong element, thus the event didn't fire.

I've also changed keypress to keyup event because the keypress is missing the last letter otherwise. It wasn't a problem in the past because it only worked with Enter key (being the last keypress). Missing the last letter becomes a problem when adding it in the onblur event. So keyup solved that.

Reported here: https://community.openhab.org/t/how-to-reuse-code-between-ui-rules/161028/35

I also removed `@keyPressed.native="keyPressed"` but TBH I'm not sure why it was needed.