### PR TITLE
Copy File Definition: Process multiple objects with single api request

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/openhab/api.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/api.js
@@ -30,40 +30,29 @@ export default {
   get (uri, data) {
     return wrapPromise(Framework7.request.promise.json(uri, data))
   },
-  getPlain (uri_or_parameters, data, contentType, responseType) {
-    let parameters = {}
-    if (typeof uri_or_parameters === 'string') {
-      parameters = {
-        url: uri_or_parameters,
-        method: 'GET',
-        data,
-        processData: false,
-        contentType: contentType || 'text/plain',
-        xhrFields: typeof responseType !== 'undefined' ? { responseType } : null
-      }
-    } else if (typeof uri_or_parameters === 'object') {
-      parameters = {
-        contentType: 'text/plain',
-        processData: false,
-        method: 'GET',
-        ...uri_or_parameters
-      }
-    } else {
-      throw new Error('Invalid parameters')
-    }
-    return wrapPromise(Framework7.request.promise(parameters))
+  getPlain (uri, data, contentType, responseType, headers) {
+    return wrapPromise(Framework7.request.promise({
+      method: 'GET',
+      url: uri,
+      data,
+      processData: false,
+      contentType: contentType || 'text/plain',
+      xhrFields: typeof responseType !== 'undefined' ? { responseType } : null,
+      headers
+    }))
   },
   post (uri, data, dataType) {
     return wrapPromise(Framework7.request.promise.postJSON(uri, data, dataType))
   },
-  postPlain (uri, data, dataType, contentType) {
+  postPlain (uri, data, dataType, contentType, headers) {
     return wrapPromise(Framework7.request.promise({
       method: 'POST',
       url: uri,
       data,
       processData: false,
       contentType: contentType || 'text/plain',
-      dataType: dataType || 'application/json'
+      dataType: dataType || 'application/json',
+      headers
     }))
   },
   put (uri, data) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -24,7 +24,7 @@ function executeFileDefinitionCopy (vueInstance, objectType, objectTypeLabel, ob
     })
     .catch(error => {
       progressDialog.close()
-      vueInstance.$f7.dialog.alert(`Error copying ${objectTypeLabel} ${fileFormatLabel} definition: ${error}`, 'Error')
+      vueInstance.$f7.dialog.alert(`Error loading ${objectTypeLabel} ${fileFormatLabel} definition: ${error}`, 'Error')
     })
 }
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -7,22 +7,17 @@ function executeFileDefinitionCopy (vueInstance, objectType, objectTypeLabel, ob
   const progressDialog = vueInstance.$f7.dialog.progress(`Loading ${objectTypeLabel} ${fileFormatLabel} definition...`)
 
   const path = `/rest/file-format/${objectType}s`
-  let apiCalls = []
+  const headers = { accept: mediaType }
+  let apiCall = null
   if (objectIds !== null) {
-    apiCalls = objectIds.map((id) => vueInstance.$oh.api.getPlain({
-      url: path + '/' + id,
-      headers: { accept: mediaType }
-    }))
+    const data = JSON.stringify(objectIds)
+    apiCall = vueInstance.$oh.api.postPlain(path, data, 'text', 'application/json', headers)
   } else {
-    apiCalls = [vueInstance.$oh.api.getPlain({
-      url: path,
-      headers: { accept: mediaType }
-    })]
+    apiCall = vueInstance.$oh.api.getPlain(path, null, 'text', undefined, headers)
   }
 
-  Promise.all(apiCalls)
-    .then(definitions => {
-      const definition = definitions.join('\n')
+  apiCall
+    .then(definition => {
       progressDialog.close()
       if (vueInstance.$clipboard(definition)) {
         vueInstance.$f7.toast.create({

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -8,15 +8,8 @@ function executeFileDefinitionCopy (vueInstance, objectType, objectTypeLabel, ob
 
   const path = `/rest/file-format/${objectType}s`
   const headers = { accept: mediaType }
-  let apiCall = null
-  if (objectIds !== null) {
-    const data = JSON.stringify(objectIds)
-    apiCall = vueInstance.$oh.api.postPlain(path, data, 'text', 'application/json', headers)
-  } else {
-    apiCall = vueInstance.$oh.api.getPlain(path, null, 'text', undefined, headers)
-  }
-
-  apiCall
+  const data = JSON.stringify(objectIds)
+  vueInstance.$oh.api.postPlain(path, data, 'text', 'application/json', headers)
     .then(definition => {
       progressDialog.close()
       if (vueInstance.$clipboard(definition)) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -302,10 +302,7 @@ export default {
       }
     },
     copySelected () {
-      // When _all_ (not just filtered) items are selected, pass null to copyFileDefinitionToClipboard
-      // so that it only makes one call to the backend
-      const selectedItems = this.selectedItems.length === this.items.length ? null : this.selectedItems
-      this.copyFileDefinitionToClipboard(this.ObjectType.ITEM, selectedItems)
+      this.copyFileDefinitionToClipboard(this.ObjectType.ITEM, this.selectedItems)
     },
     removeSelected () {
       const vm = this


### PR DESCRIPTION
Depends on core PR: https://github.com/openhab/openhab-core/pull/4734

This solves the problem with YAML format returning the `version` and `things` (or `items`) keys for each item in multi-select requests. By combining them into a single request, only one key will be returned at the top.

See discussion in https://github.com/openhab/openhab-webui/pull/3130#issuecomment-2817126752