### PR TITLE
Don't use virtual lists where not necessary

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
@@ -39,9 +39,7 @@ export default {
     return {
       smartSelectParams: {
         view: this.$f7.view.main,
-        openIn: 'popup',
-        virtualList: true,
-        virtualListHeight: (this.$theme.aurora) ? 32 : undefined
+        openIn: 'popup'
       }
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
@@ -35,9 +35,7 @@ export default {
     return {
       smartSelectParams: {
         view: this.$f7.view.main,
-        openIn: 'popup',
-        virtualList: true,
-        virtualListHeight: (this.$theme.aurora) ? 32 : undefined
+        openIn: 'popup'
       }
     }
   },


### PR DESCRIPTION
Don't use virtual lists for:

- persistence config filter picker
- persistence config strategy picker