### PR TITLE
Config sheet: Fix loading of multi-line default values

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -90,7 +90,13 @@ export default {
       const conf = Object.assign({}, this.configuration)
       this.parameters.forEach((p) => {
         if (conf[p.name] === undefined && p.default !== undefined) {
-          conf[p.name] = typeof p.default === 'function' ? p.default(this.configuration) : p.default
+          if (typeof p.default === 'function') {
+            conf[p.name] = p.default(this.configuration)
+          } else if (p.defaultValues !== undefined) {
+            conf[p.name] = p.defaultValues
+          } else {
+            conf[p.name] = p.default
+          }
         }
       })
       return conf

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -92,7 +92,7 @@ export default {
         if (conf[p.name] === undefined && p.default !== undefined) {
           if (typeof p.default === 'function') {
             conf[p.name] = p.default(this.configuration)
-          } else if (p.defaultValues !== undefined) {
+          } else if (p.multiple) {
             conf[p.name] = p.defaultValues
           } else {
             conf[p.name] = p.default


### PR DESCRIPTION
A config parameter with multiple="true" (a multiline / list) can have default values specified in the config.xml by separating them with commas.

For example,

```
  "parameters": [
    {
      "defaultValues": [
        "a",
        "b",
        "c"
      ],
      "default": "a,b,c",
    ...
```

`default` gets split up into `defaultValues` in core by https://github.com/openhab/openhab-core/blob/baf79c5f27a7f69b70c21241c8aae68c2e8ca05a/bundles/org.openhab.core.io.rest.core/src/main/java/org/openhab/core/io/rest/core/config/EnrichedConfigDescriptionParameterDTO.java#L49

There is an attempt to "join" the values here: https://github.com/openhab/openhab-webui/blob/d714a1cd1599ebba6c9a171a06cab446e437cf13/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue#L36

However the value it is trying to join isn't the array (defaultValue), but the single unsplit String value `default`.

This PR corrects that and sets `value` to the the correct list/array default value when `multiple="true"` so that `join('\n')` would work correctly.

Also related: https://github.com/openhab/openhab-core/pull/4657