### PR TITLE
Things List: Add multiple search, select all & Inbox: Go to newly approved Thing(s)

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -311,6 +311,10 @@ html
       margin-left 8px
       color var(--f7-input-text-color)
 
+// Increase width of Thing Inbox Approve Dialog
+.thing-inbox-approve-dialog
+  --f7-dialog-width 320px
+
 // Fix safe area issues inside f7-card components, where safe areas are already respected by the f7-card itself
 .card
   .block

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -99,7 +99,7 @@ export default {
       ready: false,
       loading: false,
       initSearchbar: false,
-      things: [],
+      things: [], // This is used for Thing UID validation inside thing-mixin.js
       thingTypes: [],
       discoverySupported: false,
       inputSupported: null,

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -99,6 +99,7 @@ export default {
       ready: false,
       loading: false,
       initSearchbar: false,
+      things: [],
       thingTypes: [],
       discoverySupported: false,
       inputSupported: null,
@@ -136,6 +137,9 @@ export default {
           this.initSearchbar = true
           this.ready = true
         })
+      })
+      this.$oh.api.get('/rest/things?summary=true&staticDataOnly=true').then((things) => {
+        this.things = things
       })
     },
     finishScanning () {
@@ -240,8 +244,7 @@ export default {
             }
           ],
           [
-            this.entryActionsAddAsThingButton(entry, this.loadInbox),
-            this.entryActionsAddAsThingWithCustomIdButton(entry, this.loadInbox)
+            this.entryActionsAddAsThingButton(entry, this.loadInbox)
           ]
         ]
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -144,6 +144,7 @@ export default {
       ready: false,
       loading: false,
       initSearchbar: false,
+      things: [], // for validating thingUIDs against existing things
       inbox: [],
       // indexedInbox: {},
       selectedItems: [],
@@ -194,7 +195,6 @@ export default {
         this.inbox = data.sort((a, b) => a.label.localeCompare(b.label))
         this.initSearchbar = true
         this.loading = false
-        this.ready = true
         setTimeout(() => {
           this.$refs.listIndex.update()
           this.$nextTick(() => {
@@ -202,6 +202,10 @@ export default {
               this.$refs.searchbar.f7Searchbar.$inputEl[0].focus()
             }
           })
+        })
+        this.$oh.api.get('/rest/things?summary=true&staticDataOnly=true').then((things) => {
+          this.things = things
+          this.ready = true
         })
       })
     },
@@ -260,7 +264,6 @@ export default {
           ],
           [
             this.entryActionsAddAsThingButton(entry, this.load),
-            this.entryActionsAddAsThingWithCustomIdButton(entry, this.load),
             {
               text: (!ignored) ? 'Ignore' : 'Unignore',
               color: (!ignored) ? 'orange' : 'blue',
@@ -417,9 +420,12 @@ export default {
           destroyOnClose: true,
           closeTimeout: 2000
         }).open()
-        this.selectedItems = []
         dialog.close()
-        this.load()
+        this.$f7router.navigate('/settings/things/', {
+          props: {
+            searchFor: this.selectedItems.join(',')
+          }
+        })
       }).catch((err) => {
         dialog.close()
         this.load()

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
@@ -1,5 +1,4 @@
 import ThingMixin from '@/components/thing/thing-mixin'
-import { on } from 'process'
 
 export default {
   mixins: [ThingMixin],

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
@@ -89,6 +89,7 @@ export default {
               }
             ],
             destroyOnClose: true,
+            cssClass: 'thing-inbox-approve-dialog',
             on: {
               opened: (dialog) => {
                 const id = dialog.$el.find('.id-input')

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
@@ -1,4 +1,8 @@
+import ThingMixin from '@/components/thing/thing-mixin'
+import { on } from 'process'
+
 export default {
+  mixins: [ThingMixin],
   methods: {
     /**
      * Approve the given entry from the inbox.
@@ -31,39 +35,84 @@ export default {
         color: 'green',
         bold: true,
         onClick: () => {
-          this.$f7.dialog.prompt(`This will create a new Thing of type ${entry.thingTypeUID} with the following label:`,
-            'Add as Thing',
-            (label) => {
-              this.approveEntry(entry, label).finally(() => {
-                loadFn()
-              })
-            },
-            null,
-            entry.label)
-        }
-      }
-    },
-    entryActionsAddAsThingWithCustomIdButton (entry, loadFn) {
-      return {
-        text: 'Add as Thing (with custom ID)',
-        color: 'blue',
-        bold: true,
-        onClick: () => {
-          this.$f7.dialog.prompt(`This will create a new Thing of type ${entry.thingTypeUID}. You can change the suggested Thing ID below:`,
-            'Add as Thing',
-            (newThingId) => {
-              this.$f7.dialog.prompt('Enter the desired label of the new Thing:',
-                'Add as Thing',
-                (label) => {
-                  this.approveEntry(entry, label, newThingId).finally(() => {
-                    loadFn()
-                  })
-                },
-                null,
-                entry.label)
-            },
-            null,
-            entry.thingUID.substring(entry.thingUID.lastIndexOf(':') + 1))
+          const lastColonIdx = entry.thingUID.lastIndexOf(':')
+          const uidPrefix = entry.thingUID.substring(0, lastColonIdx + 1)
+          const defaultId = entry.thingUID.substring(lastColonIdx + 1)
+
+          const okButtonClicked = (dialog, redirect) => {
+            const newThingId = dialog.$el.find('.id-input').val()
+            const newThingUID = uidPrefix + newThingId
+
+            const error = this.validateThingUID(newThingUID, newThingId)
+            const label = dialog.$el.find('.label-input').val()
+            if (!error && label) {
+              dialog.close()
+              this.approveEntry(entry, label, newThingId)
+                .then(() => {
+                  if (redirect) this.$f7router.navigate('/settings/things/' + newThingUID)
+                  else loadFn()
+                })
+                .catch(() => loadFn())
+            }
+          }
+
+          this.$f7.dialog.create({
+            title: 'Add as Thing',
+            text: `This will create a new Thing of type ${entry.thingTypeUID}.`,
+            content: `
+                <div class="dialog-text">Thing ID:</div>
+                <div class="dialog-input-field input"><input type="text" class="dialog-input id-input"></div>
+                <div class="input-info id-info"></div>
+                <div>&nbsp;</div>
+                <div class="dialog-text">Thing label:</div>
+                <div class="dialog-input-field input"><input type="text" class="dialog-input label-input"></div>
+                <div class="input-info label-info"></div>
+              `,
+            buttons: [
+              {
+                text: this.$f7.params.dialog.buttonCancel,
+                color: 'gray',
+                keyCodes: [27],
+                close: true
+              },
+              {
+                text: 'OK &rarr; Edit',
+                bold: true,
+                close: false,
+                onClick: (dialog) => okButtonClicked(dialog, true)
+              },
+              {
+                text: 'OK',
+                bold: true,
+                keyCodes: [13],
+                close: false,
+                onClick: (dialog) => okButtonClicked(dialog, false)
+              }
+            ],
+            destroyOnClose: true,
+            on: {
+              opened: (dialog) => {
+                const id = dialog.$el.find('.id-input')
+                id.val(defaultId)
+                id.focus()
+
+                id.on('input', () => {
+                  const error = this.validateThingUID(uidPrefix + id.val(), id.val())
+                  const info = dialog.$el.find('.id-info')
+                  info.text(error)
+                  info[0].style.color = error ? 'red' : ''
+                })
+
+                const label = dialog.$el.find('.label-input')
+                label.val(entry.label)
+                label.on('input', () => {
+                  const info = dialog.$el.find('.label-info')
+                  info.text(label.val() ? '' : 'Label is required')
+                  info[0].style.color = label.val() ? '' : 'red'
+                })
+              }
+            }
+          }).open()
         }
       }
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -168,6 +168,7 @@ import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 
 export default {
   mixins: [thingStatus],
+  props: ['searchFor'],
   components: {
     'empty-state-placeholder': () => import('@/components/empty-state-placeholder.vue'),
     ClipboardIcon
@@ -267,6 +268,10 @@ export default {
       if (this.initSeachbar) this.$f7.data.lastThingsSearchQuery = this.$refs.searchbar?.f7Searchbar.query
       this.initSeachbar = false
 
+      if (this.searchFor) {
+        this.$refs.searchbar?.f7Searchbar.$inputEl.val(this.searchFor)
+      }
+
       this.$oh.api.get('/rest/things?summary=true').then((data) => {
         this.things = data.sort((a, b) => (a.label || a.UID).localeCompare(b.label || a.UID))
         this.filteredThings = this.things
@@ -278,7 +283,7 @@ export default {
           if (this.$device.desktop && this.$refs.searchbar) {
             this.$refs.searchbar.f7Searchbar.$inputEl[0].focus()
           }
-          this.$refs.searchbar?.f7Searchbar.search(this.$f7.data.lastThingsSearchQuery || '')
+          this.$refs.searchbar?.f7Searchbar.search(this.searchFor || this.$f7.data.lastThingsSearchQuery || '')
         })
         if (!this.eventSource) this.startEventSource()
       })


### PR DESCRIPTION
There are several changes wrapped up in this PR because they are somewhat interdependent.

## Filtering/Searching + Selections

- The Thing count is updated to reflect the number of matches found when performing search/filtering
- When filtering, the invisible Things (i.e. Things that do not meet the filter criteria) will be deselected. Only Things within the filtered result can be selected and acted upon (Remove, Disable, Enable). So if you first selected all your things (e.g. 100 things) then perform search/filtering which result in 5 things, then the total selected Things will now be just 5, and when you hit Remove, only those 5 will be removed.

  This is a change in behaviour. Originally, the selected Things remain despite the search/filtering, so whilst the user may see 5 Things checked on the list, they can be removing other Things.
- Add `Select All` / `Deselect All`. This also works in tandem with search/filter. When the filtered result shows only 5 Things, Select All will only select those 5 Things and not all the available Things on the system.

Here's an example of a filtered result + selection:
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/f2558677-edbe-497a-8a7f-6e597e088a33" />

## Search for Multiple Things

- It is possible to search and display multiple Things by separating the search terms with a comma. This is implemented to make it possible for multiple Inbox items to be approved (through multi-selection) and then the user be presented with the list of those newly approved things.
- Essentially it acts as an `OR` operator, e.g. searching for `broker1,broker2` results in showing Things that match either `broker1` or `broker2` combined into the result list

## Preload Things List search

- This allows navigating to Things List page with a pre-defined search terms, also to support the inbox approval feature

## Inbox approval

### Single Thing Approval

- `Add as Thing` and `Add as Thing (with Custom ID)` are merged into just `Add as Thing`. The subsequent dialog will prompt for both the Thing ID and the Label in one dialog, removing multiple steps.
  <img width="784" alt="image" src="https://github.com/user-attachments/assets/ad9f9c8e-f4cc-419c-8e82-a75d824dfdae" />

- Thing UID / ID validation is performed within the Add a Thing dialog, and the validation status displayed instantly under the Thing ID input
  <img width="301" alt="image" src="https://github.com/user-attachments/assets/31560b3b-cb00-44fe-a1ee-9f8e33de4b07" />
  It also checks against full UID conflicts against existing Things
  <img width="299" alt="image" src="https://github.com/user-attachments/assets/00518232-a4d2-40ae-85f7-058967d6c813" />

- Here, the user is given two OK buttons. 
  - `OK -> Edit` will approve the Thing and redirect them to the Thing Details page for that Thing
  - `OK` will approve it and bring them back to the same page (Inbox)

### Multiple Things Approval

- When multiple inbox items are selected and `Approve` is clicked, the user will be redirected to the `Things List` page, with pre-set filter to show _all_ and _only_ the approved Things.

<img width="826" alt="image" src="https://github.com/user-attachments/assets/b80354be-3d92-47f7-bdc5-6afca41d8d19" />

<img width="826" alt="image" src="https://github.com/user-attachments/assets/f4a08324-790f-425a-9533-fc602c2e933c" />
