### PR TITLE
[WIP] Add refresh interval option to photos action in OH WebUI

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.js
@@ -108,6 +108,14 @@ export const actionParams = (groupName, paramPrefix) => {
       .v((value, configuration, configDescription, parameters) => {
         return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
       }),
+    pi(paramPrefix + 'actionPhotosRefreshSec', 'Photo Refresh Interval (seconds)', 'Number of seconds between automatic refreshes of the photos')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
+    pi(paramPrefix + 'actionPhotosRefreshMs', 'Photo Refresh Interval (milliseconds)', 'Number of milliseconds between automatic refreshes of the photos')
+      .v((value, configuration, configDescription, parameters) => {
+        return ['photos'].indexOf(configuration[paramPrefix + 'action']) >= 0
+      }),
     pi(paramPrefix + 'actionGroupPopupItem', 'Group Popup Item', 'Group Item whose members to show in a popup')
       .v((value, configuration, configDescription, parameters) => {
         return ['group'].indexOf(configuration[paramPrefix + 'action']) >= 0


### PR DESCRIPTION
This is my first attempt at contributing to the OH WebUI.  
The goal is to add an optional refresh interval to the `photos` action so that images in the Framework7 Photo Browser can automatically reload after a defined number of seconds or milliseconds.

Changes include:
- Added `actionPhotosRefreshSec` (seconds) and `actionPhotosRefreshMs` (milliseconds) configuration parameters.
- Adjusted the `photos` action handling to trigger periodic refreshes when one of these values is set.

Status:
- This PR is still a work in progress (WIP).
- I currently have no test environment available, so I cannot verify the changes myself.
- Feedback from maintainers and other contributors is highly appreciated, especially regarding implementation style and any potential side effects.

Thanks in advance for your patience with my first PR attempt!