### PR TITLE
Item Detail: Fix search in developer sidebar

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -577,7 +577,16 @@ export default {
         if (dockOpts.dock) this.activeDock = dockOpts.dock
         if (dockOpts.helpTab) this.activeHelpTab = dockOpts.helpTab
         if (dockOpts.toolTab) this.activeToolTab = dockOpts.toolTab
-        if (dockOpts.searchFor) this.developerSearch = dockOpts.searchFor
+        if (dockOpts.searchFor) {
+          if (this.developerSearch === dockOpts.searchFor) {
+            // if the search term is the same, reset the search
+            this.developerSearch = ''
+          }
+          // set the search term in nextTick to allow the reset to register in the developer-sidebar's watched prop
+          this.$nextTick(() => {
+            this.developerSearch = dockOpts.searchFor
+          })
+        }
       }
       if (!this.showDeveloperDock) this.toggleDeveloperDock()
     },


### PR DESCRIPTION
Fix the following scenario:
- "search for usages of this item" for Item A is clicked
- Sidebar opens and sets `searchFor=itemA` preloads the search as requested
- User then types new query in the sidebar, meanwhile the searchFor prop remains unchanged
- Clicking on "search for usages of this item" for item A again, caused no changes in `searchFor`, as a result, the watch for this prop didn't fire

This PR fixes this situation by resetting the searchFor prop, therefore causing the watch to perform the search again.
