### PR TITLE
Developer Sidebar: make pinned objects persistent

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -445,7 +445,7 @@ export default {
         transformations: [],
         persistenceConfigs: []
       },
-      pinnedObjects: {
+      pinnedObjects: this.$f7.data.pinnedObjects || {
         items: [],
         things: [],
         rules: [],
@@ -490,6 +490,7 @@ export default {
   beforeDestroy () {
     this.stopEventSource()
     if (this.addThingAutocomplete) this.addThingAutocomplete.destroy()
+    this.$f7.data.pinnedObjects = this.pinnedObjects
   },
   methods: {
     addItemsFromModel (value) {


### PR DESCRIPTION
Make pinned objects persistent within the browser session, so they don't disappear when closing / reopening the developer sidebar, or when switching to Help tab and back.