### PR TITLE
oh-slider-item: Respect `ignoreDisplayState` config & Improve docs

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-slider-item.md
+++ b/bundles/org.openhab.ui/doc/components/oh-slider-item.md
@@ -21,6 +21,17 @@ prev: /docs/ui/components/
 Display a slider control in a list
 <!-- GENERATED /componentDescription -->
 
+By default, the slider control will use the display state of the Item, if available.
+If the display state is not available, it will use the raw state of the Item.
+If you want to always use the raw state, set the `ignoreDisplayState` property to `true`.
+
+> [!NOTE]
+> If you have problems with the slider resetting to a different value than the one you set, it is likely that the display state of the Item does not allow enough decimals for the step size of the slider.
+> If you have problems with the displayed state having a different number of decimals than the slider, it is likely that the display state of the Item does not allow enough decimals for the step size of the slider.
+> 
+> In those cases, make sure that either the state description of the Item is set to the same number of decimals than the step size (so that the display state has the same precision as the slider),
+> or that the `ignoreDisplayState` property is set to `true`.
+
 ## Configuration
 
 <!-- DO NOT REMOVE the following comments -->

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-slider-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-slider-item.vue
@@ -1,7 +1,7 @@
 <template>
   <oh-list-item :context="context" class="slider-listitem">
     <div slot="after">
-      {{ context.store[config.item].displayState || context.store[config.item].state }}
+      {{ value }}
     </div>
     <div slot="footer" class="padding">
       <generic-widget-component :context="childContext(sliderComponent)" v-on="$listeners" />
@@ -29,6 +29,9 @@ export default {
   mixins: [mixin],
   widget: OhSliderItemDefinition,
   computed: {
+    value () {
+      return (this.config?.ignoreDisplayState === true) ? this.context.store[this.config.item].state : this.context.store[this.config.item].displayState || this.context.store[this.config.item].state
+    },
     sliderComponent () {
       return {
         component: 'oh-slider',


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/1503.

https://github.com/openhab/openhab-webui/issues/1503 is caused by the display state of the Item formatting the raw state different from the slider.
With this change, it is possible to make the oh-slider-item ignore the display state for the displayed state value.
oh-slider also ignores the display state if that value is set.