### PR TITLE
oh-slider: Fix display state with decimal comma parsed to integer

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -80,7 +80,7 @@ export default {
         const item = this.context.store[this.config.item]
         if (item.state !== 'NULL' && item.state !== 'UNDEF' && item.state !== 'Invalid Date') {
           const value = (this.config.useDisplayState && item.displayState) || item.state
-          return this.config.type === 'number' ? this.extractValue(value).replace(',', '.') : value
+          return this.config.type === 'number' ? parseFloat(this.extractValue(value)) : value
         }
       }
       return this.config.defaultValue

--- a/bundles/org.openhab.ui/web/src/js/app.js
+++ b/bundles/org.openhab.ui/web/src/js/app.js
@@ -1,5 +1,6 @@
 import './compatibility'
 import './logging'
+import './monkeypatch'
 
 // Import Vue
 import Vue from 'vue'

--- a/bundles/org.openhab.ui/web/src/js/monkeypatch.js
+++ b/bundles/org.openhab.ui/web/src/js/monkeypatch.js
@@ -1,0 +1,9 @@
+// Monkey patching parseFloat to add decimal comma, parseFloat normally only supports decimal point
+const originalParseFloat = parseFloat
+globalThis.parseFloat = function (value) {
+  if (typeof value === 'string') {
+    // Replace comma with dot for decimal values
+    value = value.replace(',', '.')
+  }
+  return originalParseFloat(value)
+}


### PR DESCRIPTION
Fixes #1949.
This monkey patches parseFloat to also handle decimal comma and updates oh-input to take advantage of that.