### PR TITLE
Main UI mvn build: Various enhancements to improve DX in Eclipse IDE

### DIFF
--- a/bundles/org.openhab.ui/CONTRIBUTING.md
+++ b/bundles/org.openhab.ui/CONTRIBUTING.md
@@ -16,7 +16,8 @@ Change to the `web` directory, gather the necessary dependencies with `npm insta
 ## NPM Scripts
 
 * `npm start` - run the development server (see below)
-* `npm run build-prod` - build web app for production (note: no need to prepare a production version when submitting a PR, the build server will do it)
+* `npm run build:prod` - build web app for production (note: no need to prepare a production version when submitting a PR, the build server will do it)
+* `npm run build:mvn` - build web app through Maven for production (note: no need to prepare a production version when submitting a PR, the build server will do it)
 * `npm run dev` - run the development server (same as above)
 * `npm run dev:blockly` - run the development server with Blockly source-maps (allows Blockly debugging)
 * `npm run test:unit` - start the Jest test runner and run the unit tests

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -76,6 +76,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
+            <phase>generate-resources</phase>
             <configuration>
               <arguments>install --save false</arguments>
             </configuration>
@@ -87,7 +88,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>validate</phase>
+            <phase>test</phase>
             <configuration>
               <arguments>run lint</arguments>
             </configuration>
@@ -110,28 +111,9 @@
             <goals>
               <goal>npm</goal>
             </goals>
+            <phase>compile</phase>
             <configuration>
-              <arguments>run build-prod ${project.version}</arguments>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>add-resource</goal>
-            </goals>
-            <phase>generate-resources</phase>
-            <configuration>
-              <resources>
-                <resource>
-                  <directory>web/www</directory>
-                  <targetPath>app</targetPath>
-                </resource>
-              </resources>
+              <arguments>run build:mvn ${project.version}</arguments>
             </configuration>
           </execution>
         </executions>

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -55,13 +55,15 @@
           <workingDirectory>web</workingDirectory>
         </configuration>
 
+        <!-- run all executions in the prepare-package phase, to build the UI at the latest possible time and avoid building it when only compiling Java code -->
+        <!-- this helps Eclipse IDE to compile Java code faster -->
         <executions>
           <execution>
             <id>Install node and npm</id>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <phase>initialize</phase>
+            <phase>prepare-package</phase>
           </execution>
 
           <execution>
@@ -69,7 +71,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>generate-sources</phase>
+            <phase>prepare-package</phase>
             <configuration>
               <arguments>install --save false</arguments>
             </configuration>
@@ -80,7 +82,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>prepare-package</phase>
             <configuration>
               <arguments>run build:mvn ${project.version}</arguments>
             </configuration>

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -61,7 +61,7 @@
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>initialize</phase>
           </execution>
 
           <execution>
@@ -69,7 +69,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>generate-resources</phase>
+            <phase>generate-sources</phase>
             <configuration>
               <arguments>install --save false</arguments>
             </configuration>
@@ -80,7 +80,7 @@
             <goals>
               <goal>npm</goal>
             </goals>
-            <phase>compile</phase>
+            <phase>generate-resources</phase>
             <configuration>
               <arguments>run build:mvn ${project.version}</arguments>
             </configuration>

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -32,6 +32,26 @@
 
   <build>
     <plugins>
+      <!-- Delete web/node_modules in Maven clean goal -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>web/node_modules</directory>
+            </fileset>
+          </filesets>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Build Main UI -->
       <plugin>
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
@@ -52,12 +72,36 @@
           </execution>
 
           <execution>
-            <id>npm ci</id>
+            <id>npm install</id>
             <goals>
               <goal>npm</goal>
             </goals>
             <configuration>
-              <arguments>ci</arguments>
+              <arguments>install --save false</arguments>
+            </configuration>
+          </execution>
+
+          <!-- Run ESLint during the Maven initialize phase -->
+          <execution>
+            <id>npm lint</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>validate</phase>
+            <configuration>
+              <arguments>run lint</arguments>
+            </configuration>
+          </execution>
+
+          <!-- Run unit tests during the Maven test phase -->
+          <execution>
+            <id>npm test</id>
+            <goals>
+              <goal>npm</goal>
+            </goals>
+            <phase>test</phase>
+            <configuration>
+              <arguments>run test:unit</arguments>
             </configuration>
           </execution>
 

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -43,13 +43,6 @@
             </fileset>
           </filesets>
         </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>clean</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <!-- Build Main UI -->
       <plugin>

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -78,7 +78,7 @@
           </execution>
 
           <execution>
-            <id>npm run build-prod</id>
+            <id>npm run build:mvn</id>
             <goals>
               <goal>npm</goal>
             </goals>

--- a/bundles/org.openhab.ui/pom.xml
+++ b/bundles/org.openhab.ui/pom.xml
@@ -75,30 +75,6 @@
             </configuration>
           </execution>
 
-          <!-- Run ESLint during the Maven initialize phase -->
-          <execution>
-            <id>npm lint</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>test</phase>
-            <configuration>
-              <arguments>run lint</arguments>
-            </configuration>
-          </execution>
-
-          <!-- Run unit tests during the Maven test phase -->
-          <execution>
-            <id>npm test</id>
-            <goals>
-              <goal>npm</goal>
-            </goals>
-            <phase>test</phase>
-            <configuration>
-              <arguments>run test:unit</arguments>
-            </configuration>
-          </execution>
-
           <execution>
             <id>npm run build-prod</id>
             <goals>

--- a/bundles/org.openhab.ui/web/build/build.js
+++ b/bundles/org.openhab.ui/web/build/build.js
@@ -10,12 +10,14 @@ const config = require('./webpack.config.js');
 
 const env = process.env.NODE_ENV || 'development';
 const target = process.env.TARGET || 'web';
+const maven = process.env.MAVEN || false;
+const outPath = maven ? '../target/classes/app' : 'www';
 
 const spinner = ora(env === 'production' ? chalk.cyan('Building for production...') : chalk.cyan('Building development version...'));
 spinner.start();
 
 exec(`npm run generate-build-info ${process.argv[2]}`).then(() => {
-  return rm('./www/')
+  return rm(outPath)
 }).then(() => {
   webpack(config, (err, stats) => {
     if (err) throw err;

--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -19,6 +19,8 @@ function resolvePath(dir) {
 const env = process.env.NODE_ENV || 'development'
 const target = process.env.TARGET || 'web'
 const buildSourceMaps = process.env.SOURCE_MAPS || false
+const maven = process.env.MAVEN || false
+const outPath = maven ? '../target/classes/app' : 'www'
 
 const apiBaseUrl = process.env.OH_APIBASE || 'http://localhost:8080'
 
@@ -31,7 +33,7 @@ module.exports = {
     './src/js/app.js'
   ],
   output: {
-    path: resolvePath('www'),
+    path: resolvePath(outPath),
     filename: 'js/app.[contenthash].js',
     publicPath: '/',
     hotUpdateChunkFilename: 'hot/[id].[fullhash].hot-update.js',
@@ -263,15 +265,15 @@ module.exports = {
       patterns: [
         {
           from: resolvePath('src/res'),
-          to: resolvePath('www/res')
+          to: resolvePath(`${outPath}/res`)
         },
         {
           from: resolvePath('src/manifest.json'),
-          to: resolvePath('www/manifest.json')
+          to: resolvePath(`${outPath}/manifest.json`)
         },
         {
           from: resolvePath('src/robots.txt'),
-          to: resolvePath('www/robots.txt')
+          to: resolvePath(`${outPath}/robots.txt`)
         }
       ]
     }),

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -24,7 +24,8 @@
   },
   "scripts": {
     "generate-build-info": "node build/generate-build-info.mjs",
-    "build-prod": "cross-env NODE_ENV=production node ./build/build.js",
+    "build:prod": "cross-env NODE_ENV=production node ./build/build.js",
+    "build:mvn": "cross-env NODE_ENV=production cross-env MAVEN=true node ./build/build.js",
     "webpack-analyzer": "cross-env NODE_ENV=production cross-env WEBPACK_ANALYZER=1 node ./build/build.js",
     "webpack-analyzer-report": "cross-env NODE_ENV=production cross-env WEBPACK_ANALYZER=1 WEBPACK_ANALYZER_REPORT=1 node ./build/build.js",
     "webpack-analyzer-report-stats": "cross-env NODE_ENV=production cross-env WEBPACK_ANALYZER=1 WEBPACK_ANALYZER_REPORT=1 WEBPACK_ANALYZER_REPORT_STATS=1 node ./build/build.js",


### PR DESCRIPTION
- Do not always clean install, do only so in mvn `clean` phase.
- Built web app directly to mvn target dir.
- Perform all Main UI related executions in the `prepare-package` phase to allow faster Java code compilation.

This improves the behaviour when using Eclipse IDE, as the M2E plugin causes a recompilation "loop" due to the Main UI build writing to a mvn source folder.