### PR TITLE
Refactor Semantic Tags

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/semantics-picker.vue
@@ -49,13 +49,13 @@ export default {
   },
   methods: {
     semanticType (tag) {
-      if (this.semanticClasses.Locations.indexOf(tag) >= 0) return 'Location'
-      if (this.semanticClasses.Equipment.indexOf(tag) >= 0) return 'Equipment'
-      if (this.semanticClasses.Points.indexOf(tag) >= 0) return 'Point'
+      if (this.semanticClasses.Locations[tag]) return 'Location'
+      if (this.semanticClasses.Equipment[tag]) return 'Equipment'
+      if (this.semanticClasses.Points[tag]) return 'Point'
       return ''
     },
     isSemanticPropertyTag (tag) {
-      return (this.semanticClasses.Properties.indexOf(tag) >= 0)
+      return !!this.semanticClasses.Properties[tag]
     },
     update (type, value) {
       if (type === 'property') {
@@ -75,7 +75,7 @@ export default {
       this.semanticClass = ''
       this.semanticProperty = ''
       item.tags.forEach((t) => {
-        if (this.semanticType(t) !== '') {
+        if (this.semanticType(t)) {
           this.semanticClass = t
         }
         if (this.isSemanticPropertyTag(t)) {
@@ -108,24 +108,16 @@ export default {
       return this.createMode || (this.item && this.item.editable)
     },
     orderedLocations () {
-      return [...this.semanticClasses.Locations].sort((a, b) => {
-        return a.localeCompare(b)
-      })
+      return Object.keys(this.semanticClasses.Locations).sort((a, b) => a.localeCompare(b))
     },
     orderedEquipment () {
-      return [...this.semanticClasses.Equipment].sort((a, b) => {
-        return a.localeCompare(b)
-      })
+      return Object.keys(this.semanticClasses.Equipment).sort((a, b) => a.localeCompare(b))
     },
     orderedPoints () {
-      return [...this.semanticClasses.Points].sort((a, b) => {
-        return a.localeCompare(b)
-      })
+      return Object.keys(this.semanticClasses.Points).sort((a, b) => a.localeCompare(b))
     },
     orderedProperties () {
-      return [...this.semanticClasses.Properties].sort((a, b) => {
-        return a.localeCompare(b)
-      })
+      return Object.keys(this.semanticClasses.Properties).sort((a, b) => a.localeCompare(b))
     },
     currentSemanticType () {
       return this.semanticType(this.semanticClass)

--- a/bundles/org.openhab.ui/web/src/components/tags/tag-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-mixin.js
@@ -1,15 +1,7 @@
 export default {
-  data () {
-    return {
-      semanticClasses: this.$store.getters.semanticClasses
-    }
-  },
   methods: {
     isSemanticTag (tag) {
-      return [this.semanticClasses.Locations,
-        this.semanticClasses.Equipment,
-        this.semanticClasses.Points,
-        this.semanticClasses.Properties].some((t) => t.indexOf(tag) >= 0)
+      return !!this.$store.state.semantics.Tags[tag]
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -208,7 +208,7 @@ export default {
           type: channel.itemType,
           unit: this.channelUnit(channel, channelType),
           stateDescriptionPattern: '',
-          tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
+          tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points[t])) ? defaultTags : [...defaultTags, 'Point']
         }
         this.newItems.push(newItem)
       }

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -19,10 +19,10 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
     }
   } else {
     item.tags.forEach((tag) => {
-      if (store.getters.semanticClasses.Points.indexOf(tag) >= 0) {
+      if (store.getters.semanticClasses.Points[tag]) {
         semanticClass = tag
       }
-      if (store.getters.semanticClasses.Properties.indexOf(tag) >= 0) {
+      if (store.getters.semanticClasses.Properties[tag]) {
         semanticProperty = tag
       }
     })

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/default-standalone-item.js
@@ -19,10 +19,10 @@ export default function itemDefaultStandaloneComponent (item) {
     }
   } else {
     item.tags.forEach((tag) => {
-      if (store.getters.semanticClasses.Points.indexOf(tag) >= 0) {
+      if (store.getters.semanticClasses.Points[tag]) {
         semanticClass = tag
       }
-      if (store.getters.semanticClasses.Properties.indexOf(tag) >= 0) {
+      if (store.getters.semanticClasses.Properties[tag]) {
         semanticProperty = tag
       }
     })

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/default-list-item.js
@@ -22,10 +22,10 @@ export default function itemDefaultListComponent (item, footer) {
     }
   } else {
     item.tags.forEach((tag) => {
-      if (store.getters.semanticClasses.Points.indexOf(tag) >= 0) {
+      if (store.getters.semanticClasses.Points[tag]) {
         semanticClass = tag
       }
-      if (store.getters.semanticClasses.Properties.indexOf(tag) >= 0) {
+      if (store.getters.semanticClasses.Properties[tag]) {
         semanticProperty = tag
       }
     })

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-equipment-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-equipment-card.vue
@@ -19,7 +19,7 @@ export default {
   },
   widget: () => {
     const widget = OhEquipmentCardParameters()
-    widget.props.parameters.find(p => p.name === 'item').options = store.state.semantics.Equipment.map(p => { return { name: p, label: store.state.semantics.Labels[p] } })
+    widget.props.parameters.find(p => p.name === 'item').options = store.state.semantics.Equipment
     return widget
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-property-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/oh-property-card.vue
@@ -19,7 +19,7 @@ export default {
   },
   widget: () => {
     const widget = OhPropertyCardParameters()
-    widget.props.parameters.find(p => p.name === 'item').options = store.state.semantics.Properties.map(p => { return { name: p, label: store.state.semantics.Labels[p] } })
+    widget.props.parameters.find(p => p.name === 'item').options = store.state.semantics.Properties
     return widget
   }
 }

--- a/bundles/org.openhab.ui/web/src/js/store/modules/semantics.js
+++ b/bundles/org.openhab.ui/web/src/js/store/modules/semantics.js
@@ -2,11 +2,11 @@ import i18n from '@/js/i18n'
 import api from '@/js/openhab/api'
 
 const state = {
-  Locations: [],
-  Equipment: [],
-  Points: [],
-  Properties: [],
-  Labels: {}
+  Locations: {},
+  Equipment: {},
+  Points: {},
+  Properties: {},
+  Tags: {} // all tag objects
 }
 
 const getters = {
@@ -17,18 +17,30 @@ const getters = {
 
 const mutations = {
   setSemantics (state, { tags }) {
-    state.Locations = tags.filter(t => t.uid.startsWith('Location')).map(t => t.name)
-    state.Equipment = tags.filter(t => t.uid.startsWith('Equipment')).map(t => t.name)
-    state.Points = tags.filter(t => t.uid.startsWith('Point')).map(t => t.name)
-    state.Properties = tags.filter(t => t.uid.startsWith('Property')).map(t => t.name)
-    // Store i18n labels
-    state.Labels = {} // Clear existing labels
-    for (const i in tags) {
-      const t = tags[i]
-      state.Labels[t.name] = t.label || t.name
-    }
+    state.Locations = {}
+    state.Equipment = {}
+    state.Points = {}
+    state.Properties = {}
+    state.Tags = {}
+    const labels = {}
+    tags.forEach(t => {
+      const type = t.uid.split('_')[0]
+      if (type === 'Location') {
+        state.Locations[t.name] = t
+      } else if (type === 'Equipment') {
+        state.Equipment[t.name] = t
+      } else if (type === 'Point') {
+        state.Points[t.name] = t
+      } else if (type === 'Property') {
+        state.Properties[t.name] = t
+      }
+      state.Tags[t.name] = t
+      t.label = t.label || t.name
+      t.type = type
+      labels[t.name] = t.label
+    })
     // Save as i18n messages
-    i18n.mergeLocaleMessage(i18n.locale, state.Labels)
+    i18n.mergeLocaleMessage(i18n.locale, labels)
   }
 }
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -87,8 +87,6 @@ export default {
       itemYaml: '',
       items: [],
       types: Types,
-      semanticClasses: this.$store.getters.semanticClasses,
-      semanticClass: '',
       semanticProperty: '',
       pendingTag: '',
       currentTab: 'design',

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/generate-textual-definition.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/generate-textual-definition.js
@@ -41,7 +41,7 @@ export default (thing, channelTypes, newEquipmentItem, parentGroupsForEquipment,
       groupNames: parentGroupsForPoints,
       category: (channelType) ? channelType.category : '',
       type: channel.itemType,
-      tags: (defaultTags.find((t) => store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
+      tags: (defaultTags.find((t) => store.getters.semanticClasses.Points[tags])) ? defaultTags : [...defaultTags, 'Point']
     }
 
     let line = []

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -199,7 +199,7 @@ export default {
         groupNames: [],
         type: this.channel.itemType || 'Switch',
         unit: this.linkUnit(),
-        tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
+        tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points[tags])) ? defaultTags : [...defaultTags, 'Point']
       })
     },
     linkUnit () {


### PR DESCRIPTION
Store the full details of semantic tags so that:
We have the labels, synonyms, hierarchy (parent), description, etc.
This will allow richer tags handling, e.g. to display tag description and hierarchy.

