### PR TITLE
Rule Module Popup: Hide Save link on inline script language selection

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -12,7 +12,7 @@
           Edit {{ SectionLabels[currentSection][1] }}
         </f7-nav-title>
         <f7-nav-right>
-          <f7-link v-show="currentRuleModuleType" @click="updateModuleConfig">
+          <f7-link v-show="currentRuleModuleType && currentRuleModuleType.uid !== 'script.ScriptAction'" @click="updateModuleConfig">
             Save
           </f7-link>
         </f7-nav-right>


### PR DESCRIPTION
Clicking Save here would create an invalid module with a missing language, so just hide it.

![image](https://github.com/user-attachments/assets/0f6aad8d-8a0c-4e9f-a92d-4cb98b9463b0)

