### PR TITLE
Upgrade (Vue) Echarts

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -53,7 +53,7 @@
         "vue-async-computed": "^3.9.0",
         "vue-codemirror": "^4.0.6",
         "vue-draggable-resizable": "^2.3.0",
-        "vue-echarts": "^6.6.9",
+        "vue-echarts": "^7.0.3",
         "vue-fragment": "^1.5.1",
         "vue-fullscreen": "^2.6.1",
         "vue-grid-layout": "^2.4.0",
@@ -18820,11 +18820,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
-    "node_modules/resize-detector": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.3.0.tgz",
-      "integrity": "sha512-R/tCuvuOHQ8o2boRP6vgx8hXCCy87H1eY9V5imBYeVNyNVpuL9ciReSccLj2gDcax9+2weXy3bc8Vv+NRXeEvQ=="
-    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -21275,24 +21270,18 @@
       }
     },
     "node_modules/vue-echarts": {
-      "version": "6.6.9",
-      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-6.6.9.tgz",
-      "integrity": "sha512-mojIq3ZvsjabeVmDthhAUDV8Kgf2Rr/X4lV4da7gEFd1fP05gcSJ0j7wa7HQkW5LlFmF2gdCJ8p4Chas6NNIQQ==",
-      "hasInstallScript": true,
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-7.0.3.tgz",
+      "integrity": "sha512-/jSxNwOsw5+dYAUcwSfkLwKPuzTQ0Cepz1LxCOpj2QcHrrmUa/Ql0eQqMmc1rTPQVrh2JQ29n2dhq75ZcHvRDw==",
       "dependencies": {
-        "resize-detector": "^0.3.0",
         "vue-demi": "^0.13.11"
       },
       "peerDependencies": {
-        "@vue/composition-api": "^1.0.5",
         "@vue/runtime-core": "^3.0.0",
-        "echarts": "^5.4.1",
-        "vue": "^2.6.12 || ^3.1.1"
+        "echarts": "^5.5.1",
+        "vue": "^2.7.0 || ^3.1.1"
       },
       "peerDependenciesMeta": {
-        "@vue/composition-api": {
-          "optional": true
-        },
         "@vue/runtime-core": {
           "optional": true
         }
@@ -35992,11 +35981,6 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
-    "resize-detector": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/resize-detector/-/resize-detector-0.3.0.tgz",
-      "integrity": "sha512-R/tCuvuOHQ8o2boRP6vgx8hXCCy87H1eY9V5imBYeVNyNVpuL9ciReSccLj2gDcax9+2weXy3bc8Vv+NRXeEvQ=="
-    },
     "resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -37795,11 +37779,10 @@
       "integrity": "sha512-77CLRj1TPwB30pwsjOf3pkd1UzYanCdKXbqhILJ0Oo5QQl50lvBfyQCXxMFzwWwTc3sbBbQH3FfWSV+BkoSElA=="
     },
     "vue-echarts": {
-      "version": "6.6.9",
-      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-6.6.9.tgz",
-      "integrity": "sha512-mojIq3ZvsjabeVmDthhAUDV8Kgf2Rr/X4lV4da7gEFd1fP05gcSJ0j7wa7HQkW5LlFmF2gdCJ8p4Chas6NNIQQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/vue-echarts/-/vue-echarts-7.0.3.tgz",
+      "integrity": "sha512-/jSxNwOsw5+dYAUcwSfkLwKPuzTQ0Cepz1LxCOpj2QcHrrmUa/Ql0eQqMmc1rTPQVrh2JQ29n2dhq75ZcHvRDw==",
       "requires": {
-        "resize-detector": "^0.3.0",
         "vue-demi": "^0.13.11"
       }
     },

--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -26,7 +26,7 @@
         "dayjs": "^1.11.12",
         "diacritic": "^0.0.2",
         "dom7": "^2.1.5",
-        "echarts": "^5.5.1",
+        "echarts": "^5.6.0",
         "event-source-polyfill": "^1.0.22",
         "fast-deep-equal": "^3.1.3",
         "framework7": "^5.7.14",
@@ -9226,13 +9226,12 @@
       }
     },
     "node_modules/echarts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
-      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
-      "license": "Apache-2.0",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
       "dependencies": {
         "tslib": "2.3.0",
-        "zrender": "5.6.0"
+        "zrender": "5.6.1"
       }
     },
     "node_modules/echarts/node_modules/tslib": {
@@ -22901,10 +22900,9 @@
       }
     },
     "node_modules/zrender": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
-      "license": "BSD-3-Clause",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
       "dependencies": {
         "tslib": "2.3.0"
       }
@@ -22912,8 +22910,7 @@
     "node_modules/zrender/node_modules/tslib": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-      "license": "0BSD"
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     }
   },
   "dependencies": {
@@ -29199,12 +29196,12 @@
       }
     },
     "echarts": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.5.1.tgz",
-      "integrity": "sha512-Fce8upazaAXUVUVsjgV6mBnGuqgO+JNDlcgF79Dksy4+wgGpQB2lmYoO4TSweFg/mZITdpGHomw/cNBJZj1icA==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
       "requires": {
         "tslib": "2.3.0",
-        "zrender": "5.6.0"
+        "zrender": "5.6.1"
       },
       "dependencies": {
         "tslib": {
@@ -38992,9 +38989,9 @@
       "dev": true
     },
     "zrender": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.0.tgz",
-      "integrity": "sha512-uzgraf4njmmHAbEUxMJ8Oxg+P3fT04O+9p7gY+wJRVxo8Ge+KmYv0WJev945EH4wFuc4OY2NLXz46FZrWS9xJg==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
       "requires": {
         "tslib": "2.3.0"
       },

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -95,7 +95,7 @@
     "vue-async-computed": "^3.9.0",
     "vue-codemirror": "^4.0.6",
     "vue-draggable-resizable": "^2.3.0",
-    "vue-echarts": "^6.6.9",
+    "vue-echarts": "^7.0.3",
     "vue-fragment": "^1.5.1",
     "vue-fullscreen": "^2.6.1",
     "vue-grid-layout": "^2.4.0",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -68,7 +68,7 @@
     "dayjs": "^1.11.12",
     "diacritic": "^0.0.2",
     "dom7": "^2.1.5",
-    "echarts": "^5.5.1",
+    "echarts": "^5.6.0",
     "event-source-polyfill": "^1.0.22",
     "fast-deep-equal": "^3.1.3",
     "framework7": "^5.7.14",


### PR DESCRIPTION
- Upgrade Echarts from 5.5.1 to 5.6.0, changelog: https://github.com/apache/echarts/releases/tag/5.6.0
- Upgrade vue-echarts from 6.6.9 to 7.0.3, changelog: https://github.com/ecomfe/vue-echarts/blob/main/CHANGELOG.md#703