### PR TITLE
[BasicUI] Shrink labels before values

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -224,14 +224,18 @@
 		}
 		@include flex-shrink(0);
 		@include flex-grow(2);
-		// Set flex-basis to 0 to prioritize values over labels (see __text below)
-		@include flex-2011(2 0 0);
+		@include flex-2011(2 2 auto);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		html.ui-bigger-font & {
 			font-size: 18px;
 		}
+	}
+	&__label:has(+ .mdl-form__text) {
+		// this applies to labels that are followed by a text input
+		// Set flex-basis to 0 to prioritize __text over __label (see __text below)
+		@include flex-2011(2 0 0);
 	}
 	&__label-multiline {
 		min-width: 3em;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -224,7 +224,8 @@
 		}
 		@include flex-shrink(0);
 		@include flex-grow(2);
-		@include flex-2011(2 2 auto);
+		// Set flex-basis to 0 to prioritize values over labels (see __text below)
+		@include flex-2011(2 0 0);
 		white-space: nowrap;
 		overflow: hidden;
 		text-overflow: ellipsis;
@@ -501,7 +502,10 @@
 			font-size: 18px;
 		}
 		overflow: hidden;
+		// Make the label shrink first before the text (see __label above)
+		// See https://stackoverflow.com/a/67858285/15409057
 		flex-shrink: 2;
+		flex-grow: 0;
 		text-overflow: ellipsis;
 	}
 	&__webview,

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -233,7 +233,7 @@
 		}
 	}
 	&__label:has(+ .mdl-form__text) {
-		// this applies to labels that are followed by a text input
+		// this applies only to labels for sitemap text elements
 		// Set flex-basis to 0 to prioritize __text over __label (see __text below)
 		@include flex-2011(2 0 0);
 	}


### PR DESCRIPTION
Resolve #3094

Here's an animated gif:
![label-value-width](https://github.com/user-attachments/assets/fc4a60db-dd00-4c8a-9c4d-94bebb1f0ac0)
