### PR TITLE
Add-on card: Add tooltip to label

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -12,7 +12,7 @@
           <f7-button v-else class="install-button prevent-active-state-propagation"
                      :text="installActionText || 'Install'" color="blue" round small @click="buttonClicked" />
         </div>
-        <div class="addon-card-label">
+        <div class="addon-card-label" :title="addon.label">
           {{ addon.label }}
         </div>
         <div v-if="addon.verifiedAuthor" class="addon-card-subtitle">


### PR DESCRIPTION
This shows when the mouse hovers over the title
<img width="238" alt="image" src="https://github.com/user-attachments/assets/9703960f-c349-4177-b358-83064c8ab9dd" />
