### PR TITLE
Tag Input: Fix enter key on Android

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -73,7 +73,7 @@ export default {
     },
     keyUp (evt) {
       this.pendingTag = evt.target.value
-      if (evt.code === 'Enter') {
+      if (evt.key === 'Enter') {
         this.addTag(evt)
       }
     },


### PR DESCRIPTION
Fix #2890.
Fix #1440.

Tested it on browserstack:
- enter works on iphone 13
- enter works on pixel 7
- also works on my real android phone
