### PR TITLE
Model editor: drag drop fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,10 +1,10 @@
 <template>
   <f7-treeview class="model-treeview">
-    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
+    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" forceFallBack="true" fallbackOnBody="true" fallbackThreshold="5"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
-      <model-treeview-item v-for="(node, index) in children"
-                           :key="node.item.name + '_' + index" :model="node" :parentNode="model"
+      <model-treeview-item v-for="node in children"
+                           :key="node.item.name" :model="node" :parentNode="model"
                            :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="canDragDrop" :moveState="moveState"
                            @selected="nodeSelected" :selected="selected"
                            @checked="(item, check) => $emit('checked', item, check)"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -5,11 +5,11 @@
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
                     @treeview:open="model.opened = true" @treeview:close="model.opened = false" @click="select">
-    <draggable :disabled="!canDragDrop && !dropAllowed(model)" :list="children" group="model-treeview" animation="150" fallbackOnBody="true" fallbackThreshold="5"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" invertSwap="true"
+    <draggable :disabled="!canDragDrop" :list="children" :group="{name: 'model-treeview', put: dropAllowed(model)}" animation="150" forceFallback="true" fallbackOnBody="true" fallbackThreshold="5"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
-      <model-treeview-item v-for="(node, index) in children"
-                           :key="node.item.name + '_' + index"
+      <model-treeview-item v-for="node in children"
+                           :key="node.item.name"
                            :model="node"
                            :parentNode="model"
                            @selected="(event) => $emit('selected', event)"

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
@@ -24,6 +24,7 @@ export default {
       rootLocations: [],
       equipment: [],
       rootEquipment: [],
+      points: [],
       rootPoints: [],
       rootGroups: [],
       rootItems: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -243,7 +243,6 @@ import MetadataMenu from '@/components/item/metadata/item-metadata-menu.vue'
 import LinkDetails from '@/components/model/link-details.vue'
 
 import ModelMixin from '@/pages/settings/model/model-mixin'
-import ItemsAddFromTextualDefinition from '../items/parser/items-add-from-textual-definition.vue'
 
 export default {
   mixins: [ModelMixin],


### PR DESCRIPTION
This is a follow-up from https://github.com/openhab/openhab-webui/pull/2970

This applies 2 fixes:

1. Extra non-semantic tag was added with value equal to semantic class when semantic item was moved.
2. On larger models, SortableJS and Vue DOM updates sometimes got out of sync. This is solved by forcing SortableJS to use the fallback that does not directly update the DOM.

@stefan-hoehn Maybe you can check this out to see if fix 2 solves the issues you where seeing.