### PR TITLE
Sitemap treeview: Fix arrows/chevrons shown if not expandable

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -66,6 +66,7 @@ export default {
     },
     onStart (event) {
       console.debug('Drag start event:', event)
+      this.$set(this.localMoveState, 'moving', true)
       this.$set(this.localMoveState, 'widget', this.widget.slots.widgets[event.oldIndex])
       this.$set(this.localMoveState, 'oldList', this.widget.slots.widgets)
       this.$set(this.localMoveState, 'oldIndex', event.oldIndex)
@@ -73,11 +74,13 @@ export default {
     onChange (event) {
       console.debug('Drag change event:', event)
       if (event.added) {
+        this.$set(this.localMoveState, 'moving', false)
         this.validateMove(event.added.newIndex)
       }
     },
     onEnd (event) {
       console.debug('Drag end event:', event)
+      this.$set(this.localMoveState, 'moving', false)
       this.validateMove(event.newIndex)
     },
     validateMove (newIndex) {
@@ -123,7 +126,7 @@ export default {
       return this.widget.slots?.widgets || []
     },
     canHaveChildren () {
-      return this.LINKABLE_WIDGET_TYPES.includes(this.widget.component)
+      return this.LINKABLE_WIDGET_TYPES.includes(this.widget.component) && (this.children.length > 0 || this.localMoveState.moving)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -4,10 +4,11 @@
                     :textColor="iconColor" :color="'blue'"
                     :selected="selected && selected === widget"
                     :opened="!widget.closed"
+                    :toggle="canHaveChildren"
                     @treeview:open="setWidgetClosed(false)"
                     @treeview:close="setWidgetClosed(true)"
                     @click="select">
-    <draggable v-if="canHaveChildren" :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6"
+    <draggable :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6"
                @start="onStart" @change="onChange" @end="onEnd">
       <sitemap-treeview-item class="sitemap-treeview-item" v-for="(childwidget, idx) in children"
                              :key="idx"
@@ -126,7 +127,7 @@ export default {
       return this.widget.slots?.widgets || []
     },
     canHaveChildren () {
-      return this.LINKABLE_WIDGET_TYPES.includes(this.widget.component) && (this.children.length > 0 || this.localMoveState.moving)
+      return (this.LINKABLE_WIDGET_TYPES.includes(this.widget.component) && (this.children.length > 0 || this.localMoveState.moving)) === true
     }
   }
 }


### PR DESCRIPTION
Regression from #2904.
Reported in https://github.com/openhab/openhab-webui/pull/2970#issuecomment-2585663931.