### PR TITLE
Developer Sidebar: Add rule.trigger.configuration.groupName to the search (OH 4.3.x)

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -541,6 +541,10 @@ export default {
         if (m.configuration.itemName && m.configuration.itemName.toLowerCase().indexOf(query) >= 0) {
           return true
         }
+        // Match Group names non case-intensive
+        if (m.configuration.groupName && m.configuration.groupName.toLowerCase().indexOf(query) >= 0) {
+          return true
+        }
         // Match Thing names non case-intensive
         if (m.configuration.thingUID && m.configuration.thingUID.toLowerCase().indexOf(query) >= 0) {
           return true


### PR DESCRIPTION
A fix for #3222 for OH4.3

Note I haven't actually tested this on a 4.3.x installation.

A fix for this on OH5 is included in #3289, if that doesn't get merged, we'll have a regression unless this gets "forward ported". In fact, #3289 will go into 5.1, so I guess I'll also need to make this for 5.0.x 