### PR TITLE
Add top dir marker for Maven 4

### DIFF
--- a/.mvn/README
+++ b/.mvn/README
@@ -1,0 +1,1 @@
+required by Maven 4 to detect root dir; adding root=true to pom is not compatible with Maven 3


### PR DESCRIPTION
This suppresses the warning about missing top level directory marker during build with Maven 4.
The approach to add `.mvn` dir is the option to do it which does not impact our standard builds with Maven 3.