### PR TITLE
Semantic Tags Editor: Add a lock icon on non-editable tag

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -107,7 +107,11 @@
                                      error-message="Required. A-Z,a-z,0-9,- only"
                                      @input="updateName($event)">
                         <template #inner-end>
-                          <f7-icon v-if="!selectedTag.editable" f7="lock" ios="f7:lock" md="material:lock" color="gray" />
+                          <f7-icon v-if="!selectedTag.editable"
+                                   f7="lock"
+                                   ios="f7:lock"
+                                   md="material:lock"
+                                   color="gray" />
                         </template>
                       </f7-list-input>
                       <f7-list-input label="Label"


### PR DESCRIPTION
<img width="2112" height="778" alt="image" src="https://github.com/user-attachments/assets/0e8b20a2-cf8a-4e51-b33d-73d53b6c7be5" />
