### PR TITLE
[BasicUI] Remove top/bottom margins in buttons-multiline

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -515,10 +515,8 @@
 		padding-bottom: 2px;
 	}
 	&__buttons-multiline {
-		margin: 6px 0;
 		gap: 4px;
 		html.ui-layout-condensed & {
-			margin: 0;
 			gap: 3px;
 		}
 		padding-top: 2px;

--- a/bundles/org.openhab.ui.basic/web-src/_layout.scss
+++ b/bundles/org.openhab.ui.basic/web-src/_layout.scss
@@ -516,11 +516,13 @@
 	}
 	&__buttons-multiline {
 		gap: 4px;
-		html.ui-layout-condensed & {
-			gap: 3px;
-		}
 		padding-top: 2px;
 		padding-bottom: 2px;
+		html.ui-layout-condensed & {
+			gap: 3px;
+			padding-top: 0;
+			padding-bottom: 0;
+		}
 		display: flex;
 		flex-wrap: wrap;
 		justify-content: end;


### PR DESCRIPTION
Before:
<img width="882" alt="image" src="https://github.com/user-attachments/assets/cfd7b872-ecc0-487d-a1dd-4b56b3da03b7" />
condensed mode:
<img width="847" alt="image" src="https://github.com/user-attachments/assets/54ee7e8e-f980-4505-b9ae-54f02562b331" />


After:

<img width="881" alt="image" src="https://github.com/user-attachments/assets/2f75f02e-4dfe-4eba-84e3-005a07aefe95" />

condensed mode:
<img width="854" alt="image" src="https://github.com/user-attachments/assets/f66904d7-25f5-4d14-85aa-0e1ec499211f" />


```java
sitemap test {
    Text item=TestString1 label="Test"
    Switch item=TestSwitch1 label="Test" mappings=[ON="ON Label", OFF="OFF label"]
    Text item=TestString1  label="Test"
    Switch item=TestSwitch1 label="Test" mappings=[ON="ON Label", OFF="OFF label"]
}
```
