### PR TITLE
Widgets: Fix check for action not checking actionPropsParameterGroup

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
@@ -11,7 +11,7 @@
       <oh-trend v-else-if="config.trendItem" :key="'trend' + config.item" class="trend card-opened-fade-out" :width="($refs.card) ? $refs.card.$el.clientWidth : 0" :context="context" />
       <div v-else class="cell-background" :class="[(config.color) ? 'bg-color-' + config.color : '', { 'on': isOn }, { 'card-opened-fade-out': !config.keepColorWhenOpened }]" />
     </slot>
-    <f7-link v-show="!opened && hasExpandedControls && config.action" icon-f7="ellipsis_vertical" icon-size="30" @click.native="openCell" class="float-right cell-open-button card-opened-fade-out no-ripple" />
+    <f7-link v-show="!opened && hasExpandedControls && hasAction" icon-f7="ellipsis_vertical" icon-size="30" @click.native="openCell" class="float-right cell-open-button card-opened-fade-out no-ripple" />
     <f7-card-content ref="cell" class="cell-contents">
       <f7-card-header class="cell-button card-opened-fade-out no-padding" v-show="!opened">
         <slot name="header">
@@ -193,7 +193,7 @@ export default {
         return
       }
       if (this.opened) return
-      if (this.config.action || this.config.actionPropsParameterGroup) {
+      if (this.hasAction) {
         this.performAction()
       } else {
         this.openCell()

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -5,7 +5,7 @@
                 :media-item="context.parent.component.config.mediaList && !config.divider"
                 :badge="(config.divider) ? 'Divider' : (config.listButton) ? 'List button' : config.badge"
                 :accordion-item="isRegularAccordion && !config.divider && !context.editmode"
-                :link="(config.action !== undefined && config.action !== '' && !context.editmode) ? true : undefined"
+                :link="(hasAction && !context.editmode) ? true : undefined"
                 @click.stop="openAccordionOrPerformAction"
                 :class="{ 'oh-equipment-accordion-item' : isEquipmentAccordion}"
                 ref="f7AccordionContent">

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-card.vue
@@ -44,7 +44,7 @@ export default {
   computed: {
     computedContentClass () {
       return [
-        ...(this.config.action ? ['card-link'] : []),
+        ...(this.hasAction ? ['card-link'] : []),
         ...(Array.isArray(this.contentClass) ? this.contentClass : ['padding']),
         ...(Array.isArray(this.config.contentClass) ? this.config.contentClass : [])
       ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-gauge-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-gauge-card.vue
@@ -2,7 +2,7 @@
   <oh-card :context="context" :content-class="['oh-gauge-card', 'display-flex', 'justify-content-center']">
     <template #content-root>
       <f7-card-content :style="config.contentStyle" :class="[ ...(Array.isArray(config.contentClass) ? config.contentClass : []), 'oh-gauge-card', 'display-flex', 'justify-content-center']">
-        <f7-link v-if="config.action" class="oh-gauge-link" @click="performAction">
+        <f7-link v-if="hasAction" class="oh-gauge-link" @click="performAction">
           <oh-gauge :context="childContext(context.component)" />
         </f7-link>
         <oh-gauge v-else :context="childContext(context.component)" />

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-image-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-image-card.vue
@@ -2,7 +2,7 @@
   <oh-card :context="context" :content-class="['oh-image-card', 'no-padding']">
     <template #content-root>
       <f7-card-content :style="config.contentStyle" :class="[ ...(Array.isArray(config.contentClass) ? config.contentClass : []), 'oh-image-card', 'no-padding']">
-        <f7-list v-if="config.action" class="image-link">
+        <f7-list v-if="hasAction" class="image-link">
           <f7-list-item class="oh-image-clickable" link="#" no-chevron @click="performAction">
             <oh-image slot="content-start" :context="childContext(context.component)" />
           </f7-list-item>

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-label-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-label-card.vue
@@ -4,7 +4,7 @@
       <f7-card-content ref="cardContent" @click.native="performAction" @taphold.native="onTaphold($event)" @contextmenu.native="onContextMenu($event)" :class="['label-card-content', (config.vertical ? 'vertical-arrangement' : ''), ...(Array.isArray(config.contentClass) ? config.contentClass : [])]" :style="{ background: config.background, ...config.contentStyle }">
         <oh-trend v-if="config.trendItem" :key="'trend' + config.item" class="trend" :width="($refs.cardContent) ? $refs.cardContent.$el.clientWidth : 0" :context="context" />
         <f7-list>
-          <f7-list-item :link="config.action ? true : false" no-chevron>
+          <f7-list-item :link="hasAction ? true : false" no-chevron>
             <oh-icon slot="media" v-if="config.icon" :icon="config.icon" :height="config.iconSize || 32" :width="config.iconSize || 32" :state="(config.item && config.iconUseState) ? context.store[config.item].state : null" :color="config.iconColor" />
             <div v-if="config.label || config.item" :class="config.class">
               <span :style="{ 'font-size': config.fontSize || '24px', 'font-weight': config.fontWeight || 'normal' }">
@@ -13,8 +13,6 @@
             </div>
           </f7-list-item>
         </f7-list>
-        <!-- <f7-link class="label-link" v-if="config.action">{{context.store[config.item].displayState || context.store[config.item].state}}</f7-link> -->
-        <!-- <h2>{{context.store[config.item].displayState || context.store[config.item].state}}</h2> -->
       </f7-card-content>
     </template>
   </oh-card>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-button.vue
@@ -17,7 +17,7 @@ export default {
   widget: OhButtonDefinition,
   methods: {
     clicked () {
-      if (this.config.action || this.config.actionPropsParameterGroup) {
+      if (this.hasAction) {
         this.performAction()
       }
       if (this.config.clearVariable && !this.config.clearVariableKey) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
@@ -58,7 +58,7 @@ export default {
     },
     clicked () {
       if (this.context.component.component !== 'oh-image') return // don't interfere if we're in the context of a oh-image-card for example
-      if (this.config.action || this.config.actionPropsParameterGroup) {
+      if (this.hasAction) {
         this.performAction()
       }
     },

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-link.vue
@@ -17,7 +17,7 @@ export default {
   widget: OhLinkDefinition,
   methods: {
     clicked () {
-      if (this.config.action || this.config.actionPropsParameterGroup) {
+      if (this.hasAction) {
         this.performAction()
       }
       if (this.config.clearVariable && !this.config.clearVariableKey) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -66,6 +66,9 @@ export default {
         return visibleTo.indexOf('user:' + user.name) >= 0
       }
       return true
+    },
+    hasAction () {
+      return this.config && (this.config.action || this.config.actionPropsParameterGroup)
     }
   },
   mounted () {


### PR DESCRIPTION
The code that should check whether an action is configured did only take the action prop into account, but an action can also be configured through actionPropsParameterGroup.