### PR TITLE
Replace GH Action from tj-actions by custom code

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -101,8 +101,10 @@ jobs:
           mode: inline
 
       - name: Verify Changed Files
-        uses: tj-actions/verify-changed-files@v20
         id: verify-changed-files
+        run: |
+          changed_files=$(git diff --name-only ${{ github.sha }} | tr '\n' ' ')
+          echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
 
       - name: Fail on Changed Files
         if: steps.verify-changed-files.outputs.changed_files != ''


### PR DESCRIPTION
The GitHub Actions build workflow includes external Actions from 3rd party repositories. The functionality of tj-actions/verify-changed-files was used to detect modifications of files under source control during the build process. The external action is removed and replaced by custom code. This is less flexible, but does not require an external action in the build toolchain.

Currently, tj-actions is not available and anyway no longer allowed by our GH Actions configuration. This PR needs to be picked to every active branch (or branches to be rebased).