### PR TITLE
[basicui] Recalculate widths for multiline buttons in dynamic Frames

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -774,6 +774,14 @@
 		_t.setVisible = function(state) {
 			if (state) {
 				_t.parentNode.classList.remove(o.formHidden);
+				_t.parentNode.querySelectorAll(o.formControls).forEach(function(e) {
+					var id = e.getAttribute(o.idAttribute);
+					var control = smarthome.dataModel[id];
+					// readjust child buttons width when the parent frame becomes visible
+					if (control.minimizeWidth) {
+						control.minimizeWidth();
+					}
+				});
 			} else {
 				_t.parentNode.classList.add(o.formHidden);
 			}


### PR DESCRIPTION
Fixes an issue where multiline buttons inside a Frame did not properly recalculate their widths when the Frame's visibility changed. Ensures layout updates are triggered to maintain correct button sizing.

Fix #3233

Complements #3237