### PR TITLE
oh-state-series: Fix issues with fixed time duration charts

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-time-axis.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-time-axis.js
@@ -10,9 +10,11 @@ export default {
     axis.type = 'time'
     if (chart.config.chartType) {
       axis.min = (v) => {
+        if(isNaN(v.min)) return startTime.toDate().getTime()
         return isFinite(v.min) ? dayjs(v.min).startOf(chart.config.chartType).toDate().getTime() : v.min
       }
       axis.max = (v) => {
+        if(isNaN(v.min)) return endTime.toDate().getTime()
         return isFinite(v.min) ? dayjs(v.min).startOf(chart.config.chartType).add(1, chart.config.chartType === 'isoWeek' ? 'week' : chart.config.chartType).toDate().getTime() : v.max
       }
     } else {

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-state-series.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-state-series.js
@@ -5,27 +5,18 @@ import { graphic } from 'echarts/core'
 function renderState (params, api) {
   const yValue = api.value(0)
   const start = api.coord([api.value(1), yValue])
-  const duration = api.value(2)
-  const end = api.coord([api.value(1) + duration, yValue])
+  const end = api.coord([api.value(2), yValue])
   const state = api.value(3)
   const yHeight = api.value(4)
 
   if (state === 'UNDEF' || state === 'NULL') return
   const height = api.size([0, 1])[1] * yHeight
-  const rectShape = graphic.clipRectByRect(
-    {
-      x: start[0],
-      y: start[1] - height / 2,
-      width: end[0] - start[0],
-      height
-    },
-    {
-      x: params.coordSys.x,
-      y: params.coordSys.y,
-      width: params.coordSys.width,
-      height: params.coordSys.height
-    }
-  )
+  const rectShape = {
+    x: start[0],
+    y: start[1] - height / 2,
+    width: end[0] - start[0],
+    height
+  }
   return (
     rectShape && {
       type: 'rect',
@@ -53,6 +44,7 @@ export default {
       itemName: 3
     }
     series.colorBy = 'data'
+    series.clip = true
     series.label = series.label || { }
     if (series.label.show === undefined) series.label.show = true
     series.label.position = series.label.position || 'insideLeft'
@@ -61,7 +53,7 @@ export default {
     series.tooltip = series.tooltip || { }
     if (series.tooltip.formatter === undefined) {
       series.tooltip.formatter = (params) => {
-        let durationSec = params.value[2] / 1000
+        let durationSec = (params.value[2] - params.value[1]) / 1000
         let hours = Math.floor(durationSec / 3600).toString().padStart(2, '0')
         let minutes = Math.floor((durationSec - (hours * 3600)) / 60).toString().padStart(2, '0')
         return params.seriesName + '<br />' + params.marker + params.name + '&#9;(' + hours + ':' + minutes + ')'
@@ -90,11 +82,10 @@ export default {
 
         itemStartTime = itemStartTime || new Date(itemPoints[i].time)
         let itemEndTime = new Date(itemPoints[i + 1] ? itemPoints[i + 1].time : endTime)
-        let itemDuration = itemEndTime - itemStartTime
 
         let stateColor = (series.stateColor) ? series.stateColor[itemPoints[i].state] : null
         data.push({
-          value: [series.yValue || 0, itemStartTime, itemDuration, itemPoints[i].state, series.yHeight || 0.6],
+          value: [series.yValue || 0, itemStartTime, itemEndTime, itemPoints[i].state, series.yHeight || 0.6],
           itemStyle: {
             color: stateColor
           }


### PR DESCRIPTION
Fixes #3408.

oh-state-series for fixed duration periods (State series not working in non-dynamic modes (i.e. day, month, ...) did not work. To calculate the min / max values for the time axis, a callback function is used where echarts provides the min/max values of the dataset. Since echarts does not kow about the x value in custom series dataset, the provided min/max values are NaN. To correct, we now check for isNaN and return the bounds for the chart itself.

Also, some minor adjustments in the dataset parameters and clipping is now done by echarts with the series.clip=true.