### PR TITLE
Allow float values for widget order

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-order.js
@@ -3,8 +3,8 @@ export function compareItems (i1, i2) {
     i2.metadata && i2.metadata.semantics && i2.metadata.semantics.value.indexOf('Location') === 0
 
   // Compare widgetOrder
-  const order1 = (i1.metadata && i1.metadata.widgetOrder) ? parseInt(i1.metadata.widgetOrder.value) : Infinity
-  const order2 = (i2.metadata && i2.metadata.widgetOrder) ? parseInt(i2.metadata.widgetOrder.value) : Infinity
+  const order1 = (i1.metadata && i1.metadata.widgetOrder) ? parseFloat(i1.metadata.widgetOrder.value) : Infinity
+  const order2 = (i2.metadata && i2.metadata.widgetOrder) ? parseFloat(i2.metadata.widgetOrder.value) : Infinity
   const widgetOrder = (order1 !== order2) ? ((order1 < order2) ? -1 : 1) : 0
 
   // Unless comparing Location Items simply return the order based on widgetOrder metadata if determined


### PR DESCRIPTION
Regression from #3138.
Reported on the community: https://community.openhab.org/t/openhab-5-0-snapshot-discussion/161404/13?u=florian-h05