### PR TITLE
Better clarity for rule-edit alert dialog when missing label or id (issue #3379)

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -548,11 +548,11 @@ export default {
         }
       }
       if (!this.rule.uid) {
-        f7.dialog.alert('Please give an ID to the rule')
+        f7.dialog.alert('Please provide a unique rule ID. The ID must not be empty and should only contain letters, numbers, hyphens or underscores.', 'ID required').open()
         return Promise.reject()
       }
       if (!this.rule.name) {
-        f7.dialog.alert('Please give a name to the rule')
+        f7.dialog.alert('Please provide a rule label. The label is required and will be shown in the UI to identify this rule.', 'Label required').open()
         return Promise.reject()
       }
       const promise = (this.createMode)


### PR DESCRIPTION
Fixes #3379.

@florian-h05 - should we be moving these messages to i18n?