### PR TITLE
Channel Settings: Make long Channel UID fully visible

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -23,6 +23,13 @@
   </f7-block>
 </template>
 
+<style lang="stylus">
+.list
+  .item-subtitle
+    overflow-wrap break-word
+    white-space inherit
+</style>
+
 <script>
 import ClipboardIcon from '@/components/util/clipboard-icon.vue'
 export default {


### PR DESCRIPTION
Fix #3023

<img width="765" alt="image" src="https://github.com/user-attachments/assets/9b86a81b-f52d-4fa8-820f-007befc8558e" />

<img width="754" alt="image" src="https://github.com/user-attachments/assets/178b14c5-41f5-498a-b77b-118a2e8d84fb" />
