### PR TITLE
[mainui] Video widget enhancements

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.js
@@ -6,11 +6,14 @@ export default () => [
   pt('type', 'Type', 'Content Type of the video, for example <em>video/mp4</em> (optional)'),
   pb('hideControls', 'Hide Controls', 'Hide the control buttons of the video'),
   pb('startManually', 'Start Manually', 'Does not start playing the video automatically'),
-  pt('posterURL', 'Poster URL', 'URL of an image to use as a poster before the video loads').a(),
+  pb('startMuted', 'Start Muted', 'Mute audio output by default').a(),
+  pi('posterItem', 'Poster Item', 'Image item or String item containing the URL of an image to use as a poster before the video loads').a(),
+  pt('posterURL', 'Poster URL', 'URL of an image to use as a poster before the video loads (if item if not specified)').a(),
   pt('playerType', 'Player Type', 'Select the player type (optional), defualts to Video.js').o([
     { value: 'videojs', label: 'Video.js (Dash, HLS, Others)' },
     { value: 'webrtc', label: 'WebRTC' }
   ], true, false).a(),
   pt('stunServer', 'Stun Server', 'WebRTC stun server (optional), defaults to \'stun:stun.l.google.com:19302\'').a(),
-  pd('candidatesTimeout', 'ICE candidates timeout', 'WebRTC ICE candidates discovery timeout length in milliseconds (optional), defaults to \'2000\', \'0\' to disable').a()
+  pd('candidatesTimeout', 'ICE candidates timeout', 'WebRTC ICE candidates discovery timeout length in milliseconds (optional), defaults to \'2000\', \'0\' to disable').a(),
+  pb('sendAudio', 'Two Way Audio', 'Send audio to the WebRTC connection if supported (requires WebRTC player type)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-videojs.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-videojs.vue
@@ -18,6 +18,7 @@ export default {
     type: { type: String },
     config: { type: Object },
     startManually: { type: Boolean },
+    startMuted: { type: Boolean },
     hideControls: { type: Boolean },
     posterURL: { type: String }
   },
@@ -35,6 +36,9 @@ export default {
   },
   computed: {
     computedPosterUrl () {
+      if (this.posterURL && this.posterURL.startsWith('data:')) {
+        return this.posterURL
+      }
       const ts = (new Date()).toISOString()
       return this.posterURL ? this.posterURL.indexOf('?') === -1 ? `${this.posterURL}?_ts=${ts}` : `${this.posterURL}&_ts=${ts}` : this.posterURL
     }
@@ -54,7 +58,8 @@ export default {
       }
       const playerOpts = Object.assign({}, {
         liveui: true,
-        autoplay: this.startManually ? false : 'muted',
+        autoplay: this.startManually ? false : (this.startMuted ? 'muted' : 'play'),
+        muted: this.startMuted,
         controls: !this.hideControls
       }, this.config || {})
       this.player = videojs(

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -1,13 +1,24 @@
 <template>
-  <video
-    ref="videoPlayer"
-    :autoplay="this.startManually ? false : true"
-    :controls="this.hideControls ? false : true"
-    :poster="computedPosterUrl"
-    playsinline
-    style="max-width: 100%">
-    Sorry, your browser doesn't support embedded videos.
-  </video>
+  <div class="oh-video-wrapper">
+    <video
+      ref="videoPlayer"
+      :autoplay="this.startManually ? false : true"
+      :controls="this.hideControls ? false : true"
+      :muted="startMuted ? true : false"
+      :poster="computedPosterUrl"
+      playsinline
+      style="max-width: 100%">
+      Sorry, your browser doesn't support embedded videos.
+    </video>
+    <button
+      v-if="sendAudio"
+      class="oh-video-mic"
+      :class="{ 'active': isMicOn }"
+      @click="toggleMic"
+      :title="isMicOn ? 'Mute microphone' : 'Send microphone'">
+      <i class="material-icons">{{ isMicOn ? 'mic' : 'mic_off' }}</i>
+    </button>
+  </div>
 </template>
 
 <script>
@@ -21,21 +32,35 @@ export default {
     stunServer: { type: String },
     candidatesTimeout: { type: Number },
     startManually: { type: Boolean },
+    startMuted: { type: Boolean },
     hideControls: { type: Boolean },
-    posterURL: { type: String }
+    posterURL: { type: String },
+    sendAudio: { type: Boolean }
   },
   data () {
     return {
-      webrtc: null
+      webrtc: null,
+      localAudioStream: null,
+      audioTransceiver: null,
+      isMicOn: false
     }
   },
   watch: {
     src (value) {
       this.startStream()
+    },
+    sendAudio (value) {
+      if (value === false && this.isMicOn) {
+        this.isMicOn = false
+        this.disableMicrophone()
+      }
     }
   },
   computed: {
     computedPosterUrl () {
+      if (this.posterURL && this.posterURL.startsWith('data:')) {
+        return this.posterURL
+      }
       const ts = (new Date()).toISOString()
       return this.posterURL ? this.posterURL.indexOf('?') === -1 ? `${this.posterURL}?_ts=${ts}` : `${this.posterURL}&_ts=${ts}` : this.posterURL
     }
@@ -45,8 +70,10 @@ export default {
       console.debug('WebRTC Closing Connection')
       if (this.webrtc) {
         this.webrtc.isClosed = true
+        try { this.disableMicrophone() } catch (e) { }
         this.webrtc.close()
         // see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close
+        this.audioTransceiver = null
         this.webrtc = null
       }
     },
@@ -69,8 +96,15 @@ export default {
         console.debug(event.streams.length + ' track is delivered')
         self.$refs.videoPlayer.srcObject = event.streams[0]
       }
+      // some cameras require streams to be sendrecv, despite the fact that we don't send video.
+      // Since we don't send anything, it does not have any negative effects.
       webrtc.addTransceiver('video', { direction: 'sendrecv' })
-      webrtc.addTransceiver('audio', { direction: 'sendrecv' })
+      this.audioTransceiver = webrtc.addTransceiver('audio', { direction: 'sendrecv' })
+
+      if (this.isMicOn) {
+        // Try to enable microphone before/around negotiation
+        this.enableMicrophone(webrtc, this.audioTransceiver)
+      }
       webrtc.onnegotiationneeded = function handleNegotiationNeeded () {
         // WebRTC lifecycle to create a live stream
         webrtc.createOffer()
@@ -134,6 +168,59 @@ export default {
       }
       this.webrtc = webrtc
     },
+    toggleMic () {
+      this.isMicOn = !this.isMicOn
+      if (!this.webrtc) {
+        // If no connection yet, start it so microphone state can apply during negotiation
+        if (this.inForeground && this.src) {
+          this.startStream()
+        }
+        return
+      }
+      if (this.isMicOn) {
+        this.enableMicrophone(this.webrtc, this.audioTransceiver)
+      } else {
+        this.disableMicrophone()
+      }
+    },
+    async enableMicrophone (webrtc, audioTransceiver) {
+      try {
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+          console.warn('getUserMedia not supported in this browser')
+          return
+        }
+        // If already enabled, do nothing
+        if (this.localAudioStream && this.localAudioStream.getAudioTracks().some(t => t.enabled)) {
+          return
+        }
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true })
+        this.localAudioStream = stream
+        const [audioTrack] = stream.getAudioTracks()
+        if (!audioTrack) return
+        if (audioTransceiver && audioTransceiver.sender) {
+          await audioTransceiver.sender.replaceTrack(audioTrack)
+        } else if (webrtc) {
+          webrtc.addTrack(audioTrack, stream)
+        }
+      } catch (e) {
+        console.warn('Failed to enable microphone:', e)
+      }
+    },
+    disableMicrophone () {
+      try {
+        if (this.audioTransceiver && this.audioTransceiver.sender) {
+          this.audioTransceiver.sender.replaceTrack(null)
+        }
+        if (this.localAudioStream) {
+          this.localAudioStream.getTracks().forEach(t => {
+            try { t.stop() } catch (e) {}
+          })
+          this.localAudioStream = null
+        }
+      } catch (e) {
+        console.warn('Failed to disable microphone:', e)
+      }
+    },
     startForegroundActivity () {
       this.startStream()
     },
@@ -143,3 +230,35 @@ export default {
   }
 }
 </script>
+
+<style lang="stylus" scoped>
+.oh-video-wrapper
+  position relative
+
+.oh-video-mic
+  position absolute
+  top 8px
+  right 8px
+  z-index 2
+  display inline-flex
+  align-items center
+  justify-content center
+  width 36px
+  height 36px
+  border none
+  border-radius 18px
+  background var(--f7-card-bg-color)
+  box-shadow 0 1px 3px rgba(0,0,0,0.2)
+  cursor pointer
+  opacity 0.8
+  transition opacity .15s ease, background-color .15s ease, color .15s ease
+  &:hover
+    opacity 1
+  &.active
+    background var(--f7-color-red)
+    i.material-icons
+      color #fff
+  i.material-icons
+    font-size 20px
+    color var(--f7-text-color)
+</style>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -6,16 +6,19 @@
       :stunServer="config.stunServer"
       :candidatesTimeout="config.candidatesTimeout"
       :startManually="config.startManually"
+      :startMuted="config.startMuted"
       :hideControls="config.hideControls"
-      :posterURL="config.posterURL" />
+      :posterURL="posterSrc"
+      :sendAudio="config.sendAudio" />
     <oh-video-videojs
       v-else
       :src="src"
       :type="config.type"
       :config="config.videoOptions"
+      :startMuted="config.startMuted"
       :startManually="config.startManually"
       :hideControls="config.hideControls"
-      :posterURL="config.posterURL" />
+      :posterURL="posterSrc" />
   </div>
 </template>
 
@@ -30,10 +33,14 @@ export default {
     'oh-video-videojs': () => import(/* webpackChunkName: "oh-video-videojs" */ './oh-video-videojs.vue'),
     'oh-video-webrtc': () => import(/* webpackChunkName: "oh-video-webrtc" */ './oh-video-webrtc.vue')
   },
+  props: {
+    sendAudio: { type: Boolean }
+  },
   data () {
     return {
       t: this.$utils.id(),
-      src: null
+      src: null,
+      posterSrc: null
     }
   },
   watch: {
@@ -59,6 +66,11 @@ export default {
     } else {
       this.src = this.config.url
     }
+    if (this.config.posterItem) {
+      this.loadPosterItemURL()
+    } else {
+      this.posterSrc = this.config.posterURL
+    }
   },
   methods: {
     loadItemURL () {
@@ -66,6 +78,13 @@ export default {
         .getPlain(`/rest/items/${this.config.item}/state`, 'text/plain')
         .then((data) => {
           this.src = data
+        })
+    },
+    loadPosterItemURL () {
+      this.$oh.api
+        .getPlain(`/rest/items/${this.config.posterItem}/state`, 'text/plain')
+        .then((data) => {
+          this.posterSrc = data
         })
     }
   }


### PR DESCRIPTION
This PR adds a few enhancements to the video widget

- 2-way audio support for WebRTC streams
- Option to start video muted
- Support for Image and String items for the poster image 

The 2-way audio feature is useful for things like cameras that support it.   I have a binding i have been running internally for a while i'll open a PR for that takes advantage of this, but it should work with any standard WebRTC service that support bi-directional audio (so many cameras) 