### PR TITLE
Addons Store: Extend search to the add-on descriptions

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -370,7 +370,7 @@ export default {
         results = results.filter((a) => a.type === this.currentTab)
       }
       query = query.toLowerCase()
-      results = results.filter((a) => a.id.includes(query) || a.label.toLowerCase().includes(query))
+      results = results.filter((a) => a.id.includes(query) || a.label.toLowerCase().includes(query) || a.description?.toLowerCase()?.includes(query))
 
       this.$set(this, 'query', query)
       this.$set(this, 'searchResults', results)


### PR DESCRIPTION
Resolve #2870

Related: https://github.com/openhab/openhab-core/pull/4564

<img width="558" alt="image" src="https://github.com/user-attachments/assets/8b50fea1-245b-4de1-b7d0-79198ef5ef35" />

TODO: Go through addon descriptions and refine the wordings, e.g. a lot of them start with `This is the binding for...`