### PR TITLE
Sitemap editor: Small fixes & Add duplicate element functionality

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -10,7 +10,7 @@
           <f7-list-input ref="icon" label="Icon" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="widget.config.icon"
                          @input="updateParameter('icon', $event)" clear-button>
             <div slot="root-end" style="margin-left: calc(35% + 8px)">
-              <oh-icon :icon="widget.config.icon" height="32" width="32" />
+              <oh-icon :icon="widget.config.icon || ''" height="32" width="32" />
             </div>
           </f7-list-input>
           <f7-list-item title="Static icon">
@@ -82,6 +82,9 @@
         <f7-button color="blue" @click="$emit('moveup', widget)" icon-f7="chevron_up" />
         <f7-button color="blue" @click="$emit('movedown', widget)" icon-f7="chevron_down" />
       </f7-segmented>
+      <f7-button v-if="widget.component !== 'Sitemap'" color="blue" @click="$emit('duplicate', widget)">
+        Duplicate
+      </f7-button>
       <f7-button v-if="widget.component !== 'Sitemap'" color="red" @click="$emit('remove', widget)">
         Remove
       </f7-button>
@@ -149,7 +152,6 @@ export default {
   },
   mounted () {
     if (!this.widget) return
-    if (!this.widget.config.icon) this.$set(this.widget.config, 'icon', '')
     const iconControl = this.$refs.icon
     if (!iconControl || !iconControl.$el) return
     const inputElement = this.$$(iconControl.$el).find('input')

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -282,14 +282,14 @@
 </style>
 
 <script>
+import cloneDeep from 'lodash/cloneDeep'
+
 import SitemapCode from '@/components/pagedesigner/sitemap/sitemap-code.vue'
 import WidgetDetails from '@/components/pagedesigner/sitemap/widget-details.vue'
 import AttributeDetails from '@/components/pagedesigner/sitemap/attribute-details.vue'
 import SitemapTreeviewItem from '@/components/pagedesigner/sitemap/treeview-item.vue'
 import SitemapMixin from '@/components/pagedesigner/sitemap/sitemap-mixin'
-import DirtyMixin from '../../dirty-mixin'
-
-import cloneDeep from 'lodash/cloneDeep'
+import DirtyMixin from '@/pages/settings/dirty-mixin'
 
 export default {
   mixins: [DirtyMixin, SitemapMixin],

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -355,7 +355,7 @@ export default {
       },
       deep: true
     },
-    currentTab(newTab, oldTab) {
+    currentTab (newTab, oldTab) {
       if (oldTab === 'tree' && this.$refs.detailsSheet) {
         this.$refs.detailsSheet.close()
       }


### PR DESCRIPTION
This fixes:
- Scrollbar for sitemap tree not visible on narrow screens
- Details sheet not closed resulting in browser error
- Sitemap marked dirty when no icon defined on one of the sitemap elements

This adds a sitemap element duplicate function. This will duplicate a sitemap element with all of its sitemap children elements and can drastically speeds up sitemap creation or editing. Before, the easiest way was doing this in the code editor. With this change it can easily be done in the treeview.