### PR TITLE
oh-image-card: Fix inconsistent image size when action is defined

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-image-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-image-card.vue
@@ -1,7 +1,7 @@
 <template>
   <oh-card :context="context" :content-class="['oh-image-card', 'no-padding']">
     <template #content-root>
-      <f7-card-content :style="config.contentStyle" :class="[ ...(Array.isArray(config.contentClass) ? config.contentClass : []), 'oh-image-card', (config.action ? '' : 'no-padding')]">
+      <f7-card-content :style="config.contentStyle" :class="[ ...(Array.isArray(config.contentClass) ? config.contentClass : []), 'oh-image-card', 'no-padding']">
         <f7-list v-if="config.action" class="image-link">
           <f7-list-item class="oh-image-clickable" link="#" no-chevron @click="performAction">
             <oh-image slot="content-start" :context="childContext(context.component)" />
@@ -29,6 +29,9 @@
       display none
     .oh-image
       margin-bottom 5px
+.card
+  .list
+    margin 0 !important
 </style>
 
 <script>


### PR DESCRIPTION
Fix #3002

Before:
<img width="324" alt="image" src="https://github.com/user-attachments/assets/cc61c8c0-5867-40cc-8b15-91722d6f3bb9" />


After:
<img width="337" alt="image" src="https://github.com/user-attachments/assets/b86ba09f-d136-4baa-af56-5289833f8560" />
