### PR TITLE
Link add/edit: Fix link String Items to any channel

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-mixin.js
@@ -12,6 +12,7 @@ export default {
       if (!channel || !channel.itemType) return true
       if (!item || !item.type) return true
       if (channel.itemType === 'Color' && ['Color', 'Switch', 'Dimmer'].includes(item.type)) return true
+      if (item.type === 'String') return true
       if (channel.itemType.startsWith('Number')) {
         return item.type.startsWith('Number')
       }


### PR DESCRIPTION
String Items can be linked to any channel, so allow this.