### PR TITLE
Link add/edit: Fix config-sheet not properly re-rendered on profile type change

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -219,8 +219,8 @@ export default {
       })
     },
     onProfileTypeChange (profileTypeUid) {
+      this.profileTypeConfiguration = null
       if (!profileTypeUid) {
-        this.profileTypeConfiguration = null
         this.currentProfileType = null
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -180,8 +180,8 @@ export default {
       }
     },
     onProfileTypeChange (profileTypeUid) {
+      this.profileTypeConfiguration = null
       if (!profileTypeUid) {
-        this.profileTypeConfiguration = null
         this.currentProfileType = null
         return
       }


### PR DESCRIPTION
Previously, autocomplete for parameter text sometimes did not properly initialize due to receiving the old config descriptions of the previous profile type.
This fixes this by making sure the config sheet is re-rendered when the new profile type config has been loaded.