### PR TITLE
Sitemap edit: Fix save button not working due to JSON error

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -720,7 +720,9 @@ export default {
       }
     },
     preProcessSitemapSave (sitemap) {
-      const processed = JSON.parse(JSON.stringify(sitemap))
+      const clone = cloneDeep(sitemap)
+      clone.slots.widgets.forEach(w => delete w.parent) // remove parent from widgets, as this causes a circular reference
+      const processed = JSON.parse(JSON.stringify(clone))
       processed.slots?.widgets?.forEach(this.preProcessWidgetSave)
       return processed
     },


### PR DESCRIPTION
Fixes #3290.

Fixes
```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'slots' -> object with constructor 'Object'
    |     property 'widgets' -> object with constructor 'Array'
    |     index 0 -> object with constructor 'Object'
    --- property 'parent' closes the circle
```
when trying to save a sitemap.