### PR TITLE
Item edit: Relabel category to icon

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -52,7 +52,7 @@
         <group-form ref="groupForm" v-if="itemType === 'Group'" :item="item" :createMode="createMode" />
       </f7-list-group>
       <f7-list-group v-if="!hideCategory">
-        <f7-list-input ref="category" label="Category" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="itemCategory"
+        <f7-list-input ref="category" label="Icon" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="itemCategory"
                        @input="itemCategory = $event.target.value" :disabled="!editable" :clear-button="editable">
           <div slot="root-end" style="margin-left: calc(35% + 14px)">
             <oh-icon :icon="itemCategory" :state="(createMode || itemType === 'Image') ? null : item.state" height="32" width="32" />

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -1,4 +1,4 @@
- <template>
+<template>
   <div v-if="item" class="quick-link-form no-padding">
     <f7-list inline-labels no-hairlines-md>
       <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -1,4 +1,4 @@
-<template>
+ <template>
   <div v-if="item" class="quick-link-form no-padding">
     <f7-list inline-labels no-hairlines-md>
       <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -237,7 +237,7 @@ export default {
       const yamlObj = {
         label: this.item.label,
         type: this.item.type,
-        category: this.item.category || '',
+        icon: this.item.category || '',
         groupNames: this.item.groupNames || [],
         tags: this.item.tags
         // metadata: this.item.metadata
@@ -257,7 +257,7 @@ export default {
         if (updatedItem.tags == null) updatedItem.tags = []
         this.$set(this.item, 'label', updatedItem.label)
         this.$set(this.item, 'type', updatedItem.type)
-        this.$set(this.item, 'category', updatedItem.category)
+        this.$set(this.item, 'category', updatedItem.icon)
         this.$set(this.item, 'groupNames', updatedItem.groupNames)
         this.$set(this.item, 'groupType', updatedItem.groupType)
         this.$set(this.item, 'function', updatedItem.function)


### PR DESCRIPTION
Closes #3146.

Changed label from "Category" to "Icon" to make usage more clear.