### PR TITLE
Persistence edit: Fix multiple selection

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -25,22 +25,22 @@
             </f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker :key="'groups-' + groupItems.length" title="Select groups" name="groupItems" multiple="true" filterType="Group"
+            <item-picker key="group" title="Select groups" name="groupItems" multiple="true" filterType="Group"
                          :disabled="allItemsSelected" :value="groupItems" @input="groupItems = $event" />
             <f7-list-item>... whose members are to be persisted.</f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker :key="'items-' + items.length" title="Select Items" name="items" multiple="true"
+            <item-picker key="items" title="Select Items" name="items" multiple="true"
                          :disabled="allItemsSelected" :value="items" @input="items = $event" />
             <f7-list-item>... to be persisted.</f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker :key="'exclude-groups-' + excludeGroupItems.length" title="Select exclude groups" name="excludeGroupItems" multiple="true" filterType="Group"
+            <item-picker key="exclude-groups" title="Select exclude groups" name="excludeGroupItems" multiple="true" filterType="Group"
                          :disabled="!anySelected" :value="excludeGroupItems" @input="excludeGroupItems = $event" />
             <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker :key="'exclude-items-' + excludeItems.length" title="Select exclude Items" name="excludeItems" multiple="true"
+            <item-picker key="exclude-items" title="Select exclude Items" name="excludeItems" multiple="true"
                          :disabled="!anySelected" :value="excludeItems" @input="excludeItems = $event" />
             <f7-list-item>... to be excluded from persistence.</f7-list-item>
           </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -25,7 +25,7 @@
             </f7-list-item>
           </f7-list>
           <f7-list>
-            <item-picker key="group" title="Select groups" name="groupItems" multiple="true" filterType="Group"
+            <item-picker key="groups" title="Select groups" name="groupItems" multiple="true" filterType="Group"
                          :disabled="allItemsSelected" :value="groupItems" @input="groupItems = $event" />
             <f7-list-item>... whose members are to be persisted.</f7-list-item>
           </f7-list>


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/3104

As the item picker keys where dependent on the length of the selection, they got recreated each time something was selected. This made multi-selection impossible.

If there is no issue with this fix, it may be a candidate for back porting.