### PR TITLE
Update oh-slider handing of steps when rounding state values

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -55,8 +55,8 @@ export default {
     },
     toStepFixed (value) {
       // uses the number of decimals in the step config to round the provided number
-      const nbDecimals = this.config.step ? Number(this.config.step).toString().replace(',', '.').split('.')[1] : 0
-      return parseFloat(Number(value).toFixed(nbDecimals))
+      const nbDecimals = this.config.step ? Number(this.config.step).toString().replace(',', '.').split('.')[1]?.length : 0
+      return parseFloat(Number(value).toFixed(nbDecimals ?? 0))
     },
     onChange (newValue) {
       if (isNaN(this.value)) return

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -50,9 +50,8 @@ export default {
     toStepFixed (value) {
       // uses the number of decimals in the step config to round the provided number
       if (!this.config.step) return value
-      const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]
-      // do NOT convert to number, instead return string, otherwise formatting wouldn't work
-      return parseFloat(value).toFixed(nbDecimals ? nbDecimals.length : 0)
+      const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]?.length
+      return parseFloat(Number(value).toFixed(nbDecimals ?? 0))
     },
     onPlusMinusClick () {
       setTimeout(() => {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-stepper.vue
@@ -50,8 +50,9 @@ export default {
     toStepFixed (value) {
       // uses the number of decimals in the step config to round the provided number
       if (!this.config.step) return value
-      const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]?.length
-      return parseFloat(Number(value).toFixed(nbDecimals ?? 0))
+      const nbDecimals = Number(this.config.step).toString().replace(',', '.').split('.')[1]
+      // do NOT convert to number, instead return string, otherwise formatting wouldn't work
+      return parseFloat(value).toFixed(nbDecimals ? nbDecimals.length : 0)
     },
     onPlusMinusClick () {
       setTimeout(() => {


### PR DESCRIPTION
Fixes #3019, see that bug for precise details on what led to this change and the details of the broken behavior.

Updating oh-slider to round the format label, scale, etc based on the step provided (which comes from the StateDescription). Before this change, a step value such as 1.234 would try to fix the value like:

Number(...).toFixed(234)

which causes a RangeError (toFixed requires inputs ranging 0..100). It needs to be checking the length of the decimal portion of the string, not the value itself.

This change attempts to keep as close to the current behavior, and the intention mentioned by the comments. In the above example it fix the state to 3 digits (instead of 234).

# Testing

Tested using local MainUI server via NPM checking my various items that had been broken by 4.3.X.

Confirmed that this addresses the console errors listed in the bug as well as makes the sliders interactive again when using very precise step values.

Tested with integer steps (fixing to 0 decimal digits), undefined steps (fixing to 0 decimal digits), and very precise steps generated from my mqtt.generic items (0.3937007874015748, fixing to 16). All work as expected and the sliders are functional again.

 Signed-off-by: David Tschida <dmtschida1@gmail.com> (github: vidia)