### PR TITLE
Add blockly "rule enable" block

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -348,7 +348,7 @@ export default function defineOHBlocks_Scripts (f7, transformationServices) {
     const ruleUID = javascriptGenerator.valueToCode(block, 'ruleUID', javascriptGenerator.ORDER_ATOMIC)
     const enableValue = javascriptGenerator.valueToCode(block, 'enable', javascriptGenerator.ORDER_ATOMIC)
     const enableType = blockGetCheckedInputType(block, 'enable')
-    let enable = (enableType === 'Boolean') ? enableValue : (enableValue === '\'true\'')
+    let enable = (enableType === 'Boolean') ? enableValue : (enableValue === '\'true\'' || enableValue === '\'enabled\'')
     return `rules.setEnabled(${ruleUID}, ${enable});\n`
   }
 }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -7,6 +7,7 @@
 */
 import Blockly from 'blockly'
 import { javascriptGenerator } from 'blockly/javascript.js'
+import { blockGetCheckedInputType } from '@/assets/definitions/blockly/utils.js'
 
 export default function defineOHBlocks_Scripts (f7, transformationServices) {
   /*
@@ -323,5 +324,31 @@ export default function defineOHBlocks_Scripts (f7, transformationServices) {
   javascriptGenerator.forBlock['oh_script_inline'] = function (block) {
     const code = block.getFieldValue('inlineScript') + '\n'
     return code
+  }
+
+  Blockly.Blocks['oh_rule_enable'] = {
+    init: function () {
+      this.appendValueInput('ruleUID')
+        .setCheck('String')
+        .appendField('Set Rule ')
+      this.appendValueInput('enable')
+        .appendField('as ')
+        .setCheck(['Boolean', 'String'])
+      this.setInputsInline(true)
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+      this.setColour(0)
+      this.setTooltip('Allows to enable or disable a rule')
+
+      this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#enableRule')
+    }
+  }
+
+  javascriptGenerator.forBlock['oh_rule_enable'] = function (block) {
+    const ruleUID = javascriptGenerator.valueToCode(block, 'ruleUID', javascriptGenerator.ORDER_ATOMIC)
+    const enableValue = javascriptGenerator.valueToCode(block, 'enable', javascriptGenerator.ORDER_ATOMIC)
+    const enableType = blockGetCheckedInputType(block, 'enable')
+    let enable = (enableType === 'Boolean') ? enableValue : (enableValue === '\'true\'')
+    return `rules.setEnabled(${ruleUID}, ${enable});\n`
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1112,6 +1112,18 @@
           </block>
           <sep gap="48" />
           <block type="oh_script_inline" />
+          <block type="oh_rule_enable">
+            <value name="ruleUID">
+              <shadow type="text">
+                <field name="TEXT">ruleUID</field>
+              </shadow>
+            </value>
+            <value name="enable">
+              <shadow type="logic_boolean">
+                <field name="BOOL">TRUE</field>
+              </shadow>
+            </value>
+          </block>
         </category>
 
         <category name="Logging &amp; Output">
@@ -1358,6 +1370,7 @@ export default {
         ['Thing object', 'oh_thingtype'],
         ['Quantity', 'oh_quantity'],
         ['String', 'String'],
+        ['Boolean', 'Boolean'],
         ['Number', 'Number'],
         ['Dictionary', 'Dictionary'],
         ['Colour', 'Colour']


### PR DESCRIPTION
fixes #3096

Adds a new block to allow enabling/disabling rules.
Variables of type Boolean and String are supported. A String with "true" or "enabled" will be converted to true, all other values will result into false.

<img width="471" alt="image" src="https://github.com/user-attachments/assets/30210a96-5adb-4b65-ad45-0e6a082fe486" />

I also added Boolean to typed variables as this was missing:

<img width="417" alt="image" src="https://github.com/user-attachments/assets/30cf9ec1-46bd-45d8-95bc-6fb11ea99a16" />

I used "as" because I think this is the most intuitive way of describing what the block does, in particular when you use "enabled". If anyone has a better idea to make the block design better, then please provide feedback. Using a dropdown with Note that "Enable/Disable" ruleUID would be nicer but would not allow to use variables.