### PR TITLE
Sitemap editor: Fix sitemap save

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -788,13 +788,12 @@ export default {
       }
     },
     preProcessSitemapSave (sitemap) {
-      const clone = cloneDeep(sitemap)
-      clone.slots.widgets.forEach(w => delete w.parent) // remove parent from widgets, as this causes a circular reference
-      const processed = JSON.parse(JSON.stringify(clone))
+      const processed = cloneDeep(sitemap)
       processed.slots?.widgets?.forEach(this.preProcessWidgetSave)
       return processed
     },
     preProcessWidgetSave (widget) {
+      delete widget.parent  // remove parent from widget, as this would cause a circular reference error when converting to JSON
       if (widget.config) {
         for (let key in widget.config) {
           if (widget.config[key] && Array.isArray(widget.config[key])) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -793,7 +793,7 @@ export default {
       return processed
     },
     preProcessWidgetSave (widget) {
-      delete widget.parent  // remove parent from widget, as this would cause a circular reference error when converting to JSON
+      delete widget.parent // remove parent from widget, as this would cause a circular reference error when converting to JSON
       if (widget.config) {
         for (let key in widget.config) {
           if (widget.config[key] && Array.isArray(widget.config[key])) {


### PR DESCRIPTION
The fix provided with https://github.com/openhab/openhab-webui/pull/3300 was incomplete. It only removed the parent field from the first level of the tree.

This fix iterates over the levels.
It also removes the JSON parse/stringify combination as it was used to copy the object and is replaced by a deepClone.

This should be backported to 5.0 as the backported fix provided did not work in all cases.