### PR TITLE
[blockly ]oh_taggeditems block: Fix multiple tags in vars & Add array support

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-items.js
@@ -88,7 +88,7 @@ export default function (f7) {
     init: function () {
       this.appendValueInput('tagName')
         .appendField('get items with tag')
-        .setCheck('String')
+        .setCheck(['String', 'Array'])
       this.setInputsInline(false)
       this.setOutput(true, 'Array')
       this.setColour(0)
@@ -99,16 +99,24 @@ export default function (f7) {
   }
 
   javascriptGenerator.forBlock['oh_taggeditems'] = function (block) {
-    let tagNames = javascriptGenerator.valueToCode(block, 'tagName', javascriptGenerator.ORDER_ATOMIC)
-    tagNames = tagNames.split(',')
+    let tagNames = javascriptGenerator.valueToCode(block, 'tagName', javascriptGenerator.ORDER_ATOMIC).replace(/'/g, '')
+    const inputType = blockGetCheckedInputType(block, 'tagName')
     let tags = ''
-    for (let i = 0; i < tagNames.length; i++) {
-      if (i > 0) {
-        tags += '\',\''
+    if (inputType === '') {
+      tags = `... (${tagNames}.split(',').map(tagElement => tagElement.trim()))`
+    } else {
+      if (inputType === 'Array') {
+        tagNames = tagNames.replace('[', '').replace(']', '')
       }
-      tags += tagNames[i]
+      tagNames = tagNames.split(',').map(tagElement => tagElement.trim())
+      for (let i = 0; i < tagNames.length; i++) {
+        if (i > 0) {
+          tags += '\',\''
+        }
+        tags += tagNames[i]
+      }
+      tags = '\'' + tags + '\''
     }
-
     return [`items.getItemsByTag(${tags})`, 0]
   }
 


### PR DESCRIPTION
fixes #3077

- allows multiple tags variables
- adds array support
- more resilient by trimming away spaces in tags

<img width="622" alt="image" src="https://github.com/user-attachments/assets/e6a4fcb9-cb66-4831-8134-619578d9cffa" />
