### PR TITLE
Sitemap editor: fix missing row parameter

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -48,6 +48,7 @@
               </option>
             </select>
           </f7-list-item>
+          <f7-list-input v-if="supports('row')" label="Row" type="number" required validate min="1":value="widget.config.row" @input="updateParameter('row', $event)" clear-button />
           <f7-list-input v-if="supports('column')" label="Column" type="number" required validate min="1" max="12" :value="widget.config.column" @input="updateParameter('column', $event)" clear-button />
           <f7-list-input v-if="supports('cmd')" label="Click command" type="text" required validate :value="widget.config.cmd" @input="updateParameter('cmd', $event)" clear-button />
           <f7-list-input v-if="supports('releaseCmd')" label="Release command" type="text" :value="widget.config.releaseCmd" @input="updateParameter('releaseCmd', $event)" clear-button />


### PR DESCRIPTION
The row parameter for buttons in a Buttongrid was missing from the sitemap editor.