### PR TITLE
[BasicUI] Fix multiline buttons to optimize width when set to visible

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -1425,6 +1425,9 @@
 			}
 
 			_t.minimizeWidth = function() {
+				if (!_t.visible) {
+					return;
+				}
 				// Minimize the width taken by the buttons without adding extra rows.
 				// Start from the maximum width the buttons can take,
 				// then shrink it down to the minimum without causing additional wrapping.
@@ -1454,6 +1457,13 @@
 		} else {
 			_t.minimizeWidth = function() {};
 		}
+
+
+		_t.parentSetVisible = _t.setVisible;
+		_t.setVisible = function(state) {
+			_t.parentSetVisible(state);
+			_t.minimizeWidth();
+		};
 
 		_t.destroy = function() {
 			_t.buttons.forEach(function(button) {


### PR DESCRIPTION
Regression from #2388
Fix #3233

May need to be backported to 4.3.x