### PR TITLE
Add log details popup

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
@@ -140,6 +140,13 @@
                   </div>
                 </template>
               </f7-list-item>
+              <f7-list-item>
+                <template #title>
+                  <div class="wrap-text">
+                    {{ selectedLog.stackTrace }}
+                  </div>
+                </template>
+              </f7-list-item>
             </f7-list>
           </div>
         </div>
@@ -223,9 +230,8 @@
 <style lang="stylus">
 .log-viewer
   .wrap-text
-    white-space: pre-line !important
+    white-space: pre-line
     word-break: break-word
-    align: left
 
   /* Ensure the card takes full width and removes padding */
   .custom-card
@@ -585,7 +591,8 @@ export default {
         milliseconds: ms,
         level: logEntry.level.toUpperCase(),
         loggerName: logEntry.loggerName,
-        message: logEntry.message
+        message: logEntry.message,
+        stackTrace: logEntry.stackTrace
       }
 
       this.batchLogs.push(entry)

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
@@ -213,7 +213,7 @@
     <f7-block class="table-block">
       <f7-col>
         <f7-card class="custom-card">
-          <div class="table-container" ref="tableContainer" @click="handleTableClick" @scroll="handleScroll">
+          <div class="table-container" ref="tableContainer" @scroll="handleScroll">
             <table ref="dataTable">
               <tbody />
             </table>
@@ -429,8 +429,7 @@ export default {
         '#808080', // Gray
         '#8B4513', // Saddle Brown
         '#4682B4' // Steel Blue
-      ],
-      LINE_HEIGHT: 31
+      ]
     }
   },
   computed: {
@@ -548,24 +547,17 @@ export default {
           icon = 'exclamationmark_octagon_fill'
           break
       }
-      tr.innerHTML = '<td class="sticky" @click="this.onRowClick(entity)"><i class="icon f7-icons" style="font-size: 18px;">' + icon + `</i> ${entity.time}<span class="milliseconds">${entity.milliseconds}</span></td>` +
+      tr.innerHTML = '<td class="sticky"><i class="icon f7-icons" style="font-size: 18px;">' + icon + `</i> ${entity.time}<span class="milliseconds">${entity.milliseconds}</span></td>` +
         `<td class="level">${entity.level}</td>` +
         `<td class="logger"><span class="logger">${entity.loggerName}</span></td>` +
         `<td class="nowrap">${this.highlightText(entity.message)}</td>`
+      tr.addEventListener('click', () => {
+        this.onRowClick(entity.id)
+      })
       return tr
     },
-    handleTableClick (event) {
-      const tableContainer = this.$refs.tableContainer
-      const currentIndexAtTop = Math.floor(tableContainer.scrollTop / this.LINE_HEIGHT)
-      const rect = tableContainer.getBoundingClientRect()
-      const index = Math.floor((event.clientY - rect.top) / this.LINE_HEIGHT) + currentIndexAtTop
-
-      if (index >= this.filteredTableData.length) {
-        return
-      }
-
-      this.selectedLog = this.filteredTableData[index]
-
+    onRowClick (entityId) {
+      this.selectedLog = this.filteredTableData[entityId]
       this.$f7.popup.open('#logdetails-popup')
     },
     addLogEntry (logEntry) {
@@ -687,11 +679,13 @@ export default {
       this.redrawPartOfTable()
     },
     redrawPartOfTable () {
+      const LINE_HEIGHT = 31
+
       const tableContainer = this.$refs.tableContainer
       const tableBody = this.$refs.dataTable.firstChild
       const filteredItemsCount = this.filteredTableData.length
-      const currentIndexAtTop = Math.floor(tableContainer.scrollTop / this.LINE_HEIGHT)
-      const nbVisibleLines = Math.floor(tableContainer.offsetHeight / this.LINE_HEIGHT)
+      const currentIndexAtTop = Math.floor(tableContainer.scrollTop / LINE_HEIGHT)
+      const nbVisibleLines = Math.floor(tableContainer.offsetHeight / LINE_HEIGHT)
 
       // make sure to redraw only 50 elements below around visible area
       const firstIndexToRedraw = Math.max(0, currentIndexAtTop - 50)
@@ -702,7 +696,7 @@ export default {
       if (firstIndexToRedraw > 0) {
         const padder = document.createElement('tr')
         padder.className = 'padder'
-        padder.style.height = (this.LINE_HEIGHT * firstIndexToRedraw) + 'px'
+        padder.style.height = (LINE_HEIGHT * firstIndexToRedraw) + 'px'
         tableBody.appendChild(padder)
       }
       for (let i = firstIndexToRedraw; i <= lastIndexToRedraw; i++) {
@@ -711,7 +705,7 @@ export default {
       if (lastIndexToRedraw < filteredItemsCount - 1) {
         const padder = document.createElement('tr')
         padder.className = 'padder'
-        padder.style.height = (this.LINE_HEIGHT * (filteredItemsCount - 1 - lastIndexToRedraw)) + 'px'
+        padder.style.height = (LINE_HEIGHT * (filteredItemsCount - 1 - lastIndexToRedraw)) + 'px'
         tableBody.appendChild(padder)
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
@@ -112,7 +112,7 @@
     </f7-popover>
 
     <!-- Log Details Popup -->
-    <f7-popup id="logdetails-popup">
+    <f7-popup id="logdetails-popup" close-on-escape close-by-backdrop-click>
       <f7-page>
         <f7-navbar title="Log Details">
           <f7-nav-right>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
@@ -112,46 +112,48 @@
     </f7-popover>
 
     <!-- Log Details Popup -->
-    <div class="popup" id="logdetails-popup">
-      <div class="view">
-        <div class="page">
-          <div class="navbar">
-            <div class="navbar-bg" />
-            <div class="navbar-inner">
-              <div class="title">
-                Log Details
+    <f7-popup id="logdetails-popup">
+      <f7-page>
+        <f7-navbar title="Log Details">
+          <f7-nav-right>
+            <f7-link class="popup-close">
+              Close
+            </f7-link>
+          </f7-nav-right>
+        </f7-navbar>
+
+        <f7-list class="col wide">
+          <f7-list-item header="Time" :title="selectedLog.time + selectedLog.milliseconds" />
+          <f7-list-item header="Timestamp" :title="selectedLog.timestamp" />
+          <f7-list-item header="Level" :title="selectedLog.level" />
+          <f7-list-item header="Logger Class" :title="selectedLog.loggerName" />
+          <f7-list-item>
+            <template #title>
+              <div class="item-title">
+                <div class="item-header">
+                  Message
+                </div>
+                <div class="log-message">
+                  {{ selectedLog.message }}
+                </div>
               </div>
-              <div class="right">
-                <!-- Link to close popup -->
-                <a class="link popup-close">Close</a>
+            </template>
+          </f7-list-item>
+          <f7-list-item v-if="selectedLog.stackTrace">
+            <template #title>
+              <div class="item-title">
+                <div class="item-header">
+                  Stack Trace
+                </div>
+                <div class="stack-trace">
+                  {{ selectedLog.stackTrace }}
+                </div>
               </div>
-            </div>
-          </div>
-          <div class="page-content">
-            <f7-list class="col wide">
-              <f7-list-item header="Time" :title="selectedLog.time + selectedLog.milliseconds" />
-              <f7-list-item header="Timestamp" :title="selectedLog.timestamp" />
-              <f7-list-item header="Level" :title="selectedLog.level" />
-              <f7-list-item header="Logger Class" :title="selectedLog.loggerName" />
-              <f7-list-item>
-                <template #title>
-                  <div class="wrap-text">
-                    {{ selectedLog.message }}
-                  </div>
-                </template>
-              </f7-list-item>
-              <f7-list-item>
-                <template #title>
-                  <div class="wrap-text">
-                    {{ selectedLog.stackTrace }}
-                  </div>
-                </template>
-              </f7-list-item>
-            </f7-list>
-          </div>
-        </div>
-      </div>
-    </div>
+            </template>
+          </f7-list-item>
+        </f7-list>
+      </f7-page>
+    </f7-popup>
 
     <!-- Main Display -->
     <f7-navbar title="Log Viewer" back-link="Developer Tools" back-link-url="/developer/" back-link-force>
@@ -229,9 +231,6 @@
 
 <style lang="stylus">
 .log-viewer
-  .wrap-text
-    white-space: pre-line
-    word-break: break-word
 
   /* Ensure the card takes full width and removes padding */
   .custom-card
@@ -266,6 +265,9 @@
     padding 5px
     text-align left
     white-space nowrap
+    overflow hidden
+    text-overflow ellipsis
+    max-width 100dvw
 
   td.sticky
     position sticky
@@ -348,6 +350,14 @@
 
   .log-period
     white-space nowrap !important
+
+#logdetails-popup
+  .log-message
+    white-space normal
+    word-break break-word
+  .stack-trace
+    white-space pre-line
+    word-break break-word
 
 #color-picker-popover
   .color-palette


### PR DESCRIPTION
This adds a click handler to the log viewer, and then displays a full window popup with the details of this entry.  This allows long entries to be viewed, and (hopefully!) multiline exceptions.

However, I've found that exceptions don't come through fully from the server -:

<img width="366" alt="image" src="https://github.com/user-attachments/assets/f9a31bb4-c957-4c30-98a7-82d81c921e8b" />

<img width="776" alt="image" src="https://github.com/user-attachments/assets/07a09537-49fe-4360-ab70-af02e2c7ebd5" />

But in the log itself -:

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/15a4da13-9873-4ac6-9266-73dd40c1ae5a" />

So, while this should provide the ability to view large exception dumps, it looks like the server side needs some work as well.


Closes #2961


<img width="1670" alt="image" src="https://github.com/user-attachments/assets/c4a089d0-34ed-41ce-9381-83a8cfe00198" />


Signed-off-by: Chris Jackson <chris@cd-jackson.com>
