### PR TITLE
Fix JavaDoc output directory

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,7 @@ Import-Package: \\
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>3.11.2</version>
           <configuration>
+            <outputDirectory>${project.build.directory}/site</outputDirectory>
             <failOnError>!${quality.skip}</failOnError>
           </configuration>
         </plugin>


### PR DESCRIPTION
Regression, fix issue introduced by #2972.
JavaDoc output dir changed from target/site to target/reports.
This will get it back to the known location.