### PR TITLE
GH Action: Detection of new files

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -103,7 +103,8 @@ jobs:
       - name: Verify Changed Files
         id: verify-changed-files
         run: |
-          changed_files=$(git diff --name-only ${{ github.sha }} | tr '\n' ' ')
+          set -o pipefail
+          changed_files=$(echo -n "$(git diff --name-only HEAD && git ls-files --others --exclude-standard)"|tr '\n' ' ')
           echo "changed_files=$changed_files" >> $GITHUB_OUTPUT
 
       - name: Fail on Changed Files


### PR DESCRIPTION
This restores the behavior before tj-actions was removed. New untracked files created during build will break the build.

Follow-up to #3106. Consistent to what we merged on core/distro.