### PR TITLE
[MainUI] Support of oh-state-series chart in Analyzer pages

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -186,7 +186,8 @@ export default {
             { value: 'day', label: 'Hours of day' },
             { value: 'week', label: 'Days of week' },
             { value: 'month', label: 'Days of month' },
-            { value: 'year', label: 'Months of year' }
+            { value: 'year', label: 'Months of year' },
+            { value: 'values', label: 'Values' }
           ]
         },
         {
@@ -227,6 +228,16 @@ export default {
           ],
           visible: (value, configuration, configDescription, parameters) => {
             return configuration.categoryType === 'year'
+          }
+        },
+        {
+          name: 'data',
+          label: 'Category Values',
+          type: 'TEXT',
+          description: 'Category values to display',
+          multiple: true,
+          visible: (value, configuration, configDescription, parameters) => {
+            return configuration.categoryType === 'values'
           }
         },
         gridIndexParameter
@@ -300,6 +311,31 @@ export default {
       parameters: [
         ...seriesParameters,
         seriesTypeParameter('line', 'bar', 'heatmap', 'scatter'),
+        xAxisIndexParameter,
+        yAxisIndexParameter,
+        ...actionParams()
+      ]
+    }
+  },
+
+  'oh-state-series': {
+    label: 'State Series',
+    props: {
+      parameterGroups: [componentRelationsGroup, actionGroup()],
+      parameters: [
+        ...seriesParameters,
+        {
+          name: 'yValue',
+          label: 'Y Value',
+          type: 'DECIMAL',
+          description: 'The position the state timeline should appear on the Y axis (in graph coordinates). If Y axis is a category axis, this should be the index of the category'
+        },
+        {
+          name: 'yHeight',
+          label: 'Y Height',
+          type: 'DECIMAL',
+          description: 'The height the state timeline bar in graph coordinates (default is 0.6)'
+        },
         xAxisIndexParameter,
         yAxisIndexParameter,
         ...actionParams()

--- a/bundles/org.openhab.ui/web/src/assets/i18n/analyzer/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/analyzer/en.json
@@ -13,6 +13,7 @@
   "analyzer.series.table.type.bar": "Bar",
   "analyzer.series.table.type.line": "Line",
   "analyzer.series.table.type.area": "Area",
+  "analyzer.series.table.type.state": "State",
   "analyzer.series.table.type.heatmap": "Heatmap",
   "analyzer.series.table.na": "N/A",
   "analyzer.coords": "Coords",

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -64,6 +64,9 @@
               <f7-list-button color="blue" @click="addSeries('oh-aggregate-series', gridIdx)">
                 Add Aggregate Series
               </f7-list-button>
+              <f7-list-button color="blue" @click="addSeries('oh-state-series', gridIdx)">
+                Add State Series
+              </f7-list-button>
             </f7-list>
           </f7-card>
         </div>
@@ -378,7 +381,7 @@ export default {
       let firstXAxis = this.context.component.slots.xAxis.find(a => a.config.gridIndex === gridIdx)
       let firstYAxis = this.context.component.slots.yAxis.find(a => a.config.gridIndex === gridIdx)
       if (!firstXAxis) {
-        if (type === 'oh-time-series') {
+        if (type === 'oh-time-series' || type === 'oh-state-series') {
           this.addAxis(gridIdx, 'xAxis', 'oh-time-axis')
           firstXAxis = this.context.component.slots.xAxis.find(a => a.config.gridIndex === gridIdx)
           automaticAxisCreated = true
@@ -391,6 +394,11 @@ export default {
         if (type === 'oh-time-series') {
           this.addAxis(gridIdx, 'yAxis', 'oh-value-axis')
           firstYAxis = this.context.component.slots.yAxis.find(a => a.config.gridIndex === gridIdx)
+          automaticAxisCreated = true
+        } else if (type === 'oh-state-series') {
+          this.addAxis(gridIdx, 'yAxis', 'oh-category-axis')
+          firstYAxis = this.context.component.slots.yAxis.find(a => a.config.gridIndex === gridIdx)
+          firstYAxis.config.categoryType = 'values'
           automaticAxisCreated = true
         } else {
           this.$f7.dialog.alert('Please add at least one X axis and one Y axis')
@@ -406,16 +414,27 @@ export default {
         }).open()
       }
 
-      this.context.component.slots.series.push({
+      let component = {
         component: type,
         config: {
           name: 'Series ' + (this.context.component.slots.series.length + 1),
           gridIndex: gridIdx,
           xAxisIndex: this.context.component.slots.xAxis.indexOf(firstXAxis),
-          yAxisIndex: this.context.component.slots.yAxis.indexOf(firstYAxis),
-          type: 'line'
+          yAxisIndex: this.context.component.slots.yAxis.indexOf(firstYAxis)
         }
-      })
+      }
+
+      if (type === 'oh-state-series') {
+        if (firstYAxis.config.categoryType === 'values') {
+          firstYAxis.config.data = firstYAxis.config.data || []
+          firstYAxis.config.data.unshift(component.config.name)
+          component.config.yValue = firstYAxis.config.data.length - 1
+        }
+      } else {
+        component.config.type = 'line'
+      }
+
+      this.context.component.slots.series.push(component)
     },
     configureSeries (ev, series, context) {
       let el = ev.target

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.js
@@ -22,7 +22,7 @@ export default {
     let axis = chartWidget.evaluateExpression(ComponentId.get(component), component.config)
     axis.type = 'category'
 
-    axis.data = []
+    axis.data = axis.data || []
     switch (config.categoryType) {
       case 'hour':
         axis.name = 'min'

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -13,6 +13,7 @@ import OhDataSeries from './series/oh-data-series'
 import OhTimeSeries from './series/oh-time-series'
 import OhAggregateSeries from './series/oh-aggregate-series'
 import OhCalendarSeries from './series/oh-calendar-series'
+import OhStateSeries from './series/oh-state-series'
 
 // Other components
 import OhChartTooltip from './misc/oh-chart-tooltip'
@@ -35,7 +36,8 @@ const seriesComponents = {
   'oh-data-series': OhDataSeries,
   'oh-time-series': OhTimeSeries,
   'oh-aggregate-series': OhAggregateSeries,
-  'oh-calendar-series': OhCalendarSeries
+  'oh-calendar-series': OhCalendarSeries,
+  'oh-state-series': OhStateSeries
 }
 
 export default {

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-state-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-state-series.js
@@ -1,0 +1,116 @@
+import ComponentId from '../../component-id'
+import Framework7 from 'framework7'
+import { graphic } from 'echarts/core'
+
+function renderState (params, api) {
+  const yValue = api.value(0)
+  const start = api.coord([api.value(1), yValue])
+  const duration = api.value(2)
+  const end = api.coord([api.value(1) + duration, yValue])
+  const state = api.value(3)
+  const yHeight = api.value(4)
+
+  if (state === 'UNDEF' || state === 'NULL') return
+  const height = api.size([0, 1])[1] * yHeight
+  const rectShape = graphic.clipRectByRect(
+    {
+      x: start[0],
+      y: start[1] - height / 2,
+      width: end[0] - start[0],
+      height
+    },
+    {
+      x: params.coordSys.x,
+      y: params.coordSys.y,
+      width: params.coordSys.width,
+      height: params.coordSys.height
+    }
+  )
+  return (
+    rectShape && {
+      type: 'rect',
+      shape: rectShape,
+      style: api.style({})
+    }
+  )
+}
+
+export default {
+  neededItems (component, chart) {
+    let series = chart.evaluateExpression(ComponentId.get(component), component.config)
+    return [
+      series.item
+    ]
+  },
+  get (component, points, startTime, endTime, chart) {
+    let series = chart.evaluateExpression(ComponentId.get(component), component.config)
+    series.type = 'custom'
+    series.renderItem = renderState
+    series.encode = {
+      x: -1, // don't filter by x value when zooming
+      y: 0,
+      tooltip: [3],
+      itemName: 3
+    }
+    series.colorBy = 'data'
+    series.label = series.label || { }
+    series.label.show = series.label.show || true
+    series.label.position = series.label.position || 'insideLeft'
+    series.label.formatter = series.label.formatter || '{@[3]}'
+    series.labelLayout = series.labelLayout || { hideOverlap: true }
+    series.tooltip = series.tooltip || { }
+    if (series.tooltip.formatter === undefined) {
+      series.tooltip.formatter = (params) => {
+        let durationSec = params.value[2] / 1000
+        let hours = Math.floor(durationSec / 3600).toString().padStart(2, '0')
+        let minutes = Math.floor((durationSec - (hours * 3600)) / 60).toString().padStart(2, '0')
+        return params.seriesName + '<br />' + params.marker + params.name + '&#9;(' + hours + ':' + minutes + ')'
+      }
+    }
+
+    series.data = []
+
+    if (series.item) {
+      let itemPoints = points.find(p => p.name === series.item).data
+
+      if (series.mapState) {
+        for (let i = 0; i < itemPoints.length; i++) {
+          itemPoints[i].state = series.mapState(itemPoints[i].state)
+        }
+      }
+
+      let data = []
+      let itemStartTime = null
+      // fill data array - combine state updates where state does not change
+      for (let i = 0; i < itemPoints.length; i++) {
+        if (itemPoints[i + 1] && itemPoints[i].state === itemPoints[i + 1].state) {
+          itemStartTime = itemStartTime || new Date(itemPoints[i].time)
+          continue
+        }
+
+        itemStartTime = itemStartTime || new Date(itemPoints[i].time)
+        let itemEndTime = new Date(itemPoints[i + 1] ? itemPoints[i + 1].time : endTime)
+        let itemDuration = itemEndTime - itemStartTime
+
+        let stateColor = (series.stateColor) ? series.stateColor[itemPoints[i].state] : null
+        data.push({
+          value: [series.yValue || 0, itemStartTime, itemDuration, itemPoints[i].state, series.yHeight || 0.6],
+          itemStyle: {
+            color: stateColor
+          }
+        })
+        itemStartTime = null
+      }
+
+      series.data = data
+
+      series.id = `oh-state-series#${series.item}#${Framework7.utils.id()}`
+    }
+
+    if (!series.tooltip) {
+      series.tooltip = { show: true }
+    }
+
+    return series
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart-component.vue
@@ -48,16 +48,17 @@ dayjs.extend(LocalizedFormat)
 
 import { use, registerLocale } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
-import { LineChart, BarChart, GaugeChart, HeatmapChart, PieChart, ScatterChart } from 'echarts/charts'
+import { LineChart, BarChart, GaugeChart, HeatmapChart, PieChart, ScatterChart, CustomChart } from 'echarts/charts'
+import { LabelLayout } from 'echarts/features'
 import {
   TitleComponent, LegendComponent, LegendScrollComponent, GridComponent, SingleAxisComponent, ToolboxComponent, TooltipComponent,
   DataZoomComponent, MarkLineComponent, MarkPointComponent, MarkAreaComponent, VisualMapComponent, CalendarComponent
 } from 'echarts/components'
 import VChart from 'vue-echarts'
 
-use([CanvasRenderer, LineChart, BarChart, GaugeChart, HeatmapChart, PieChart, ScatterChart, TitleComponent,
+use([CanvasRenderer, LineChart, BarChart, GaugeChart, HeatmapChart, PieChart, ScatterChart, CustomChart, TitleComponent,
   LegendComponent, LegendScrollComponent, GridComponent, SingleAxisComponent, ToolboxComponent, TooltipComponent, DataZoomComponent,
-  MarkLineComponent, MarkPointComponent, MarkAreaComponent, VisualMapComponent, CalendarComponent])
+  MarkLineComponent, MarkPointComponent, MarkAreaComponent, VisualMapComponent, CalendarComponent, LabelLayout])
 
 const ECHARTS_LOCALE = i18n.locale.split('-')[0].toUpperCase()
 

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -69,7 +69,8 @@
                           <f7-segmented round>
                             <f7-button v-if="!options.discrete && coordSystem === 'aggregate' && aggregateDimensions === 1" small outline style="width: 60px" :fill="options.type === 'bar'" @click="options.type = 'bar'" v-t="'analyzer.series.table.type.bar'" />
                             <f7-button v-if="!options.discrete && coordSystem !== 'calendar' && aggregateDimensions === 1" small outline style="width: 60px" :fill="options.type === 'line'" @click="options.type = 'line'" v-t="'analyzer.series.table.type.line'" />
-                            <f7-button v-if="coordSystem === 'time' || (coordSystem === 'aggregate' && aggregateDimensions === 1)" small outline style="width: 60px" :fill="options.type === 'area'" @click="options.type = 'area'" v-t="'analyzer.series.table.type.area'" />
+                            <f7-button v-if="!options.discrete && coordSystem === 'time' || (coordSystem === 'aggregate' && aggregateDimensions === 1)" small outline style="width: 60px" :fill="options.type === 'area'" @click="options.type = 'area'" v-t="'analyzer.series.table.type.area'" />
+                            <f7-button v-if="options.discrete && coordSystem === 'time' || (coordSystem === 'aggregate' && aggregateDimensions === 1)" small outline style="width: 60px" :fill="options.type === 'state'" @click="options.type = 'state'" v-t="'analyzer.series.table.type.state'" />
                             <f7-button v-if="coordSystem === 'calendar' || (coordSystem === 'aggregate' && aggregateDimensions === 2)" small fill outline style="width: 90px" v-t="'analyzer.series.table.type.heatmap'" />
                           </f7-segmented>
                         </td>
@@ -261,6 +262,7 @@ export default {
       items: null,
       seriesOptions: {},
       valueAxesOptions: {},
+      categoryAxisValues: [],
       orientation: (this.$device.desktop || this.$device.ipad) ? 'horizontal' : 'vertical',
       period: 'D',
       chartType: '',
@@ -335,9 +337,11 @@ export default {
     updateItems (itemNames) {
       this.itemNames = itemNames
       const promises = itemNames.map((n) => this.$oh.api.get('/rest/items/' + n))
+      this.showChart = false
       return Promise.all(promises).then((resp) => {
         this.$set(this, 'items', [])
         this.$set(this, 'valueAxesOptions', [])
+        this.$set(this, 'categoryAxisValues', [])
         resp.forEach((item) => {
           this.items.push(item)
 
@@ -363,6 +367,9 @@ export default {
               this.valueAxesOptions.push({ name: unit, unit, split: 'line' })
               this.$set(seriesOptions, 'valueAxisIndex', this.valueAxesOptions.length - 1)
             }
+          } else if (seriesOptions.type === 'state') {
+            this.categoryAxisValues.unshift(item.name)
+            this.$set(seriesOptions, 'yValue', this.categoryAxisValues.length - 1)
           }
         })
         this.$set(this, 'items', resp)
@@ -383,11 +390,11 @@ export default {
         discrete: true
       }
 
-      if (item.type.indexOf('Number') === 0 || item.type === 'Dimmer') seriesOptions.discrete = false
-      if (item.groupType && (item.groupType.indexOf('Number') === 0 || item.groupType === 'Dimmer')) seriesOptions.discrete = false
+      if (item.type.indexOf('Number') === 0) seriesOptions.discrete = false
+      if (item.groupType && (item.groupType.indexOf('Number') === 0)) seriesOptions.discrete = false
       if (!seriesOptions.discrete && this.coordSystem === 'aggregate' && this.aggregateDimensions === 1) seriesOptions.type = 'bar'
       if (!seriesOptions.discrete && (this.coordSystem === 'calendar' || (this.coordSystem === 'aggregate' && this.aggregateDimensions === 2))) seriesOptions.type = 'heatmap'
-      if (seriesOptions.discrete) seriesOptions.type = 'area'
+      if (seriesOptions.discrete) seriesOptions.type = 'state'
 
       this.$set(this.seriesOptions, item.name, seriesOptions)
     },


### PR DESCRIPTION
This PR is dependent on the #3179   which adds support for the a new chart series for state types. This PR further adds support and default behavior for discrete items to use this new state-series. Depending on the selected items, it will use separate grids - one using a y-axis of a oh-value-series and one use oh-category-series (discrete items).

Note, that there seems to be a issue with echarts where if the chart is showing when updates are made where there are multiple value-axis with different units AND there are multiple grids, there is an echart exception complaining about y- and x-axis having to be on the same chart. To address this, i added a showChart=false in the updateItems function. However, this now causes an exception in the vue framework:
```
smart-select-class.js:105 Uncaught TypeError: Cannot read properties of undefined (reading 'options')
    at HTMLInputElement.handleInputChange (smart-select-class.js:105:41)
    at HTMLDivElement.handleLiveEvent (dom7.module.js:320:48)
```
@florian-h05, before spending more time debugging:
- will the oh-state-series #3179 make it into 5.0?
- what are your thoughts on changing analyzer to support this series type for discrete items?
- any suggestions/thoughts on the above error?  This one seems to be some interaction of echarts/vue and difficult to track down. Was thinking if/when we update the vue3, this behavior might be totally different?