### PR TITLE
[basicUI] ColorpickerRenderer.java: remove comment about jquery.miniColors

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/ColorpickerRenderer.java
@@ -34,8 +34,6 @@ import org.osgi.service.component.annotations.Reference;
  * widgets.
  *
  * <p>
- * Note: This renderer requires the files "jquery.miniColors.css" and "jquery.miniColors.js" in the web folder of this
- * bundle
  *
  * @author Kai Kreuzer - Initial contribution and API
  * @author Vlad Ivanov - BasicUI changes


### PR DESCRIPTION
The deleted text was just copied from bundles/org.openhab.ui.classic/src/main/java/org/openhab/ui/classic/internal/render/ColorpickerRenderer.java

At commit 30dfe0d9eedf76687aae bundles/org.openhab.ui.classic/src/main/resources/snippets/colorpicker.html has required jquery.minicolors, and bundles/org.openhab.ui.basic/src/main/resources/snippets/colorpicker.html has not required it.

So the deleted text was never correct.