### PR TITLE
Sitemap editor: Various fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
@@ -78,7 +78,7 @@ export default {
     }
   },
   methods: {
-    allowedWidgetTypes (parentWidget, excludeWidgetIndex) {
+    allowedWidgetTypes (parentWidget) {
       let types = this.WIDGET_TYPES.filter(w => w.type !== 'Sitemap')
       // Button only allowed inside Buttongrid
       if (parentWidget.component === 'Buttongrid') return types.filter(t => t.type === 'Button')
@@ -88,8 +88,7 @@ export default {
       // Linkable widget types only contain frames or none at all
       if (this.LINKABLE_WIDGET_TYPES.includes(parentWidget.component)) {
         if (parentWidget.slots?.widgets?.length > 0) {
-          const widgetList = parentWidget.slots.widgets.filter((widget, index) => index !== excludeWidgetIndex)
-          if (widgetList.find(w => w.component === 'Frame')) {
+          if (parentWidget.slots.widgets.find(w => w.component === 'Frame')) {
             return types.filter(t => t.type === 'Frame')
           } else {
             return types.filter(t => t.type !== 'Frame')
@@ -97,6 +96,14 @@ export default {
         }
       }
       return types
+    },
+    canAddChildren (widget) {
+      if (!widget) return false
+      if (widget.component === 'Buttongrid') {
+        const buttons = widget.config.buttons
+        if (Array.isArray(buttons) && buttons.length) return false
+      }
+      return this.LINKABLE_WIDGET_TYPES.includes(widget.component)
     },
     widgetTypeDef (component) {
       const componentType = component ?? this.widget.component

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -8,7 +8,7 @@
                     @treeview:open="setWidgetClosed(false)"
                     @treeview:close="setWidgetClosed(true)"
                     @click="select">
-    <draggable :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6"
+    <draggable :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6" scrollSensitivity="200" delay="400" delayOnTouchOnly="true"
                @start="onStart" @change="onChange" @end="onEnd">
       <sitemap-treeview-item class="sitemap-treeview-item" v-for="(childwidget, idx) in children"
                              :key="idx"

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -8,8 +8,8 @@
                     @treeview:open="setWidgetClosed(false)"
                     @treeview:close="setWidgetClosed(true)"
                     @click="select">
-    <draggable :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6" scrollSensitivity="200" delay="400" delayOnTouchOnly="true"
-               @start="onStart" @change="onChange" @end="onEnd">
+    <draggable :disabled="!dropAllowed(widget)" :list="children" group="sitemap-treeview" animation="150" fallbackOnBody="true" swapThreshold="0.6" scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10"
+               @start="onStart" @end="onEnd" :move="onMove">
       <sitemap-treeview-item class="sitemap-treeview-item" v-for="(childwidget, idx) in children"
                              :key="idx"
                              :includeItemName="includeItemName"
@@ -39,7 +39,6 @@
 <script>
 import SitemapMixin from '@/components/pagedesigner/sitemap/sitemap-mixin'
 import Draggable from 'vuedraggable'
-import fastDeepEqual from 'fast-deep-equal/es6'
 
 export default {
   name: 'sitemap-treeview-item',
@@ -69,51 +68,32 @@ export default {
       console.debug('Drag start event:', event)
       this.$set(this.localMoveState, 'moving', true)
       this.$set(this.localMoveState, 'widget', this.widget.slots.widgets[event.oldIndex])
-      this.$set(this.localMoveState, 'oldList', this.widget.slots.widgets)
-      this.$set(this.localMoveState, 'oldIndex', event.oldIndex)
+      this.$set(this.localMoveState, 'newParent', this.parentWidget)
     },
-    onChange (event) {
-      console.debug('Drag change event:', event)
-      if (event.added) {
-        this.$set(this.localMoveState, 'moving', false)
-        this.validateMove(event.added.newIndex)
+    onMove (event) {
+      console.debug('Drag move event:', event)
+      const newParent = event.relatedContext?.element?.parent
+      if (newParent) {
+        this.$set(this.localMoveState, 'newParent', newParent)
       }
     },
     onEnd (event) {
       console.debug('Drag end event:', event)
-      this.$set(this.localMoveState, 'moving', false)
-      this.validateMove(event.newIndex)
-    },
-    validateMove (newIndex) {
       const widget = this.localMoveState.widget
-      const parentWidget = this.findParent(widget, this.localSitemap)
-      const newList = parentWidget.slots.widgets
-      console.debug('New parent:', parentWidget)
-      if (!this.allowedWidgetTypes(parentWidget, newIndex).map(wt => wt.type).includes(widget.component)) {
-        this.$f7.toast.create({
-          text: 'Move invalid',
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        console.debug('Move invalid, restore in original position:', this.localMoveState)
-        newList.splice(newIndex, 1)
-        this.localMoveState.oldList.splice(this.localMoveState.oldIndex, 0, widget)
-      } else {
-        console.debug('Move valid')
+      const parentWidget = this.localMoveState.newParent
+      if (widget && parentWidget) {
+        this.$set(widget, 'parent', parentWidget)
       }
+      this.$set(this.localMoveState, 'moving', false)
+      this.$set(this.localMoveState, 'widget', null)
+      this.$set(this.localMoveState, 'newParent', null)
     },
-    findParent (widget, parentWidget) {
-      if (parentWidget.slots?.widgets) {
-        for (const w of parentWidget.slots.widgets) {
-          if (fastDeepEqual(widget, w)) {
-            return parentWidget
-          } else {
-            const parent = this.findParent(widget, w)
-            if (parent != null) return parent
-          }
-        }
+    dropAllowed (widget) {
+      if (!this.canAddChildren(widget)) return false
+      if (!this.localMoveState.widget || this.allowedWidgetTypes(widget).map(wt => wt.type).includes(this.localMoveState.widget.component)) {
+        return true
       }
-      return null
+      return false
     },
     setWidgetClosed (closed) {
       this.$set(this.widget, 'closed', closed)

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -411,7 +411,6 @@ export default {
         this.$set(this, 'lastCleanSitemap', this.stripClosed(this.sitemap))
         this.loading = false
         this.ready = true
-
       } else {
         this.$oh.api.get('/rest/ui/components/system:sitemap/' + this.uid).then((data) => {
           const sitemap = this.preProcessSitemapLoad(data)


### PR DESCRIPTION
Relates to: https://github.com/openhab/openhab-webui/pull/3184#issuecomment-2886630684

- I cannot scroll through the three on iOS, it immediately moves elements: this should be fixed, but I could only test in BrowserStack. Performance is not great in BrowserStack, so it would be better to test on a real device.
- When selecting an item, I get a dirty warning: this doesn't happen for me. I can't reproduced, but may actually be impacted by the fix for the next item.
- When collapsing the tree, the editor gets dirty: this is fixed.

Drag and drop also struggled when there were mutiple equal trees. When dragging one of these, it could not find the proper new position. This has been fixed as well.