### PR TITLE
Addon Card: Give title has more room to avoid overflow

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -65,8 +65,9 @@
     .addon-card-label
       text-overflow ellipsis
       overflow clip
-      white-space nowrap
       color var(--f7-text-color)
+      max-height 3.4rem
+      line-height 1.1
     .addon-card-title-after
       .preloader-inner .preloader-inner-left, .preloader-inner .preloader-inner-right, .preloader-inner .preloader-inner-line
         margin-left inherit !important

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-stats-line.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-stats-line.vue
@@ -17,6 +17,7 @@
 
 <style lang="stylus">
 .addon-stats-line
+  white-space nowrap
   & > span
     margin-right 4px
 </style>


### PR DESCRIPTION
Before:

<img width="708" alt="image" src="https://github.com/user-attachments/assets/aa6527a7-756f-4468-bced-12239b2d7d93" />


After:

<img width="755" alt="image" src="https://github.com/user-attachments/assets/7d4ca51e-6eae-490d-a680-a70007457867" />

<img width="995" alt="image" src="https://github.com/user-attachments/assets/6172d37c-36e8-4021-9978-8873fa26e339" />


