### PR TITLE
[Blockly] Fix blockly persistence code generation

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-persistence.js
@@ -324,6 +324,12 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
       case 'minimumSince':
       case 'minimumUntil':
       case 'minimumBetween':
+      case 'deltaSince':
+      case 'deltaUntil':
+      case 'deltaBetween':
+      case 'sumSince':
+      case 'sumUntil':
+      case 'sumBetween':
         code = `${itemCode}.persistence.${methodName}(${dayInfo}${persistenceExtension})?.${returnTypeName}`
         break
 
@@ -353,18 +359,12 @@ export default function defineOHBlocks_Persistence (f7, persistenceServices) {
       case 'medianSince':
       case 'medianUntil':
       case 'medianBetween':
-      case 'deltaSince':
-      case 'deltaUntil':
-      case 'deltaBetween':
       case 'deviationSince':
       case 'deviationUntil':
       case 'deviationBetween':
       case 'riemannSumSince':
       case 'riemannSumUntil':
       case 'riemannSumBetween':
-      case 'sumSince':
-      case 'sumUntil':
-      case 'sumBetween':
       case 'varianceSince':
       case 'varianceUntil':
       case 'varianceBetween':


### PR DESCRIPTION
Reported here: https://community.openhab.org/t/openhab-5-0-milestone-discussion/162686/108

A few persistence extension calls were expecting a RiemannType input, which should not have been there.

@stefan-hoehn Could you have a look?