### PR TITLE
Layout edit: Move page settings to bottom of screen in edit mode

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-col>
-    <f7-list inline-labels accordion-list no-hairline-md>
+    <f7-list inline-labels accordion-list no-hairline-md class="no-margin-top">
       <f7-list-input ref="pageId" label="Page ID" type="text" placeholder="A unique identifier for the page" :value="page.uid" @input="page.uid = $event.target.value"
                      :clear-button="createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''" input-id="input"
                      required validate pattern="[A-Za-z0-9_]+" error-message="Required. A-Z,a-z,0-9,_ only" :disabled="!createMode">

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -107,7 +107,9 @@
                 </f7-link>
               </div>
             </f7-toolbar>
-            <page-settings :page="page" :createMode="createMode" />
+            <f7-block class="block-narrow">
+              <page-settings :page="page" :createMode="createMode" />
+            </f7-block>
           </f7-page>
         </f7-sheet>
       </f7-tab>


### PR DESCRIPTION
This frees up screen real estate to see more widgets

In Edit mode, remove the page settings from the top of editor page
![image](https://github.com/user-attachments/assets/af046b4d-bd2c-4912-82d7-8b5322375be5)

<img width="599" alt="image" src="https://github.com/user-attachments/assets/6045f53d-7915-422c-9092-e5a6c698e508" />


In createMode, it is still shown at the top as before, but a note added
<img width="744" alt="image" src="https://github.com/user-attachments/assets/d325ac2b-ff30-4ed2-803e-4633f858f58a" />

