### PR TITLE
Settings menu: Always show things count even when inbox is not empty

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -29,7 +29,7 @@
               link="things/"
               title="Things"
               :badge="(inboxCount > 0) ? inboxCount : undefined"
-              :after="(inboxCount > 0) ? undefined : thingsCount"
+              :after="(inboxCount > 0) ? (thingsCount + '+') : thingsCount"
               :badge-color="inboxCount ? 'red' : 'blue'"
               :footer="objectsSubtitles.things">
               <f7-icon slot="media" f7="lightbulb" color="gray" />


### PR DESCRIPTION
Change from:
<img width="382" alt="image" src="https://github.com/user-attachments/assets/e16b2020-228c-49a6-8d3e-5e16972f7415" />

To:
<img width="379" alt="image" src="https://github.com/user-attachments/assets/d3125ac5-26d3-41ae-abc2-25cef4f90896" />

When there is nothing in inbox:
<img width="378" alt="image" src="https://github.com/user-attachments/assets/24ed7ef5-6078-41a1-bd22-333905edd5e3" />

