### PR TITLE
Item metadata: Fix metadata from uneditable Items is editable

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="ready">
-    <div style="text-align:right" class="padding-right" v-if="itemType !== 'Group'">
+    <div style="text-align:right" class="padding-right" v-if="itemType !== 'Group' && editable">
       <label @click="toggleMultiple" style="cursor:pointer">Multiple</label>
       <f7-checkbox :checked="multiple" @change="toggleMultiple" />
     </div>
@@ -8,6 +8,7 @@
       <f7-list-item
         :key="classSelectKey"
         :title="'Alexa Device Type' + (itemType !== 'Group' ? (!multiple ? '/Attribute' : '/Attributes') : '')"
+        :disabled="!editable"
         smart-select
         :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple, scrollToSelectedItem: true }"
         ref="classes">
@@ -41,7 +42,7 @@
       </f7-block-footer>
     </f7-list>
     <div>
-      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
+      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
     <f7-block class="padding-top no-padding no-margin" v-if="itemType === 'Group' && classes.length">
       <f7-block-title class="padding-left">
@@ -53,7 +54,7 @@
           :title="cap.name + (cap.isIgnored ? ' (Ignored)' : '')"
           :after="cap.item"
           :key="`${cap.name}:${cap.item}`"
-          :disabled="cap.isIgnored"
+          :disabled="cap.isIgnored || !editable"
           :link="`/settings/items/${cap.item}/metadata/alexa`" />
       </f7-list>
       <f7-block-footer class="padding-left" v-if="!groupCapabilities.length">
@@ -77,7 +78,7 @@ import AlexaDefinitions from '@/assets/definitions/metadata/alexa'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['item', 'metadata', 'namespace'],
+  props: ['item', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
@@ -2,7 +2,7 @@
   <div>
     <f7-list>
       <f7-list-item title="Force auto-update" checkbox :checked="typeof (metadata.value) === 'string' ? metadata.value === 'true' : metadata.value"
-                    :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'"
+                    :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'" :disabled="!editable"
                     @change="(ev) => metadata.value = new Boolean(ev.target.checked).toString()" />
     </f7-list>
     <f7-block-footer class="param-description">
@@ -13,6 +13,6 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace']
+  props: ['itemName', 'metadata', 'namespace', 'editable']
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
@@ -3,7 +3,7 @@
     <f7-block-title medium>
       Do
     </f7-block-title>
-    <f7-list>
+    <f7-list v-if="editable">
       <f7-list-item radio :checked="parsedAction.action === 'state'" name="action" title="update state" @click="updateAction('state')" />
       <f7-list-item radio :checked="parsedAction.action === 'command'" name="action" title="send command" @click="updateAction('command')" />
       <f7-list-input
@@ -17,6 +17,10 @@
       <f7-list-item title="ignore state updates" checkbox :checked="ignoreStateUpdates" @change="(ev) => metadata.config['ignoreStateUpdates'] = new Boolean(ev.target.checked).toString()" />
       <f7-list-item title="ignore commands" checkbox :checked="ignoreCommands" @change="(ev) => metadata.config['ignoreCommands'] = new Boolean(ev.target.checked).toString()" />
     </f7-list>
+    <f7-block v-else>
+      {{ parsedAction.action === 'state' ? 'Update state to' : 'Send command' }} <strong>{{ parsedAction.value || 'UNDEF' }}</strong><br>
+      {{ `${ignoreStateUpdates ? 'Ignore state updates' : ''}${ignoreCommands && ignoreCommands ? ', ' : ''}${ignoreCommands ? 'Ignore commands' : ''}` }}
+    </f7-block>
     <f7-block-footer class="param-description padding-left">
       <small>After a different command or state update is received, perform the chosen action when the duration specified below has passed. The timer is reset if another state update or command is received before it expires. If the ignore state updates checkbox is set, only state changes and commands will reset the timer. If the ignore commands checkbox is set, only state updates and state changes will reset the timer.</small>
     </f7-block-footer>
@@ -31,9 +35,10 @@
         ref="duration"
         type="text"
         :value="sanitizedDuration"
+        :disabled="!editable"
         @blur="(evt) => updateDuration(evt.target.value)"
         pattern="(\d+h)*(\d+m)*(\d+s)*" validate validate-on-blur />
-      <f7-list-item class="display-flex justify-content-center">
+      <f7-list-item v-if="editable" class="display-flex justify-content-center">
         <div ref="picker" />
       </f7-list-item>
     </f7-list>
@@ -45,7 +50,7 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['itemName', 'metadata', 'namespace', 'editable'],
   data () {
     return {
     }
@@ -93,6 +98,8 @@ export default {
     const containerControl = this.$refs.picker
     if (!inputControl || !inputControl.$el || !containerControl) return
     const inputElement = this.$$(inputControl.$el).find('input')
+
+    if (!this.editable) return
     this.picker = this.$f7.picker.create({
       containerEl: containerControl,
       inputEl: inputElement,

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <f7-list>
-      <f7-list-item :key="classSelectKey"
-                    :title="'Google Assistant Class'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="classes">
+      <f7-list-item :key="classSelectKey" title="Google Assistant Class" :disabled="!editable"
+                    smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="classes">
         <select name="classes" @change="updateClass">
           <option value="" />
           <optgroup label="Types">
@@ -25,7 +25,7 @@
       </f7-list-item>
     </f7-list>
     <div>
-      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" />
+      <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
     <p class="padding">
       <f7-link color="blue" external target="_blank" :href="`${$store.state.websiteUrl}/link/google-assistant`">
@@ -40,7 +40,7 @@ import GoogleDefinitions from '@/assets/definitions/metadata/ga'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['itemName', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -1,11 +1,12 @@
 <template>
   <div>
-    <div style="text-align:right" class="padding-right">
+    <div v-if="editable" style="text-align:right" class="padding-right">
       <label @click="toggleMultiple" style="cursor:pointer">Multiple</label> <f7-checkbox :checked="multiple" @change="toggleMultiple" />
     </div>
     <f7-list>
-      <f7-list-item :key="classSelectKey"
-                    :title="(multiple) ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }" ref="classes">
+      <f7-list-item :key="classSelectKey" :title="(multiple) ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'"
+                    :disabled="!editable"
+                    smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }" ref="classes">
         <select v-if="itemType == 'Group'" name="parameters" @change="updateClasses" :multiple="multiple">
           <option v-if="!multiple" value="" />
           <option v-for="cl in classesDefs.filter((c) => c.indexOf('.')===-1).filter((c) => c.indexOf('label:') !== 0)"
@@ -25,7 +26,7 @@
       </f7-list-item>
     </f7-list>
     <div>
-      <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" />
+      <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
     <f7-block class="padding-top no-padding no-margin" v-if="itemType === 'Group' && classes.length">
       <f7-block-title class="padding-left">
@@ -36,7 +37,7 @@
           {{ cl }}
         </f7-block-title>
         <f7-list>
-          <f7-list-item v-for="accessory in accessories[cl]" :key="accessory.label" smart-select :title="accessory.mandatory?accessory.label+'*':accessory.label" :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
+          <f7-list-item v-for="accessory in accessories[cl]" :key="accessory.label" :disabled="!editable" smart-select :title="accessory.mandatory?accessory.label+'*':accessory.label" :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
             <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
               <option value="" />
               <option v-for="mbr in item.members" :value="mbr.name" :key="mbr.id" :selected="isLinked(cl, accessory.label, mbr)">
@@ -46,7 +47,7 @@
           </f7-list-item>
         </f7-list>
       </f7-block>
-      <f7-block-footer>
+      <f7-block-footer v-if="editable">
         <f7-button color="blue" @click="updatedLinkedItem">
           Update group members
         </f7-button>
@@ -65,7 +66,7 @@ import { accessoriesAndCharacteristics, homekitParameters, accessories } from '@
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['item', 'itemName', 'metadata', 'namespace'],
+  props: ['item', 'itemName', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="ready">
-    <config-sheet v-if="namespace === 'stateDescription'" :parameterGroups="[]" :parameters="stateDescriptionParameters" :configuration="metadata.config" />
+    <config-sheet v-if="namespace === 'stateDescription'" :parameterGroups="[]" :parameters="stateDescriptionParameters" :configuration="metadata.config" :read-only="!editable" />
     <f7-list>
       <f7-list-input
         ref="input"
@@ -8,6 +8,7 @@
         :floating-label="$theme.md"
         :label="'Options'"
         name="options"
+        :disabled="!editable"
         :value="options"
         @input="updateOptions" />
       <f7-block-footer class="param-description" alot="after-list">
@@ -29,7 +30,7 @@
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['itemName', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -7,6 +7,7 @@
         ref="value"
         type="text"
         :value="metadata.value"
+        :disabled="!editable"
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>
@@ -20,7 +21,7 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['itemName', 'metadata', 'namespace', 'editable'],
   methods: {
     updateValue (ev) {
       this.metadata.value = ev.target.value

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -1,13 +1,14 @@
 <template>
   <div v-if="ready">
     <div>
-      <div style="text-align:right" class="padding-right">
+      <div v-if="editable" style="text-align:right" class="padding-right">
         <label @click="toggleMultiple" style="cursor:pointer">Multiple</label>
         <f7-checkbox :checked="multiple" @change="toggleMultiple" />
       </div>
       <f7-list v-if="deviceTypes">
         <f7-list-item :key="classSelectKey"
                       :title="'Matter Device Type'"
+                      :disabled="!editable"
                       smart-select
                       :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }"
                       ref="classes">
@@ -23,7 +24,7 @@
         </f7-list-item>
       </f7-list>
       <div v-if="parameters && parameters.length">
-        <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" />
+        <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
       </div>
       <f7-block class="padding-top no-padding no-margin"
                 v-if="shouldShowAttributeMapping">
@@ -42,6 +43,7 @@
           <f7-list>
             <f7-list-item v-for="attribute in deviceTypes[deviceType]?.attributes"
                           :key="attribute.name"
+                          :disabled="!editable"
                           smart-select
                           :title="attribute.mandatory ? attribute.label+'*' : attribute.label"
                           :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }">
@@ -71,6 +73,7 @@
                     type="text"
                     :label="option.label"
                     :value="getChildMapping(attribute.name, option.label, option.value)"
+                    :disabled="!editable"
                     @input="setChildMapping(attribute.name, option.label, $event.target.value)" />
                 </f7-list>
               </div>
@@ -105,7 +108,7 @@ import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
   name: 'item-metadata-matter',
-  props: ['item', 'metadata', 'namespace'],
+  props: ['item', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -19,7 +19,7 @@
         </ul>
       </f7-list>
     </f7-card-content>
-    <f7-card-footer>
+    <f7-card-footer v-if="item.editable">
       <f7-button color="blue" @click="addMetadata">
         Add Metadata
       </f7-button>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
@@ -8,6 +8,7 @@
         :label="'Synonyms'"
         name="synonyms"
         :value="synonyms"
+        :disabled="!editable"
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>Enter each synonym on a separate line.</small>
@@ -18,7 +19,7 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['itemName', 'metadata', 'namespace', 'editable'],
   computed: {
     synonyms () {
       if (!this.metadata.value) return []

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
@@ -11,6 +11,7 @@
         type="text"
         placeholder="leave empty to use system default"
         :value="metadata.value"
+        :disabled="!editable"
         @blur="(evt) => metadata.value = evt.target.value" />
     </f7-list>
     <f7-block-footer class="param-description padding-horizontal">
@@ -27,6 +28,6 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace']
+  props: ['itemName', 'metadata', 'namespace', 'editable']
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -2,19 +2,19 @@
   <div>
     <f7-list>
       <f7-list-input ref="input" type="textarea" :floating-label="$theme.md" :label="'Custom Rules'" name="custom-rules"
-                     :value="customRules" @input="updateValue" />
+                     :value="customRules" :disabled="!editable" @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>Enter each rule on a separate line. Available placeholders: $name$, $cmd$ and $*$</small>
       </f7-block-footer>
     </f7-list>
-    <config-sheet :parameterGroups="[]" :parameters="ruleOptionParameters" :configuration="metadata.config" />
+    <config-sheet :parameterGroups="[]" :parameters="ruleOptionParameters" :configuration="metadata.config" :read-only="!editable" />
   </div>
 </template>
 
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
 export default {
-  props: ['itemName', 'metadata', 'namespace'],
+  props: ['itemName', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -7,7 +7,7 @@
     </f7-block>
 
     <f7-list v-if="defaultComponent.component">
-      <f7-list-item :title="'Widget'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="widgets">
+      <f7-list-item :title="'Widget'" :disabled="!editable" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="widgets">
         <select name="widgets" @change="updateComponent">
           <option value="">
             Default ({{ defaultComponent.component }})
@@ -46,7 +46,7 @@
       <f7-block-footer v-if="currentComponent.component && currentComponent.component.indexOf('widget:') === 0" class="padding-horizontal margin-bottom">
         Make sure the personal widget is of the expected type (cell, list item or standalone).
       </f7-block-footer>
-      <config-sheet :parameterGroups="configDescriptions.parameterGroups" :parameters="configDescriptions.parameters" :configuration="metadata.config" @updated="widgetConfigUpdated" set-empty-config-as-null="true" />
+      <config-sheet :parameterGroups="configDescriptions.parameterGroups" :parameters="configDescriptions.parameters" :configuration="metadata.config" :read-only="!editable" @updated="widgetConfigUpdated" set-empty-config-as-null="true" />
     </div>
   </div>
 </template>
@@ -74,7 +74,7 @@ import itemDefaultCellComponent from '@/components/widgets/standard/cell/default
 import { VisibilityGroup, VisibilityParameters } from '@/assets/definitions/widgets/visibility'
 
 export default {
-  props: ['item', 'metadata', 'namespace'],
+  props: ['item', 'metadata', 'namespace', 'editable'],
   components: {
     ConfigSheet
   },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
@@ -7,6 +7,7 @@
         ref="value"
         type="text"
         :value="metadata.value"
+        :disabled="!editable"
         @input="(ev) => metadata.value = ev.target.value" />
     </f7-list>
     <f7-block-footer class="param-description padding-left">
@@ -19,6 +20,6 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace']
+  props: ['itemName', 'metadata', 'namespace', 'editable']
 }
 </script>


### PR DESCRIPTION
When viewing an uneditable item, its metadata is shown as editable in the UI. Use the editable property of the Item to decide whether its metadata is editable. (Technically seen you can have managed metadata for an unmanaged item, but this will cause confusing behaviour for the user).