### PR TITLE
blockly: set value to key of dictionary

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
@@ -210,6 +210,35 @@ export default function (f7) {
     return [code, 0]
   }
 
+  Blockly.Blocks['dicts_set'] = {
+    init: function () {
+      this.appendDummyInput()
+        .appendField('set')
+      this.appendValueInput('key')
+        .setCheck(['String'])
+      this.appendValueInput('value')
+        .appendField('to value')
+      this.appendValueInput('dictionary')
+        .appendField('with dictionary')
+        .setCheck(['String'])
+
+      this.setColour('%{BKY_LISTS_HUE}')
+      this.setInputsInline(true)
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setTooltip('updates the key\'s value in the dictionary provided via the named variable.')
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/https://www.openhab.org/docs/configuration/blockly/rules-blockly-standard-ext.html#set-value-of-key-of-dictionary')
+    }
+  }
+
+  javascriptGenerator.forBlock['dicts_set'] = function (block) {
+    const key = javascriptGenerator.valueToCode(block, 'key', javascriptGenerator.ORDER_ATOMIC)
+    const value = javascriptGenerator.valueToCode(block, 'value', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
+    const dict = javascriptGenerator.valueToCode(block, 'dictionary', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
+    let code = `${dict}[${key}] = '${value}';\n`
+    return code
+  }
+
   /*
     * creates a loop for dictionaries
     *

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-dicts.js
@@ -220,7 +220,7 @@ export default function (f7) {
         .appendField('to value')
       this.appendValueInput('dictionary')
         .appendField('with dictionary')
-        .setCheck(['String'])
+        .setCheck('String')
 
       this.setColour('%{BKY_LISTS_HUE}')
       this.setInputsInline(true)
@@ -232,9 +232,12 @@ export default function (f7) {
   }
 
   javascriptGenerator.forBlock['dicts_set'] = function (block) {
-    const key = javascriptGenerator.valueToCode(block, 'key', javascriptGenerator.ORDER_ATOMIC)
-    const value = javascriptGenerator.valueToCode(block, 'value', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
     const dict = javascriptGenerator.valueToCode(block, 'dictionary', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
+    const key = javascriptGenerator.valueToCode(block, 'key', javascriptGenerator.ORDER_ATOMIC)
+    if (dict === '' || key === '\'\'') {
+      throw new Error('dictionary and key name need to be provided')
+    }
+    const value = javascriptGenerator.valueToCode(block, 'value', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
     let code = `${dict}[${key}] = '${value}';\n`
     return code
   }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -345,6 +345,17 @@
             </shadow>
           </value>
         </block>
+        <block type="dicts_set">
+          <value name="key">
+            <shadow type="text" />
+          </value>
+          <value name="value">
+            <shadow type="text" />
+          </value>
+          <value name="dictionary">
+            <shadow type="text" />
+          </value>
+        </block>
       </category>
 
       <category name="Color" colour="%{BKY_COLOUR_HUE}">


### PR DESCRIPTION
fixes #3075 

Provides a block that allows to update a dictionary that was assigned to a (named) variable:

![image](https://github.com/user-attachments/assets/d8cb881e-341d-4a70-8870-b42115dc0fa6)
