### PR TITLE
Update openhab-js tern defs for v5.11.2

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/openhab-js-tern-defs.json
@@ -38,6 +38,38 @@
                 "!doc": "The raw state of the item, as a java object.",
                 "!type": "?"
             },
+            "previousState": {
+                "!doc": "The previous state of the item, as a string, or null if no previous state is available.",
+                "!type": "string|null"
+            },
+            "previousNumericState": {
+                "!doc": "Numeric representation of previous Item state, or null if state is not numeric",
+                "!type": "number|null"
+            },
+            "previousQuantityState": {
+                "!doc": "Previous Item state as Quantity or null if state is not Quantity-compatible",
+                "!type": "QuantityClass|null"
+            },
+            "previousRawState": {
+                "!doc": "The previous raw state of the item, as a java object.",
+                "!type": "?"
+            },
+            "lastStateUpdateTimestamp": {
+                "!doc": "The timestamp of the last state update of the item.",
+                "!type": "+ZonedDateTime"
+            },
+            "lastStateUpdateInstant": {
+                "!doc": "The timestamp of the last state update of the item.",
+                "!type": "+Instant"
+            },
+            "lastStateChangeTimestamp": {
+                "!doc": "The timestamp of the last state change of the item.",
+                "!type": "+ZonedDateTime"
+            },
+            "lastStateChangeInstant": {
+                "!doc": "The timestamp of the last state change of the item.",
+                "!type": "+Instant"
+            },
             "members": {
                 "!doc": "Members / children / direct descendents of the current group Item (as returned by 'getMembers()'). Must be a group item.",
                 "!type": "[Item]"
@@ -71,8 +103,8 @@
                 "!type": "fn(namespace?: string) -> object|null"
             },
             "sendCommand": {
-                "!doc": "Sends a command to the item.",
-                "!type": "fn(value: ?)"
+                "!doc": "Sends a command to the item. When expire is set to a time.Duration (see JavaScript Scripting docs/Standard Library/Time), the Item will return to the current status or onExpire after the given duration.",
+                "!type": "fn(value: ?, expire?: +Duration, onExpire?: ?)"
             },
             "sendCommandIfDifferent": {
                 "!doc": "Sends a command to the item, but only if the current state is not what is being sent.",
@@ -686,6 +718,10 @@
             "toZDT": {
                 "!doc": "Converts nearly any representation of a time to a time.ZonedDateTime (see JavaScript Scripting Docs/Standard Library/Time)",
                 "!type": "fn(time: ?) -> time.ZonedDateTime"
+            },
+            "toInstant": {
+                "!doc": "Converts nearly any representation of a time to a time.Instant (see JavaScript Scripting Docs/Standard Library/Time)",
+                "!type": "fn(time: ?) -> +Instant"
             },
             "ZonedDateTime": {
                 "!doc": "Represents a date-time with a time offset and/or a time zone in the ISO-8601 calendar system (see JavaScript Scripting Docs/Standard Library/Time)."


### PR DESCRIPTION
This updates the tern defs used for autocompletion to the current library version included in the add-on (5.11.2).

See https://github.com/openhab/openhab-js/compare/v5.8.1...v5.11.2 for changes.

Last update was in #2911.