### PR TITLE
Add to model from thing, allow picking existing items and groups

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -1,6 +1,6 @@
 <template>
   <ul class="item-picker-container">
-    <f7-list-item :title="title" :disabled="disabled" smart-select :smart-select-params="smartSelectParams" v-if="ready" ref="smartSelect" class="item-picker">
+    <f7-list-item :title="title" :disabled="disabled" smart-select :smart-select-params="smartSelectParams" :textColor="textColor" v-if="ready" ref="smartSelect" class="item-picker">
       <select :name="name" :multiple="multiple" @change="select" :required="required">
         <option value="" v-if="!multiple" />
         <option v-for="item in preparedItems" :value="item.name" :key="item.name" :selected="(multiple) ? Array.isArray(value) && value.indexOf(item.name) >= 0 : value === item.name">
@@ -33,14 +33,14 @@ import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 
 export default {
   props: ['title', 'name', 'value', 'items', 'multiple', 'filterType', 'required', 'editableOnly', 'disabled', 'setValueText', 'noModelPicker',
-    'iconColor', 'auroraIcon', 'iosIcon', 'mdIcon'],
+    'iconColor', 'auroraIcon', 'iosIcon', 'mdIcon', 'textColor', 'hideIcon'],
   data () {
     return {
       ready: false,
       preparedItems: [],
-      aurora: this.auroraIcon || 'f7:list_bullet_indent',
-      ios: this.iosIcon || 'f7:list_bullet_indent',
-      md: this.mdIcon || 'f7:list_bullet_indent',
+      aurora: !this.hideIcon ? (this.auroraIcon || 'f7:list_bullet_indent') : undefined,
+      ios: !this.hideIcon ? (this.iosIcon || 'f7:list_bullet_indent') : undefined,
+      md: !this.hideIcon ? (this.mdIcon || 'f7:list_bullet_indent') : undefined,
       color: this.iconColor || undefined,
       smartSelectParams: {
         view: this.$f7.view.main,

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -4,7 +4,7 @@
       <f7-list-group>
         <f7-list-input label="Name" type="text" placeholder="A unique identifier for the Item." :value="item.name"
                        :disabled="!createMode" :info="(createMode) ? 'Required. Note: cannot be changed after the creation' : ''"
-                       required :error-message="nameErrorMessage" :error-message-force="!!nameErrorMessage" input-id="input"
+                       required :error-message="nameErrorMessage" :error-message-force="createMode && !!nameErrorMessage" input-id="input"
                        @input="item.name = $event.target.value" :clear-button="createMode">
           <f7-link slot="inner" icon-f7="hammer_fill" style="margin-top: 4px; margin-left: 4px; margin-bottom: auto" tooltip="Fix ID" v-if="createMode && nameErrorMessage && !nameErrorMessage.includes('exists') && item.name.trim()" @click="$oh.utils.normalizeInput('#input')" />
         </f7-list-input>
@@ -55,7 +55,8 @@
         <f7-list-input ref="category" label="Icon" autocomplete="off" type="text" placeholder="temperature, firstfloor..." :value="itemCategory"
                        @input="itemCategory = $event.target.value" :disabled="!editable" :clear-button="editable">
           <div slot="root-end" style="margin-left: calc(35% + 14px)">
-            <oh-icon :icon="itemCategory" :state="(createMode || itemType === 'Image') ? null : item.state" height="32" width="32" />
+            <oh-icon v-if="itemCategory" :icon="itemCategory" :state="(createMode || itemType === 'Image') ? null : item.state" height="32" width="32" />
+            <oh-icon v-else icon="" height="32" width="32" />
           </div>
         </f7-list-input>
       </f7-list-group>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -48,12 +48,21 @@
                               @channel-updated="(e) => $emit('channels-updated', e)" />
               </template>
               <template #default="{ channelType, channel }" v-else-if="multipleLinksMode">
-                <item-form v-if="isChecked(channel)"
+                <item-picker v-if="isChecked(channel) && hasLinks(channel)"
+                             :title="selectedItem(channel) ? 'Change Selected Item' : 'Pick Existing Linked Item'"
+                             textColor="blue" :hideIcon="true"
+                             :items="items.filter((i) => channel.linkedItems.includes(i.name))"
+                             :multiple="false" :noModelPicker="true" :setValueText="false"
+                             :value="selectedItem(channel)?.name"
+                             @input="selectExistingItem($event, channel, channelType)" />
+                <item-form v-if="selectedItem(channel)"
+                           :item="selectedItem(channel)"
+                           :items="items"
+                           :createMode="false" />
+                <item-form v-else-if="isChecked(channel)"
                            :item="newItem(channel)"
                            :items="items"
                            :createMode="true"
-                           :channel="channel"
-                           :checked="isChecked(channel)"
                            :unitHint="getUnitHint(channel, channelType)"
                            :stateDescription="stateDescription(channelType)" />
               </template>
@@ -62,7 +71,7 @@
           </f7-col>
         </f7-row>
         <f7-list v-if="multipleLinksMode">
-          <f7-list-button color="blue" @click="toggleAllChecks(true)">
+          <f7-list-button style="padding-left: 0; text-align: left" color="blue" @click="toggleAllChecks(true)">
             Select All
           </f7-list-button>
           <f7-list-button color="blue" @click="toggleAllChecks(false)">
@@ -84,7 +93,6 @@
 </template>
 
 <style lang="stylus">
-
 .channel-list
   margin-left calc(-1*var(--f7-block-padding-horizontal))
   padding-left 0
@@ -99,16 +107,20 @@
 import ChannelGroup from './channel-group.vue'
 import ChannelLink from './channel-link.vue'
 import ItemForm from '@/components/item/item-form.vue'
+import ItemPicker from '@/components/config/controls/item-picker.vue'
 
 import uomMixin from '@/components/item/uom-mixin'
 
+import cloneDeep from 'lodash/cloneDeep'
+
 export default {
   mixins: [uomMixin],
-  props: ['thingType', 'thing', 'channelTypes', 'items', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems', 'context'],
+  props: ['thingType', 'thing', 'channelTypes', 'items', 'pickerMode', 'multipleLinksMode', 'itemTypeFilter', 'newItemsPrefix', 'newItems', 'updatedItems', 'context'],
   components: {
     ChannelGroup,
     ChannelLink,
-    ItemForm
+    ItemForm,
+    ItemPicker
   },
   data () {
     return {
@@ -119,6 +131,13 @@ export default {
       selectedChannel: null,
       selectedChannels: [],
       channelTypesMap: new Map(this.channelTypes.map(ct => [ct.UID, ct]))
+    }
+  },
+  watch: {
+    newItemsPrefix () {
+      this.newItems.forEach((i) => {
+        i.name = this.newItemName(i.channel, i.channelType)
+      })
     }
   },
   computed: {
@@ -189,28 +208,10 @@ export default {
       if (this.isChecked(channel)) {
         this.selectedChannels.splice(this.selectedChannels.indexOf(channel), 1)
         this.newItems.splice(this.newItems.findIndex((i) => i.channel === channel), 1)
+        this.updatedItems.splice(this.updatedItems.findIndex((i) => i.channel === channel))
       } else {
         this.selectedChannels.push(channel)
-        let newItemName = this.newItemsPrefix || this.$oh.utils.normalizeLabel(this.thing.label)
-        newItemName += '_'
-        let suffix = channel.label || channelType.label || channel.id
-        if (this.thing.channels.filter((c) => c.label === suffix || (c.channelTypeUID && this.channelTypesMap[c.channelTypeUID] && this.channelTypesMap[c.channelTypeUID].label === suffix)).length > 1) {
-          suffix = channel.id.replace('#', '_').replace(/(^\w{1})|(_+\w{1})/g, letter => letter.toUpperCase())
-        }
-        newItemName += this.$oh.utils.normalizeLabel(suffix)
-        const defaultTags = (channel.defaultTags.length > 0) ? channel.defaultTags : channelType.tags
-        const newItem = {
-          channel,
-          channelType,
-          name: newItemName,
-          label: channel.label || channelType.label,
-          category: (channelType) ? channelType.category : '',
-          type: channel.itemType,
-          unit: this.channelUnit(channel, channelType),
-          stateDescriptionPattern: '',
-          tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
-        }
-        this.newItems.push(newItem)
+        this.createNewItem(channel, channelType)
       }
     },
     channelUnit (channel, channelType) {
@@ -234,6 +235,52 @@ export default {
     },
     newItem (channel) {
       return this.newItems.find((i) => i.channel === channel)
+    },
+    createNewItem (channel, channelType) {
+      const defaultTags = (channel.defaultTags.length > 0) ? channel.defaultTags : channelType.tags
+      const newItem = {
+        channel,
+        channelType,
+        name: this.newItemName(channel, channelType),
+        label: channel.label || channelType.label,
+        category: (channelType) ? channelType.category : '',
+        type: channel.itemType,
+        unit: this.channelUnit(channel, channelType),
+        stateDescriptionPattern: '',
+        tags: (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? defaultTags : [...defaultTags, 'Point']
+      }
+      this.newItems.push(newItem)
+    },
+    newItemName (channel, channelType) {
+      let name = this.newItemsPrefix || this.$oh.utils.normalizeLabel(this.thing.label)
+      name += '_'
+      let suffix = channel.label || channelType.label || channel.id
+      if (this.thing.channels.filter((c) => c.label === suffix || (c.channelTypeUID && this.channelTypesMap[c.channelTypeUID] && this.channelTypesMap[c.channelTypeUID].label === suffix)).length > 1) {
+        suffix = channel.id.replace('#', '_').replace(/(^\w{1})|(_+\w{1})/g, letter => letter.toUpperCase())
+      }
+      name += this.$oh.utils.normalizeLabel(suffix)
+      return name
+    },
+    selectExistingItem (value, channel, channelType) {
+      const item = cloneDeep(this.items.find((i) => i.name === value))
+      if (!item) {
+        this.updatedItems.splice(this.updatedItems.findIndex((i) => i.channel === channel), 1)
+        this.createNewItem(channel, channelType)
+        return
+      }
+      item.channel = channel
+      if (!item.tags) {
+        item.tags = []
+      }
+      const hasPointTag = item.tags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)
+      if (!hasPointTag) {
+        const defaultTags = (channel.defaultTags.length > 0) ? channel.defaultTags : channelType.tags
+        item.tags = (defaultTags.find((t) => this.$store.getters.semanticClasses.Points.indexOf(t) >= 0)) ? [...item.tags, ...defaultTags] : [...item.tags, ...defaultTags, 'Point']
+      }
+      this.updatedItems.push(item)
+    },
+    selectedItem (channel) {
+      return this.updatedItems.find((i) => i.channel === channel)
     },
     channelOpened (payload) {
       this.openedChannelId = payload.channelId


### PR DESCRIPTION
Resolves https://github.com/openhab/openhab-webui/issues/433

Adding to the model from thing channels has been enhanced in a few ways:

- Add Points to Model: now allows to pick an existing item already linked to the channel. The item will get default semantic tags from the channel defaults if it does not have semantic tags already.
- Add Equipment to Model: ability to pick an existing group for the equipment. This group will get the default equipment semantic tag from the thing if it does not have a semantic tag already. Groups tagged as locations cannot be selected to guard model consistency. Adding points in this case is enhanced just as above.

The purpose of this enhancement is to ease the creation of a semantic model for users that already have items linked to channels and group structure that could be used as a basis for equipment definition.

This PR does not do anything to ease the creation of items linked to channels outside of the model, another requested, but secondary, feature in the above issue.

When doing this, I ran into some reactivity issues with oh-icon, where switching icon and state at the same time caused update issues. This was caused by conflicts in the 2 watchers updating the same properties. I fixed that by grouping these 2 elements in 1 object with a single watcher.

I will do some further tests before this is ready for review.