### PR TITLE
Model Item Details: `View/Hide Details` instead of `Edit` for uneditable Items

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -22,16 +22,22 @@
       <f7-button v-else color="blue" fill raised @click="save" v-show="model.item.editable">
         Save
       </f7-button>
-      <f7-button v-if="createMode || editMode" color="blue" @click="cancel">
+      <f7-button v-if="model.item.editable" color="blue" @click="cancel">
         Cancel
+      </f7-button>
+      <f7-button v-else color="blue" @click="cancel" icon-ios="material:expand_less" icon-md="material:expand_less" icon-aurora="material:expand_less">
+        Hide Details
       </f7-button>
     </f7-card-footer>
     <f7-card-footer v-else key="item-card-buttons-edit-mode">
-      <f7-button v-if="!editMode && !createMode" color="blue" @click="edit" icon-ios="material:expand_more" icon-md="material:expand_more" icon-aurora="material:expand_more">
+      <f7-button v-if="model.item.editable" color="blue" @click="edit" icon-ios="material:expand_more" icon-md="material:expand_more" icon-aurora="material:expand_more">
         Edit
       </f7-button>
-      <f7-button v-if="!editMode && !createMode && model.item.editable" color="red" @click="remove">
+      <f7-button v-if="model.item.editable" color="red" @click="remove">
         Remove
+      </f7-button>
+      <f7-button v-else color="blue" @click="edit" icon-ios="material:expand_more" icon-md="material:expand_more" icon-aurora="material:expand_more">
+        View Details
       </f7-button>
     </f7-card-footer>
   </f7-card>


### PR DESCRIPTION
From:

![image](https://github.com/user-attachments/assets/e9307ed0-3189-43dd-98af-6f29ea4a927a)
<img width="345" alt="image" src="https://github.com/user-attachments/assets/8bbeb562-d5fe-40da-9705-6350afa9d772" />


To:

<img width="476" alt="image" src="https://github.com/user-attachments/assets/dff79ef2-562b-4dc2-974b-7ff5746e6f25" />
<img width="472" alt="image" src="https://github.com/user-attachments/assets/73736dd9-0db8-4673-b64d-fd8252151791" />

