### PR TITLE
Fix "Select All" in channel-list.vue

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -245,6 +245,7 @@ export default {
     },
     toggleAllChecks (checked) {
       this.thing.channels.forEach((c) => {
+        if (this.multipleLinksMode && c.kind === 'TRIGGER') return
         const channelType = this.channelTypesMap.get(c.channelTypeUID)
         if (!channelType) return
         if (channelType.advanced && !this.showAdvanced) return


### PR DESCRIPTION
In `multipleLinksMode` mode, `channel-list.vue` hides trigger channels, but `toggleAllChecks()` didn't take that into account, which led to exceptions since trigger channels lack an `itemType`. By excluding trigger channels from `toggleAllChecks()`, the exceptions are avoided, and "Select All" works.

I believe this fixes #3343.