### PR TITLE
Use versioned branch for add-on & sidebar docs

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
@@ -26,13 +26,6 @@ export default {
     }
   },
   computed: {
-    docsBranch () {
-      if (this.$store.state.runtimeInfo.buildString === 'Release Build') return 'final-stable'
-      return 'final'
-    },
-    docSrcUrl () {
-      return `https://raw.githubusercontent.com/openhab/openhab-docs/${this.docsBranch}/mainui`
-    },
     localUrl () {
       if (!this.$store.state.pagePath.endsWith('/')) return '/'
       return this.$store.state.pagePath
@@ -60,7 +53,7 @@ export default {
         return
       }
       console.debug('Sidebar Help: Docs not found in cache, loading from GitHub ...')
-      fetch(this.docSrcUrl + this.path + '.md').then((response) => {
+      fetch(this.$store.state.docSrcUrl + '/mainui' + this.path + '.md').then((response) => {
         if (response.status === 404) {
           this.parsedDocs = '<p>Failed to load docs. It seems they are missing.</p><p>Please <a class="external" target="_blank" href="https://github.com/openhab/openhab-docs/issues/new">report this on the openHAB docs repo</a>.</p>'
           this.ready = true

--- a/bundles/org.openhab.ui/web/src/index.html
+++ b/bundles/org.openhab.ui/web/src/index.html
@@ -20,11 +20,11 @@
     * allow loading images from any source, and data: URIs
     * allow loading media from any source, and data:, blob: and media: URIs
     * allow embedding (<iframe>) any source
-    * allow connecting (through fetch(), XMLHttpRequest, WebSocket etc.) to the same origin, raw.githubusercontent.com (add-on logos etc.), Iconify icon sources, and any source
+    * allow connecting (through fetch(), XMLHttpRequest, WebSocket etc.) to the same origin, *.openhab.org, raw.githubusercontent.com (add-on logos etc.), Iconify icon sources, and any source
     * allows loading web workers from the same origin, and blob: URIs
   -->
   <% if (process.env.NODE_ENV === 'production') { %>
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; frame-src *; connect-src 'self' raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *; worker-src 'self' blob:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; frame-src *; connect-src 'self' *.openhab.org raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *; worker-src 'self' blob:;">
   <% } %>
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
 

--- a/bundles/org.openhab.ui/web/src/js/store/index.js
+++ b/bundles/org.openhab.ui/web/src/js/store/index.js
@@ -32,6 +32,7 @@ const store = new Vuex.Store({
       commit: buildInfo.commit
     },
     websiteUrl: null,
+    docSrcUrl: null,
     developerDock: false,
     pagePath: null
   },
@@ -46,6 +47,7 @@ const store = new Vuex.Store({
       state.runtimeInfo = rootResponse.runtimeInfo
       state.apiEndpoints = rootResponse.links
       state.websiteUrl = `https://${rootResponse.runtimeInfo?.buildString !== 'Release Build' ? 'next' : 'www'}.openhab.org`
+      state.docSrcUrl = `https://www.openhab.org./link/docs-src/${rootResponse.runtimeInfo.version.replace(/(\d+\.\d+)\.\d+/g, '$1.x')}`
     },
     setLocale (state, locale) {
       state.locale = locale

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
@@ -270,7 +270,7 @@ export default {
         let addonTypeFolder = '_addons_' + this.addon.type
         if (this.addon.type === 'misc') addonTypeFolder = '_addons_io'
         if (this.addon.type !== 'automation') addonTypeFolder += 's'
-        let docSrcUrl = `https://raw.githubusercontent.com/openhab/openhab-docs/${docsBranch}/${addonTypeFolder}/${this.addon.id}`
+        let docSrcUrl = `${this.$store.state.docSrcUrl}/${addonTypeFolder}/${this.addon.id}`
 
         fetch(docSrcUrl + '/readme.md').then((readme) => {
           readme.text().then((text) => {


### PR DESCRIPTION
Closes #2945.

Load the markdown source files used by the add-on details and the developer sidebar from the versioned git branch instead of always using the latest docs. This is implemented by loading the docs src from the website, were Netlify redirects are used to point each version to the proper branch.