### PR TITLE
Model treeview: Fixes for drag and drop

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-picker-popup.vue
@@ -179,6 +179,7 @@ export default {
         this.$nextTick(() => {
           this.initSearchbar = true
           this.restoreExpanded()
+          this.expandSelected()
         })
       })
     },

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -4,11 +4,15 @@
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false" ghost-class="model-sortable-ghost"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="node in children"
-                           :key="node.item.name" :model="node" :parentNode="model"
+                           :key="node.item.name" :model="node" :parentNode="model" :rootNode="model"
                            :includeItemName="includeItemName" :includeItemTags="includeItemTags" :canDragDrop="canDragDrop" :moveState="moveState"
                            @selected="nodeSelected" :selected="selected"
                            @checked="(item, check) => $emit('checked', item, check)"
                            @reload="$emit('reload')" />
+      <!-- Drop zone for adding at root level -->
+      <div v-if="canDragDrop" class="root-drop-zone">
+        <!-- empty space to catch drops outside children -->
+      </div>
     </draggable>
   </f7-treeview>
 </template>
@@ -32,6 +36,9 @@
     margin 0 !important
     padding 0 !important
     border none !important
+  .root-drop-zone
+    height 40px
+    margin-top 4px
 </style>
 
 <script>
@@ -48,21 +55,22 @@ export default {
     ModelTreeviewItem
   },
   computed: {
-    model: {
-      get: function () {
-        return {
-          class: '',
-          children: {
-            locations: this.rootNodes.filter(n => n.class.startsWith('Location')),
-            equipment: this.rootNodes.filter(n => n.class.startsWith('Equipment')),
-            points: this.rootNodes.filter(n => n.class.startsWith('Point')),
-            groups: this.rootNodes.filter(n => !n.class && n.item.type === 'Group'),
-            items: this.rootNodes.filter(n => !n.class && n.item.type !== 'Group')
-          },
-          opened: true,
-          item: null
-        }
+    model () {
+      return {
+        class: '',
+        children: {
+          locations: this.rootNodes.filter(n => n.class.startsWith('Location')),
+          equipment: this.rootNodes.filter(n => n.class.startsWith('Equipment')),
+          points: this.rootNodes.filter(n => n.class.startsWith('Point')),
+          groups: this.rootNodes.filter(n => !n.class && n.item.type === 'Group'),
+          items: this.rootNodes.filter(n => !n.class && n.item.type !== 'Group')
+        },
+        opened: true,
+        item: null
       }
+    },
+    rootNode () {
+      return this.model
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-treeview class="model-treeview">
-    <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" forceFallBack="true" fallbackOnBody="true" fallbackThreshold="5"
+    <draggable :disabled="!canDragDrop" :list="children" :group="{ name: 'model-treeview', put: allowDrop }" animation="150" forceFallBack="true" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false" ghost-class="model-sortable-ghost"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="node in children"

--- a/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/model-treeview.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-treeview class="model-treeview">
     <draggable :disabled="!canDragDrop" :list="children" group="model-treeview" animation="150" forceFallBack="true" fallbackOnBody="true" fallbackThreshold="5"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false" ghost-class="model-sortable-ghost"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="node in children"
                            :key="node.item.name" :model="node" :parentNode="model"
@@ -23,6 +23,15 @@
   .semantic-class
     font-size 8pt
     color var(--f7-list-item-footer-text-color)
+  .model-sortable-ghost
+    visibility hidden      /* Don't show, but don't use display none as this will misalign the dragged item relative to the cursor, style to have 0 total height */
+    position absolute
+    z-index -1
+    pointer-events none
+    height 0 !important
+    margin 0 !important
+    padding 0 !important
+    border none !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -13,6 +13,7 @@
                              :key="node.item.name"
                              :model="node"
                              :parentNode="model"
+                             :rootNode="rootNode"
                              @selected="(event) => $emit('selected', event)"
                              :selected="selected"
                              :includeItemName="includeItemName" :includeItemTags="includeItemTags"
@@ -48,7 +49,7 @@ import Draggable from 'vuedraggable'
 export default {
   name: 'model-treeview-item',
   mixins: [ItemMixin, ModelDragDropMixin],
-  props: ['model', 'parentNode', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop'],
+  props: ['model', 'parentNode', 'rootNode', 'selected', 'includeItemName', 'includeItemTags', 'canDragDrop'],
   emits: ['reload'],
   components: {
     Draggable,

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -6,7 +6,7 @@
                     :opened="model.opened" :toggle="canHaveChildren"
                     @treeview:open="model.opened = true" @treeview:close="model.opened = false" @click="select">
     <draggable :disabled="!canDragDrop" :list="children" :group="{name: 'model-treeview', put: dropAllowed(model)}" animation="150" forceFallback="true" fallbackOnBody="true" fallbackThreshold="5"
-               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false"
+               scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false" ghost-class="model-sortable-ghost"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
       <model-treeview-item v-for="node in children"
                            :key="node.item.name"

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -1,27 +1,29 @@
 <template>
-  <f7-treeview-item selectable :label="(model.item.created === false) ? '(New Item)' : (model.item.label ? (includeItemName ? model.item.label + ' (' + model.item.name + ')' : model.item.label) : model.item.name)"
+  <f7-treeview-item selectable :label="label"
                     :icon-ios="icon('ios')" :icon-aurora="icon('aurora')" :icon-md="icon('md')"
                     :textColor="iconColor" :color="(model.item.created !== false) ? 'blue' :'orange'"
                     :selected="selected && selected.item.name === model.item.name"
                     :opened="model.opened" :toggle="canHaveChildren"
                     @treeview:open="model.opened = true" @treeview:close="model.opened = false" @click="select">
-    <draggable :disabled="!canDragDrop" :list="children" :group="{name: 'model-treeview', put: dropAllowed(model)}" animation="150" forceFallback="true" fallbackOnBody="true" fallbackThreshold="5"
+    <draggable :disabled="!canDragDrop" :list="children" :group="{ name: 'model-treeview', put: allowDrop }" animation="150" forceFallback="true" fallbackOnBody="true" fallbackThreshold="5"
                scrollSensitivity="200" delay="400" delayOnTouchOnly="true" touchStartThreshold="10" invertSwap="true" sort="false" ghost-class="model-sortable-ghost"
                @start="onDragStart" @change="onDragChange" @end="onDragEnd" :move="onDragMove">
-      <model-treeview-item v-for="node in children"
-                           :key="node.item.name"
-                           :model="node"
-                           :parentNode="model"
-                           @selected="(event) => $emit('selected', event)"
-                           :selected="selected"
-                           :includeItemName="includeItemName" :includeItemTags="includeItemTags"
-                           :canDragDrop="canDragDrop"
-                           :moveState="moveState"
-                           @checked="(item, check) => $emit('checked', item, check)"
-                           @reload="$emit('reload')" />
+      <template v-if="model.opened">
+        <model-treeview-item v-for="node in children"
+                             :key="node.item.name"
+                             :model="node"
+                             :parentNode="model"
+                             @selected="(event) => $emit('selected', event)"
+                             :selected="selected"
+                             :includeItemName="includeItemName" :includeItemTags="includeItemTags"
+                             :canDragDrop="canDragDrop"
+                             :moveState="moveState"
+                             @checked="(item, check) => $emit('checked', item, check)"
+                             @reload="$emit('reload')" />
+      </template>
     </draggable>
     <div slot="label" class="semantic-class">
-      {{ className() }}
+      {{ className }}
       <template v-if="includeItemTags">
         <div class="semantic-class chip" v-for="tag in getNonSemanticTags(model.item)" :key="tag" style="height: 16px; margin-left: 4px">
           <div class="chip-media bg-color-blue" style="height: 16px; width: 16px">
@@ -52,6 +54,22 @@ export default {
     Draggable,
     ModelTreeviewItem: 'model-treeview-item'
   },
+  computed: {
+    label () {
+      const item = this.model.item
+      if (item.created === false) return '(New Item)'
+      if (item.label) return this.includeItemName ? `${item.label} (${item.name})` : item.label
+      return item.name
+    },
+    className () {
+      if (!this.model.item.metadata || !this.model.item.metadata.semantics) return ''
+      const semantics = this.model.item.metadata.semantics
+      const property = (semantics.config && semantics.config.relatesTo)
+        ? semantics.config.relatesTo : null
+      return this.model.class.substring(this.model.class.lastIndexOf('_') + 1) +
+        ((property) ? ' (' + property.replace('Property_', '') + ')' : '')
+    }
+  },
   methods: {
     icon (theme) {
       if (this.model.class?.indexOf('Location') === 0) {
@@ -65,14 +83,6 @@ export default {
       } else {
         return 'material:label_outline'
       }
-    },
-    className () {
-      if (!this.model.item.metadata || !this.model.item.metadata.semantics) return
-      const semantics = this.model.item.metadata.semantics
-      const property = (semantics.config && semantics.config.relatesTo)
-        ? semantics.config.relatesTo : null
-      return this.model.class.substring(this.model.class.lastIndexOf('_') + 1) +
-        ((property) ? ' (' + property.replace('Property_', '') + ')' : '')
     },
     select (event) {
       let self = this

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -79,6 +79,9 @@ export default {
     },
     canHaveChildren () {
       return ((this.model.item.type === 'Group') && (this.children.length > 0 || this.moveState.moving)) === true
+    },
+    allowDrop () {
+      return this.dropAllowed(this.model)
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -117,8 +117,10 @@ export default {
         this.moveState.oldIndex = event.removed.oldIndex
         this.moveState.canRemove = true
       } else if (event.moved) {
-        // in theory, this should not happen as sorting within the same list is disabled
-        this.moveState.cancelled = true
+        this.moveState.newParent = this.moveState.moveTarget || this.model
+        this.moveState.canAdd = true
+        this.moveState.oldParent = this.model
+        this.moveState.canRemove = true
         return
       }
       console.debug('Drag change - moveState:', cloneDeep(this.moveState))

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -98,7 +98,7 @@ export default {
       this.moveState.moveConfirmed = false
       this.moveState.nodesToUpdate.splice(0)
       this.moveState.moveDelayedOpen = null
-      this.moveState.moveTarget = null
+      this.moveState.moveTarget = this.rootNode
       console.debug('Drag start - moveState:', cloneDeep(this.moveState))
     },
     onDragChange (event) {
@@ -109,14 +109,14 @@ export default {
         return
       }
       if (event.added) {
-        this.moveState.newParent = this.moveState.moveTarget || this.model
+        this.moveState.newParent = this.moveState.moveTarget
         this.moveState.canAdd = true
       } else if (event.removed) {
         this.moveState.oldParent = this.model
         this.moveState.oldIndex = event.removed.oldIndex
         this.moveState.canRemove = true
       } else if (event.moved) {
-        this.moveState.newParent = this.moveState.moveTarget || this.model
+        this.moveState.newParent = this.moveState.moveTarget
         this.moveState.canAdd = true
         this.moveState.oldParent = this.model
         this.moveState.canRemove = true
@@ -127,7 +127,7 @@ export default {
     onDragMove (event) {
       console.timeLog('Timer: Drag')
       console.debug('Drag move - event:', event)
-      const target = event.relatedContext?.element
+      const target = event.relatedContext?.element || this.rootNode
       // cancel opening previous group we moved over as we moved away from it
       const movedToSamePlace = target?.item?.name === this.moveState.moveTarget?.item?.name
       if (!movedToSamePlace && this.moveState.moveDelayedOpen) {
@@ -138,7 +138,9 @@ export default {
       if (this.moveState.cancelled || !this.moveState.node.item.editable || !this.dropAllowed(target)) {
         return false
       }
-      this.moveState.moveTarget = target
+      if (!target.item || target.item.type === 'Group') {
+        this.moveState.moveTarget = target
+      }
       // Open group if not open yet, with a delay so you don't open it if you just drag over it
       if (!movedToSamePlace && target?.item?.type === 'Group' && !target.opened) {
         this.moveState.moveDelayedOpen = setTimeout((node) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -30,13 +30,13 @@ export default {
     }
   },
   watch: {
-    canSave(val) {
+    canSave (val) {
       if (val) this.saveUpdate()
     },
-    canRemove(val) {
+    canRemove (val) {
       if (val) this.validateRemove()
     },
-    canAdd(val) {
+    canAdd (val) {
       if (val) this.validateAdd()
     }
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -30,17 +30,14 @@ export default {
     }
   },
   watch: {
-    moveState: {
-      handler: function () {
-        if (this.canSave) {
-          this.saveUpdate()
-        } else if (this.canRemove) {
-          this.validateRemove()
-        } else if (this.canAdd) {
-          this.validateAdd()
-        }
-      },
-      deep: true
+    canSave(val) {
+      if (val) this.saveUpdate()
+    },
+    canRemove(val) {
+      if (val) this.validateRemove()
+    },
+    canAdd(val) {
+      if (val) this.validateAdd()
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -98,7 +98,7 @@ export default {
       this.moveState.moveConfirmed = false
       this.moveState.nodesToUpdate.splice(0)
       this.moveState.moveDelayedOpen = null
-      this.moveState.moveTarget = this.rootNode
+      this.moveState.moveTarget = null
       console.debug('Drag start - moveState:', cloneDeep(this.moveState))
     },
     onDragChange (event) {
@@ -165,6 +165,9 @@ export default {
       this.moveState.moving = false
       this.moveState.dragEnd = true
       console.debug('Drag end - moveState:', cloneDeep(this.moveState))
+      if (!this.moveState.moveTarget) {
+        console.timeEnd('Timer: Drag')
+      }
     },
     dropAllowed (node) {
       if (!this.moveState.moving || this.moveState.node.item?.name === node.item?.name) return true

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -166,6 +166,7 @@ export default {
     },
     dropAllowed (node) {
       if (!this.moveState.moving || this.moveState.node.item?.name === node.item?.name) return true
+      if (node.item?.type && node.item.type !== 'Group') return false
       if (node?.class?.startsWith('Point')) {
         return false
       }
@@ -278,7 +279,10 @@ export default {
       console.time('Timer: isValidGroupType')
       const groupTypeDef = parentNode.item?.groupType?.split(':')
       const baseType = groupTypeDef ? groupTypeDef[0] : 'None'
-      if (baseType === 'None') return true
+      if (baseType === 'None') {
+        console.timeEnd('Timer: isValidGroupType')
+        return true
+      }
       const baseDimension = groupTypeDef && groupTypeDef.length > 1 ? groupTypeDef[1] : null
 
       const typeDef = node.item.type !== 'Group' ? node.item.type?.split(':') : node.item.groupType?.split(':')

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-mixin.js
@@ -37,7 +37,7 @@ export default {
   },
   computed: {
     rootElements () {
-      return [...this.rootLocations, ...this.rootEquipment, ...this.rootPoints, ... this.rootGroups, ... this.rootItems]
+      return [...this.rootLocations, ...this.rootEquipment, ...this.rootPoints, ...this.rootGroups, ...this.rootItems]
     }
   },
   methods: {


### PR DESCRIPTION
This fixes 2 issues:

- When picking items from model, the already checked or selected items would not appear if these are non-semantic. It would also return a bad selection (selecting the already selected semantic item twice). This PR fixes it by enabling showNonSemantic if any of the selected or checked items are non-semantic and expanding the tree to show all selected or checked items.
- Drag/drop sometimes fails when moving into a subtree of a sibling of a node being moved, as the added and removed events where not generated, but a moved event is created instead. This fix also interprets the moved event. To make things more easily understood for the users when dragging, the ghost element is now hidden, as it sometimes showed in another place than where it would be dropped.
- Drag/drop performance on large models was sometimes very slugish. Some performance improvements where made that should improve this.