### PR TITLE
Add semantic model warnings to health UI

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -260,14 +260,7 @@ export default [
             path: 'orphanlinks',
             beforeEnter: [enforceAdminForRoute],
             async: loadAsync(HealthOrphanLinksPage)
-          }
-        ]
-      },
-      {
-        path: 'health',
-        beforeEnter: [enforceAdminForRoute],
-        async: loadAsync(HealthOverviewPage),
-        routes: [
+          },
           {
             path: 'semantics',
             beforeEnter: [enforceAdminForRoute],

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -23,6 +23,7 @@ const ItemsAddFromTextualDefinition = () => import(/* webpackChunkName: "admin-c
 
 const HealthOverviewPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/health/health-overview.vue')
 const HealthOrphanLinksPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/health/health-orphanlinks.vue')
+const HealthSemanticsPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/health/health-semantics.vue')
 const ThingsListPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/things/things-list.vue')
 const ThingDetailsPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/things/thing-details.vue')
 const AddThingChooseBindingPage = () => import(/* webpackChunkName: "admin-config" */ '../pages/settings/things/add/choose-binding.vue')
@@ -259,6 +260,18 @@ export default [
             path: 'orphanlinks',
             beforeEnter: [enforceAdminForRoute],
             async: loadAsync(HealthOrphanLinksPage)
+          }
+        ]
+      },
+      {
+        path: 'health',
+        beforeEnter: [enforceAdminForRoute],
+        async: loadAsync(HealthOverviewPage),
+        routes: [
+          {
+            path: 'semantics',
+            beforeEnter: [enforceAdminForRoute],
+            async: loadAsync(HealthSemanticsPage)
           }
         ]
       },

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -16,18 +16,22 @@
       </f7-col>
     </f7-block>
 
-    <f7-block v-if="healthCount > 0" class="block-narrow">
+    <f7-block class="block-narrow">
       <f7-col>
         <f7-list media-list>
-          <f7-list-item v-if="orphanLinksCount > 0"
+          <f7-list-item
             media-item link="orphanlinks/" title="Orphan Links"
-            :badge="orphanLinksCount" badge-color="red"
+            :badge="orphanLinksCount > 0 ? orphanLinksCount : undefined"
+            :after="orphanLinksCount > 0 ? undefined : orphanLinksCount"
+            :badge-color="orphanLinksCount ? 'red' : 'blue'"
             :footer="objectsSubtitles.orphanLinks">
             <f7-icon slot="media" f7="link" color="gray" />
           </f7-list-item>
-          <f7-list-item v-if="semanticsProblemCount > 0"
+          <f7-list-item
             media-item link="semantics/" title="Semantics Problems"
-            :badge="semanticsProblemCount" badge-color="red"
+            :badge="semanticsProblemCount > 0 ? semanticsProblemCount : undefined"
+            :after="semanticsProblemCount > 0 ? undefined : semanticsProblemCount"
+            :badge-color="semanticsProblemCount ? 'red' : 'blue'"
             :footer="objectsSubtitles.semanticsProblems">
             <f7-icon slot="media" f7="link" color="gray" />
           </f7-list-item>
@@ -56,9 +60,6 @@ export default {
   computed: {
     apiEndpoints () {
       return this.$store.state.apiEndpoints
-    },
-    healthCount () {
-      return this.orphanLinksCount + this.semanticsProblemCount
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -33,7 +33,7 @@
             :after="semanticsProblemCount > 0 ? undefined : semanticsProblemCount"
             :badge-color="semanticsProblemCount ? 'red' : 'blue'"
             :footer="objectsSubtitles.semanticsProblems">
-            <f7-icon slot="media" f7="link" color="gray" />
+            <f7-icon slot="media" f7="list_bullet_indent" color="gray" />
           </f7-list-item>
         </f7-list>
       </f7-col>
@@ -69,16 +69,15 @@ export default {
   },
   methods: {
     loadCounters () {
-      let self = this
       if (!this.apiEndpoints) return
       if (this.$store.getters.apiEndpoint('links')) {
         this.$oh.api.get('/rest/links/orphans').then((data) => {
-          self.orphanLinksCount = data.length || 0
+          this.orphanLinksCount = data.length || 0
         })
       }
       if (this.$store.getters.apiEndpoint('items')) {
         this.$oh.api.get('/rest/items/semantics/health').then((data) => {
-          self.semanticsProblemCount = data.length || 0
+          this.semanticsProblemCount = data.length || 0
         })
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -28,7 +28,7 @@
             <f7-icon slot="media" f7="link" color="gray" />
           </f7-list-item>
           <f7-list-item
-            media-item link="semantics/" title="Semantics Problems"
+            media-item link="semantics/" title="Semantic Model Conflicts"
             :badge="semanticsProblemCount > 0 ? semanticsProblemCount : undefined"
             :after="semanticsProblemCount > 0 ? undefined : semanticsProblemCount"
             :badge-color="semanticsProblemCount ? 'red' : 'blue'"
@@ -47,7 +47,7 @@ export default {
     return {
       objectsSubtitles: {
         orphanLinks: 'Items pointing to non-existent thing channels or vica versa',
-        semanticsProblems: 'Issues with semantic model setup'
+        semanticsProblems: 'Issues with semantic model configuration'
       },
       orphanLinksCount: 0,
       semanticsProblemCount: 0,

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -16,32 +16,18 @@
       </f7-col>
     </f7-block>
 
-    <f7-block v-if="orphanLinksCount !== '0'" class="block-narrow">
+    <f7-block v-if="healthCount > 0" class="block-narrow">
       <f7-col>
         <f7-list media-list>
-          <f7-list-item
-            media-item
-            link="orphanlinks/"
-            title="Orphan Links"
-            :badge="orphanLinksCount > 0 ? orphanLinksCount : undefined"
-            :after="orphanLinksCount > 0 ? undefined : orphanLinksCount"
-            :badge-color="orphanLinksCount ? 'red' : 'blue'"
+          <f7-list-item v-if="orphanLinksCount > 0"
+            media-item link="orphanlinks/" title="Orphan Links"
+            :badge="orphanLinksCount" badge-color="red"
             :footer="objectsSubtitles.orphanLinks">
             <f7-icon slot="media" f7="link" color="gray" />
           </f7-list-item>
-        </f7-list>
-      </f7-col>
-    </f7-block>
-    <f7-block v-if="semanticsProblemCount !== '0'" class="block-narrow">
-      <f7-col>
-        <f7-list media-list>
-          <f7-list-item
-            media-item
-            link="semantics/"
-            title="Semantics Problems"
-            :badge="semanticsProblemCount > 0 ? semanticsProblemCount : undefined"
-            :after="semanticsProblemCount > 0 ? undefined : semanticsProblemCount"
-            :badge-color="semanticsProblemCount ? 'red' : 'blue'"
+          <f7-list-item v-if="semanticsProblemCount > 0"
+            media-item link="semantics/" title="Semantics Problems"
+            :badge="semanticsProblemCount" badge-color="red"
             :footer="objectsSubtitles.semanticsProblems">
             <f7-icon slot="media" f7="link" color="gray" />
           </f7-list-item>
@@ -59,8 +45,8 @@ export default {
         orphanLinks: 'Items pointing to non-existent thing channels or vica versa',
         semanticsProblems: 'Issues with semantic model setup'
       },
-      orphanLinksCount: '',
-      semanticsProblemCount: '',
+      orphanLinksCount: 0,
+      semanticsProblemCount: 0,
 
       expandedTypes: {
         systemSettings: this.$f7.width >= 1450
@@ -70,6 +56,9 @@ export default {
   computed: {
     apiEndpoints () {
       return this.$store.state.apiEndpoints
+    },
+    healthCount () {
+      return this.orphanLinksCount + this.semanticsProblemCount
     }
   },
   watch: {
@@ -83,12 +72,12 @@ export default {
       if (!this.apiEndpoints) return
       if (this.$store.getters.apiEndpoint('links')) {
         this.$oh.api.get('/rest/links/orphans').then((data) => {
-          self.orphanLinksCount = data.length.toString()
+          self.orphanLinksCount = data.length || 0
         })
       }
       if (this.$store.getters.apiEndpoint('items')) {
         this.$oh.api.get('/rest/items/semantics/health').then((data) => {
-          self.semanticsProblemCount = data.length.toString()
+          self.semanticsProblemCount = data.length || 0
         })
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -87,7 +87,7 @@ export default {
         })
       }
       if (this.$store.getters.apiEndpoint('items')) {
-        this.$oh.api.get('/rest/items/semanticshealth').then((data) => {
+        this.$oh.api.get('/rest/items/semantics/health').then((data) => {
           self.semanticsProblemCount = data.length.toString()
         })
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -16,7 +16,7 @@
       </f7-col>
     </f7-block>
 
-    <f7-block class="block-narrow">
+    <f7-block v-if="orphanLinksCount !== '0'" class="block-narrow">
       <f7-col>
         <f7-list media-list>
           <f7-list-item
@@ -32,6 +32,22 @@
         </f7-list>
       </f7-col>
     </f7-block>
+    <f7-block v-if="semanticsProblemCount !== '0'" class="block-narrow">
+      <f7-col>
+        <f7-list media-list>
+          <f7-list-item
+            media-item
+            link="semantics/"
+            title="Semantics Problems"
+            :badge="semanticsProblemCount > 0 ? semanticsProblemCount : undefined"
+            :after="semanticsProblemCount > 0 ? undefined : semanticsProblemCount"
+            :badge-color="semanticsProblemCount ? 'red' : 'blue'"
+            :footer="objectsSubtitles.semanticsProblems">
+            <f7-icon slot="media" f7="link" color="gray" />
+          </f7-list-item>
+        </f7-list>
+      </f7-col>
+    </f7-block>
   </f7-page>
 </template>
 
@@ -40,10 +56,11 @@ export default {
   data () {
     return {
       objectsSubtitles: {
-        orphanLinks:
-          'Items pointing to non-existent thing channels or vica versa'
+        orphanLinks: 'Items pointing to non-existent thing channels or vica versa',
+        semanticsProblems: 'Issues with semantic model setup'
       },
       orphanLinksCount: '',
+      semanticsProblemCount: '',
 
       expandedTypes: {
         systemSettings: this.$f7.width >= 1450
@@ -62,10 +79,16 @@ export default {
   },
   methods: {
     loadCounters () {
+      let self = this
       if (!this.apiEndpoints) return
       if (this.$store.getters.apiEndpoint('links')) {
         this.$oh.api.get('/rest/links/orphans').then((data) => {
-          this.orphanLinksCount = data.length.toString()
+          self.orphanLinksCount = data.length.toString()
+        })
+      }
+      if (this.$store.getters.apiEndpoint('items')) {
+        this.$oh.api.get('/rest/items/semanticshealth').then((data) => {
+          self.semanticsProblemCount = data.length.toString()
         })
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -1,0 +1,83 @@
+<template>
+  <f7-page @page:afterin="onPageAfterIn">
+    <f7-navbar title="Semantic Model Configuration Issues" back-link="Health Checks" back-link-url="/settings/health/" back-link-force>
+      <f7-nav-right>
+        <developer-dock-icon />
+      </f7-nav-right>
+    </f7-navbar>
+
+    <f7-block class="block-narrow">
+      <f7-col>
+        <f7-block-footer class="padding-horizontal">
+          Item semantics need to be configured without ambiguity:<br>
+          A Point only belongs to one Equipment or Location. It can have a Property.<br>
+          An Equipment only belongs to one Equipment or Location.<br>
+          A Location only belongs to one Location.<br>
+          <br>
+          Note that only the semantics configuration of managed items can be changed through the UI,
+          not file based configurations - these must be fixed manually in the corresponding file.
+        </f7-block-footer>
+      </f7-col>
+    </f7-block>
+
+    <f7-block class="block-narrow">
+      <!-- skeleton for not ready -->
+      <f7-col v-if="!ready">
+        <f7-block-title>&nbsp;Loading...</f7-block-title>
+        <f7-list contacts-list class="col">
+          <f7-list-group>
+            <f7-list-item media-item v-for="n in 10" :key="n" :class="`skeleton-text skeleton-effect-blink`"
+                          title="Type of problem" subtitle="Semantics model" footer="" />
+          </f7-list-group>
+        </f7-list>
+      </f7-col>
+
+      <f7-col v-else>
+        <f7-block-title>
+          {{ semanticsProblems.length }} semantics configuration problem{{ plural(semanticsProblems.length) }} found
+        </f7-block-title>
+        <f7-list class="col" contacts-list>
+          <f7-list-item v-for="semanticsProblem in semanticsProblems" :key="problemKey(semanticsProblem)" media-item
+                        :link="getLinkForProblem(semanticsProblem)"
+                        :title="'Item: ' + semanticsProblem.item + (semanticsProblem.semanticType ? ' (' + semanticsProblem.semanticType + ')' : '')"
+                        :subtitle="semanticsProblem.reason"
+                        :footer="semanticsProblem.explanation" />
+        </f7-list>
+      </f7-col>
+    </f7-block>
+  </f7-page>
+</template>
+
+<script>
+export default {
+  data () {
+    return {
+      ready: false,
+      loading: false,
+      semanticsProblems: []
+    }
+  },
+  methods: {
+    onPageAfterIn () {
+      this.load()
+    },
+    load () {
+      this.loading = true
+      this.$oh.api.get('/rest/items/semanticshealth').then((data) => {
+        this.semanticsProblems = data
+        this.loading = false
+        this.ready = true
+      })
+    },
+    problemKey (semanticsProblem) {
+      return semanticsProblem.item + '_' + semanticsProblem.reason
+    },
+    getLinkForProblem (semanticsProblem) {
+      return '/settings/items/' + semanticsProblem.item
+    },
+    plural (count) {
+      return count === 1 ? '' : 's'
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-page @page:afterin="onPageAfterIn">
+  <f7-page @page:afterin="onPageAfterIn" class="health-semantics-page">
     <f7-navbar title="Semantic Model Configuration Conflicts" back-link="Health Checks" back-link-url="/settings/health/" back-link-force>
       <f7-nav-right>
         <developer-dock-icon />
@@ -52,10 +52,11 @@
 </template>
 
 <style lang="stylus">
-    .health-problem-item
-        .item-title
-        .item-footer
-            text-wrap: auto
+.health-semantics-page
+  .health-problem-item
+    .item-title
+    .item-footer
+      text-wrap: auto
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -38,9 +38,10 @@
         </f7-block-title>
         <f7-list class="col" contacts-list>
           <f7-list-item v-for="semanticsProblem in semanticsProblems" :key="problemKey(semanticsProblem)" media-item
+                        class="health-problem-item"
                         :link="getLinkForProblem(semanticsProblem)"
-                        :title="'Item: ' + semanticsProblem.item + (semanticsProblem.semanticType ? ' (' + semanticsProblem.semanticType + ')' : '')"
-                        :subtitle="semanticsProblem.reason"
+                        :title="semanticsProblem.reason"
+                        :subtitle="'Item: ' + semanticsProblem.item + (semanticsProblem.semanticType ? ' (' + semanticsProblem.semanticType + ')' : '')"
                         :footer="semanticsProblem.explanation">
             <f7-icon v-if="!semanticsProblem.editable" slot="after-title" f7="lock_fill" size="1rem" color="gray" />
           </f7-list-item>
@@ -49,6 +50,13 @@
     </f7-block>
   </f7-page>
 </template>
+
+<style lang="stylus">
+    .health-problem-item
+        .item-title
+        .item-footer
+            text-wrap: auto
+</style>
 
 <script>
 export default {

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn">
-    <f7-navbar title="Semantic Model Configuration Issues" back-link="Health Checks" back-link-url="/settings/health/" back-link-force>
+    <f7-navbar title="Semantic Model Configuration Conflicts" back-link="Health Checks" back-link-url="/settings/health/" back-link-force>
       <f7-nav-right>
         <developer-dock-icon />
       </f7-nav-right>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -63,7 +63,7 @@ export default {
     },
     load () {
       this.loading = true
-      this.$oh.api.get('/rest/items/semanticshealth').then((data) => {
+      this.$oh.api.get('/rest/items/semantics/health').then((data) => {
         this.semanticsProblems = data
         this.loading = false
         this.ready = true

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -34,14 +34,16 @@
 
       <f7-col v-else>
         <f7-block-title>
-          {{ semanticsProblems.length }} semantics configuration problem{{ plural(semanticsProblems.length) }} found
+          {{ semanticsProblems.length }} semantic model configuration conflict{{ plural(semanticsProblems.length) }} found
         </f7-block-title>
         <f7-list class="col" contacts-list>
           <f7-list-item v-for="semanticsProblem in semanticsProblems" :key="problemKey(semanticsProblem)" media-item
                         :link="getLinkForProblem(semanticsProblem)"
                         :title="'Item: ' + semanticsProblem.item + (semanticsProblem.semanticType ? ' (' + semanticsProblem.semanticType + ')' : '')"
                         :subtitle="semanticsProblem.reason"
-                        :footer="semanticsProblem.explanation" />
+                        :footer="semanticsProblem.explanation">
+            <f7-icon v-if="!semanticsProblem.editable" slot="after-title" f7="lock_fill" size="1rem" color="gray" />
+          </f7-list-item>
         </f7-list>
       </f7-col>
     </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -233,6 +233,9 @@ export default {
       scenesCount: '',
       scriptsCount: '',
 
+      orphanLinkCount: 0,
+      semanticsProblemCount: 0,
+
       advancedSystemServices: [
         'org.openhab.storage.json',
         'org.openhab.restauth',
@@ -260,6 +263,10 @@ export default {
         const hide = this.advancedSystemServices.includes(service.id)
         return Object.assign({ hidden: hide }, service)
       })
+    },
+    healthCount () {
+      const problemCount = this.orphanLinkCount + this.semanticsProblemCount
+      return problemCount.toString()
     }
   },
   watch: {
@@ -297,7 +304,8 @@ export default {
     },
     loadCounters () {
       if (!this.apiEndpoints) return
-      if (this.$store.getters.apiEndpoint('links')) this.$oh.api.get('/rest/links/orphans').then((data) => { this.healthCount = data.length.toString() })
+      if (this.$store.getters.apiEndpoint('links')) this.$oh.api.get('/rest/links/orphans').then((data) => { this.orphanLinkCount = data.length })
+      if (this.$store.getters.apiEndpoint('items')) this.$oh.api.get('/rest/items/semanticshealth').then((data) => { this.semanticsProblemCount = data.length })
       if (this.$store.getters.apiEndpoint('inbox')) this.$oh.api.get('/rest/inbox?includeIgnored=false').then((data) => { this.inboxCount = data.filter((e) => e.flag === 'NEW').length.toString() })
       if (this.$store.getters.apiEndpoint('things')) this.$oh.api.get('/rest/things?staticDataOnly=true').then((data) => { this.thingsCount = data.length.toString() })
       if (this.$store.getters.apiEndpoint('items')) this.$oh.api.get('/rest/items?staticDataOnly=true').then((data) => { this.itemsCount = data.length.toString() })

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -223,7 +223,6 @@ export default {
         scripts: 'Rules dedicated to running code',
         schedule: 'View upcoming time-based rules'
       },
-      healthCount: '',
       inboxCount: '',
       thingsCount: '',
       itemsCount: '',

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -305,7 +305,7 @@ export default {
     loadCounters () {
       if (!this.apiEndpoints) return
       if (this.$store.getters.apiEndpoint('links')) this.$oh.api.get('/rest/links/orphans').then((data) => { this.orphanLinkCount = data.length })
-      if (this.$store.getters.apiEndpoint('items')) this.$oh.api.get('/rest/items/semanticshealth').then((data) => { this.semanticsProblemCount = data.length })
+      if (this.$store.getters.apiEndpoint('items')) this.$oh.api.get('/rest/items/semantics/health').then((data) => { this.semanticsProblemCount = data.length })
       if (this.$store.getters.apiEndpoint('inbox')) this.$oh.api.get('/rest/inbox?includeIgnored=false').then((data) => { this.inboxCount = data.filter((e) => e.flag === 'NEW').length.toString() })
       if (this.$store.getters.apiEndpoint('things')) this.$oh.api.get('/rest/things?staticDataOnly=true').then((data) => { this.thingsCount = data.length.toString() })
       if (this.$store.getters.apiEndpoint('items')) this.$oh.api.get('/rest/items?staticDataOnly=true').then((data) => { this.itemsCount = data.length.toString() })


### PR DESCRIPTION
Requires https://github.com/openhab/openhab-core/pull/4827

All of the semantics warning messages that are written in the log at startup are made available in the REST API with https://github.com/openhab/openhab-core/pull/4827.

This PR is the UI part, which shows it in the health messages, with links to the offending item configurations.