### PR TITLE
Remove ESLintPlugin from webpack build

### DIFF
--- a/bundles/org.openhab.ui/web/build/webpack.config.js
+++ b/bundles/org.openhab.ui/web/build/webpack.config.js
@@ -7,7 +7,6 @@ const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin')
 const WorkboxPlugin = require('workbox-webpack-plugin')
 const WebpackAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
-const ESLintPlugin = require('eslint-webpack-plugin');
 const CompressionPlugin = require('compression-webpack-plugin')
 
 const path = require('path')
@@ -239,9 +238,7 @@ module.exports = {
     }),
     new VueLoaderPlugin(),
     ...(env === 'production' ? [
-      new ESLintPlugin({
-        extensions: ['js', 'vue']
-      })
+      // Production only plugins
     ] : [
       // Development only plugins
     ]),

--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -98,7 +98,6 @@
         "eslint-plugin-import": "^2.29.1",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-vue": "^9.27.0",
-        "eslint-webpack-plugin": "^4.2.0",
         "global-prefix": "^3.0.0",
         "html-webpack-plugin": "^5.6.0",
         "jest": "^29.7.0",
@@ -4817,17 +4816,6 @@
       "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
       "dependencies": {
         "@types/ms": "*"
-      }
-    },
-    "node_modules/@types/eslint": {
-      "version": "8.56.11",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
-      "integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -10364,31 +10352,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/eslint-webpack-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-4.2.0.tgz",
-      "integrity": "sha512-rsfpFQ01AWQbqtjgPRr2usVRxhWDuG0YDYcG8DJOteD3EFnpeuYuOwk0PQiN7PRBTqS6ElNdtPZPggj8If9WnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/eslint": "^8.56.10",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 14.15.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      },
-      "peerDependencies": {
-        "eslint": "^8.0.0 || ^9.0.0",
-        "webpack": "^5.0.0"
       }
     },
     "node_modules/eslint/node_modules/ansi-regex": {
@@ -25850,16 +25813,6 @@
         "@types/ms": "*"
       }
     },
-    "@types/eslint": {
-      "version": "8.56.11",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.11.tgz",
-      "integrity": "sha512-sVBpJMf7UPo/wGecYOpk2aQya2VUGeHhe38WG7/mN5FufNSubf5VT9Uh9Uyp8/eLJpu1/tuhJ/qTo4mhSB4V4Q==",
-      "dev": true,
-      "requires": {
-        "@types/estree": "*",
-        "@types/json-schema": "*"
-      }
-    },
     "@types/estree": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
@@ -30183,19 +30136,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
       "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
       "dev": true
-    },
-    "eslint-webpack-plugin": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-webpack-plugin/-/eslint-webpack-plugin-4.2.0.tgz",
-      "integrity": "sha512-rsfpFQ01AWQbqtjgPRr2usVRxhWDuG0YDYcG8DJOteD3EFnpeuYuOwk0PQiN7PRBTqS6ElNdtPZPggj8If9WnA==",
-      "dev": true,
-      "requires": {
-        "@types/eslint": "^8.56.10",
-        "jest-worker": "^29.7.0",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "schema-utils": "^4.2.0"
-      }
     },
     "espree": {
       "version": "9.6.1",

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -140,7 +140,6 @@
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-vue": "^9.27.0",
-    "eslint-webpack-plugin": "^4.2.0",
     "global-prefix": "^3.0.0",
     "html-webpack-plugin": "^5.6.0",
     "jest": "^29.7.0",


### PR DESCRIPTION
Removed `ESLintPlugin` execution from the webpack build as discussed [here](https://community.openhab.org/t/using-eclipse-with-openhab-webui/162923/30).

@florian-h05 I'm not sure if this is how you envisioned it, we could remove `VueLoaderPlugin()` completely, but I figured that it might be better to leave it there as a "skeleton" if needed in the future?