### PR TITLE
Create equipment from model: Use semanticEquipmentTag of Thing

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -287,10 +287,11 @@ export default {
           this.selectedThingChannelTypes = data2[1]
 
           if (this.createEquipment) {
+            const semanticEquipmentTag = this.selectedThing.semanticEquipmentTag || 'Equipment'
             this.newEquipmentItem = {
               name: this.$oh.utils.normalizeLabel(this.selectedThing.label),
               label: this.selectedThing.label,
-              tags: ['Equipment'],
+              tags: [semanticEquipmentTag],
               type: 'Group',
               groupNames: (this.parent) ? [this.parent.item.name] : []
             }


### PR DESCRIPTION
Depends on https://github.com/openhab/openhab-core/pull/4617

If the thing provides a default `semanticEquipmentTag`, this will be used when creating an equipment from thing instead of the default `Equipment`.

@andrewfg FYI