### PR TITLE
Semantic Tags Editor: Require tag names to be capitalized

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -103,8 +103,8 @@
                                      placeholder="name"
                                      required
                                      validate
-                                     pattern="^[A-Za-z][A-Za-z0-9]*$"
-                                     error-message="Required. A-Z,a-z,0-9 only"
+                                     pattern="^[A-Z][A-Za-z0-9]*$"
+                                     error-message="Required. A-Z,a-z,0-9 only, and must start with A-Z"
                                      @input="updateName($event)">
                         <template #inner-end>
                           <f7-icon v-if="!selectedTag.editable"


### PR DESCRIPTION
In addition to https://github.com/openhab/openhab-webui/pull/3410.

Matches the core validation: https://github.com/openhab/openhab-core/blob/b1670ec2fae5e523f440f220b582eef8e9d004ff/bundles/org.openhab.core.semantics/src/main/java/org/openhab/core/semantics/internal/SemanticTagRegistryImpl.java#L130
