### PR TITLE
Interactive SVG Canvas: Use percentage state for color state computing

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-embedded-svg-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-embedded-svg-mixin.js
@@ -382,7 +382,7 @@ export default {
             }
           }
         } else { // Percent, OpenClosed
-          if (svgElementConfig.stateAsOpacity && state) {
+          if (svgElementConfig.stateAsOpacity && state) { // meant to be used as opacity
             // we expect that number between 0 - 100
             let opacity
             if (stateType === 'OpenClosed') {
@@ -393,6 +393,10 @@ export default {
             opacity = (svgElementConfig.invertStateOpacity) ? 1 - opacity : opacity
             opacity = (opacity < svgElementConfig.stateMinOpacity) ? svgElementConfig.stateMinOpacity : opacity
             element.style.opacity = opacity
+          } else if (state) { // treat it as color use the colorOnState that may be computed based on that
+            if (stateOnColorRgbStyle) {
+              element.style.fill = stateOnColorRgbStyle
+            }
           }
         }
       }


### PR DESCRIPTION
fixes what has been mentioned at 
https://community.openhab.org/t/interactive-svg-background-expression-works-in-widgets-expression-tester-but-not-in-svg-object/162078/2

> when a stateOnColor is defined and Percentage state or OnOff state is received (on stateAsOpacity is not chosen), then the stateOnColor is applied to the svg-element. This allows a stateOnColor to be used that is based on a computed value derived from these two State-Types.

After creating the following Layout and a dimmer item named slider1, the dimmer will color the element based on the given formular

> =(items.slider1.state>'50') ? '#ffff00':'#00ffff'

**Example SVG**

```
<svg width="210mm" height="297mm">
<defs id="defs1" />
  <g id="element1" openhab="true">
    <rect style="fill:#0000ff;fill-rule:evenodd;stroke-width:0.264583" id="rect1" flash="true" 
    width="36.495762"
    height="25.169491"
    x="30.203388"
    y="31.461863"
     />
  </g>
</svg>
```

**Example Layout Code**

```
config:
  embedSvg: true
  embedSvgFlashing: true
  fixedType: canvas
  grid: 10
  hideNavbar: true
  imageUrl: /static/simple.svg
  label: svg_text_sample
  layoutType: fixed
  screenHeight: 600
  screenWidth: 1024
  sidebar: false
  visibleTo:
    - role:administrator
  embeddedSvgActions:
    element1:
      actionCommand: ON
      actionCommandAlt: OFF
      actionItem: Button2
      stateOnColor: =(items.slider1.state>'50') ? '#ffff00':'#00ffff'
      stateOffColor: "#444444"
      useProxyElementForState: true
      stateItems:
        - slider1
blocks: []
masonry: []
grid: []
canvas:
  - component: oh-canvas-layer
    config:
      preload: true
    slots:
      default: []
```
