### PR TITLE
UID Input: Add `Fix UID` button to normalize UID input

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -9,7 +9,7 @@
           <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && nameErrorMessage && !nameErrorMessage.includes('exists') && item.name.trim()" @click="$oh.utils.normalizeInput('#input')" />
         </f7-list-input>
         <f7-list-input label="Label" type="text" placeholder="Item label for display purposes" :value="item.label"
-                       @input="item.name = $event.target.value" :disabled="!editable" :clear-button="editable" />
+                       @input="updateLabel" :disabled="!editable" :clear-button="editable" />
       </f7-list-group>
       <f7-list-group v-if="!hideType" v-show="itemType">
         <!-- Type -->
@@ -268,6 +268,14 @@ export default {
       if (groupIndex >= 0) {
         this.item.groupNames.splice(groupIndex, 1)
       }
+    },
+    updateLabel (event) {
+      if (this.createMode && (!this.item.name || this.item.name === this.$oh.utils.normalizeLabel(this.item.label))) {
+        const inputElement = document.getElementById('input')
+        inputElement.value = this.$oh.utils.normalizeLabel(event.target.value)
+        inputElement.dispatchEvent(new Event('input'))
+      }
+      this.item.label = event.target.value
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -4,10 +4,12 @@
       <f7-list-group>
         <f7-list-input label="Name" type="text" placeholder="A unique identifier for the Item." :value="item.name"
                        :disabled="!createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''"
-                       required :error-message="nameErrorMessage" :error-message-force="!!nameErrorMessage"
-                       @input="item.name = $event.target.value" :clear-button="createMode" />
+                       required :error-message="nameErrorMessage" :error-message-force="!!nameErrorMessage" input-id="input"
+                       @input="item.name = $event.target.value" :clear-button="createMode">
+          <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && nameErrorMessage && !nameErrorMessage.includes('exists') && item.name.trim()" @click="$oh.utils.normalizeInput('#input')" />
+        </f7-list-input>
         <f7-list-input label="Label" type="text" placeholder="Item label for display purposes" :value="item.label"
-                       @input="item.label = $event.target.value" :disabled="!editable" :clear-button="editable" />
+                       @input="item.name = $event.target.value" :disabled="!editable" :clear-button="editable" />
       </f7-list-group>
       <f7-list-group v-if="!hideType" v-show="itemType">
         <!-- Type -->

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -1,9 +1,11 @@
 <template>
   <f7-col>
     <f7-list inline-labels accordion-list no-hairline-md>
-      <f7-list-input label="Page ID" type="text" placeholder="A unique identifier for the page" :value="page.uid" @input="page.uid = $event.target.value"
-                     :clear-button="createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''"
-                     required validate pattern="[A-Za-z0-9_]+" error-message="Required. A-Z,a-z,0-9,_ only" :disabled="!createMode" />
+      <f7-list-input ref="pageId" label="Page ID" type="text" placeholder="A unique identifier for the page" :value="page.uid" @input="page.uid = $event.target.value"
+                     :clear-button="createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''" input-id="input"
+                     required validate pattern="[A-Za-z0-9_]+" error-message="Required. A-Z,a-z,0-9,_ only" :disabled="!createMode">
+        <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && $refs.pageId?.state?.inputInvalid && page.uid.trim()" @click="$oh.utils.normalizeInput('#input')" />
+      </f7-list-input>
       <f7-list-input label="Label" type="text" placeholder="Page label used for display purposes" :info="(createMode) ? 'Required' : ''" :value="page.config.label" @input="page.config.label = $event.target.value" required validate clear-button />
       <f7-list-item accordion-item title="Sidebar &amp; Visibility" :disabled="page.uid === 'overview'">
         <f7-accordion-content>

--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -3,10 +3,12 @@
     <f7-block v-if="ready" class="block-narrow">
       <f7-col>
         <f7-list inline-labels no-hairlines-md>
-          <f7-list-input :label="`${type} ID`" type="text" :placeholder="`A unique identifier for the ${type.toLowerCase()}`" :value="rule.uid" required validate
-                         :disabled="!createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''"
+          <f7-list-input ref="ruleId" :label="`${type} ID`" type="text" :placeholder="`A unique identifier for the ${type.toLowerCase()}`" :value="rule.uid" required validate
+                         :disabled="!createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''" input-id="input"
                          pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
-                         @input="rule.uid = $event.target.value" :clear-button="createMode" />
+                         @input="rule.uid = $event.target.value" :clear-button="createMode">
+            <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && $refs.ruleId?.state?.inputInvalid && rule.uid.trim()" @click="$oh.utils.normalizeInput('#input')" />
+          </f7-list-input>
           <f7-list-input label="Label" type="text" :placeholder="`${type} label for display purposes`" :info="(createMode) ? 'Required' : ''" :value="rule.name" required validate
                          :disabled="!editable" @input="rule.name = $event.target.value" :clear-button="editable" />
           <f7-list-input label="Description" type="text" :value="rule.description"

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -5,9 +5,11 @@
         <f7-row>
           <f7-col>
             <f7-list inline-labels no-hairlines-md class="no-margin">
-              <f7-list-input v-if="createMode" label="Thing ID" type="text" placeholder="Required" :value="thing.ID"
-                             @input="changeUID" info="Note: cannot be changed after the creation"
-                             required :error-message="idErrorMessage" :error-message-force="!!idErrorMessage" />
+              <f7-list-input v-if="createMode" label="Thing ID" type="text" placeholder="Required" :value="thing.ID" input-id="input"
+                             @input="changeUID" info="Note: cannot be changed after the creation" clear-button
+                             required :error-message="idErrorMessage" :error-message-force="!!idErrorMessage">
+                <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && idErrorMessage && !idErrorMessage.includes('exists') && thing.ID" @click="$oh.utils.normalizeInput('#input')" />
+              </f7-list-input>
               <f7-list-input label="Thing UID" type="text" :input="false" disabled>
                 <span slot="input">
                   {{ thing.UID }}

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -8,7 +8,7 @@
               <f7-list-input v-if="createMode" label="Thing ID" type="text" placeholder="Required" :value="thing.ID" input-id="input"
                              @input="changeUID" info="Note: cannot be changed after the creation" clear-button
                              required :error-message="idErrorMessage" :error-message-force="!!idErrorMessage">
-                <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && idErrorMessage && !idErrorMessage.includes('exists') && thing.ID" @click="$oh.utils.normalizeInput('#input')" />
+                <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && idErrorMessage && !idErrorMessage.includes('exists') && thing.ID" @click="$oh.utils.normalizeInputForThingId('#input')" />
               </f7-list-input>
               <f7-list-input label="Thing UID" type="text" :input="false" disabled>
                 <span slot="input">

--- a/bundles/org.openhab.ui/web/src/js/openhab/utils.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/utils.js
@@ -3,10 +3,10 @@ import diacritic from 'diacritic'
 
 export default {
   normalizeLabel: (label) => {
-    return diacritic.clean(label.normalize('NFKD')).replace(/\s+/g, '_').replace(/[^0-9a-z_]/gi, '').replace(/^([0-9])/, '_$1')
+    return diacritic.clean(label.normalize('NFKD')).trim().replace(/\s+/g, '_').replace(/[^0-9a-z_]/gi, '').replace(/^([0-9])/, '_$1')
   },
   normalizeLabelForThingId: (label) => {
-    return diacritic.clean(label.normalize('NFKD')).replace(/\s+/g, '-').replace(/[^0-9a-z_-]/gi, '').replace(/^-+/, '')
+    return diacritic.clean(label.normalize('NFKD')).trim().replace(/\s+/g, '-').replace(/[^0-9a-z_-]/gi, '').replace(/^-+/, '')
   },
   normalizeInput (id) {
     const inputElement = document.querySelector(id)

--- a/bundles/org.openhab.ui/web/src/js/openhab/utils.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/utils.js
@@ -3,7 +3,12 @@ import diacritic from 'diacritic'
 
 export default {
   normalizeLabel: (label) => {
-    return diacritic.clean(label.normalize('NFKD')).replace(/\s+/g, '_').replace(/[^0-9a-z_]/gi, '')
+    return diacritic.clean(label.normalize('NFKD')).replace(/\s+/g, '_').replace(/[^0-9a-z_]/gi, '').replace(/^([0-9])/, '_$1')
+  },
+  normalizeInput (id) {
+    const inputElement = document.querySelector(id)
+    inputElement.value = this.normalizeLabel(inputElement.value.trim())
+    inputElement.dispatchEvent(new Event('input'))
   },
   /**
    * Convert a color from HSB to RGB.

--- a/bundles/org.openhab.ui/web/src/js/openhab/utils.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/utils.js
@@ -5,9 +5,17 @@ export default {
   normalizeLabel: (label) => {
     return diacritic.clean(label.normalize('NFKD')).replace(/\s+/g, '_').replace(/[^0-9a-z_]/gi, '').replace(/^([0-9])/, '_$1')
   },
+  normalizeLabelForThingId: (label) => {
+    return diacritic.clean(label.normalize('NFKD')).replace(/\s+/g, '-').replace(/[^0-9a-z_-]/gi, '').replace(/^-+/, '')
+  },
   normalizeInput (id) {
     const inputElement = document.querySelector(id)
     inputElement.value = this.normalizeLabel(inputElement.value.trim())
+    inputElement.dispatchEvent(new Event('input'))
+  },
+  normalizeInputForThingId (id) {
+    const inputElement = document.querySelector(id)
+    inputElement.value = this.normalizeLabelForThingId(inputElement.value.trim())
     inputElement.dispatchEvent(new Event('input'))
   },
   /**

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -2,10 +2,12 @@
   <f7-block class="padding-vertical no-padding-horizontal">
     <f7-col>
       <f7-list class="no-margin" inline-labels no-hairlines-md>
-        <f7-list-input v-if="createMode" label="Channel ID" type="text" placeholder="A unique identifier for the channel" :value="channel.id"
-                       info="Required. Note: cannot be changed after the creation"
-                       required validate pattern="[A-Za-z0-9_\-]+" error-message="Required. A-Z,a-z,0-9,_,- only"
-                       @input="channel.id = $event.target.value" />
+        <f7-list-input v-if="createMode" ref="channelId" label="Channel ID" type="text" placeholder="A unique identifier for the channel" :value="channel.id"
+                       info="Required. Note: cannot be changed after the creation" input-id="input"
+                       required validate pattern="[A-Za-z0-9_][A-Za-z0-9_\-]*" error-message="Required. Must not start with a dash. A-Z,a-z,0-9,_,- only"
+                       @input="channel.id = $event.target.value">
+          <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && $refs.channelId?.state?.inputInvalid && channel.id.trim()" @click="$oh.utils.normalizeInputForThingId('#input')" />
+        </f7-list-input>
         <f7-list-item v-if="!createMode" media-item class="channel-item" title="Channel UID">
           <div slot="subtitle">
             {{ channel.uid }}

--- a/bundles/org.openhab.ui/web/test/jest/__tests__/utils.test.js
+++ b/bundles/org.openhab.ui/web/test/jest/__tests__/utils.test.js
@@ -4,4 +4,8 @@ describe('normalizeLabel', () => {
   test('normalize the label to be a valid item name', () => {
     expect('openHAB_3_0').toEqual(util.normalizeLabel('opénHAB? ₃?$_&.0'))
   })
+
+  test('prepend leading digit with underscore', () => {
+    expect('_123').toEqual(util.normalizeLabel('123'))
+  })
 })


### PR DESCRIPTION
Resolve #3052 

<img width="746" alt="image" src="https://github.com/user-attachments/assets/fd987dc1-8486-48d6-a069-1e2c37d831d6" />

After clicking the hammer icon:


<img width="741" alt="image" src="https://github.com/user-attachments/assets/79f5cbf0-839a-49ea-960a-f95f270340d8" />

Also add automatic item name generation as the label is typed (only when name hasn't been entered)
![uid_fix_sync](https://github.com/user-attachments/assets/8e20a79d-9952-4536-b08e-37729f0cf69a)
