### PR TITLE
Addons Store: Search the add-on id and show search term before loading addons

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -309,6 +309,10 @@ export default {
       this.stopEventSource()
     },
     load () {
+      if (this.searchFor) {
+        // Show this in the searchbar while the page is loading
+        this.$refs.storeSearchbar.f7Searchbar.$inputEl.val(this.searchFor)
+      }
       this.stopEventSource()
       this.$oh.api.get('/rest/services/org.openhab.i18n/config').then((data) => {
         if (data.region) {

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -371,7 +371,7 @@ export default {
         results = results.filter((a) => a.type === this.currentTab)
       }
       query = query.toLowerCase()
-      results = results.filter((a) => a.label.toLowerCase().indexOf(query) >= 0)
+      results = results.filter((a) => a.id.includes(query) || a.label.toLowerCase().includes(query))
 
       this.$set(this, 'query', query)
       this.$set(this, 'searchResults', results)


### PR DESCRIPTION
This is a refinement of #3003.

I noticed that when the Thing-Details shows `HANDLER_MISSING_ERROR` and I clicked `Install Binding`, it takes me to the Addons Store loading page while it's trying to load the list of addons from the server.

During this time, the search bar is visible, but blank.

This PR sets the search term (i.e. the Binding name) in the search bar to be displayed _whilst_ the list of addons is being loaded, to give the user quicker feedback of what's going on.

This PR consists of 2 commits that probably should be kept separate. The second commit makes the search match the addon id, so that when `Install Binding` looks for `amazonechocontrol` it would find it. Previously, it only searched the addon title which is "Amazon Echo Control", so it wouldn't have been found.

The same goes for when user searches for `jsscripting`, currently this wouldn't have shown a result. This PR fixes that.