### PR TITLE
Tabbed Page: Support Iconify and openHAB icons for tabs

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/tabs/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/tabs/index.js
@@ -5,7 +5,7 @@ import { WidgetDefinition, pt } from '../helpers.js'
 export const OhTabDefinition = () => new WidgetDefinition('oh-tab', 'Tab', 'Displays a widget in a tab')
   .params([
     pt('title', 'Title', 'Title of the tab'),
-    pt('icon', 'Icon', 'Use <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>) or <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>)'),
+    pt('icon', 'Icon', 'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'),
     pt('badge', 'Badge', 'Badge text to display').a(),
     pt('badgeColor', 'Badge Color', 'Color of the badge').a(),
     pt('page', 'Page', 'Page to display').c('page'),

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -20,7 +20,13 @@
 
     <!-- Tabbed Pages -->
     <f7-toolbar tabbar labels bottom v-if="page && pageType === 'tabs' && visibleToCurrentUser">
-      <f7-link v-for="(tab, idx) in page.slots.default" :key="idx" tab-link @click="onTabChange(idx)" :tab-link-active="currentTab === idx" :icon-ios="tabEvaluateExpression(tab, idx, 'icon')" :icon-md="tabEvaluateExpression(tab, idx, 'icon')" :icon-aurora="tabEvaluateExpression(tab, idx, 'icon')" :text="tabEvaluateExpression(tab, idx, 'title')" :icon-badge="tabEvaluateExpression(tab, idx, 'badge')" :badge-color="tabEvaluateExpression(tab, idx, 'badgeColor')" />
+      <f7-link v-for="(tab, idx) in page.slots.default" :key="idx" tab-link @click="onTabChange(idx)" :tab-link-active="currentTab === idx">
+        <i v-if="tabEvaluateExpression(tab, idx, 'icon')" class="icon" :style="{ width: tabBarIconSize, height: tabBarIconSize }">
+          <oh-icon :icon="tabEvaluateExpression(tab, idx, 'icon')" :width="tabBarIconSize" :height="tabBarIconSize" />
+          <f7-badge v-if="tabEvaluateExpression(tab, idx, 'badge')" :color="tabEvaluateExpression(tab, idx, 'badgeColor')">{{ tabEvaluateExpression(tab, idx, 'badge') }}</f7-badge>
+        </i>
+        {{ tabEvaluateExpression(tab, idx, 'title') }}
+      </f7-link>
     </f7-toolbar>
     <f7-tabs v-if="page && pageType === 'tabs' && visibleToCurrentUser">
       <f7-tab v-for="(tab, idx) in page.slots.default" :key="idx" :tab-active="currentTab === idx">
@@ -45,6 +51,9 @@
   position absolute
   top 8px
   right 8px
+.icon
+  .badge
+    margin-left -10px !important
 </style>
 
 <script>
@@ -86,6 +95,10 @@ export default {
       const pageComponent = (this.pageType === 'tabs') ? this.tabContext(this.context.component.slots.default[this.currentTab]).component : this.context.component
       if (!pageComponent || !pageComponent.config || !pageComponent.config.style) return null
       return pageComponent.config.style
+    },
+    // Resolve the f7 CSS variable because iconify's SVG element doesn't like css variables
+    tabBarIconSize () {
+      return window.getComputedStyle(document.documentElement).getPropertyValue('--f7-tabbar-icon-size')
     },
     context () {
       return {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -41,7 +41,7 @@
               <f7-list-item media-item v-for="(tab, idx) in page.slots.default" :key="idx"
                             :title="tabEvaluateExpression(tab, idx, 'title')" :subtitle="tab.config.page"
                             link="#" @click.native="(ev) => configureTab(ev, tab, context)">
-                <f7-icon slot="media" :ios="tabEvaluateExpression(tab, idx, 'icon')" :md="tabEvaluateExpression(tab, idx, 'icon')" :aurora="tabEvaluateExpression(tab, idx, 'icon')" color="gray" :size="32" />
+                <oh-icon slot="media" :icon="tabEvaluateExpression(tab, idx, 'icon')" :color="'gray'" :width="32" :height="32" />
                 <f7-menu slot="content-start" class="configure-layout-menu">
                   <f7-menu-item icon-f7="list_bullet" dropdown>
                     <f7-menu-dropdown>


### PR DESCRIPTION
Resolve #2937

<img width="708" alt="image" src="https://github.com/user-attachments/assets/152ea485-ddee-41ff-b8f6-0094bc3f3bb7" />

With badge:
<img width="709" alt="image" src="https://github.com/user-attachments/assets/8e2057e3-01e5-4cc7-b4ce-9d016b40ffc4" />

<img width="702" alt="image" src="https://github.com/user-attachments/assets/2186b41f-f1e6-47dd-9766-965fd1b1f2e5" />


```yaml
config:
  label: tabbed test
  sidebar: true
tabs:
  - component: oh-tab
    config:
      badgeColor: green
      icon: if:f7:archivebox-fill
      page: page:photos
      title: Iconify XXXXXXXXXX
    slots:
      default: []
  - component: oh-tab
    config:
      icon: f7:archivebox_fill
      page: page:photos
      title: F7 XXXXXXXXXX
    slots:
      default: []
  - component: oh-tab
    config:
      badgeColor: blue
      icon: oh:siren
      page: page:home
      title: OH Icon
    slots:
      default: []
```
