### PR TITLE
Developer Sidebar: Add rule.trigger.configuration.groupName to the search

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -573,6 +573,10 @@ export default {
         if (m.configuration.itemName && m.configuration.itemName.toLowerCase().indexOf(query) >= 0) {
           return true
         }
+        // Match Group names non case-intensive
+        if (m.configuration.groupName && m.configuration.groupName.toLowerCase().indexOf(query) >= 0) {
+          return true
+        }
         // Match Thing names non case-intensive
         if (m.configuration.thingUID && m.configuration.thingUID.toLowerCase().indexOf(query) >= 0) {
           return true


### PR DESCRIPTION
Fix #3222 in OH5.0
Should be backported to 4.3.x

A fix for this on OH5.1 is included in #3289