### PR TITLE
Sitemap edit: Fix quotes for icon value not allowed

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
+++ b/bundles/org.openhab.ui/web/src/assets/sitemap-lexer.nearley
@@ -90,6 +90,11 @@
     }
     return widget
   }
+
+  // helper function to join values if array, pass through if string
+  function joinValue(val) {
+    return Array.isArray(val) ? val.join("") : val;
+  }
 %}
 
 @lexer lexer
@@ -119,8 +124,8 @@ WidgetAttr -> %widgetswitchattr                                                 
   | %widgetclickattr _ WidgetAttrValue                                            {% (d) => ['cmd', d[2]] %}
   | %widgetreleaseattr _ WidgetAttrValue                                          {% (d) => ['releaseCmd', d[2]] %}
   | %icon _ WidgetIconRulesAttrValue                                              {% (d) => ['iconrules', d[2]] %}
-  | %icon _ WidgetIconAttrValue                                                   {% (d) => [d[0].value, d[2].join("")] %}
-  | %staticIcon _ WidgetIconAttrValue                                             {% (d) => [d[0].value, d[2].join("")] %}
+  | %icon _ WidgetIconAttrValue                                                   {% (d) => [d[0].value, joinValue(d[2])] %}
+  | %staticIcon _ WidgetIconAttrValue                                             {% (d) => [d[0].value, joinValue(d[2])] %}
   | WidgetAttrName _ WidgetAttrValue                                              {% (d) => [d[0][0].value, d[2]] %}
   | WidgetMappingsAttrName WidgetMappingsAttrValue                                {% (d) => [d[0][0].value, d[1]] %}
   | WidgetButtonsAttrName WidgetButtonsAttrValue                                  {% (d) => [d[0][0].value, d[1]] %}

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/dslUtil_jest.spec.js
@@ -55,10 +55,16 @@ describe('dslUtil', () => {
       label: 'Test Switch',
       icon: 'lightbulb'
     })
+    addWidget(component, 'Text', {
+      item: 'TestItem',
+      label: 'Test Text',
+      icon: 'lightbulb-30'
+    })
     const sitemap = dslUtil.toDsl(component).split('\n')
     expect(sitemap).toEqual([
       'sitemap test label="Test" {',
       '    Switch item=TestItem label="Test Switch" icon=lightbulb',
+      '    Text item=TestItem label="Test Text" icon="lightbulb-30"',
       '}',
       ''
     ])
@@ -72,10 +78,17 @@ describe('dslUtil', () => {
       icon: 'lightbulb',
       staticIcon: true
     })
+    addWidget(component, 'Text', {
+      item: 'TestItem',
+      label: 'Test Text',
+      icon: 'lightbulb-30',
+      staticIcon: true
+    })
     const sitemap = dslUtil.toDsl(component).split('\n')
     expect(sitemap).toEqual([
       'sitemap test label="Test" {',
       '    Switch item=TestItem label="Test Switch" staticIcon=lightbulb',
+      '    Text item=TestItem label="Test Text" staticIcon="lightbulb-30"',
       '}',
       ''
     ])

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/__tests__/sitemap-code_jest.spec.js
@@ -143,48 +143,7 @@ describe('SitemapCode', () => {
       'sitemap test label="Test" {',
       '    Switch item=Item_Icon icon=lightbulb',
       '    Switch item=Item_Icon icon=iconify:material-symbols:height',
-      '}',
-      ''
-    ].join('\n')
-    wrapper.vm.updateSitemap(sitemap)
-    expect(wrapper.vm.sitemapDsl).toMatch(/^sitemap test label="Test"/)
-    expect(wrapper.vm.parsedSitemap.error).toBeFalsy()
-
-    await wrapper.vm.$nextTick()
-
-    // check whether an 'updated' event was emitted and its payload
-    // (should contain the parsing result for the new sitemap definition)
-    const events = wrapper.emitted().updated
-    expect(events).toBeTruthy()
-    expect(events.length).toBe(1)
-    const payload = events[0][0]
-    expect(payload.slots).toBeDefined()
-    expect(payload.slots.widgets).toBeDefined()
-    expect(payload.slots.widgets.length).toBe(2)
-    expect(payload.slots.widgets[0]).toEqual({
-      component: 'Switch',
-      config: {
-        item: 'Item_Icon',
-        icon: 'lightbulb'
-      }
-    })
-    expect(payload.slots.widgets[1]).toEqual({
-      component: 'Switch',
-      config: {
-        item: 'Item_Icon',
-        icon: 'iconify:material-symbols:height'
-      }
-    })
-  })
-
-  it('parses a staticIcon definition', async () => {
-    expect(wrapper.vm.sitemapDsl).toBeDefined()
-    // simulate updating the sitemap in code
-    const sitemap = [
-      'sitemap test label="Test" {',
-      '    Switch item=Item_Icon icon=lightbulb',
-      '    Switch item=Item_Icon staticIcon=lightbulb_static',
-      '    Switch item=Item_Icon icon=lightbulb staticIcon=lightbulb_static',
+      '    Switch item=Test_Icon icon="lightbulb-30"',
       '}',
       ''
     ].join('\n')
@@ -214,6 +173,56 @@ describe('SitemapCode', () => {
       component: 'Switch',
       config: {
         item: 'Item_Icon',
+        icon: 'iconify:material-symbols:height'
+      }
+    })
+    expect(payload.slots.widgets[2]).toEqual({
+      component: 'Switch',
+      config: {
+        item: 'Test_Icon',
+        icon: 'lightbulb-30'
+      }
+    })
+  })
+
+  it('parses a staticIcon definition', async () => {
+    expect(wrapper.vm.sitemapDsl).toBeDefined()
+    // simulate updating the sitemap in code
+    const sitemap = [
+      'sitemap test label="Test" {',
+      '    Switch item=Item_Icon icon=lightbulb',
+      '    Switch item=Item_Icon staticIcon=lightbulb_static',
+      '    Switch item=Item_Icon icon=lightbulb staticIcon=lightbulb_static',
+      '    Switch item=Test_Icon icon="lightbulb-30"',
+      '}',
+      ''
+    ].join('\n')
+    wrapper.vm.updateSitemap(sitemap)
+    expect(wrapper.vm.sitemapDsl).toMatch(/^sitemap test label="Test"/)
+    expect(wrapper.vm.parsedSitemap.error).toBeFalsy()
+
+    await wrapper.vm.$nextTick()
+
+    // check whether an 'updated' event was emitted and its payload
+    // (should contain the parsing result for the new sitemap definition)
+    const events = wrapper.emitted().updated
+    expect(events).toBeTruthy()
+    expect(events.length).toBe(1)
+    const payload = events[0][0]
+    expect(payload.slots).toBeDefined()
+    expect(payload.slots.widgets).toBeDefined()
+    expect(payload.slots.widgets.length).toBe(4)
+    expect(payload.slots.widgets[0]).toEqual({
+      component: 'Switch',
+      config: {
+        item: 'Item_Icon',
+        icon: 'lightbulb'
+      }
+    })
+    expect(payload.slots.widgets[1]).toEqual({
+      component: 'Switch',
+      config: {
+        item: 'Item_Icon',
         icon: 'lightbulb_static',
         staticIcon: true
       }
@@ -223,6 +232,13 @@ describe('SitemapCode', () => {
       config: {
         item: 'Item_Icon',
         icon: 'lightbulb'
+      }
+    })
+    expect(payload.slots.widgets[3]).toEqual({
+      component: 'Switch',
+      config: {
+        item: 'Test_Icon',
+        icon: 'lightbulb-30'
       }
     })
   })

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/dslUtil.js
@@ -14,10 +14,12 @@ function writeWidget (widget, indent) {
       } else if (key === 'stateless') {
         dsl += ' stateless'
       } else if (key === 'icon') {
+        let value = widget.config[key]
+        if (/\d$/.test(value)) value = '"' + value + '"'
         if (widget.config.staticIcon) {
-          dsl += ' staticIcon=' + widget.config[key]
+          dsl += ' staticIcon=' + value
         } else if (!widget.config['iconrules'] || widget.config['iconrules'].length === 0) {
-          dsl += ' icon=' + widget.config[key]
+          dsl += ' icon=' + value
         }
       } else if (key !== 'staticIcon') {
         if (key === 'iconrules') {


### PR DESCRIPTION
Fixes #3291.

`icon=` or `staticIcon=` values names ending with a number double quotes around them. Properly parse and generate those.