### PR TITLE
Improve GitHub Actions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -24,6 +24,8 @@ jobs:
         os: [ 'ubuntu-24.04' ]
     name: Build (Java ${{ matrix.java }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # typical duration is ~5min, set a reasonable amount as limit (default is 6h)
+    timeout-minutes: 20
     steps:
       - name: Checkout
         if: github.head_ref == ''
@@ -51,6 +53,7 @@ jobs:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}
 
+      # pinning to SHA to mitigate possible supply chain attack
       - name: Set up Maven ${{ matrix.maven }}
         uses: stCarolas/setup-maven@d6af6abeda15e98926a57b5aa970a96bb37f97d1 # v5
         with:
@@ -100,6 +103,8 @@ jobs:
           path: '**/checkstyle-result.xml'
           mode: inline
 
+      # this will identify modifications to files under source control during the workflow run;
+      # untracked files will be included as well!
       - name: Verify Changed Files
         id: verify-changed-files
         run: |

--- a/.github/workflows/mainui.yml
+++ b/.github/workflows/mainui.yml
@@ -88,8 +88,9 @@ jobs:
           name: report
           path: /home/runner/work/openhab-webui/openhab-webui/bundles/org.openhab.ui/web/report.html
 
-      # Upload bundle stats to use on relative-ci.yaml workflow
+      # Upload bundle stats to use on relative-ci.yaml workflow,
+      # pinning to SHA to mitigate possible supply chain attack
       - name: Upload webpack stats artifact to RelativeCI
-        uses: relative-ci/agent-upload-artifact-action@v2
+        uses: relative-ci/agent-upload-artifact-action@a2b5741b4f7e6a989c84ec1a3059696b23c152e5 # v2.0.0
         with:
           webpackStatsFile: ./bundles/org.openhab.ui/web/stats.json

--- a/.github/workflows/relative-ci.yml
+++ b/.github/workflows/relative-ci.yml
@@ -10,8 +10,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # pinning to SHA to mitigate possible supply chain attack
       - name: Send bundle stats and build information to RelativeCI
-        uses: relative-ci/agent-action@v2.1.10
+        uses: relative-ci/agent-action@38328454d6a23942175eba485fca4fbb807b1f03 # v2.2.0
         with:
           key: ${{ secrets.RELATIVE_CI_KEY }}
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* upgrade relative-ci/agent-action from 2.1.10 to 2.2.0 https://github.com/relative-ci/agent-action/compare/v2.1.10...v2.2.0
* pin external action relative-ci/agent-action to specific SHA
* pin external action relative-ci/agent-upload-artifact-action to specific SHA
* set global timeout
* comments

@florian-h05 the upgrade of `agent-action`is not really necessary and I cannot evaluate - I can set the pinning to the older version if you want. I just saw the latest release and pinned this one.