### PR TITLE
Item Details and Items List: Add Copy DSL Definition button

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -36,8 +36,8 @@
         <tag-input :item="page" />
       </f7-list>
       <f7-list v-if="!createMode" inline-labels no-hairline-md>
-        <f7-list-button color="blue" @click="copyPage">
-          Copy Page
+        <f7-list-button color="blue" @click="duplicatePage">
+          Duplicate Page
         </f7-list-button>
         <f7-list-button color="red" @click="deletePage">
           Remove Page
@@ -76,7 +76,7 @@ export default {
         }).open()
       }
     },
-    copyPage () {
+    duplicatePage () {
       const pageClone = cloneDeep(this.page)
       const pageType = pageClone.component.replace(/^oh-|-page$/g, '')
       pageClone.uid = pageClone.uid + '_copy'

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -44,7 +44,7 @@
       <f7-icon slot="media" color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
     </f7-list-item>
     <f7-list-button class="searchbar-ignore" color="blue" :title="thing.editable && (channelType.parameterGroups.length || channelType.parameters.length) ? 'Configure Channel' : 'Channel Details'" @click="configureChannel()" />
-    <f7-list-button class="searchbar-ignore" v-if="extensible && thing.editable" color="blue" title="Copy Channel" @click="copyChannel()" />
+    <f7-list-button class="searchbar-ignore" v-if="extensible && thing.editable" color="blue" title="Duplicate Channel" @click="duplicateChannel()" />
     <f7-list-button class="searchbar-ignore" v-if="extensible && thing.editable" color="red" title="Remove Channel" @click="removeChannel()" />
   </f7-list>
 </template>
@@ -62,7 +62,7 @@
 import AddLinkPage from '@/pages/settings/things/link/link-add.vue'
 import ConfigureLinkPage from '@/pages/settings/things/link/link-edit.vue'
 import ConfigureChannelPage from '@/pages/settings/things/channel/channel-edit.vue'
-import CopyChannelPage from '@/pages/settings/things/channel/channel-copy.vue'
+import DuplicateChannelPage from '@/pages/settings/things/channel/channel-duplicate.vue'
 
 import ItemMixin from '@/components/item/item-mixin'
 
@@ -177,16 +177,16 @@ export default {
         }
       })
     },
-    copyChannel () {
+    duplicateChannel () {
       const self = this
       const path = 'channels/' + this.channelId + '/edit'
       this.$f7router.navigate({
         url: path,
         route: {
-          component: CopyChannelPage,
+          component: DuplicateChannelPage,
           path,
           context: {
-            operation: 'copy-channel'
+            operation: 'duplicate-channel'
           },
           on: {
             pageAfterOut (event, page) {

--- a/bundles/org.openhab.ui/web/src/js/openhab/api.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/api.js
@@ -30,15 +30,28 @@ export default {
   get (uri, data) {
     return wrapPromise(Framework7.request.promise.json(uri, data))
   },
-  getPlain (uri, data, contentType, responseType) {
-    return wrapPromise(Framework7.request.promise({
-      method: 'GET',
-      url: uri,
-      data,
-      processData: false,
-      contentType: contentType || 'text/plain',
-      xhrFields: typeof responseType !== 'undefined' ? { responseType } : null
-    }))
+  getPlain (uri_or_parameters, data, contentType, responseType) {
+    let parameters = {}
+    if (typeof uri_or_parameters === 'string') {
+      parameters = {
+        url: uri_or_parameters,
+        method: 'GET',
+        data,
+        processData: false,
+        contentType: contentType || 'text/plain',
+        xhrFields: typeof responseType !== 'undefined' ? { responseType } : null
+      }
+    } else if (typeof uri_or_parameters === 'object') {
+      parameters = {
+        contentType: 'text/plain',
+        processData: false,
+        method: 'GET',
+        ...uri_or_parameters
+      }
+    } else {
+      throw new Error('Invalid parameters')
+    }
+    return wrapPromise(Framework7.request.promise(parameters))
   },
   post (uri, data, dataType) {
     return wrapPromise(Framework7.request.promise.postJSON(uri, data, dataType))

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -192,7 +192,7 @@ export default [
             async: loadAsync(ItemEditPage, { createMode: true })
           },
           {
-            path: 'copy',
+            path: 'duplicate',
             beforeEnter: [enforceAdminForRoute],
             async: loadAsync(ItemEditPage, { createMode: true })
           },
@@ -287,7 +287,7 @@ export default [
             ]
           },
           {
-            path: 'copy',
+            path: 'duplicate',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
             async: loadAsync(AddThingPage)
@@ -336,7 +336,7 @@ export default [
             async: loadAsync(RuleEditPage, { createMode: true })
           },
           {
-            path: 'copy',
+            path: 'duplicate',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
             async: loadAsync(RuleEditPage, { createMode: true })
@@ -369,7 +369,7 @@ export default [
             async: loadAsync(SceneEditPage, { createMode: true })
           },
           {
-            path: 'copy',
+            path: 'duplicate',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
             async: loadAsync(SceneEditPage, { createMode: true })
@@ -394,7 +394,7 @@ export default [
             async: loadAsync(ScriptEditPage, { createMode: true })
           },
           {
-            path: 'copy',
+            path: 'duplicate',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
             async: loadAsync(ScriptEditPage, { createMode: true })

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -90,6 +90,9 @@
             <f7-list-button color="blue" @click="duplicateItem">
               Duplicate Item
             </f7-list-button>
+            <f7-list-button color="blue" @click="copyItemDslDefinition">
+              Copy DSL Definition
+            </f7-list-button>
             <f7-list-button v-if="item.editable" color="red" @click="deleteItem">
               Remove Item
             </f7-list-button>
@@ -214,6 +217,20 @@ export default {
       }, {
         props: {
           itemCopy: itemClone
+        }
+      })
+    },
+    copyItemDslDefinition () {
+      this.$oh.api.getPlain({
+        url: '/rest/file-format/items/' + this.item.name,
+        headers: { accept: 'text/vnd.openhab.dsl.item' }
+      }).then(definition => {
+        if (this.$clipboard(definition)) {
+          this.$f7.toast.create({
+            text: `DSL Item definition for '${this.item.name}' copied to clipboard`,
+            destroyOnClose: true,
+            closeTimeout: 2000
+          }).open()
         }
       })
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -87,8 +87,8 @@
       <f7-row>
         <f7-col>
           <f7-list>
-            <f7-list-button color="blue" @click="copyItem">
-              Copy Item
+            <f7-list-button color="blue" @click="duplicateItem">
+              Duplicate Item
             </f7-list-button>
             <f7-list-button v-if="item.editable" color="red" @click="deleteItem">
               Remove Item
@@ -207,10 +207,10 @@ export default {
         this.iconUrl = '/icon/' + this.item.category + '?format=svg'
       })
     },
-    copyItem () {
+    duplicateItem () {
       let itemClone = cloneDeep(this.item)
       this.$f7router.navigate({
-        url: '/settings/items/copy'
+        url: '/settings/items/duplicate'
       }, {
         props: {
           itemCopy: itemClone

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -132,8 +132,8 @@
           </f7-col>
           <f7-col v-if="isEditable && (!createMode)">
             <f7-list>
-              <f7-list-button color="blue" @click="copyRule">
-                Copy Rule
+              <f7-list-button color="blue" @click="duplicateRule">
+                Duplicate Rule
               </f7-list-button>
               <f7-list-button color="red" @click="deleteRule">
                 Remove Rule
@@ -333,7 +333,7 @@ export default {
           }).open()
           this.$f7router.navigate(this.$f7route.url
             .replace('/add', '/' + this.rule.uid)
-            .replace('/copy', '/' + this.rule.uid)
+            .replace('/duplicate', '/' + this.rule.uid)
             .replace('/schedule/', '/rules/'), { reloadCurrent: true })
           this.load()
         } else {
@@ -355,10 +355,10 @@ export default {
         }).open()
       })
     },
-    copyRule () {
+    duplicateRule () {
       let ruleClone = cloneDeep(this.rule)
       this.$f7router.navigate({
-        url: '/settings/rules/copy'
+        url: '/settings/rules/duplicate'
       }, {
         props: {
           ruleCopy: ruleClone

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -115,8 +115,8 @@
           </f7-col>
           <f7-col v-if="isEditable && !createMode">
             <f7-list>
-              <f7-list-button color="blue" @click="copyRule">
-                Copy Scene
+              <f7-list-button color="blue" @click="duplicateRule">
+                Duplicate Scene
               </f7-list-button>
               <f7-list-button color="red" @click="deleteRule">
                 Remove Scene
@@ -372,10 +372,10 @@ export default {
         })
       })
     },
-    copyRule () {
+    duplicateRule () {
       let ruleClone = cloneDeep(this.rule)
       this.$f7router.navigate({
-        url: '/settings/scenes/copy'
+        url: '/settings/scenes/duplicate'
       }, {
         props: {
           ruleCopy: ruleClone

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -131,8 +131,8 @@
           <f7-block class="block-narrow" v-if="editable && isScriptRule">
             <f7-col>
               <f7-list>
-                <f7-list-button color="blue" @click="copyRule">
-                  Copy Script
+                <f7-list-button color="blue" @click="duplicateRule">
+                  Duplicate Script
                 </f7-list-button>
                 <f7-list-button color="red" @click="deleteRule">
                   Remove Script
@@ -388,7 +388,7 @@ export default {
           destroyOnClose: true,
           closeTimeout: 2000
         }).open()
-        this.$f7router.navigate(this.$f7route.url.replace(/(\/add)|(\/copy)/, '/' + this.rule.uid), { reloadCurrent: true })
+        this.$f7router.navigate(this.$f7route.url.replace(/(\/add)|(\/duplicate)/, '/' + this.rule.uid), { reloadCurrent: true })
       })
     },
     isMimeTypeAvailable (mimeType) {
@@ -595,10 +595,10 @@ export default {
         run(false)
       }
     },
-    copyRule () {
+    duplicateRule () {
       let ruleClone = cloneDeep(this.rule)
       this.$f7router.navigate({
-        url: '/settings/scripts/copy'
+        url: '/settings/scripts/duplicate'
       }, {
         props: {
           ruleCopy: ruleClone

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-duplicate.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-duplicate.vue
@@ -1,6 +1,6 @@
 <template>
-  <f7-page @page:afterin="onPageAfterIn" name="channel-copy">
-    <f7-navbar title="Copy channel" :subtitle="thing.label" back-link="Cancel">
+  <f7-page @page:afterin="onPageAfterIn" name="channel-duplicate">
+    <f7-navbar title="Duplicate channel" :subtitle="thing.label" back-link="Cancel">
       <f7-nav-right>
         <f7-link @click="save()" v-if="$theme.md" icon-md="material:save" icon-only />
         <f7-link @click="save()" v-if="!$theme.md">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -137,8 +137,12 @@
           <f7-col>
             <f7-list>
               <f7-list-button v-if="thing.statusInfo.statusDetail === 'HANDLER_MISSING_ERROR'" color="blue" title="Install Binding" @click="installBinding" />
-              <f7-list-button v-if="!error" color="blue" title="Copy Thing" @click="copyThing" />
-              <f7-list-button v-if="editable" color="red" title="Delete Thing" @click="deleteThing" />
+              <f7-list-button v-if="!error" color="blue" @click="duplicateThing">
+                Duplicate Thing
+              </f7-list-button>
+              <f7-list-button v-if="editable" color="red" @click="deleteThing">
+                Remove Thing
+              </f7-list-button>
             </f7-list>
           </f7-col>
         </f7-block>
@@ -619,10 +623,10 @@ export default {
         }
       })
     },
-    copyThing () {
+    duplicateThing () {
       let thingClone = cloneDeep(this.thing)
       this.$f7router.navigate({
-        url: '/settings/things/copy'
+        url: '/settings/things/duplicate'
       }, {
         props: {
           thingTypeId: this.thing.thingTypeUID,


### PR DESCRIPTION
Add Copy DSL Definition for items, both in Item Details and Items List using the definition provided by https://github.com/openhab/openhab-core/pull/4569

Resolve https://github.com/openhab/openhab-core/issues/4509

To do this, all the "Copy XXX" (e.g. Copy Item, Copy Rule, Copy Thing, Copy Channel, etc) are renamed to "Duplicate XXX". This will make the distinction extra clear between duplicating vs copying to clipboard. This change is done in a separate commit, so don't squash merge.

Depends on #3021 for the changes in api.js (included here but will be rebased).

<img width="385" alt="image" src="https://github.com/user-attachments/assets/5f8a5652-cc05-4f3f-8201-662215117462" />
<img width="289" alt="image" src="https://github.com/user-attachments/assets/355ad155-6f12-4609-9e33-332083fd908a" />

<img width="312" alt="image" src="https://github.com/user-attachments/assets/1f468005-5b94-4f31-8cb4-a5682022f882" />

