### PR TITLE
oh-input: Fix editing a number item with unit & Several enhancements

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-input-card.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-card.md
@@ -120,6 +120,16 @@ Display an input in a card
     Use the formatted state as the value for the input control
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="min" label="Minimum">
+  <PropDescription>
+    Minimum allowed value when type set to number
+  </PropDescription>
+</PropBlock>
+<PropBlock type="DECIMAL" name="max" label="Maximum">
+  <PropDescription>
+    Maximum allowed value when type set to number
+  </PropDescription>
+</PropBlock>
 <PropBlock type="DECIMAL" name="step" label="Step">
   <PropDescription>
     Step value when type set to number, any if left empty

--- a/bundles/org.openhab.ui/doc/components/oh-input-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input-item.md
@@ -125,6 +125,16 @@ Display an input field in a list
     Use the formatted state as the value for the input control
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="min" label="Minimum">
+  <PropDescription>
+    Minimum allowed value when type set to number
+  </PropDescription>
+</PropBlock>
+<PropBlock type="DECIMAL" name="max" label="Maximum">
+  <PropDescription>
+    Maximum allowed value when type set to number
+  </PropDescription>
+</PropBlock>
 <PropBlock type="DECIMAL" name="step" label="Step">
   <PropDescription>
     Step value when type set to number, any if left empty

--- a/bundles/org.openhab.ui/doc/components/oh-input.md
+++ b/bundles/org.openhab.ui/doc/components/oh-input.md
@@ -88,6 +88,16 @@ Displays an input field, used to set a variable
     Use the formatted state as the value for the input control
   </PropDescription>
 </PropBlock>
+<PropBlock type="DECIMAL" name="min" label="Minimum">
+  <PropDescription>
+    Minimum allowed value when type set to number
+  </PropDescription>
+</PropBlock>
+<PropBlock type="DECIMAL" name="max" label="Maximum">
+  <PropDescription>
+    Maximum allowed value when type set to number
+  </PropDescription>
+</PropBlock>
 <PropBlock type="DECIMAL" name="step" label="Step">
   <PropDescription>
     Step value when type set to number, any if left empty

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.js
@@ -13,6 +13,8 @@ export default () => [
   pb('validate-on-blur', 'Validate on blur', 'Only validate when focus moves away from input field'),
   pi('item', 'Item', 'Link the input value to the state of this item'),
   pb('useDisplayState', 'Use Display State', 'Use the formatted state as the value for the input control'),
+  pd('min', 'Minimum', 'Minimum allowed value when type set to number'),
+  pd('max', 'Maximum', 'Maximum allowed value when type set to number'),
   pd('step', 'Step', 'Step value when type set to number, any if left empty'),
   pb('showTime', 'Show time', 'Display time when type set to datepicker'),
   pt('defaultValue', 'Default value', 'Default value when not found in item state or variable'),

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-input-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-input-item.vue
@@ -1,6 +1,6 @@
 <template>
   <oh-list-item :context="context" class="input-listitem">
-    <div slot="footer" class="padding">
+    <div slot="footer">
       <generic-widget-component :context="childContext(afterComponent)" v-on="$listeners" />
     </div>
   </oh-list-item>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -80,7 +80,7 @@ export default {
         const item = this.context.store[this.config.item]
         if (item.state !== 'NULL' && item.state !== 'UNDEF' && item.state !== 'Invalid Date') {
           const value = (this.config.useDisplayState && item.displayState) || item.state
-          return this.config.type === 'number' ? this.extractValue(value) : value
+          return this.config.type === 'number' ? this.extractValue(value).replace(',', '.') : value
         }
       }
       return this.config.defaultValue

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -30,11 +30,11 @@
 </template>
 
 <style lang="stylus">
-input[type=number]
-  text-align right
 .oh-input
   flex-wrap nowrap !important
   align-items center !important
+  input[type=number]
+    text-align right
   .unit
     margin-left 4px
   .input-field

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -1,33 +1,47 @@
 <template>
-  <f7-input v-if="!config.item || !config.sendButton" class="input-field" ref="input" v-bind="config" :style="config.style"
-            :value="((config.type && config.type.indexOf('date') === 0) || config.type === 'time') ? valueForDatepicker : value"
-            :calendar-params="calendarParams" :step="config.step ? config.step : 'any'"
-            @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated">
-    <template v-if="context.component.slots && context.component.slots.default">
-      <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
-    </template>
-  </f7-input>
-  <f7-row no-gap v-else class="oh-input-with-send-button" :style="config.style">
-    <f7-input class="input-field col-80" ref="input" v-bind="config"
+  <f7-row no-gap v-if="!config.item || !config.sendButton" class="oh-input" :style="config.style">
+    <f7-input class="input-field" ref="input" v-bind="config" :style="{width: '100%', ...config.style}"
               :value="((config.type && config.type.indexOf('date') === 0) || config.type === 'time') ? valueForDatepicker : value"
               :calendar-params="calendarParams" :step="config.step ? config.step : 'any'"
+              @focus="listenForEnterKey"
+              @blur="stopListeningForEnterKey"
               @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated">
       <template v-if="context.component.slots && context.component.slots.default">
         <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
       </template>
     </f7-input>
+    <span v-if="unit" class="unit">{{ unit }}</span>
+  </f7-row>
+  <f7-row no-gap v-else class="oh-input" :style="config.style">
+    <f7-input class="input-field" ref="input" v-bind="config"
+              :value="((config.type && config.type.indexOf('date') === 0) || config.type === 'time') ? valueForDatepicker : value"
+              :calendar-params="calendarParams" :step="config.step ? config.step : 'any'"
+              :style="{ width: '100%' }"
+              @focus="listenForEnterKey"
+              @blur="stopListeningForEnterKey"
+              @input="$evt => updated($evt.target.value)" :change="updated" @calendar:change="updated" @texteditor:change="updated" @colorpicker:change="updated">
+      <template v-if="context.component.slots && context.component.slots.default">
+        <generic-widget-component :context="childContext(slotComponent)" v-for="(slotComponent, idx) in context.component.slots.default" :key="'default-' + idx" />
+      </template>
+    </f7-input>
+    <span v-if="unit" class="unit">{{ unit }}</span>
     <f7-button class="send-button col-10" v-if="this.config.sendButton" @click.stop="sendButtonClicked" v-bind="config.sendButtonConfig || { iconMaterial: 'done', iconColor: 'gray' }" />
   </f7-row>
 </template>
 
 <style lang="stylus">
-.oh-input-with-send-button
+input[type=number]
+  text-align right
+.oh-input
+  flex-wrap nowrap !important
+  align-items center !important
+  .unit
+    margin-left 4px
   .input-field
     padding-left 8px
     padding-right 8px
-    --f7-input-font-size 1rem
   .send-button
-    --f7-button-padding-horizontal 0px
+    --f7-button-padding-horizontal 0
 </style>
 
 <script>
@@ -59,16 +73,22 @@ export default {
         }
       } else if (this.config.variable && variableLocation[this.config.variable] !== undefined) {
         return variableLocation[this.config.variable]
-      } else if (this.config.sendButton && this.pendingUpdate !== null) {
+      } else if (this.pendingUpdate !== null) {
         return this.pendingUpdate
-      } else if (this.config.item && this.context.store[this.config.item].state !== 'NULL' && this.context.store[this.config.item].state !== 'UNDEF' && this.context.store[this.config.item].state !== 'Invalid Date') {
-        if (this.config.useDisplayState) {
-          return this.context.store[this.config.item].displayState || this.context.store[this.config.item].state
-        } else {
-          return this.context.store[this.config.item].state
+      } else if (this.config.item) {
+        const item = this.context.store[this.config.item]
+        if (item.state !== 'NULL' && item.state !== 'UNDEF' && item.state !== 'Invalid Date') {
+          let value = this.config.useDisplayState ? item.displayState || item.state : item.state
+          if (this.unit) {
+            value = value.split(' ')[0]
+          }
+          return value
         }
       }
       return this.config.defaultValue
+    },
+    unit () {
+      return this.config.type === 'number' && this.config.item && this.context.store[this.config.item].unit
     },
     calendarParams () {
       if (this.config.type !== 'datepicker') return null
@@ -121,9 +141,7 @@ export default {
       } else if (this.config.type === 'datepicker' && Array.isArray(value) && this.valueForDatepicker[0].getTime() === value[0].getTime()) {
         return
       }
-      if (this.config.sendButton) {
-        this.$set(this, 'pendingUpdate', value)
-      }
+      this.$set(this, 'pendingUpdate', value)
       if (this.config.variable) {
         const variableScope = this.getVariableScope(this.context.ctxVars, this.context.varScope, this.config.variable)
         const variableLocation = (variableScope) ? this.context.ctxVars[variableScope] : this.context.vars
@@ -133,13 +151,26 @@ export default {
         this.$set(variableLocation, this.config.variable, value)
       }
     },
+    listenForEnterKey (evt) {
+      evt.target.addEventListener('keyup', this.keyUp)
+    },
+    stopListeningForEnterKey (evt) {
+      evt.target.removeEventListener('keyup', this.keyUp)
+    },
+    keyUp (evt) {
+      if (evt.key === 'Enter') {
+        this.sendButtonClicked()
+      }
+    },
     sendButtonClicked () {
       if (this.config.item && this.pendingUpdate) {
         let cmd = this.pendingUpdate
-        if (this.config.type === 'datepicker' && Array.isArray(cmd)) {
+        if (this.unit) {
+          cmd += ' ' + this.unit
+        } else if (this.config.type === 'datepicker' && Array.isArray(cmd)) {
           cmd = dayjs(cmd[0]).format()
+          if (cmd === 'Invalid Date') return
         }
-        if (cmd === 'Invalid Date') return
         this.$store.dispatch('sendCommand', { itemName: this.config.item, cmd })
         this.$set(this, 'pendingUpdate', null)
       }


### PR DESCRIPTION
When oh-input is set to a Number item with unit, the f7-input in 'numeric' mode cannot set its numeric value to the item state because it contains the unit.

This PR:

- Display the number's unit after the input field for numeric type
- Make numeric input field right-aligned
- Improve input-elements alignment
- Accept Enter key to send the value, with or without a sendButton
- Honor useDisplayState config
- Add `min` and `max` config
- If the stateDescription on the item specifies `minimum`, `maximum`, and `step`, they will be used as the default, but it can be overridden by the widget's config
- Tested against Dimensionless Percent
- Tested against patterns with multiple format specifiers, e.g. `Test format %1$.4f and %1$.2f %unit%`. The last format specifier will be used.


<img width="656" alt="image" src="https://github.com/user-attachments/assets/d658a8f0-0f52-4449-8aed-9e0b9df2178c" />

