### PR TITLE
Item Add: Navigate to the new Item once added

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -217,7 +217,11 @@ export default {
         }
 
         this.dirty = false
-        this.$f7router.back()
+        if (this.createMode) {
+          this.$f7router.navigate('/settings/items/' + this.item.name)
+        } else {
+          this.$f7router.back()
+        }
       }).catch((err) => {
         this.$f7.toast.create({
           text: 'Item not saved: ' + err,


### PR DESCRIPTION
This PR changes the navigation / where the user is sent to after creating/adding a new item.

Currently, if you go to Settings -> Items -> Add -> Save, you'll be brought back to the Items list (back navigation). 

- If the user wants to add another item - it's easy, they can click `+` again to add another item. No problems.
- But if the user wants to edit that new item, e.g. to edit metadata, add a link, etc. they would need to scroll around, or do a search for the item, click on it to get to that new item.

This PR changes this behavior so that after the new item is saved/added, the user is redirected to the Item Details page **of that new item**, so they can immediately work on it.
- If they want to add more item, they can click `< Back` which will bring them to the Add Item page, so they can enter new details and create a new item.
- If they want to go to the items list, they can just click cancel or Back again.

I think this workflow is more streamlined whether the user wants to add one item or multiple items.

This PR doesn't change the navigation behavior when **editing** an item. As previously done, the user would be sent back to the previous page, which would be the Item details. In other words: Settings -> Items (list) -> Item Details -> Edit -> Save -> Back to Item Details.

