### PR TITLE
Pin icons: Make "pinned" state icon solid and "unpinned" state outlined

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -32,7 +32,7 @@
         <f7-link class="breakpoint-pin" @click="toggleVisibleBreakpoint">
           <f7-icon
             size="14"
-            :f7="uiOptionsStore.visibleBreakpointDisabled ? 'pin_slash' : 'pin'"
+            :f7="uiOptionsStore.visibleBreakpointDisabled ? 'pin' : 'pin_filled'"
             color="gray" />
         </f7-link>
 

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -83,8 +83,8 @@
                              :href="'/settings/items/' + item.name"
                              :animate="false" />
                     <f7-link class="itemlist-actions"
-                             color="red"
-                             icon-f7="pin_slash_fill"
+                             color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('items', item, 'name')" />
@@ -137,8 +137,8 @@
                              tooltip="Edit"
                              :href="'/settings/things/' + thing.UID"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('things', thing, 'UID')" />
@@ -197,8 +197,8 @@
                              tooltip="Edit"
                              :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('rules', rule, 'uid')" />
@@ -257,8 +257,8 @@
                              tooltip="Edit"
                              :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('scenes', rule, 'uid')" />
@@ -318,8 +318,8 @@
                              tooltip="Edit"
                              :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('scripts', rule, 'uid')" />
@@ -369,8 +369,8 @@
                              tooltip="Edit"
                              :href="'/settings/pages/' + getPageType(page).type + '/' + page.uid"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('pages', page, 'uid')" />
@@ -410,8 +410,8 @@
                              tooltip="Edit"
                              :href="'/developer/widgets/' + widget.uid"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('widgets', widget, 'uid')" />
@@ -453,8 +453,8 @@
                              tooltip="Edit"
                              :href="'/settings/transformations/' + transformation.uid"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('transformations', transformation, 'uid')" />
@@ -496,8 +496,8 @@
                              tooltip="Edit"
                              :href="'/settings/persistence/' + persistenceConfig.serviceId"
                              :animate="false" />
-                    <f7-link color="red"
-                             icon-f7="pin_slash_fill"
+                    <f7-link color="blue"
+                             icon-f7="pin_fill"
                              icon-size="18"
                              tooltip="Unpin"
                              @click="unpin('persistenceConfig', persistenceConfig, 'serviceId')" />

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -40,13 +40,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('items', item, 'name')"
                      @click="$emit('unpin', 'items', item, 'name')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'items', item, 'name')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -85,13 +85,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('things', thing, 'UID')"
                      @click="$emit('unpin', 'things', thing, 'UID')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'things', thing, 'UID')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -130,13 +130,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('rules', rule, 'uid')"
                      @click="$emit('unpin', 'rules', rule, 'uid')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'rules', rule, 'uid')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -175,13 +175,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('scenes', rule, 'uid')"
                      @click="$emit('unpin', 'scenes', rule, 'uid')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'scenes', rule, 'uid')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -220,13 +220,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('scripts', rule, 'uid')"
                      @click="$emit('unpin', 'scripts', rule, 'uid')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'scripts', rule, 'uid')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -265,13 +265,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('pages', page, 'uid')"
                      @click="$emit('unpin', 'pages', page, 'uid')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'pages', page, 'uid')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -309,13 +309,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('widgets', widget, 'uid')"
                      @click="$emit('unpin', 'widgets', widget, 'uid')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'widgets', widget, 'uid')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -354,13 +354,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('transformations', transformation, 'uid')"
                      @click="$emit('unpin', 'transformations', transformation, 'uid')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'transformations', transformation, 'uid')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />
@@ -399,13 +399,13 @@
                      :animate="false" />
             <f7-link v-if="isPinned('persistenceConfigs', persistenceConfig, 'serviceId')"
                      @click="$emit('unpin', 'persistenceConfigs', persistenceConfig, 'serviceId')"
-                     color="red"
-                     icon-f7="pin_slash_fill"
+                     color="blue"
+                     icon-f7="pin_fill"
                      icon-size="18"
                      tooltip="Unpin" />
             <f7-link v-else
                      @click="$emit('pin', 'persistenceConfigs', persistenceConfig, 'serviceId')"
-                     color="blue"
+                     color="gray"
                      icon-f7="unpin"
                      icon-size="18"
                      tooltip="Pin" />


### PR DESCRIPTION
The way the "pin" icons are currently displayed:

When an item is pinned, the pin icon is shown as red with slash. This makes me wonder: is this item currently pinned or not?

So instead of the icon showing what will happen when it's clicked, show the current state (is it currently pinned or unpinned). Clicking it will toggle it.

I think it's more intuitive this way.

Furthermore, when it's unpinned, show it as gray color, and when it's pinned, show it as blue, indicating that "yes it's pinned".


Before:
<img width="1114" height="546" alt="image" src="https://github.com/user-attachments/assets/91a15be3-75db-4317-ad75-87e254bdce54" />

After:
<img width="1166" height="560" alt="image" src="https://github.com/user-attachments/assets/0b5a18a3-72c5-4023-b8a5-47896bea0b74" />

