### PR TITLE
Charts: Add support for selecting markers & Add current time marker

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-aggregate-series.md
@@ -71,6 +71,16 @@ prev: /docs/ui/components/
     <PropOption value="year" label="Year" />
   </PropOptions>
 </PropBlock>
+<PropBlock type="TEXT" name="markers" label="Markers">
+  <PropDescription>
+    The markers to display for the series
+  </PropDescription>
+  <PropOptions multiple="true">
+    <PropOption value="avg" label="Average" />
+    <PropOption value="min" label="Minimum" />
+    <PropOption value="max" label="Maximum" />
+  </PropOptions>
+</PropBlock>
 <PropBlock type="TEXT" name="type" label="Type">
   <PropDescription>
     The type of the series.<br/><em>Note: <code>heatmap</code> needs a configured visual map or uses the default and is not supported for time series!</em>

--- a/bundles/org.openhab.ui/doc/components/oh-time-series.md
+++ b/bundles/org.openhab.ui/doc/components/oh-time-series.md
@@ -71,6 +71,17 @@ prev: /docs/ui/components/
     <PropOption value="year" label="Year" />
   </PropOptions>
 </PropBlock>
+<PropBlock type="TEXT" name="markers" label="Markers">
+  <PropDescription>
+    The markers to display for the series
+  </PropDescription>
+  <PropOptions multiple="true">
+    <PropOption value="avg" label="Average" />
+    <PropOption value="min" label="Minimum" />
+    <PropOption value="max" label="Maximum" />
+    <PropOption value="time" label="Current Time" />
+  </PropOptions>
+</PropBlock>
 <PropBlock type="TEXT" name="type" label="Type">
   <PropDescription>
     The type of the series.<br/><em>Note: <code>heatmap</code> needs a configured visual map or uses the default and is not supported for time series!</em>

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -3,7 +3,7 @@
 
 import { actionGroup, actionParams } from '../actions.js'
 import { pg, pb, pt, pn, pi } from '../helpers.js'
-import { aggregationTypeOptions, dimensionTypeOptions } from './options.js'
+import { aggregationTypeOptions, dimensionTypeOptions, markerOptions } from './options.js'
 
 const positionGroup = pg('position', 'Position', 'Each parameter accepts pixel values or percentages. Additionally, top accepts "top", "middle" and "bottom" to align the component vertically, and left accepts "left", "center" and "right" to align the component horizontally')
 
@@ -62,6 +62,8 @@ const yAxisIndexParameter = pn('yAxisIndex', 'Y Axis Index', 'The index of the Y
 
 const persistenceServiceParameter = pt('service', 'Persistence Service', 'The identifier of the persistence service to retrieve the data from. Leave blank to the use the default.')
   .c('persistenceService').a()
+
+const markersParameter = pt('markers', 'Markers', 'The markers to display for the series').o(markerOptions, true, true)
 
 const boundaryParameter = pb('noBoundary', 'Don\'t Include Boundary', 'Do not get one value before and after the requested period and move them to the start and end of the period').a()
 
@@ -293,6 +295,7 @@ export default {
       parameterGroups: [componentRelationsGroup, actionGroup()],
       parameters: [
         ...seriesParameters,
+        markersParameter,
         seriesTypeParameter('line', 'bar', 'heatmap', 'scatter'),
         xAxisIndexParameter,
         yAxisIndexParameter,

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.js
@@ -63,7 +63,7 @@ const yAxisIndexParameter = pn('yAxisIndex', 'Y Axis Index', 'The index of the Y
 const persistenceServiceParameter = pt('service', 'Persistence Service', 'The identifier of the persistence service to retrieve the data from. Leave blank to the use the default.')
   .c('persistenceService').a()
 
-const markersParameter = pt('markers', 'Markers', 'The markers to display for the series').o(markerOptions, true, true)
+const markersParameter = (withTime) => pt('markers', 'Markers', 'The markers to display for the series').o(markerOptions(withTime), true, true)
 
 const boundaryParameter = pb('noBoundary', 'Don\'t Include Boundary', 'Do not get one value before and after the requested period and move them to the start and end of the period').a()
 
@@ -295,7 +295,7 @@ export default {
       parameterGroups: [componentRelationsGroup, actionGroup()],
       parameters: [
         ...seriesParameters,
-        markersParameter,
+        markersParameter(true),
         seriesTypeParameter('line', 'bar', 'heatmap', 'scatter'),
         xAxisIndexParameter,
         yAxisIndexParameter,
@@ -336,6 +336,7 @@ export default {
       parameterGroups: [componentRelationsGroup, actionGroup()],
       parameters: [
         ...seriesParameters,
+        markersParameter(),
         seriesTypeParameter('line', 'bar', 'heatmap', 'scatter'),
         {
           name: 'dimension1',

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/options.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/options.js
@@ -17,3 +17,10 @@ export const aggregationTypeOptions = [
   { value: 'diff_first', label: 'Difference of firsts' },
   { value: 'diff_last', label: 'Difference of lasts' }
 ]
+
+export const markerOptions = [
+  { value: 'avg', label: 'Average' },
+  { value: 'min', label: 'Minimum' },
+  { value: 'max', label: 'Maximum' },
+  { value: 'time', label: 'Current Time' }
+]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/options.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/options.js
@@ -18,9 +18,12 @@ export const aggregationTypeOptions = [
   { value: 'diff_last', label: 'Difference of lasts' }
 ]
 
-export const markerOptions = [
-  { value: 'avg', label: 'Average' },
-  { value: 'min', label: 'Minimum' },
-  { value: 'max', label: 'Maximum' },
-  { value: 'time', label: 'Current Time' }
-]
+export function markerOptions (withTime = false) {
+  const opts = [
+    { value: 'avg', label: 'Average' },
+    { value: 'min', label: 'Minimum' },
+    { value: 'max', label: 'Maximum' }
+  ]
+  if (withTime) opts.push({ value: 'time', label: 'Current Time' })
+  return opts
+}

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/markers.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/markers.js
@@ -1,0 +1,44 @@
+import dayjs from 'dayjs'
+
+export default (series) => {
+  if (Array.isArray(series.markers)) {
+    if (!series.markLine) {
+      series.markLine = {
+        data: []
+      }
+    }
+    if (!series.markPoint) {
+      series.markPoint = {
+        label: {
+          backgroundColor: 'auto'
+        },
+        data: []
+      }
+    }
+    if (series.markers.includes('avg')) {
+      series.markLine.data.push({
+        type: 'average'
+      })
+    }
+    if (series.markers.includes('time')) {
+      series.markLine.data.push({
+        label: {
+          show: false
+        },
+        lineStyle: {
+          color: '#e64a19',
+          type: 'solid',
+          width: 1
+        },
+        symbol: 'none',
+        xAxis: dayjs().format()
+      })
+    }
+    if (series.markers.includes('min')) {
+      series.markPoint.data.push({ type: 'min', name: 'min' })
+    }
+    if (series.markers.includes('max')) {
+      series.markPoint.data.push({ type: 'max', name: 'max' })
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.js
@@ -1,8 +1,9 @@
 import * as dayjs from 'dayjs'
 import IsoWeek from 'dayjs/plugin/isoWeek'
 dayjs.extend(IsoWeek)
+import ComponentId from '@/components/widgets/component-id'
 import aggregate from './aggregators'
-import ComponentId from '../../component-id'
+import applyMarkers from '@/components/widgets/chart/series/markers'
 
 function dimensionFromDate (d, dimension, invert) {
   switch (dimension) {
@@ -99,6 +100,8 @@ export default {
     series.data = data
 
     // other things
+    applyMarkers(series)
+
     return series
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
@@ -1,6 +1,8 @@
-import ComponentId from '../../component-id'
-import MarkArea from './oh-mark-area'
 import Framework7 from 'framework7'
+import dayjs from 'dayjs'
+
+import ComponentId from '@/components/widgets/component-id'
+import MarkArea from './oh-mark-area'
 
 export default {
   neededItems (component, chart) {
@@ -35,6 +37,47 @@ export default {
     // other things
     if (component.slots && component.slots.markArea) {
       series.markArea = MarkArea.get(component.slots.markArea[0], points, startTime, endTime, chart)
+    }
+
+    if (Array.isArray(series.markers)) {
+      if (!series.markLine) {
+        series.markLine = {
+          data: []
+        }
+      }
+      if (!series.markPoint) {
+        series.markPoint = {
+          label: {
+            backgroundColor: 'auto'
+          },
+          data: []
+        }
+      }
+      if (series.markers.includes('avg')) {
+        series.markLine.data.push({
+          type: 'average'
+        })
+      }
+      if (series.markers.includes('time')) {
+        series.markLine.data.push({
+          label: {
+            show: false
+          },
+          lineStyle: {
+            color: '#e64a19',
+            type: 'solid',
+            width: 1
+          },
+          symbol: 'none',
+          xAxis: dayjs().format()
+        })
+      }
+      if (series.markers.includes('min')) {
+        series.markPoint.data.push({ type: 'min', name: 'min' })
+      }
+      if (series.markers.includes('max')) {
+        series.markPoint.data.push({ type: 'max', name: 'max' })
+      }
     }
 
     if (!series.showSymbol) series.showSymbol = false

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
@@ -3,6 +3,7 @@ import dayjs from 'dayjs'
 
 import ComponentId from '@/components/widgets/component-id'
 import MarkArea from './oh-mark-area'
+import applyMarkers from '@/components/widgets/chart/series/markers'
 
 export default {
   neededItems (component, chart) {
@@ -39,46 +40,7 @@ export default {
       series.markArea = MarkArea.get(component.slots.markArea[0], points, startTime, endTime, chart)
     }
 
-    if (Array.isArray(series.markers)) {
-      if (!series.markLine) {
-        series.markLine = {
-          data: []
-        }
-      }
-      if (!series.markPoint) {
-        series.markPoint = {
-          label: {
-            backgroundColor: 'auto'
-          },
-          data: []
-        }
-      }
-      if (series.markers.includes('avg')) {
-        series.markLine.data.push({
-          type: 'average'
-        })
-      }
-      if (series.markers.includes('time')) {
-        series.markLine.data.push({
-          label: {
-            show: false
-          },
-          lineStyle: {
-            color: '#e64a19',
-            type: 'solid',
-            width: 1
-          },
-          symbol: 'none',
-          xAxis: dayjs().format()
-        })
-      }
-      if (series.markers.includes('min')) {
-        series.markPoint.data.push({ type: 'min', name: 'min' })
-      }
-      if (series.markers.includes('max')) {
-        series.markPoint.data.push({ type: 'max', name: 'max' })
-      }
-    }
+    applyMarkers(series)
 
     if (!series.showSymbol) series.showSymbol = false
     if (!series.tooltip) {

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/chart-aggregate.js
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/chart-aggregate.js
@@ -84,20 +84,10 @@ export default {
     page.slots.series = analyzer.items.map((item) => {
       const seriesOptions = analyzer.seriesOptions[item.name]
 
-      const markLine = (seriesOptions.markers === 'avg' || seriesOptions.markers === 'all') ? {
-        data: [
-          { type: 'average' }
-        ]
-      } : undefined
-      const markPoint = (seriesOptions.markers === 'min-max' || seriesOptions.markers === 'all') ? {
-        label: {
-          backgroundColor: 'auto'
-        },
-        data: [
-          { type: 'min', name: 'min' },
-          { type: 'max', name: 'max' }
-        ]
-      } : undefined
+      const markers = []
+      if (seriesOptions.markers === 'all') markers.push('min', 'max', 'avg')
+      if (seriesOptions.markers === 'min-max') markers.push('min', 'max')
+      if (seriesOptions.markers === 'avg') markers.push('avg')
 
       return {
         component: 'oh-aggregate-series',
@@ -110,8 +100,7 @@ export default {
           type: dimension2 ? 'heatmap' : (seriesOptions.type === 'bar') ? 'bar' : 'line',
           dimension1,
           dimension2,
-          markLine,
-          markPoint,
+          markers,
           transpose: analyzer.orientation === 'vertical' ? true : undefined,
           areaStyle: seriesOptions.type === 'area' ? { opacity: 0.2 } : undefined,
           aggregationFunction: seriesOptions.aggregation

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/chart-time.js
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/chart-time.js
@@ -74,20 +74,10 @@ export default {
         }
       }
 
-      const markLine = (seriesOptions.markers === 'avg' || seriesOptions.markers === 'all') ? {
-        data: [
-          { type: 'average' }
-        ]
-      } : undefined
-      const markPoint = (seriesOptions.markers === 'min-max' || seriesOptions.markers === 'all') ? {
-        label: {
-          backgroundColor: 'auto'
-        },
-        data: [
-          { type: 'min', name: 'min' },
-          { type: 'max', name: 'max' }
-        ]
-      } : undefined
+      const markers = []
+      if (seriesOptions.markers === 'all') markers.push('min', 'max', 'avg')
+      if (seriesOptions.markers === 'min-max') markers.push('min', 'max')
+      if (seriesOptions.markers === 'avg') markers.push('avg')
 
       return {
         component: 'oh-time-series',
@@ -99,8 +89,7 @@ export default {
           type: 'line',
           item: item.name,
           areaStyle: seriesOptions.type === 'area' ? { opacity: 0.2 } : undefined,
-          markLine,
-          markPoint
+          markers
         }
       }
     })


### PR DESCRIPTION
This adds support for selecting markers for time and aggregate series on chart pages.
It also adds a current time marker that allows to mark the current time in a chart.