### PR TITLE
Item Details: Add a link to search for the item in the developer bar

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -148,7 +148,7 @@
     </f7-panel>
 
     <f7-panel v-if="showDeveloperDock" right :visible-breakpoint="1280" resizable>
-      <developer-dock :dock="activeDock" :helpTab="activeHelpTab" :toolTab="activeToolTab" />
+      <developer-dock :dock="activeDock" :helpTab="activeHelpTab" :toolTab="activeToolTab" :searchFor="developerSearch" />
     </f7-panel>
 
     <f7-block v-if="!ready && communicationFailureMsg" class="block-narrow">
@@ -384,6 +384,7 @@ export default {
       activeDock: 'tools',
       activeToolTab: 'pin',
       activeHelpTab: 'current',
+      developerSearch: null,
       currentUrl: ''
     }
   },
@@ -576,6 +577,7 @@ export default {
         if (dockOpts.dock) this.activeDock = dockOpts.dock
         if (dockOpts.helpTab) this.activeHelpTab = dockOpts.helpTab
         if (dockOpts.toolTab) this.activeToolTab = dockOpts.toolTab
+        if (dockOpts.searchFor) this.developerSearch = dockOpts.searchFor
       }
       if (!this.showDeveloperDock) this.toggleDeveloperDock()
     },

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-dock.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-dock.vue
@@ -21,7 +21,7 @@
       <f7-button :active="activeHelpTab === 'faq'" icon-f7="question_diamond_fill" icon-size="18" @click="$f7.emit('selectDeveloperDock',{'dock': 'help','helpTab': 'faq'})" />
       <f7-button :active="activeHelpTab === 'quick'" icon-f7="cursor_rays" icon-size="18" @click="$f7.emit('selectDeveloperDock',{'dock': 'help','helpTab': 'quick'})" />
     </f7-segmented>
-    <developer-sidebar v-if="dockView === 'tools'" :activeToolTab="activeToolTab" />
+    <developer-sidebar v-if="dockView === 'tools'" :activeToolTab="activeToolTab" :searchFor="searchFor" />
     <help-sidebar v-if="dockView === 'help'" :activeHelpTab="activeHelpTab" />
   </f7-page>
 </template>
@@ -47,7 +47,7 @@ import DeveloperSidebar from './developer-sidebar.vue'
 import HelpSidebar from './help-sidebar.vue'
 
 export default {
-  props: ['dock', 'helpTab', 'toolTab'],
+  props: ['dock', 'helpTab', 'toolTab', 'searchFor'],
   components: {
     DeveloperSidebar,
     HelpSidebar

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -395,7 +395,12 @@ export default {
     SearchResults,
     ExpressionTester
   },
-  props: ['activeToolTab'],
+  props: ['activeToolTab', 'searchFor'],
+  watch: {
+    searchFor (val) {
+      if (val) this.$refs.searchbar.search(val)
+    }
+  },
   data () {
     return {
       searchQuery: '',
@@ -453,6 +458,7 @@ export default {
     this.$nextTick(() => {
       if (this.$device.desktop && this.$refs.searchbar) {
         this.$refs.searchbar.f7Searchbar.$inputEl.focus()
+        if (this.searchFor) this.$refs.searchbar.search(this.searchFor)
       }
     })
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -95,7 +95,7 @@
             </f7-list-button>
           </f7-list>
           <p class="developer-sidebar-tip text-align-center">
-            Tip: Use the developer sidebar (Shift+Alt+D) to search for usages of this Item
+            Tip: Use the developer sidebar (Shift+Alt+D) to <f7-link text="search for usages of this Item" @click="searchInSidebar" />
           </p>
         </f7-col>
       </f7-row>
@@ -227,6 +227,9 @@ export default {
           })
         }
       )
+    },
+    searchInSidebar () {
+      this.$f7.emit('selectDeveloperDock', { 'dock': 'tools', 'toolTab': 'pin', 'searchFor': this.item.name })
     }
   }
 }


### PR DESCRIPTION
This makes it super convenient. Just click on the link and it's pre-searched for you.

![image](https://github.com/user-attachments/assets/1f3b7167-2be7-42a3-870b-e4852441b39f)

Which leads to:

<img width="1051" alt="image" src="https://github.com/user-attachments/assets/b64e5c21-dfec-4b37-a338-bd5236acdf0f" />
