### PR TITLE
Canvas Layout: Fix embedding SVG errors

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-embedded-svg-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-embedded-svg-mixin.js
@@ -20,7 +20,13 @@ export default {
       // Load the real SVG content, in editmode we add a random number to the URL to prevent caching
       const svgUrl = (this.context.editmode) ? this.config.imageUrl + `?rnd=${Math.random()}` : this.config.imageUrl
       return fetch(svgUrl)
-        .then(response => response.text())
+        .then(response => {
+          if (response.headers.get('Content-Type') === 'image/svg+xml') {
+            return response.text()
+          } else {
+            return Promise.reject(new Error('The imageUrl does not return an SVG file.'))
+          }
+        })
         .then(svgCode => {
           this.$refs.canvasBackground.innerHTML = svgCode
           const svgEl = this.$refs.canvasBackground.querySelector('svg')

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -224,19 +224,25 @@ export default {
     this.$fullscreen.support = true
     this.canvasLayoutStyle()
     this.computeLayout()
-
-    if (this.config.embedSvg) {
-      this.embedSvg().then(() => {
-        this.subscribeEmbeddedSvgListeners()
-        this.setupEmbeddedSvgStateTracking()
-        this.embeddedSvgReady = true
-      })
-    }
   },
   mounted () {
     // Chrome reports a wrong size in fullscreen, store initial resolution and use non-dynamically.
     this.windowWidth = window.screen.width
     this.windowHeight = window.screen.height
+    if (this.config.embedSvg && this.config.imageUrl) {
+      this.embedSvg().then(() => {
+        this.subscribeEmbeddedSvgListeners()
+        this.setupEmbeddedSvgStateTracking()
+        this.embeddedSvgReady = true
+      }).catch((err) => {
+        this.$nextTick(() => {
+          this.$f7.toast.create({
+            text: `Failed to embed SVG: ${err}`,
+            closeTimeout: 3000
+          }).open()
+        })
+      })
+    }
   },
   beforeDestroy () {
     if (!this.context.editmode) {


### PR DESCRIPTION
Canvas Layout: Fix embedding SVG errors

- When imageUrl is not configured, don't show/log an error message
- When imageUrl is not an SVG file, or
- When there's an error fetching the SVG file, show a toast message
- When flashing the embedded svg
- Show a toast message when flashing, but no 'openhab' elements were found

<img width="928" alt="Screenshot 2025-01-26 at 4 56 05 PM" src="https://github.com/user-attachments/assets/7b4f7bad-6bd2-475f-8353-7cc5f1b6162e" />
