### PR TITLE
Transformations list: Persist & restore last search query

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useLastSearchQueryStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useLastSearchQueryStore.ts
@@ -9,6 +9,7 @@ export const useLastSearchQueryStore = defineStore('lastSearchQuery', () => {
   const lastScheduleSearchQuery = ref<string>('')
   const lastModelSearchQuery = ref<string>('')
   const lastRulesSearchQuery = ref<object>({})
+  const lastTransformationSearchQuery = ref<string>('')
 
   return {
     lastItemSearchQuery,
@@ -16,6 +17,7 @@ export const useLastSearchQueryStore = defineStore('lastSearchQuery', () => {
     lastPagesSearchQuery,
     lastScheduleSearchQuery,
     lastModelSearchQuery,
-    lastRulesSearchQuery
+    lastRulesSearchQuery,
+    lastTransformationSearchQuery
   }
 })


### PR DESCRIPTION
Persistence was never implemented for the search box for transformations. This was part of the TODO-V3.1 updates required.