### PR TITLE
Sitemap editor: fix icon parsing error

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -129,13 +129,13 @@ WidgetAttr -> %widgetswitchattr                                                 
 WidgetAttrName -> %item | %label | %widgetattr
 WidgetBooleanAttrValue -> %boolean                                                {% (d) => (d[0].value === 'true') %}
   | %string                                                                       {% (d) => (d[0].value === 'true') %}
-WidgetIconAttrValue -> %string
-  | WidgetIconName
-  | %identifier %colon WidgetIconName
-  | %identifier %colon %identifier %colon WidgetIconName
+WidgetIconAttrValue -> %string                                                    {% (d) => d[0].value %}
+  | WidgetIconAttrPart
+  | WidgetIconAttrPart %colon WidgetIconAttrPart
+  | WidgetIconAttrPart %colon WidgetIconAttrPart %colon WidgetIconAttrPart
+WidgetIconAttrPart -> %identifier                                                 {% (d) => d[0].value %}
+  | %identifier %hyphen WidgetIconAttrPart                                        {% (d) => d[0].value + "-" + d[2] %}
 WidgetIconRulesAttrValue -> %lbracket _ IconRules _ %rbracket                     {% (d) => d[2] %}
-WidgetIconName -> %identifier
-  | WidgetIconName %hyphen %identifier                                            {% (d) => d[0] + "-" + d[2].value %}
 WidgetPeriodAttrValue -> %identifier %hyphen %identifier                          {% (d) => d[0].value + "-" + d[2].value %}
   | %hyphen %identifier                                                           {% (d) => "-" + d[1].value %}
   | %identifier                                                                   {% (d) => d[0].value %}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
@@ -136,6 +136,47 @@ describe('SitemapCode', () => {
     })
   })
 
+  it('parses an icon correctly', async () => {
+    expect(wrapper.vm.sitemapDsl).toBeDefined()
+    // simulate updating the sitemap in code
+    const sitemap = [
+      'sitemap test label="Test" {',
+      '    Switch item=Item_Icon icon=lightbulb',
+      '    Switch item=Item_Icon icon=iconify:material-symbols:height',
+      '}',
+      ''
+    ].join('\n')
+    wrapper.vm.updateSitemap(sitemap)
+    expect(wrapper.vm.sitemapDsl).toMatch(/^sitemap test label="Test"/)
+    expect(wrapper.vm.parsedSitemap.error).toBeFalsy()
+
+    await wrapper.vm.$nextTick()
+
+    // check whether an 'updated' event was emitted and its payload
+    // (should contain the parsing result for the new sitemap definition)
+    const events = wrapper.emitted().updated
+    expect(events).toBeTruthy()
+    expect(events.length).toBe(1)
+    const payload = events[0][0]
+    expect(payload.slots).toBeDefined()
+    expect(payload.slots.widgets).toBeDefined()
+    expect(payload.slots.widgets.length).toBe(2)
+    expect(payload.slots.widgets[0]).toEqual({
+      component: 'Switch',
+      config: {
+        item: 'Item_Icon',
+        icon: 'lightbulb'
+      }
+    })
+    expect(payload.slots.widgets[1]).toEqual({
+      component: 'Switch',
+      config: {
+        item: 'Item_Icon',
+        icon: 'iconify:material-symbols:height'
+      }
+    })
+  })
+
   it('parses a staticIcon definition', async () => {
     expect(wrapper.vm.sitemapDsl).toBeDefined()
     // simulate updating the sitemap in code


### PR DESCRIPTION
Icons with both : and - in the name where not parsed correctly in sitemap code.

See https://community.openhab.org/t/basic-ui-text-color-depending-of-item-string-content/162110/10?u=mherwege