### PR TITLE
Item metadata: Use editable field of REST response

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -76,9 +76,11 @@
 <script>
 import AlexaDefinitions from '@/assets/definitions/metadata/alexa'
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
 
 export default {
   props: ['item', 'metadata'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -167,9 +169,6 @@ export default {
       } else {
         return `${this.docUrl}#device-types`
       }
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -78,7 +78,7 @@ import AlexaDefinitions from '@/assets/definitions/metadata/alexa'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['item', 'metadata', 'namespace', 'editable'],
+  props: ['item', 'metadata'],
   components: {
     ConfigSheet
   },
@@ -167,6 +167,9 @@ export default {
       } else {
         return `${this.docUrl}#device-types`
       }
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
@@ -2,7 +2,7 @@
   <div>
     <f7-list>
       <f7-list-item title="Force auto-update" checkbox :checked="typeof (metadata.value) === 'string' ? metadata.value === 'true' : metadata.value"
-                    :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'" :disabled="!editable"
+                    :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'" :disabled="!metadata.editable"
                     @change="(ev) => metadata.value = new Boolean(ev.target.checked).toString()" />
     </f7-list>
     <f7-block-footer class="param-description">
@@ -13,6 +13,6 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable']
+  props: ['itemName', 'metadata']
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
@@ -2,7 +2,7 @@
   <div>
     <f7-list>
       <f7-list-item title="Force auto-update" checkbox :checked="typeof (metadata.value) === 'string' ? metadata.value === 'true' : metadata.value"
-                    :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'" :disabled="!metadata.editable"
+                    :indeterminate="metadata.value !== 'true' && metadata.value !== 'false'" :disabled="!editable"
                     @change="(ev) => metadata.value = new Boolean(ev.target.checked).toString()" />
     </f7-list>
     <f7-block-footer class="param-description">
@@ -12,7 +12,10 @@
 </template>
 
 <script>
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
-  props: ['itemName', 'metadata']
+  props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin]
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
@@ -50,7 +50,7 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable'],
+  props: ['itemName', 'metadata'],
   data () {
     return {
     }
@@ -90,6 +90,9 @@ export default {
       let configValue = this.metadata.config['ignoreCommands']
       if (!configValue) return false
       return typeof (configValue) === 'string' ? configValue === 'true' : configValue
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
@@ -49,8 +49,11 @@
 </template>
 
 <script>
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
   props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin],
   data () {
     return {
     }
@@ -90,9 +93,6 @@ export default {
       let configValue = this.metadata.config['ignoreCommands']
       if (!configValue) return false
       return typeof (configValue) === 'string' ? configValue === 'true' : configValue
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -38,9 +38,11 @@
 <script>
 import GoogleDefinitions from '@/assets/definitions/metadata/ga'
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
 
 export default {
   props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -62,10 +64,6 @@ export default {
     parameters () {
       if (!this.metadata.value) return []
       return GoogleDefinitions['type:' + this.metadata.value] || GoogleDefinitions['attribute:' + this.metadata.value]
-    },
-
-    editable () {
-      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -40,7 +40,7 @@ import GoogleDefinitions from '@/assets/definitions/metadata/ga'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable'],
+  props: ['itemName', 'metadata'],
   components: {
     ConfigSheet
   },
@@ -62,6 +62,10 @@ export default {
     parameters () {
       if (!this.metadata.value) return []
       return GoogleDefinitions['type:' + this.metadata.value] || GoogleDefinitions['attribute:' + this.metadata.value]
+    },
+
+    editable () {
+      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -64,9 +64,11 @@
 <script>
 import { accessoriesAndCharacteristics, homekitParameters, accessories } from '@/assets/definitions/metadata/homekit'
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
 
 export default {
   props: ['item', 'itemName', 'metadata'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -113,9 +115,6 @@ export default {
         return options
       }
       return []
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
 

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -66,7 +66,7 @@ import { accessoriesAndCharacteristics, homekitParameters, accessories } from '@
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['item', 'itemName', 'metadata', 'namespace', 'editable'],
+  props: ['item', 'itemName', 'metadata'],
   components: {
     ConfigSheet
   },
@@ -113,6 +113,9 @@ export default {
         return options
       }
       return []
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
 

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -30,7 +30,7 @@
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable'],
+  props: ['itemName', 'metadata', 'namespace'],
   components: {
     ConfigSheet
   },
@@ -64,6 +64,9 @@ export default {
       } else {
         return docUrl + '#command-description'
       }
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -28,9 +28,11 @@
 
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
 
 export default {
   props: ['itemName', 'metadata', 'namespace'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -64,9 +66,6 @@ export default {
       } else {
         return docUrl + '#command-description'
       }
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -7,7 +7,7 @@
         ref="value"
         type="text"
         :value="metadata.value"
-        :disabled="metadata.editable"
+        :disabled="editable"
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>
@@ -20,8 +20,11 @@
 </template>
 
 <script>
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
   props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin],
   methods: {
     updateValue (ev) {
       this.metadata.value = ev.target.value

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -7,7 +7,7 @@
         ref="value"
         type="text"
         :value="metadata.value"
-        :disabled="!editable"
+        :disabled="metadata.editable"
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>
@@ -21,7 +21,7 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable'],
+  props: ['itemName', 'metadata'],
   methods: {
     updateValue (ev) {
       this.metadata.value = ev.target.value

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -108,7 +108,7 @@ import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
   name: 'item-metadata-matter',
-  props: ['item', 'metadata', 'namespace', 'editable'],
+  props: ['item', 'metadata'],
   components: {
     ConfigSheet
   },
@@ -185,6 +185,9 @@ export default {
         const typeParams = matterParameters[type] || []
         return typeParams.map(opt => ({ ...opt, groupName: type }))
       }).concat(matterParameters.global || [])
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -105,10 +105,12 @@
 <script>
 import { deviceTypes, deviceTypesAndAttributes, matterParameters } from '@/assets/definitions/metadata/matter'
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
 
 export default {
   name: 'item-metadata-matter',
   props: ['item', 'metadata'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -185,9 +187,6 @@ export default {
         const typeParams = matterParameters[type] || []
         return typeParams.map(opt => ({ ...opt, groupName: type }))
       }).concat(matterParameters.global || [])
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -19,7 +19,7 @@
         </ul>
       </f7-list>
     </f7-card-content>
-    <f7-card-footer v-if="item.editable">
+    <f7-card-footer>
       <f7-button color="blue" @click="addMetadata">
         Add Metadata
       </f7-button>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -7,7 +7,9 @@
             v-for="namespace in wellKnownNamespaces" :key="namespace.name"
             :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
             :title="namespace.label"
-            :after="namespace.value || 'Not Set'" />
+            :after="namespace.value || 'Not Set'">
+            <f7-icon v-if="!namespace.editable" slot="title" f7="lock_fill" size="1rem" color="gray" />
+          </f7-list-item>
         </ul>
         <ul v-if="customNamespaces.length > 0">
           <f7-list-item divider />
@@ -15,7 +17,9 @@
             v-for="namespace in customNamespaces" :key="namespace.name"
             :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
             :title="namespace.label"
-            :after="namespace.value || 'Not Set'" />
+            :after="namespace.value || 'Not Set'">
+            <f7-icon v-if="!namespace.editable" slot="title" f7="lock_fill" size="1rem" color="gray" />
+          </f7-list-item>
         </ul>
       </f7-list>
     </f7-card-content>
@@ -51,7 +55,8 @@ export default {
         .map((n) => {
           return {
             name: n,
-            value: this.item.metadata[n].value
+            value: this.item.metadata[n].value,
+            editable: this.item.metadata[n].editable
           }
         })
     },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-mixin.js
@@ -1,0 +1,7 @@
+export default {
+  computed: {
+    editable () {
+      return this.metadata.editable !== false
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
@@ -8,7 +8,7 @@
         :label="'Synonyms'"
         name="synonyms"
         :value="synonyms"
-        :disabled="!editable"
+        :disabled="!metadata.editable"
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>Enter each synonym on a separate line.</small>
@@ -19,7 +19,7 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable'],
+  props: ['itemName', 'metadata'],
   computed: {
     synonyms () {
       if (!this.metadata.value) return []

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
@@ -8,7 +8,7 @@
         :label="'Synonyms'"
         name="synonyms"
         :value="synonyms"
-        :disabled="!metadata.editable"
+        :disabled="!editable"
         @input="updateValue" />
       <f7-block-footer class="param-description" slot="after-list">
         <small>Enter each synonym on a separate line.</small>
@@ -18,8 +18,11 @@
 </template>
 
 <script>
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
   props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin],
   computed: {
     synonyms () {
       if (!this.metadata.value) return []

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
@@ -11,7 +11,7 @@
         type="text"
         placeholder="leave empty to use system default"
         :value="metadata.value"
-        :disabled="!metadata.editable"
+        :disabled="!editable"
         @blur="(evt) => metadata.value = evt.target.value" />
     </f7-list>
     <f7-block-footer class="param-description padding-horizontal">
@@ -27,7 +27,10 @@
 </template>
 
 <script>
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
-  props: ['itemName', 'metadata']
+  props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin]
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
@@ -11,7 +11,7 @@
         type="text"
         placeholder="leave empty to use system default"
         :value="metadata.value"
-        :disabled="!editable"
+        :disabled="!metadata.editable"
         @blur="(evt) => metadata.value = evt.target.value" />
     </f7-list>
     <f7-block-footer class="param-description padding-horizontal">
@@ -28,6 +28,6 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable']
+  props: ['itemName', 'metadata']
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -14,7 +14,7 @@
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable'],
+  props: ['itemName', 'metadata'],
   components: {
     ConfigSheet
   },
@@ -31,6 +31,9 @@ export default {
     customRules () {
       if (!this.metadata.value) return []
       return this.metadata.value.split('\n').map((s) => s.trim()).join('\n')
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -13,8 +13,11 @@
 
 <script>
 import ConfigSheet from '@/components/config/config-sheet.vue'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
   props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -31,9 +34,6 @@ export default {
     customRules () {
       if (!this.metadata.value) return []
       return this.metadata.value.split('\n').map((s) => s.trim()).join('\n')
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -74,7 +74,7 @@ import itemDefaultCellComponent from '@/components/widgets/standard/cell/default
 import { VisibilityGroup, VisibilityParameters } from '@/assets/definitions/widgets/visibility'
 
 export default {
-  props: ['item', 'metadata', 'namespace', 'editable'],
+  props: ['item', 'metadata', 'namespace'],
   components: {
     ConfigSheet
   },
@@ -95,6 +95,9 @@ export default {
   computed: {
     personalWidgets () {
       return [...this.$store.getters.widgets].sort((a, b) => { return a.uid.localeCompare(b.uid) })
+    },
+    editable () {
+      return this.metadata.editable
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -72,9 +72,11 @@ import itemDefaultListComponent from '@/components/widgets/standard/list/default
 import itemDefaultCellComponent from '@/components/widgets/standard/cell/default-cell-item'
 
 import { VisibilityGroup, VisibilityParameters } from '@/assets/definitions/widgets/visibility'
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
 
 export default {
   props: ['item', 'metadata', 'namespace'],
+  mixins: [ItemMetadataMixin],
   components: {
     ConfigSheet
   },
@@ -95,9 +97,6 @@ export default {
   computed: {
     personalWidgets () {
       return [...this.$store.getters.widgets].sort((a, b) => { return a.uid.localeCompare(b.uid) })
-    },
-    editable () {
-      return this.metadata.editable
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -6,8 +6,12 @@
       </f7-col>
     </f7-block>
 
+    <f7-block-header v-if="!editable" class="padding-horizontal">
+      <b style="color: var(--f7-theme-color) !important;">INFO: This metadata is not editable as it has not been created through the UI.
+        <br>You can try out changes here, but you cannot save them.</b>
+    </f7-block-header>
     <f7-list v-if="defaultComponent.component">
-      <f7-list-item :title="'Widget'" :disabled="!editable" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="widgets">
+      <f7-list-item :title="'Widget'" smart-select :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }" ref="widgets">
         <select name="widgets" @change="updateComponent">
           <option value="">
             Default ({{ defaultComponent.component }})
@@ -46,7 +50,7 @@
       <f7-block-footer v-if="currentComponent.component && currentComponent.component.indexOf('widget:') === 0" class="padding-horizontal margin-bottom">
         Make sure the personal widget is of the expected type (cell, list item or standalone).
       </f7-block-footer>
-      <config-sheet :parameterGroups="configDescriptions.parameterGroups" :parameters="configDescriptions.parameters" :configuration="metadata.config" :read-only="!editable" @updated="widgetConfigUpdated" set-empty-config-as-null="true" />
+      <config-sheet :parameterGroups="configDescriptions.parameterGroups" :parameters="configDescriptions.parameters" :configuration="metadata.config" @updated="widgetConfigUpdated" set-empty-config-as-null="true" />
     </div>
   </div>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
@@ -7,7 +7,7 @@
         ref="value"
         type="text"
         :value="metadata.value"
-        :disabled="!metadata.editable"
+        :disabled="!editable"
         @input="(ev) => metadata.value = ev.target.value" />
     </f7-list>
     <f7-block-footer class="param-description padding-left">
@@ -19,7 +19,10 @@
 </template>
 
 <script>
+import ItemMetadataMixin from '@/components/item/metadata/item-metadata-mixin'
+
 export default {
-  props: ['itemName', 'metadata']
+  props: ['itemName', 'metadata'],
+  mixins: [ItemMetadataMixin]
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
@@ -7,7 +7,7 @@
         ref="value"
         type="text"
         :value="metadata.value"
-        :disabled="!editable"
+        :disabled="!metadata.editable"
         @input="(ev) => metadata.value = ev.target.value" />
     </f7-list>
     <f7-block-footer class="param-description padding-left">
@@ -20,6 +20,6 @@
 
 <script>
 export default {
-  props: ['itemName', 'metadata', 'namespace', 'editable']
+  props: ['itemName', 'metadata']
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -25,7 +25,7 @@
       <f7-tab id="config" class="metadata-editor-config-tab" @tab:show="() => this.currentTab = 'config'" :tab-active="currentTab === 'config'">
         <f7-block class="block-narrow" v-if="ready && currentTab === 'config'">
           <f7-col>
-            <component :is="editorControl" :item="item" :metadata="metadata" :namespace="namespace" :editable="editable" />
+            <component :is="editorControl" :item="item" :metadata="metadata" :namespace="namespace" />
           </f7-col>
         </f7-block>
         <f7-block class="block-narrow" v-if="ready">
@@ -156,7 +156,7 @@ export default {
       }
     },
     editable () {
-      return this.item.editable
+      return this.metadata.editable
     }
   },
   methods: {
@@ -239,7 +239,10 @@ export default {
       )
     },
     toYaml () {
-      this.yaml = YAML.stringify(this.metadata)
+      this.yaml = YAML.stringify({
+        value: this.metadata.value,
+        config: this.metadata.config || {}
+      })
     },
     fromYaml () {
       try {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -40,7 +40,7 @@
       </f7-tab>
 
       <f7-tab id="code" @tab:show="() => { this.currentTab = 'code' }" :tab-active="currentTab === 'code'">
-        <f7-icon v-if="!editable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" tooltip="This metadata is not editable" />
+        <f7-icon v-if="!editable" f7="lock" class="float-right margin" style="opacity:0.5; z-index: 4000; user-select: none;" size="50" color="gray" tooltip="This metadata is not editable as it has not been created through the UI" />
         <editor v-if="currentTab === 'code'" class="metadata-code-editor" mode="text/x-yaml" :value="yaml" :readOnly="!editable" @input="onEditorInput" />
       </f7-tab>
     </f7-tabs>
@@ -156,7 +156,7 @@ export default {
       }
     },
     editable () {
-      return this.metadata.editable
+      return this.metadata.editable !== false
     }
   },
   methods: {


### PR DESCRIPTION
Follow-up for #3249.
Depends on https://github.com/openhab/openhab-core/pull/4874.

This allows to add and edit editable metadata for uneditable Items, it only blocks edition of uneditable metadata.
For the `widget` metaddata, it allow to try out changes if not editable, but does not allow saving them.