### PR TITLE
Change access to f7.utils to avoid TypeScript error

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/cards/card-mixin.js
@@ -1,6 +1,5 @@
 import mixin from '@/components/widgets/widget-mixin'
 import { f7 } from 'framework7-vue'
-import { utils } from 'framework7'
 
 export default {
   mixins: [mixin],
@@ -71,8 +70,8 @@ export default {
   },
   methods: {
     cardOpening () {
-      this.cardId = this.title + '-' + utils.id()
-      history.pushState({ cardId: this.cardId }, null, window.location.href.split('#card=')[0] + '#' + utils.serializeObject({ card: this.element.key }))
+      this.cardId = this.title + '-' + f7.utils.id()
+      history.pushState({ cardId: this.cardId }, null, window.location.href.split('#card=')[0] + '#' + f7.utils.serializeObject({ card: this.element.key }))
       setTimeout(() => { this.opened = true })
     },
     cardClosed () {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import AlexaDefinitions from '@/assets/definitions/metadata/alexa'
 import ConfigSheet from '@/components/config/config-sheet.vue'
@@ -120,7 +120,7 @@ export default {
       classesDefs: Object.keys(AlexaDefinitions),
       itemType: this.item.groupType || this.item.type,
       multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
-      classSelectKey: utils.id(),
+      classSelectKey: f7.utils.id(),
       docUrl: `${useRuntimeStore().websiteUrl}/link/alexa`,
       ready: false
     }
@@ -245,7 +245,7 @@ export default {
     toggleMultiple () {
       this.multiple = !this.multiple
       if (this.metadata.value.indexOf(',') > 0) this.metadata.value = ''
-      this.classSelectKey = utils.id()
+      this.classSelectKey = f7.utils.id()
     },
     updateClasses () {
       const value = this.$refs.classes.$el.children[0].f7SmartSelect.getValue()

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
 import GoogleDefinitions from '@/assets/definitions/metadata/ga'
@@ -72,7 +72,7 @@ export default {
   data () {
     return {
       classesDefs: Object.keys(GoogleDefinitions),
-      classSelectKey: utils.id()
+      classSelectKey: f7.utils.id()
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -90,7 +90,6 @@
 
 <script>
 import { f7 } from 'framework7-vue'
-import { utils } from 'framework7'
 import { mapStores } from 'pinia'
 
 import { accessoriesAndCharacteristics, homekitParameters, accessories } from '@/assets/definitions/metadata/homekit'
@@ -114,7 +113,7 @@ export default {
       accessories,
       classesDefs: accessoriesAndCharacteristics,
       multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
-      classSelectKey: utils.id(),
+      classSelectKey: f7.utils.id(),
       itemType: this.item.groupType || this.item.type,
       dirtyItem: new Set()
     }
@@ -169,7 +168,7 @@ export default {
     toggleMultiple () {
       this.multiple = !this.multiple
       this.metadata.value = ''
-      this.classSelectKey = utils.id()
+      this.classSelectKey = f7.utils.id()
     },
     updateClasses () {
       const value = this.$refs.classes.$el.children[0].f7SmartSelect.getValue()

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -110,7 +110,6 @@
 
 <script>
 import { f7 } from 'framework7-vue'
-import { utils } from 'framework7'
 import { mapStores } from 'pinia'
 
 import { deviceTypes, deviceTypesAndAttributes, matterParameters } from '@/assets/definitions/metadata/matter'
@@ -134,7 +133,7 @@ export default {
       deviceTypes,
       classesDefs: deviceTypesAndAttributes,
       multiple: !!this.metadata.value && this.metadata.value.indexOf(',') > 0,
-      classSelectKey: utils.id(),
+      classSelectKey: f7.utils.id(),
       itemType: this.item.groupType || this.item.type,
       dirtyItem: new Set(),
       ready: false
@@ -238,7 +237,7 @@ export default {
     toggleMultiple () {
       this.multiple = !this.multiple
       this.metadata.value = ''
-      this.classSelectKey = utils.id()
+      this.classSelectKey = f7.utils.id()
     },
     updateClasses () {
       const value = this.$refs.classes.$el.children[0].f7SmartSelect.getValue()

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -85,7 +85,7 @@
 
 <script>
 import { nextTick } from 'vue'
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
@@ -120,7 +120,7 @@ export default {
       defaultComponent: {},
       currentComponent: {},
       previewContext: {},
-      previewWidgetKey: utils.id(),
+      previewWidgetKey: f7.utils.id(),
       standardWidgets: Object.values(StandardWidgets).filter((c) => c.widget).map((c) => c.widget()).sort((a, b) => { return a.name.localeCompare(b.name) }),
       standardListWidgets: Object.values(StandardListWidgets).filter((c) => c.widget && typeof c.widget === 'function').map((c) => c.widget()).sort((a, b) => { return a.name.localeCompare(b.name) }),
       standardCellWidgets: Object.values(StandardCellWidgets).filter((c) => c.widget && typeof c.widget === 'function').map((c) => c.widget()).sort((a, b) => { return a.name.localeCompare(b.name) }),
@@ -256,7 +256,7 @@ export default {
       }
       Object.assign(this.currentComponent.config, this.metadata.config || {})
       this.setPreviewContext()
-      this.previewWidgetKey = utils.id()
+      this.previewWidgetKey = f7.utils.id()
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
@@ -4,7 +4,7 @@
       v-if="model.item.created !== false"
       :item="model.item"
       :context="context"
-      :key="utils.id()" />
+      :key="f7.utils.id()" />
 
     <f7-block-title>Item</f7-block-title>
     <item-details
@@ -28,7 +28,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import ItemStatePreview from '@/components/item/item-state-preview.vue'
 import ItemDetails from '@/components/model/item-details.vue'
@@ -52,7 +52,7 @@ export default {
   emits: ['item-updated', 'item-created', 'item-removed', 'cancel-create'],
   setup () {
     return {
-      utils
+      f7
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/vue3-masonry-css/core/masonry-grid-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/vue3-masonry-css/core/masonry-grid-item.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script setup lang="ts">
-// @ts-expect-error   TODO-V3.1
-import { utils } from 'framework7'
-const id = utils.id()
+import { f7 } from 'framework7-vue'
+
+const id = f7.utils.id()
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-state-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-state-series.js
@@ -1,4 +1,4 @@
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 import ComponentId from '../../component-id'
 import { graphic } from 'echarts/core'
 
@@ -104,7 +104,7 @@ export default {
 
       series.data = data
 
-      series.id = `oh-state-series#${series.item}#${utils.id()}`
+      series.id = `oh-state-series#${series.item}#${f7.utils.id()}`
     }
 
     if (!series.tooltip) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.js
@@ -1,5 +1,4 @@
-import { utils } from 'framework7'
-import dayjs from 'dayjs'
+import { f7 } from 'framework7-vue'
 
 import ComponentId from '../../component-id'
 import MarkArea from './oh-mark-area'
@@ -32,7 +31,7 @@ export default {
       })
 
       series.data = data
-      series.id = `oh-time-series#${series.item}#${utils.id()}`
+      series.id = `oh-time-series#${series.item}#${f7.utils.id()}`
     }
 
     // other things

--- a/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-circle-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-circle-marker.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import { LCircle, LTooltip } from '@vue-leaflet/vue-leaflet'
 
@@ -32,7 +32,7 @@ export default {
   emits: ['update'],
   data () {
     return {
-      markerKey: utils.id()
+      markerKey: f7.utils.id()
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-marker.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import mixin from '../widget-mixin'
 import { LMarker, LTooltip, LIcon } from '@vue-leaflet/vue-leaflet'
@@ -32,7 +32,7 @@ export default {
   emits: ['update'],
   data () {
     return {
-      markerKey: utils.id()
+      markerKey: f7.utils.id()
     }
   },
   computed: {
@@ -56,7 +56,7 @@ export default {
     icon () {
       if (this.config.icon && this.config.icon.indexOf('oh:') === 0) {
         return this.$oh.media.getIcon(this.config.icon.substring(3)).then((icon) => {
-          this.markerKey = utils.id()
+          this.markerKey = f7.utils.id()
           this.$emit('update')
           return icon
         })

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -57,7 +57,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import mixin from '../widget-mixin'
 import { LMarker, LTooltip, LIcon, LPopup } from '@vue-leaflet/vue-leaflet'
@@ -76,7 +76,7 @@ export default {
   emits: ['update'],
   data () {
     return {
-      markerKey: 'marker-' + utils.id(),
+      markerKey: 'marker-' + f7.utils.id(),
       dragging: false
     }
   },

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
@@ -101,7 +101,7 @@ dark-tooltip()
 
 <script>
 import { nextTick } from 'vue'
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import mixin from '../widget-mixin'
 import { CRS, Icon } from 'leaflet'
@@ -137,7 +137,7 @@ export default {
       zoom: -0.5,
       crs: CRS.Simple,
       showMap: false,
-      mapKey: utils.id(),
+      mapKey: f7.utils.id(),
       markers: []
     }
   },
@@ -203,7 +203,7 @@ export default {
       if (this.$refs.map) this.$refs.map.leafletObject?.fitBounds(this.bounds)
     },
     refreshMap () {
-      this.mapKey = utils.id()
+      this.mapKey = f7.utils.id()
       nextTick(() => {
         this.fitMapBounds()
       })

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
@@ -163,7 +163,6 @@
 </style>
 
 <script>
-import { utils } from 'framework7'
 import { f7 } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -188,7 +187,7 @@ export default {
     return {
       transitioning: false,
       opened: false,
-      cardId: utils.id()
+      cardId: f7.utils.id()
     }
   },
   mounted () {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import mixin from '../widget-mixin'
 import { OhContextDefinition } from '@/assets/definitions/widgets/system'
@@ -15,7 +15,7 @@ export default {
   widget: OhContextDefinition,
   data () {
     return {
-      varScope: (this.context.varScope || 'varScope') + '-' + utils.id()
+      varScope: (this.context.varScope || 'varScope') + '-' + f7.utils.id()
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
@@ -16,7 +16,6 @@
 
 <script>
 import { nextTick } from 'vue'
-import { utils } from 'framework7'
 import { f7 } from 'framework7-vue'
 
 import mixin from '../widget-mixin'
@@ -29,7 +28,7 @@ export default {
   widget: OhImageDefinition,
   data () {
     return {
-      t: utils.id(),
+      t: f7.utils.id(),
       src: null,
       ts: 0
     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -21,7 +21,7 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import mixin from '../widget-mixin'
 import { OhVideoDefinition } from '@/assets/definitions/widgets/system'
@@ -35,7 +35,7 @@ export default {
   },
   data () {
     return {
-      t: utils.id(),
+      t: f7.utils.id(),
       src: null
     }
   },
@@ -49,7 +49,7 @@ export default {
   computed: {
     itemState () {
       if (this.config.item) {
-        return utils.id() + '|' + this.context.store[this.config.item].state
+        return f7.utils.id() + '|' + this.context.store[this.config.item].state
       }
       return null
     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -1,6 +1,6 @@
 // Import into widget components as a mixin!
 
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
 import scope from 'scope-css'
@@ -9,7 +9,6 @@ import WidgetExpressionMixin from '@/components/widgets/widget-expression-mixin'
 import { useUIOptionsStore } from '@/js/stores/useUIOptionsStore'
 import { useUserStore } from '@/js/stores/useUserStore'
 import { useComponentsStore } from '@/js/stores/useComponentsStore'
-import { useStatesStore } from '@/js/stores/useStatesStore'
 
 export default {
   mixins: [WidgetExpressionMixin],
@@ -87,7 +86,7 @@ export default {
     if (this.context?.component?.config?.stylesheet) {
       if (!this.$el.classList) return // widget is not rendered yet, skip scoped styling
 
-      this.cssUid = 'scoped-' + utils.id()
+      this.cssUid = 'scoped-' + f7.utils.id()
 
       this.$el.classList.add(this.cssUid)
 

--- a/bundles/org.openhab.ui/web/src/js/openhab/auth.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/auth.js
@@ -1,4 +1,4 @@
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 
 import { useUserStore } from '@/js/stores/useUserStore'
 
@@ -32,7 +32,7 @@ if (document.cookie.indexOf('X-OPENHAB-AUTH-HEADER') >= 0) tokenInCustomHeader =
 export async function authorize (setup) {
   import('pkce-challenge').then((PkceChallenge) => {
     const pkceChallenge = PkceChallenge.default()
-    const authState = (setup ? 'setup-' : '') + utils.id()
+    const authState = (setup ? 'setup-' : '') + f7.utils.id()
 
     sessionStorage.setItem('openhab.ui:codeVerifier', pkceChallenge.code_verifier)
     sessionStorage.setItem('openhab.ui:authState', authState)

--- a/bundles/org.openhab.ui/web/src/js/openhab/ws.js
+++ b/bundles/org.openhab.ui/web/src/js/openhab/ws.js
@@ -1,4 +1,4 @@
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 import { getAccessToken } from './auth'
 
 /**
@@ -74,7 +74,7 @@ function newWSConnection (path, messageCallback, readyCallback, errorCallback, h
   // Create a new WebSocket connection
   const socket = new WebSocket(path, [`org.openhab.ws.accessToken.base64.${encodedToken}`, 'org.openhab.ws.protocol.default'])
 
-  socket.id = 'ui-' + utils.id()
+  socket.id = 'ui-' + f7.utils.id()
 
   // Handle WebSocket connection opened
   socket.onopen = (event) => {

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -403,7 +403,6 @@
 
 <script>
 import { nextTick, defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -456,8 +455,8 @@ export default {
 
       controlsOpened: false,
       controlsTab: 'series',
-      itemsPickerKey: utils.id(),
-      chartKey: utils.id()
+      itemsPickerKey: f7.utils.id(),
+      chartKey: f7.utils.id()
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -10,7 +10,7 @@
       <f7-link @click="previewOpened = true">
         Preview<span v-if="$device.desktop">&nbsp;(Ctrl-P)</span>
       </f7-link>
-      <f7-link icon-f7="uiwindow_split_2x1" @click="split = (split === 'horizontal') ? 'vertical' : 'horizontal'; blockKey = utils.id();" />
+      <f7-link icon-f7="uiwindow_split_2x1" @click="split = (split === 'horizontal') ? 'vertical' : 'horizontal'; blockKey = f7.utils.id();" />
       <f7-link @click="refreshBlocks">
         Refresh<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </f7-link>
@@ -131,7 +131,6 @@
 </style>
 
 <script>
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { nextTick, defineAsyncComponent } from 'vue'
 
@@ -157,11 +156,10 @@ export default {
     f7route: Object
   },
   setup () {
-    return { theme }
+    return { theme, f7 }
   },
   data () {
     return {
-      utils,
       blocksDefinition: null,
       items: [],
       ready: false,
@@ -170,8 +168,8 @@ export default {
       vars: {},
       previewBlockSource: '<xml xmlns="https://developers.google.com/blockly/xml"></xml>',
       previewCode: '',
-      blockKey: utils.id(),
-      previewKey: utils.id(),
+      blockKey: f7.utils.id(),
+      previewKey: f7.utils.id(),
       previewOpened: false,
       previewMode: 'blockly',
       previewGeneratedCode: ''
@@ -206,7 +204,7 @@ export default {
       }
     },
     refreshBlocks () {
-      this.previewKey = utils.id()
+      this.previewKey = f7.utils.id()
     },
     previewClosed () {
       this.previewOpened = false
@@ -258,7 +256,7 @@ export default {
       if (this.loading) return
       this.loading = true
       if (this.createMode) {
-        const uid = utils.id()
+        const uid = f7.utils.id()
         this.blocksDefinition = YAML.stringify({
           uid: 'blocklibrary_' + uid,
           tags: [],

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -10,7 +10,7 @@
       <f7-link @click="widgetPropsOpened = true">
         Set Props<span v-if="$device.desktop">&nbsp;(Ctrl-P)</span>
       </f7-link>
-      <f7-link icon-f7="uiwindow_split_2x1" @click="split = (split === 'horizontal') ? 'vertical' : 'horizontal'; blockKey = utils.id()" />
+      <f7-link icon-f7="uiwindow_split_2x1" @click="split = (split === 'horizontal') ? 'vertical' : 'horizontal'; blockKey = f7.utils.id()" />
       <f7-link @click="redrawWidget">
         Redraw<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span>
       </f7-link>
@@ -116,7 +116,6 @@
 
 <script>
 import { defineAsyncComponent, nextTick } from 'vue'
-import { utils } from 'framework7'
 import { theme, f7 } from 'framework7-vue'
 
 import YAML from 'yaml'
@@ -142,11 +141,10 @@ export default {
     f7route: Object
   },
   setup () {
-    return { theme }
+    return { f7, theme }
   },
   data () {
     return {
-      utils,
       widgetDefinition: null,
       items: [],
       ready: false,
@@ -154,8 +152,8 @@ export default {
       props: {},
       vars: {},
       ctxVars: {},
-      blockKey: utils.id(),
-      widgetKey: utils.id(),
+      blockKey: f7.utils.id(),
+      widgetKey: f7.utils.id(),
       widgetPropsOpened: false,
       standardListWidgets: Object.values(StandardListWidgets)
         .filter((c) => c.widget && typeof c.widget === 'function')
@@ -237,7 +235,7 @@ export default {
       this.loading = true
       if (this.createMode) {
         this.widgetDefinition = YAML.stringify({
-          uid: 'widget_' + utils.id(),
+          uid: 'widget_' + f7.utils.id(),
           props: {
             parameterGroups: [],
             parameters: [
@@ -322,7 +320,7 @@ export default {
     },
     redrawWidget () {
       this.ctxVars = {}
-      this.widgetKey = utils.id()
+      this.widgetKey = f7.utils.id()
     },
     widgetPropsClosed () {
       this.widgetPropsOpened = false

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -159,7 +159,7 @@
 </style>
 
 <script>
-import { utils } from 'framework7'
+import { f7 } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
 import OverviewTab from './home/overview-tab.vue'
@@ -191,7 +191,7 @@ export default {
       showPinToHome: false,
       showExitToApp: false,
       currentTab: this.initialTab || 'overview',
-      overviewPageKey: utils.id()
+      overviewPageKey: f7.utils.id()
     }
   },
   computed: {
@@ -277,7 +277,7 @@ export default {
   },
   methods: {
     onPageBeforeIn () {
-      this.overviewPageKey = utils.id()
+      this.overviewPageKey = f7.utils.id()
     },
     onPageAfterIn () {
       if (this.ready) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -319,7 +319,6 @@
 
 <script>
 import { nextTick } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { mapWritableState } from 'pinia'
 
@@ -367,7 +366,7 @@ export default {
       detailsOpened: false,
       detailsTab: 'state',
       eventSource: null,
-      itemDetailsKey: utils.id()
+      itemDetailsKey: f7.utils.id()
     }
   },
   computed: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -90,7 +90,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import PageDesigner from '../pagedesigner-mixin'
@@ -130,7 +129,7 @@ export default {
     return {
       pageWidgetDefinition: OhChartPage.widget(),
       page: {
-        uid: 'page_' + utils.id(),
+        uid: 'page_' + f7.utils.id(),
         component: 'oh-chart-page',
         config: {},
         tags: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -215,7 +215,6 @@
 
 <script>
 import { nextTick, defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import PageDesigner from '../pagedesigner-mixin'
@@ -259,7 +258,7 @@ export default {
       currentModelTab: 'locations',
       modelTabs: [],
       showCardControls: false,
-      cardListId: utils.id(),
+      cardListId: f7.utils.id(),
       page: {
         uid: 'home',
         component: 'oh-home-page',
@@ -374,7 +373,7 @@ export default {
       this.cardListId = null
       this.showCardControls = false
       nextTick(() => {
-        this.cardListId = utils.id()
+        this.cardListId = f7.utils.id()
       })
     },
     isCardExcluded (card) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -186,7 +186,6 @@
 
 <script>
 import { nextTick, defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import YAML from 'yaml'
@@ -232,7 +231,7 @@ export default {
   data () {
     return {
       page: {
-        uid: 'page_' + utils.id(),
+        uid: 'page_' + f7.utils.id(),
         component: 'oh-layout-page',
         config: {},
         tags: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -140,7 +140,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import PageDesigner from '../pagedesigner-mixin'
@@ -228,7 +227,7 @@ export default {
       pageWidgetDefinition,
       forceEditMode: true,
       page: {
-        uid: 'page_' + utils.id(),
+        uid: 'page_' + f7.utils.id(),
         component: 'oh-map-page',
         config: {},
         tags: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pagedesigner-mixin.js
@@ -1,5 +1,4 @@
 import { nextTick } from 'vue'
-import { utils } from 'framework7'
 import { f7 } from 'framework7-vue'
 
 import YAML from 'yaml'
@@ -25,7 +24,7 @@ export default {
       pageReady: false,
       loading: false,
       savedPage: {},
-      pageKey: utils.id(),
+      pageKey: f7.utils.id(),
       pageYaml: null,
       props: {},
       previewMode: false,

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -146,7 +146,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import PageDesigner from '../pagedesigner-mixin'
@@ -186,7 +185,7 @@ export default {
       pageWidgetDefinition: OhPlanPage.widget(),
       forceEditMode: true,
       page: {
-        uid: 'page_' + utils.id(),
+        uid: 'page_' + f7.utils.id(),
         component: 'oh-plan-page',
         config: {},
         tags: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -353,7 +353,6 @@
 
 <script>
 import { nextTick } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -392,7 +391,7 @@ export default {
       ready: false,
       loading: false,
       sitemap: {
-        uid: 'page_' + utils.id(),
+        uid: 'page_' + f7.utils.id(),
         component: 'Sitemap',
         config: {
           label: 'New Sitemap'

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -108,7 +108,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import PageDesignerMixin from '@/pages/settings/pages/pagedesigner-mixin'
@@ -140,7 +139,7 @@ export default {
   data () {
     return {
       page: {
-        uid: 'page_' + utils.id(),
+        uid: 'page_' + f7.utils.id(),
         component: 'oh-tabs-page',
         config: {},
         tags: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -345,7 +345,6 @@
 
 <script>
 import { nextTick, defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -456,7 +455,7 @@ export default {
           let newRule
           if (this.ruleCopy) {
             newRule = cloneDeep(this.ruleCopy)
-            newRule.uid = utils.id()
+            newRule.uid = f7.utils.id()
             if (newRule.templateUID) {
               newRule.triggers = []
               newRule.actions = []
@@ -467,7 +466,7 @@ export default {
             }
           } else {
             newRule = {
-              uid: utils.id(),
+              uid: f7.utils.id(),
               name: '',
               triggers: [],
               actions: [],

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -246,7 +246,6 @@
 
 <script>
 import { nextTick, defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import YAML from 'yaml'
@@ -335,7 +334,7 @@ export default {
         this.moduleTypes.actions = data[0]
         if (this.createMode) {
           const newRule = this.ruleCopy || {
-            uid: utils.id(),
+            uid: f7.utils.id(),
             name: '',
             triggers: [],
             actions: [],
@@ -348,7 +347,7 @@ export default {
               status: 'NEW'
             }
           }
-          if (this.ruleCopy) newRule.uid = utils.id()
+          if (this.ruleCopy) newRule.uid = f7.utils.id()
           this.rule = newRule
           loadingFinished()
         } else {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -269,7 +269,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -465,7 +464,7 @@ export default {
     },
     initializeNewScript () {
       this.rule = this.ruleCopy || {
-        uid: utils.id(),
+        uid: f7.utils.id(),
         name: '',
         description: '',
         triggers: [],
@@ -473,7 +472,7 @@ export default {
         actions: [],
         tags: ['Script']
       }
-      if (this.ruleCopy) this.rule.uid = utils.id()
+      if (this.ruleCopy) this.rule.uid = f7.utils.id()
       this.savedRule = cloneDeep(this.rule)
       this.savedMode = this.mode = 'application/javascript+blockly'
       this.loadScriptModuleType().then(() => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -69,7 +69,6 @@
 </style>
 
 <script>
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 
 import ConfigSheet from '@/components/config/config-sheet.vue'
@@ -124,7 +123,7 @@ export default {
       this.$oh.api.get('/rest/thing-types/' + this.thingTypeId).then((data) => {
         this.thingType = data
         try {
-          this.thing.ID = utils.id()
+          this.thing.ID = f7.utils.id()
           this.thing.UID = this.thingTypeId + ':' + this.thing.ID
         } catch (e) {
           console.log('Cannot generate ID: ' + e)

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-edit.vue
@@ -136,7 +136,6 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { utils } from 'framework7'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -225,7 +224,7 @@ export default {
     },
     initializeNewTransformation () {
       this.transformation = {
-        uid: utils.id(),
+        uid: f7.utils.id(),
         label: '',
         type: '',
         configuration: {


### PR DESCRIPTION
In addressing the TODO-V3.1 areas, the way we were importing utils generated an error. Accessing utils directly on the f7 instance addresses this issue. Updated reference to utils across the app to be consistent.