### PR TITLE
Widget Config and Widget Code: Live update, dirty checking, movable popup

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-code-popup.vue
@@ -1,18 +1,24 @@
 <template>
-  <f7-popup ref="widgetCode" class="widgetcode-popup" @popup:open="widgetCodeOpened" @popup:closed="widgetCodeClosed">
+  <f7-popup ref="widgetCode" class="widgetcode-popup" :close-by-backdrop-click="false" @popup:open="widgetCodeOpened" @popup:closed="widgetCodeClosed">
     <f7-page v-if="component && code">
-      <f7-navbar>
+      <f7-navbar ref="navbar">
         <f7-nav-left>
-          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="closeWithDirtyCheck" />
         </f7-nav-left>
-        <f7-nav-title>Edit Widget Code</f7-nav-title>
+        <f7-nav-title>Edit Widget Code{{ dirtyIndicator }}</f7-nav-title>
         <f7-nav-right>
-          <f7-link @click="updateWidgetCode" popup-close>
-            Done
+          <f7-link v-if="dirty" @click="reset">
+            Reset
+          </f7-link>
+          <f7-link v-if="dirty" @click="save">
+            Save
+          </f7-link>
+          <f7-link v-else popup-close>
+            Close
           </f7-link>
         </f7-nav-right>
       </f7-navbar>
-      <editor class="page-code-editor" :mode="`application/vnd.openhab.uicomponent+yaml;type=${componentType || 'widget'}`" :value="code" @input="(value) => code = value" />
+      <editor class="page-code-editor" :mode="`application/vnd.openhab.uicomponent+yaml;type=${componentType || 'widget'}`" :value="code" @input="update" />
       <!-- <pre class="yaml-message padding-horizontal" :class="[widgetYamlError === 'OK' ? 'text-color-green' : 'text-color-red']">{{widgetYamlError}}</pre> -->
     </f7-page>
   </f7-popup>
@@ -34,14 +40,20 @@
 
 <script>
 import YAML from 'yaml'
+import DirtyMixin from '@/pages/settings/dirty-mixin'
+import MovablePopupMixin from '@/pages/settings/movable-popup-mixin'
 
 export default {
   props: ['component', 'componentType'],
+  mixins: [DirtyMixin, MovablePopupMixin],
   components: {
     'editor': () => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue')
   },
   data () {
     return {
+      leaveCancelled: false,
+      updateTimer: null,
+      originalCode: null,
       code: null
     }
   },
@@ -58,14 +70,70 @@ export default {
   methods: {
     widgetCodeOpened () {
       this.code = YAML.stringify(this.component)
+      this.originalCode = this.code
+      this.$nextTick(() => {
+        // this.$refs.navbar only exists after the code editor finished rendering
+        this.initializeMovablePopup(this.$refs.widgetCode, this.$refs.navbar)
+      })
+      window.addEventListener('keydown', this.onKeydown)
     },
     widgetCodeClosed () {
+      this.cleanupMovablePopup()
+      window.removeEventListener('keydown', this.onKeydown)
       this.$f7.emit('widgetCodeClosed')
       this.$emit('closed')
     },
-    updateWidgetCode () {
-      this.$f7.emit('widgetCodeUpdate', this.code)
-      this.$emit('update', this.code)
+    onKeydown (evt) {
+      if (evt.key === 'Escape' && !this.leaveCancelled) {
+        this.closeWithDirtyCheck()
+      }
+    },
+    closeWithDirtyCheck () {
+      if (this.dirty) {
+        const dialog = this.confirmLeaveWithoutSaving(
+          () => {
+            this.updateWidgetCode(this.originalCode)
+            this.$refs.widgetCode.close()
+          },
+          () => {
+            // prevent re-triggering the confirm dialog when ESC is pressed to close the dialog
+            this.leaveCancelled = true
+            setTimeout(() => { this.leaveCancelled = false }, 100)
+          }
+        )
+      } else {
+        this.$refs.widgetCode.close()
+      }
+    },
+    reset () {
+      this.$f7.dialog.confirm('Do you want to revert your changes?', 'Revert Changes', () => {
+        this.code = this.originalCode
+        this.updateWidgetCode(this.code)
+        this.dirty = false
+      })
+    },
+    save () {
+      if (this.widgetYamlError !== 'OK') {
+        this.$f7.dialog.alert('Invalid YAML: ' + this.widgetYamlError, 'Unable to save changes').open()
+        return
+      }
+      this.updateWidgetCode(this.code)
+      this.$refs.widgetCode.close()
+    },
+    updateWidgetCode (value) {
+      this.$f7.emit('widgetCodeUpdate', value)
+      this.$emit('update', value)
+    },
+    update (value) {
+      this.code = value
+      clearTimeout(this.updateTimer)
+      this.updateTimer = setTimeout(() => {
+        // Since update will be called on every key stroke, debounce the dirty check too
+        this.dirty = this.code !== this.originalCode
+        if (this.widgetYamlError === 'OK') {
+          this.updateWidgetCode(this.code)
+        }
+      }, 200)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-config-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-config-popup.vue
@@ -1,14 +1,20 @@
 <template>
-  <f7-popup ref="widgetConfig" class="widgetconfig-popup" close-on-escape @popup:open="widgetConfigOpened" @popup:closed="widgetConfigClosed">
+  <f7-popup ref="widgetConfig" class="widgetconfig-popup" :close-by-backdrop-click="false" @popup:opened="widgetConfigOpened" @popup:closed="widgetConfigClosed">
     <f7-page v-if="component && widget">
-      <f7-navbar>
+      <f7-navbar ref="navbar">
         <f7-nav-left>
-          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="closeWithDirtyCheck" />
         </f7-nav-left>
-        <f7-nav-title>Edit {{ widget.label || widget.uid }}</f7-nav-title>
+        <f7-nav-title>Edit {{ widget.label || widget.uid }}{{ dirtyIndicator }}</f7-nav-title>
         <f7-nav-right>
-          <f7-link @click="updateWidgetConfig" popup-close>
-            Done
+          <f7-link v-if="dirty" @click="reset">
+            Reset
+          </f7-link>
+          <f7-link v-if="dirty" @click="save">
+            Save
+          </f7-link>
+          <f7-link v-else popup-close>
+            Close
           </f7-link>
         </f7-nav-right>
       </f7-navbar>
@@ -18,7 +24,7 @@
             :parameterGroups="widget.props.parameterGroups || []"
             :parameters="widget.props.parameters || []"
             :configuration="config"
-            @updated="dirty = true" />
+            @updated="updated" />
         </f7-col>
       </f7-block>
     </f7-page>
@@ -32,28 +38,82 @@
 
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import DirtyMixin from '@/pages/settings/dirty-mixin'
+import cloneDeep from 'lodash/cloneDeep'
+import fastDeepEqual from 'fast-deep-equal/es6'
+import MovablePopupMixin from '@/pages/settings/movable-popup-mixin'
 
 export default {
+  mixins: [DirtyMixin, MovablePopupMixin],
   props: ['opened', 'component', 'widget'],
   components: {
     ConfigSheet
   },
   data () {
     return {
+      originalConfig: null,
+      updateTimer: null,
+      leaveCancelled: false,
       config: null
     }
   },
   methods: {
     widgetConfigOpened () {
-      this.config = JSON.parse(JSON.stringify(this.component.config))
+      this.config = cloneDeep(this.component.config)
+      this.originalConfig = cloneDeep(this.component.config)
+      this.initializeMovablePopup(this.$refs.widgetConfig, this.$refs.navbar)
+      window.addEventListener('keydown', this.onKeydown)
     },
     widgetConfigClosed () {
+      this.cleanupMovablePopup()
+      window.removeEventListener('keydown', this.onKeydown)
       this.$f7.emit('widgetConfigClosed')
       this.$emit('closed')
     },
-    updateWidgetConfig () {
-      this.$f7.emit('widgetConfigUpdate', this.config)
-      this.$emit('update', this.config)
+    onKeydown (evt) {
+      if (evt.key === 'Escape' && !this.leaveCancelled) {
+        this.closeWithDirtyCheck()
+      }
+    },
+    closeWithDirtyCheck () {
+      if (this.dirty) {
+        const dialog = this.confirmLeaveWithoutSaving(
+          () => {
+            this.updateWidgetConfig(this.originalConfig)
+            this.$refs.widgetConfig.close()
+          },
+          () => {
+            // prevent re-triggering the confirm dialog when ESC is pressed to close the dialog
+            this.leaveCancelled = true
+            setTimeout(() => { this.leaveCancelled = false }, 100)
+          }
+        )
+      } else {
+        this.$refs.widgetConfig.close()
+      }
+    },
+    reset () {
+      this.$f7.dialog.confirm('Do you want to revert your changes?', 'Revert Changes', () => {
+        this.config = cloneDeep(this.originalConfig)
+        this.updateWidgetConfig(this.originalConfig)
+        this.dirty = false
+      })
+    },
+    save () {
+      this.updateWidgetConfig(this.config)
+      this.$refs.widgetConfig.close()
+    },
+    updateWidgetConfig (config) {
+      const newConfig = cloneDeep(config)
+      this.$f7.emit('widgetConfigUpdate', newConfig)
+      this.$emit('update', newConfig)
+    },
+    updated () {
+      this.dirty = !fastDeepEqual(this.config, this.originalConfig)
+      clearTimeout(this.updateTimer)
+      this.updateTimer = setTimeout(() => {
+        this.updateWidgetConfig(this.config)
+      }, 500)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-embedded-svg-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-embedded-svg-mixin.js
@@ -67,8 +67,12 @@ export default {
           }
         }
       })
-      this.$f7.once('widgetConfigUpdate', (config) => {
+      const updateWidgetConfig = (config) => {
         this.$f7.emit('svgOnClickConfigUpdate', { id, config })
+      }
+      this.$f7.on('widgetConfigUpdate', updateWidgetConfig)
+      this.$f7.once('widgetConfigClosed', () => {
+        this.$f7.off('widgetConfigUpdate', updateWidgetConfig)
       })
     },
     /**

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -326,7 +326,8 @@ export default {
             ])
         }
       })
-      this.$f7.once('widgetConfigUpdate', this.storeLocalConfig)
+      this.$f7.on('widgetConfigUpdate', this.storeLocalConfig)
+      this.$f7.once('widgetConfigClosed', () => this.$f7.off('widgetConfigUpdate', this.storeLocalConfig))
     },
     storeLocalConfig (config) {
       this.localConfig = config

--- a/bundles/org.openhab.ui/web/src/pages/settings/movable-popup-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/movable-popup-mixin.js
@@ -17,24 +17,29 @@ export default {
   },
   methods: {
     /**
-     * Make the given popupRef movable by dragging the draggableRef element
-     * If draggableRef is not provided, the popupRef will be used as the draggable element
-     * 
-     * This method needs to be called in the popup:open event handler, and
-     * cleanupMovablePopup() must be called in the popup:close event handler.
-     * 
-     * The popupRef must be a reference to the popup element, e.g.
-     *   <f7-popup ref="popupRef"
-     * And the draggableRef must be a reference to the element that will be used to 
+     * Make the given `popupRef` movable by dragging the `draggableRef` element.
+     * If `draggableRef` is not provided, the `popupRef` will be used as the draggable element.
+     *
+     * This method needs to be called in the `popup:open` event handler, and
+     * `cleanupMovablePopup()` must be called in the `popup:close` event handler.
+     *
+     * The `popupRef` must be a reference to the popup element, e.g.
+     * ```
+     *   <f7-popup ref="popupRef">
+     * ```
+     *
+     * The `draggableRef` must be a reference to the element that will be used to
      * drag the popup. This is usually the navbar or the header of the popup. e.g.
+     * ```
      *   <f7-navbar ref="navbar">
-     * 
+     *
      *   this.initializeMovablePopup(this.$refs.popupRef, this.$refs.navbar)
-     * 
+     * ```
+     *
      * For usage example, see widget-config-popup.vue, and widget-code-popup.vue.
-     * 
-     * @param {Object} popupRef - The reference to the popup element
-     * @param {Object} [draggableRef] - The reference to the draggable element
+     *
+     * @param {Vue} popupRef The reference to the popup element
+     * @param {Vue} [draggableRef] The reference to the draggable element
      */
     initializeMovablePopup (popupRef, draggableRef = null) {
       if (!popupRef) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/movable-popup-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/movable-popup-mixin.js
@@ -1,0 +1,105 @@
+import { assign, pick } from 'lodash'
+
+export default {
+  data () {
+    return {
+      movablePopup: {
+        movable: false,
+        origin: null,
+        startPos: null,
+        originalStyle: null,
+        originalCursor: null,
+        popupRef: null,
+        draggableRef: null,
+        resizeObserver: null
+      }
+    }
+  },
+  methods: {
+    // Make the given popupRef movable by dragging the draggableRef element
+    // If draggableRef is not provided, the popupRef will be used as the draggable element
+    initializeMovablePopup (popupRef, draggableRef = null) {
+      if (!popupRef) {
+        console.error('popupRef is required')
+        return
+      }
+      this.movablePopup.popupRef = popupRef
+      this.movablePopup.draggableRef = draggableRef || popupRef
+      this.movablePopup.resizeObserver?.disconnect()
+      if (!this.movablePopup.resizeObserver) {
+        this.movablePopup.resizeObserver = new ResizeObserver((entries) => {
+          // When the window is resized, the popup might switch to full width due to media queries
+          // and when that happens, disable movable behavior and restore the original style
+          // This callback is called at initialization, so no need to call enableMovablePopup separately
+          const entry = entries[0]
+          if (entry.target.offsetWidth === entry.target.parentElement.offsetWidth) {
+            this.disableMovablePopup()
+            const { popupRef, draggableRef, originalStyle, originalCursor } = this.movablePopup
+            if (popupRef.$el.parentNode && originalStyle) {
+              assign(popupRef.$el.style, originalStyle)
+            }
+            if (originalCursor !== null) { // check against null, restore the cursor even if it's an empty string
+              draggableRef.$el.style.cursor = originalCursor
+            }
+          } else {
+            this.enableMovablePopup()
+          }
+        })
+      }
+      this.movablePopup.resizeObserver.observe(popupRef.$el)
+    },
+    cleanupMovablePopup () {
+      this.disableMovablePopup()
+      this.movablePopup.resizeObserver?.disconnect()
+    },
+    enableMovablePopup () {
+      if (this.movablePopup.movable) return
+
+      const { popupRef, draggableRef } = this.movablePopup
+      this.movablePopup.originalStyle = pick(popupRef.$el.style, ['left', 'top', 'marginLeft', 'marginTop'])
+      this.movablePopup.originalCursor = draggableRef.$el.style.cursor
+      draggableRef.$el.addEventListener('mousedown', this.movableStart)
+      draggableRef.$el.addEventListener('touchstart', this.movableStart)
+      draggableRef.$el.style.cursor = 'move'
+      this.movablePopup.movable = true
+    },
+    disableMovablePopup () {
+      if (!this.movablePopup.movable) return
+
+      const draggableEl = this.movablePopup.draggableRef.$el
+      draggableEl.removeEventListener('mousedown', this.movableStart)
+      draggableEl.removeEventListener('touchstart', this.movableStart)
+      this.movableEnd()
+      this.movablePopup.movable = false
+    },
+    movableStart (e) {
+      if (e instanceof MouseEvent && e.button !== 0) return // only left (primary) mouse button
+
+      const { popupRef, draggableRef } = this.movablePopup
+      this.movablePopup.origin = { left: popupRef.$el.offsetLeft, top: popupRef.$el.offsetTop }
+      const coords = e.touches ? e.touches[0] : e
+      this.movablePopup.startPos = { x: coords.pageX, y: coords.pageY }
+
+      const [moveEvent, endEvent] = e instanceof MouseEvent ? ['mousemove', 'mouseup'] : ['touchmove', 'touchend']
+      draggableRef.$el.addEventListener(moveEvent, this.movableMove)
+      draggableRef.$el.addEventListener(endEvent, this.movableEnd)
+    },
+    movableMove (e) {
+      const coords = e.touches ? e.touches[0] : e
+      const deltaX = coords.pageX - this.movablePopup.startPos.x
+      const deltaY = coords.pageY - this.movablePopup.startPos.y
+      const popupEl = this.movablePopup.popupRef.$el
+      popupEl.style.left = this.movablePopup.origin.left + deltaX + 'px'
+      popupEl.style.top = this.movablePopup.origin.top + deltaY + 'px'
+      popupEl.style.marginLeft = 0
+      popupEl.style.marginTop = 0
+    },
+    movableEnd (e) {
+      const draggableEl = this.movablePopup.draggableRef.$el
+      draggableEl.removeEventListener('mousemove', this.movableMove)
+      draggableEl.removeEventListener('touchmove', this.movableMove)
+      draggableEl.removeEventListener('mouseup', this.movableEnd)
+      draggableEl.removeEventListener('touchend', this.movableEnd)
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/pages/settings/movable-popup-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/movable-popup-mixin.js
@@ -16,8 +16,26 @@ export default {
     }
   },
   methods: {
-    // Make the given popupRef movable by dragging the draggableRef element
-    // If draggableRef is not provided, the popupRef will be used as the draggable element
+    /**
+     * Make the given popupRef movable by dragging the draggableRef element
+     * If draggableRef is not provided, the popupRef will be used as the draggable element
+     * 
+     * This method needs to be called in the popup:open event handler, and
+     * cleanupMovablePopup() must be called in the popup:close event handler.
+     * 
+     * The popupRef must be a reference to the popup element, e.g.
+     *   <f7-popup ref="popupRef"
+     * And the draggableRef must be a reference to the element that will be used to 
+     * drag the popup. This is usually the navbar or the header of the popup. e.g.
+     *   <f7-navbar ref="navbar">
+     * 
+     *   this.initializeMovablePopup(this.$refs.popupRef, this.$refs.navbar)
+     * 
+     * For usage example, see widget-config-popup.vue, and widget-code-popup.vue.
+     * 
+     * @param {Object} popupRef - The reference to the popup element
+     * @param {Object} [draggableRef] - The reference to the draggable element
+     */
     initializeMovablePopup (popupRef, draggableRef = null) {
       if (!popupRef) {
         console.error('popupRef is required')

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -179,7 +179,6 @@ export default {
     updateWidgetConfig (config) {
       this.$set(this.currentComponent, 'config', config)
       this.forceUpdate()
-      this.widgetConfigClosed()
     },
     widgetCodeClosed () {
       this.currentComponent = null
@@ -190,7 +189,6 @@ export default {
       this.$set(this.currentComponent, 'config', updatedWidget.config)
       this.$set(this.currentComponent, 'slots', updatedWidget.slots)
       this.forceUpdate()
-      this.widgetCodeClosed()
     },
     configureWidget (component, parentContext, forceComponentType) {
       const componentType = forceComponentType || component.component
@@ -240,7 +238,7 @@ export default {
         }
       })
 
-      this.$f7.once('widgetConfigUpdate', this.updateWidgetConfig)
+      this.$f7.on('widgetConfigUpdate', this.updateWidgetConfig)
       this.$f7.once('widgetConfigClosed', () => {
         this.$f7.off('widgetConfigUpdate', this.updateWidgetConfig)
         this.widgetConfigClosed()
@@ -267,7 +265,7 @@ export default {
         }
       })
 
-      this.$f7.once('widgetCodeUpdate', this.updateWidgetCode)
+      this.$f7.on('widgetCodeUpdate', this.updateWidgetCode)
       this.$f7.once('widgetCodeClosed', () => {
         this.$f7.off('widgetCodeUpdate', this.updateWidgetCode)
         this.widgetCodeClosed()

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -21,9 +21,7 @@ export default {
       clipboard: null,
       clipboardType: null,
       currentComponent: null,
-      currentWidget: null,
-      widgetConfigOpened: false,
-      widgetCodeOpened: false
+      currentWidget: null
     }
   },
   computed: {
@@ -177,7 +175,6 @@ export default {
     widgetConfigClosed () {
       this.currentComponent = null
       this.currentWidget = null
-      this.widgetConfigOpened = false
     },
     updateWidgetConfig (config) {
       this.$set(this.currentComponent, 'config', config)
@@ -187,7 +184,6 @@ export default {
     widgetCodeClosed () {
       this.currentComponent = null
       this.currentWidget = null
-      this.widgetCodeOpened = false
     },
     updateWidgetCode (code) {
       const updatedWidget = YAML.parse(code)
@@ -249,13 +245,11 @@ export default {
         this.$f7.off('widgetConfigUpdate', this.updateWidgetConfig)
         this.widgetConfigClosed()
       })
-      // this.widgetConfigOpened = true
     },
     editWidgetCode (component, parentContext, slot) {
       if (slot && !component.slots) component.slots = {}
       if (slot && !component.slots[slot]) component.slots[slot] = []
       this.currentComponent = component
-      this.widgetCodeOpened = true
       const popup = {
         component: WidgetCodePopup
       }


### PR DESCRIPTION
- Make Widget Config and Widget Code Editor popups draggable by the navbar, so they can be moved out of the way to view the widget being edited
- Preview changes immediately on the widget
- The changes can be reverted if desired by clicking the "Reset" link in the navbar.
- The changes are reverted if the popup is closed without saving.
- Implement dirty checking confirmation
- Since the Widget Config Editor is used in many other places, this also applies to them

Here's an animated GIF to show how it works
![popup_move](https://github.com/user-attachments/assets/07f404ef-aaf1-4c50-ae8d-3ffa203ee7cb)
