### PR TITLE
Log Viewer: Add text mode option

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
@@ -339,6 +339,7 @@
     font-size 0.9em
     padding-left 4em
     line-height 1.2em
+    color grey
     span
       margin-right 5px
     .time
@@ -608,13 +609,14 @@ export default {
           icon = 'exclamationmark_octagon_fill'
           break
       }
+      const levelLowerCased = entity.level.toLowerCase()
       if (this.textMode) {
         tr.innerHTML = `<td class="text"><span class="time">${entity.time}${entity.milliseconds}</span>` +
-        `[<span class="level ${entity.level.toLowerCase()}">${entity.level}</span>] ` +
+        `[<span class="level ${levelLowerCased}">${entity.level}</span>] ` +
         `[<span class="logger" title="${entity.loggerName}">${entity.loggerName}</span>] - ` +
-        `<span class="msg ${entity.level.toLowerCase()}">${this.highlightText(entity.message)}</span></td>`
+        `<span class="msg ${levelLowerCased}">${this.highlightText(entity.message)}</span></td>`
       } else {
-        tr.className = 'table-rows ' + entity.level.toLowerCase()
+        tr.className = 'table-rows ' + levelLowerCased
         tr.innerHTML = '<td class="sticky"><i class="icon f7-icons" style="font-size: 18px;">' + icon + `</i> ${entity.time}<span class="milliseconds">${entity.milliseconds}</span></td>` +
           `<td class="level">${entity.level}</td>` +
           `<td class="logger"><span class="logger" title="${entity.loggerName}">${entity.loggerName}</span></td>` +

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer.vue
@@ -434,6 +434,11 @@
 </style>
 
 <script lang="ts">
+import Vue from 'vue'
+import Clipboard from 'v-clipboard'
+
+Vue.use(Clipboard)
+
 import MovablePopupMixin from '@/pages/settings/movable-popup-mixin'
 
 export default {
@@ -878,6 +883,21 @@ export default {
       return [headers, ...rows].join('\n')
     },
     copyTableToClipboard () {
+      if (this.textMode) {
+        const logs = this.filteredTableData.map((log) => {
+          return `${log.time}${log.milliseconds} [${log.level}] [${log.loggerName}] - ${log.message}`
+        }).join('\n')
+        // v-clipboard works without https, but it can only copy plain text
+        if (this.$clipboard(logs)) {
+          this.$f7.toast.create({
+            text: 'Table copied as text to clipboard',
+            destroyOnClose: true,
+            closeTimeout: 2000
+          }).open()
+        }
+        return
+      }
+
       const table = this.$refs.dataTable
       if (!table) {
         return
@@ -901,6 +921,7 @@ export default {
         .then(() => {
           this.$f7.toast.create({
             text: 'Table copied as HTML to clipboard',
+            destroyOnClose: true,
             closeTimeout: 2000
           }).open()
         })


### PR DESCRIPTION
- Add an option to display the log in "Text mode" vs "Table mode".
- In Text Mode, the "Copy" button will copy the log as plain text. In Table Mode, the "Copy" button does what it used to do before.

Note while the text would wrap to the next line, I deliberately indented it so it's easier to see where the next log entry starts

Dark mode:
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/87bdabd5-7900-462c-85fd-8f144bf51848" />

<img width="1053" alt="image" src="https://github.com/user-attachments/assets/71886d84-a415-44ad-b596-8ef806be8ead" />


Hovering the mouse pointer over the log name reveals the full name
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/10cba0c6-ba5a-451b-994a-a46daebd87b7" />

Clicking on the log line still brings up the detail dialog
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/e2fca55a-9f9f-4a20-b3f6-deb914a34997" />

You can select the text, and copy / paste it into a text file
<img width="1057" alt="image" src="https://github.com/user-attachments/assets/d2844175-d8ad-4c0e-a181-3f64c525d176" />


Related: #2960, #2962