### PR TITLE
Left Menu: Enable shortcut also when pinned but hidden

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/app.vue
+++ b/bundles/org.openhab.ui/web/src/components/app.vue
@@ -615,9 +615,7 @@ export default {
             break
           case 77: // M for menu
             const leftPanel = this.$f7.panel.get('left')
-            if (leftPanel.visibleBreakpointDisabled) {
-              leftPanel.opened ? leftPanel.close() : leftPanel.open()
-            }
+            leftPanel.opened ? leftPanel.close() : leftPanel.open()
             break
           default:
             return


### PR DESCRIPTION
Previously the shortcut Ctrl+Shift+M only worked when the menu wasn't pinned.

But being able to show the menu is also very handy when the menu was pinned but hidden because the screen is narrowed.