### PR TITLE
Inbox: Add `Copy .things Definition` (to clipboard) button

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -241,7 +241,8 @@ export default {
           ],
           [
             this.entryActionsAddAsThingButton(entry, this.loadInbox),
-            this.entryActionsAddAsThingWithCustomIdButton(entry, this.loadInbox)
+            this.entryActionsAddAsThingWithCustomIdButton(entry, this.loadInbox),
+            this.entryActionsCopyThingDefinitionButton(entry)
           ]
         ]
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -261,6 +261,7 @@ export default {
           [
             this.entryActionsAddAsThingButton(entry, this.load),
             this.entryActionsAddAsThingWithCustomIdButton(entry, this.load),
+            this.entryActionsCopyThingDefinitionButton(entry),
             {
               text: (!ignored) ? 'Ignore' : 'Unignore',
               color: (!ignored) ? 'orange' : 'blue',

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
@@ -1,3 +1,8 @@
+import Vue from 'vue'
+import Clipboard from 'v-clipboard'
+
+Vue.use(Clipboard)
+
 export default {
   methods: {
     /**
@@ -64,6 +69,28 @@ export default {
             },
             null,
             entry.thingUID.substring(entry.thingUID.lastIndexOf(':') + 1))
+        }
+      }
+    },
+    entryActionsCopyThingDefinitionButton (entry) {
+      return {
+        text: 'Copy .things Definition',
+        color: 'blue',
+        bold: true,
+        onClick: () => {
+          const tokens = ['Thing', entry.thingUID, `"${entry.label}"`]
+          const rp = entry.representationProperty
+          if (rp) {
+            tokens.push(`[ ${rp}="${entry.properties[rp]}" ]`)
+          }
+          const definition = tokens.join(' ') + '\n'
+          if (this.$clipboard(definition)) {
+            this.$f7.toast.create({
+              text: `Thing definition for '${entry.thingUID}' copied to clipboard`,
+              destroyOnClose: true,
+              closeTimeout: 2000
+            }).open()
+          }
         }
       }
     }


### PR DESCRIPTION
## Purpose

This allows us to quickly create the Thing inside a .things file from the discovered Inbox items.

## Background

This was discussed / requested by @seime here:
https://community.openhab.org/t/adjust-width-of-f7-dialog-include-clipboard-icon/154117

## Screenshots

![image](https://github.com/user-attachments/assets/17aa41ac-3036-45dc-be75-e114a21179d7)


Once clicked, it shows a Toast message:

<img width="761" alt="image" src="https://github.com/user-attachments/assets/bf09a5d5-1b9b-4489-9ce3-bd04fa572444" />

## Output

The copied text looks like this:

```java
Thing mqtt:homeassistant:broker2:d8bfc0da0776 "backporch-switch1" [ deviceId="d8bfc0da0776" ]
```