### PR TITLE
Make Main UI log levels configurable

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/app.js
+++ b/bundles/org.openhab.ui/web/src/js/app.js
@@ -107,7 +107,7 @@ window.setLogLevel = function (level) {
   console.error = enabled >= 1 ? c.error : () => {}
   console.warn = enabled >= 2 ? c.warn : () => {}
   console.info = enabled >= 3 ? c.info : () => {}
-  console.log = enabled >= 4 ? c.debug : () => {}
+  console.log = enabled >= 3 ? c.log : () => {} // console.log is at INFO level
   console.debug = enabled >= 4 ? c.debug : () => {}
   console.trace = enabled >= 5 ? c.trace : () => {}
   console.time = enabled >= 4 ? c.time : () => {}

--- a/bundles/org.openhab.ui/web/src/js/app.js
+++ b/bundles/org.openhab.ui/web/src/js/app.js
@@ -1,4 +1,5 @@
 import './compatibility'
+import './logging'
 
 // Import Vue
 import Vue from 'vue'
@@ -82,37 +83,3 @@ const app = new Vue({
 Vue.component('oh-icon', OHIconComponent)
 Vue.component('generic-widget-component', GenericWidgetComponent)
 Vue.component('developer-dock-icon', DeveloperDockIcon)
-
-// Avoid excessive console logging, make it configurable from the UI, default to INFO level
-const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
-if (!window._originalConsole) {
-  window._originalConsole = {
-    info: console.info,
-    warn: console.warn,
-    error: console.error,
-    debug: console.debug,
-    trace: console.trace,
-    time: console.time,
-    timeEnd: console.timeEnd,
-    timeLog: console.timeLog
-  }
-}
-window.setLogLevel = function (level) {
-  window.LOG_LEVEL = level
-  localStorage.setItem('logLevel', level)
-
-  const c = window._originalConsole
-  const enabled = LOG_LEVELS.indexOf(level.toUpperCase())
-
-  console.error = enabled >= 1 ? c.error : () => {}
-  console.warn = enabled >= 2 ? c.warn : () => {}
-  console.info = enabled >= 3 ? c.info : () => {}
-  console.log = enabled >= 3 ? c.log : () => {} // console.log is at INFO level
-  console.debug = enabled >= 4 ? c.debug : () => {}
-  console.trace = enabled >= 5 ? c.trace : () => {}
-  console.time = enabled >= 4 ? c.time : () => {}
-  console.timeEnd = enabled >= 4 ? c.timeEnd : () => {}
-  console.timeLog = enabled >= 4 ? c.timeLog : () => {}
-}
-// Initialize from localStorage
-window.setLogLevel(localStorage.getItem('logLevel') || 'INFO')

--- a/bundles/org.openhab.ui/web/src/js/app.js
+++ b/bundles/org.openhab.ui/web/src/js/app.js
@@ -82,3 +82,37 @@ const app = new Vue({
 Vue.component('oh-icon', OHIconComponent)
 Vue.component('generic-widget-component', GenericWidgetComponent)
 Vue.component('developer-dock-icon', DeveloperDockIcon)
+
+// Avoid excessive console logging, make it configurable from the UI, default to INFO level
+const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
+if (!window._originalConsole) {
+  window._originalConsole = {
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug,
+    trace: console.trace,
+    time: console.time,
+    timeEnd: console.timeEnd,
+    timeLog: console.timeLog
+  }
+}
+window.setLogLevel = function (level) {
+  window.LOG_LEVEL = level
+  localStorage.setItem('logLevel', level)
+
+  const c = window._originalConsole
+  const enabled = LOG_LEVELS.indexOf(level.toUpperCase())
+
+  console.error = enabled >= 1 ? c.error : () => {}
+  console.warn = enabled >= 2 ? c.warn : () => {}
+  console.info = enabled >= 3 ? c.info : () => {}
+  console.log = enabled >= 4 ? c.debug : () => {}
+  console.debug = enabled >= 4 ? c.debug : () => {}
+  console.trace = enabled >= 5 ? c.trace : () => {}
+  console.time = enabled >= 4 ? c.time : () => {}
+  console.timeEnd = enabled >= 4 ? c.timeEnd : () => {}
+  console.timeLog = enabled >= 4 ? c.timeLog : () => {}
+}
+// Initialize from localStorage
+window.setLogLevel(localStorage.getItem('logLevel') || 'INFO')

--- a/bundles/org.openhab.ui/web/src/js/logging.js
+++ b/bundles/org.openhab.ui/web/src/js/logging.js
@@ -1,0 +1,33 @@
+// Avoid excessive console logging, make it configurable from the UI, default to INFO level
+const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
+if (!window._originalConsole) {
+  window._originalConsole = {
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug,
+    trace: console.trace,
+    time: console.time,
+    timeEnd: console.timeEnd,
+    timeLog: console.timeLog
+  }
+}
+window.setLogLevel = function (level) {
+  window.LOG_LEVEL = level
+  localStorage.setItem('logLevel', level)
+
+  const c = window._originalConsole
+  const enabled = LOG_LEVELS.indexOf(level.toUpperCase())
+
+  console.error = enabled >= 1 ? c.error : () => {}
+  console.warn = enabled >= 2 ? c.warn : () => {}
+  console.info = enabled >= 3 ? c.info : () => {}
+  console.log = enabled >= 3 ? c.log : () => {} // console.log is at INFO level
+  console.debug = enabled >= 4 ? c.debug : () => {}
+  console.trace = enabled >= 5 ? c.trace : () => {}
+  console.time = enabled >= 4 ? c.time : () => {}
+  console.timeEnd = enabled >= 4 ? c.timeEnd : () => {}
+  console.timeLog = enabled >= 4 ? c.timeLog : () => {}
+}
+// Initialize logging from localStorage
+window.setLogLevel(localStorage.getItem('logLevel') || 'INFO')

--- a/bundles/org.openhab.ui/web/src/js/logging.js
+++ b/bundles/org.openhab.ui/web/src/js/logging.js
@@ -1,4 +1,6 @@
 // Avoid excessive console logging, make it configurable from the UI, default to INFO level
+const LOCAL_STORAGE_KEY = 'openhab.ui:logLevel'
+
 const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
 if (!window._originalConsole) {
   window._originalConsole = {
@@ -15,7 +17,7 @@ if (!window._originalConsole) {
 }
 window.setLogLevel = function (level) {
   window.LOG_LEVEL = level
-  localStorage.setItem('logLevel', level)
+  localStorage.setItem(LOCAL_STORAGE_KEY, level)
 
   const c = window._originalConsole
   const enabled = LOG_LEVELS.indexOf(level.toUpperCase())
@@ -31,4 +33,4 @@ window.setLogLevel = function (level) {
   console.timeLog = enabled >= 4 ? c.timeLog : () => {}
 }
 // Initialize logging from localStorage
-window.setLogLevel(localStorage.getItem('logLevel') || 'INFO')
+window.setLogLevel(localStorage.getItem(LOCAL_STORAGE_KEY) || 'INFO')

--- a/bundles/org.openhab.ui/web/src/js/logging.js
+++ b/bundles/org.openhab.ui/web/src/js/logging.js
@@ -2,6 +2,7 @@
 const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
 if (!window._originalConsole) {
   window._originalConsole = {
+    log: console.log,
     info: console.info,
     warn: console.warn,
     error: console.error,

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -93,40 +93,6 @@ const loadAsync = (page, props) => {
   }
 }
 
-// Avoid excessive console logging, make it configurable from the UI
-const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
-if (!window._originalConsole) {
-  window._originalConsole = {
-    info: console.info,
-    warn: console.warn,
-    error: console.error,
-    debug: console.debug,
-    trace: console.trace,
-    time: console.time,
-    timeEnd: console.timeEnd,
-    timeLog: console.timeLog
-  }
-}
-window.setLogLevel = function (level) {
-  window.LOG_LEVEL = level
-  localStorage.setItem('logLevel', level)
-
-  const c = window._originalConsole
-  const enabled = LOG_LEVELS.indexOf(level.toUpperCase())
-
-  console.error = enabled >= 1 ? c.error : () => {}
-  console.warn = enabled >= 2 ? c.warn : () => {}
-  console.info = enabled >= 3 ? c.info : () => {}
-  console.log = enabled >= 4 ? c.debug : () => {}
-  console.debug = enabled >= 4 ? c.debug : () => {}
-  console.trace = enabled >= 5 ? c.trace : () => {}
-  console.time = enabled >= 4 ? c.time : () => {}
-  console.timeEnd = enabled >= 4 ? c.timeEnd : () => {}
-  console.timeLog = enabled >= 4 ? c.timeLog : () => {}
-}
-// Initialize from localStorage
-window.setLogLevel(localStorage.getItem('logLevel') || 'OFF')
-
 export default [
   {
     path: '/',

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -93,6 +93,40 @@ const loadAsync = (page, props) => {
   }
 }
 
+// Avoid excessive console logging, make it configurable from the UI
+const LOG_LEVELS = ['OFF', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE']
+if (!window._originalConsole) {
+  window._originalConsole = {
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+    debug: console.debug,
+    trace: console.trace,
+    time: console.time,
+    timeEnd: console.timeEnd,
+    timeLog: console.timeLog
+  }
+}
+window.setLogLevel = function (level) {
+  window.LOG_LEVEL = level
+  localStorage.setItem('logLevel', level)
+
+  const c = window._originalConsole
+  const enabled = LOG_LEVELS.indexOf(level.toUpperCase())
+
+  console.error = enabled >= 1 ? c.error : () => {}
+  console.warn = enabled >= 2 ? c.warn : () => {}
+  console.info = enabled >= 3 ? c.info : () => {}
+  console.log = enabled >= 4 ? c.debug : () => {}
+  console.debug = enabled >= 4 ? c.debug : () => {}
+  console.trace = enabled >= 5 ? c.trace : () => {}
+  console.time = enabled >= 4 ? c.time : () => {}
+  console.timeEnd = enabled >= 4 ? c.timeEnd : () => {}
+  console.timeLog = enabled >= 4 ? c.timeLog : () => {}
+}
+// Initialize from localStorage
+window.setLogLevel(localStorage.getItem('logLevel') || 'OFF')
+
 export default [
   {
     path: '/',

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -169,7 +169,7 @@ export default {
       wsEvents: [],
       icon: 'lightbulb',
       split: this.$device.desktop ? 'vertical' : 'horizontal',
-      logLevel: localStorage.getItem('logLevel') || 'INFO'
+      logLevel: localStorage.getItem('openhab.ui:logLevel') || 'INFO'
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -56,22 +56,22 @@
                 <f7-list-item smart-select :smartSelectParams="{ openIn: 'popup', closeOnSelect: true }" media-item title="UI Logging" footer="Set the log level for the browser console logs">
                   <f7-icon slot="media" f7="exclamationmark_circle" color="gray" />
                   <select v-model="logLevel" @change="onLogLevelChange">
-                    <option value="trace">
+                    <option value="TRACE">
                       Trace
                     </option>
-                    <option value="debug">
+                    <option value="DEBUG">
                       Debug
                     </option>
-                    <option value="info">
+                    <option value="INFO">
                       Info
                     </option>
-                    <option value="warn">
+                    <option value="WARN">
                       Warn
                     </option>
-                    <option value="error">
+                    <option value="ERROR">
                       Error
                     </option>
-                    <option value="off">
+                    <option value="OFF">
                       Off
                     </option>
                   </select>
@@ -169,7 +169,7 @@ export default {
       wsEvents: [],
       icon: 'lightbulb',
       split: this.$device.desktop ? 'vertical' : 'horizontal',
-      logLevel: localStorage.getItem('logLevel') || 'off'
+      logLevel: localStorage.getItem('logLevel') || 'INFO'
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -53,6 +53,29 @@
                 <f7-list-item media-item title="Log Viewer" footer="Monitor openHAB log output" link="log-viewer">
                   <f7-icon slot="media" f7="square_list" color="gray" />
                 </f7-list-item>
+                <f7-list-item smart-select :smartSelectParams="{ openIn: 'popup', closeOnSelect: true }" media-item title="UI Logging" footer="Set the log level for the browser console logs">
+                  <f7-icon slot="media" f7="exclamationmark_circle" color="gray" />
+                  <select v-model="logLevel" @change="onLogLevelChange">
+                    <option value="trace">
+                      Trace
+                    </option>
+                    <option value="debug">
+                      Debug
+                    </option>
+                    <option value="info">
+                      Info
+                    </option>
+                    <option value="warn">
+                      Warn
+                    </option>
+                    <option value="error">
+                      Error
+                    </option>
+                    <option value="off">
+                      Off
+                    </option>
+                  </select>
+                </f7-list-item>
               </f7-list>
             </f7-col>
           </f7-row>
@@ -145,7 +168,8 @@ export default {
       wsClient: null,
       wsEvents: [],
       icon: 'lightbulb',
-      split: this.$device.desktop ? 'vertical' : 'horizontal'
+      split: this.$device.desktop ? 'vertical' : 'horizontal',
+      logLevel: localStorage.getItem('logLevel') || 'off'
     }
   },
   methods: {
@@ -175,6 +199,9 @@ export default {
       this.$oh.ws.close(this.wsClient)
       this.wsClient = null
       this.wsEvents = []
+    },
+    onLogLevelChange () {
+      window.setLogLevel(this.logLevel)
     }
   },
   asyncComputed: {


### PR DESCRIPTION
While developing drag and drop, I inserted a lot of console.debug logs in the javascript code. Even when the browser console is closed, these still consume a considerable amount of time (especially because it deep clones objects to be able to trace back the state of the objects during drag and drop).
I did not want to completely remove the logs, as the functionality is complex and I expect these logs may proof useful when receiving user feedback and debugging.
Therefore, I rather implemented a UI wide log level to set the log level and only log to the console when the level is above a set value. The levels mimic the OH server side log levels.

The log level for the browser can be set in an extra developer tools screen entry, and are persisted in the browser store when set. I set the default logging level to INFO (will include ERROR and WARN), thereby disabling `console.log`, `console.debug` and `console.trace`.

The impact is UI wide. To test, you can look at the Log Viewer with the console open, with log level Off or at Debug level. You will notice extra logs when at Debug level.