### PR TITLE
Layout Editor: Fix invisible bottom part of the screen

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
@@ -29,6 +29,7 @@
           </f7-list>
         </f7-block>
       </template>
+      <f7-block v-if="context.editmode && !$fullscreen.isFullscreen" style="height: calc(var(--f7-toolbar-height) + var(--f7-safe-area-bottom))" />
     </template>
     <template v-else-if="config.layoutType === 'fixed' && (!config.fixedType || config.fixedType === 'grid')">
       <oh-grid-layout :context="context" />

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
@@ -29,7 +29,7 @@
           </f7-list>
         </f7-block>
       </template>
-      <f7-block v-if="context.editmode && !$fullscreen.isFullscreen" style="height: calc(var(--f7-toolbar-height) + var(--f7-safe-area-bottom))" />
+      <div v-if="context.editmode && !$fullscreen.isFullscreen" style="height: calc(var(--f7-toolbar-height) + var(--f7-safe-area-bottom) + 40px)" />
     </template>
     <template v-else-if="config.layoutType === 'fixed' && (!config.fixedType || config.fixedType === 'grid')">
       <oh-grid-layout :context="context" />


### PR DESCRIPTION
In non full-screen mode, the bottom of the screen was hidden behind the bottom toolbar. This includes the "Add Masonry" button and any components at the bottom of the screen.

Notice the missing "Add Masonry" button
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/a728c034-6d94-4a9d-b12a-ad2ac2b9319b" />

