### PR TITLE
Fix back-link url in health-overview

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -3,7 +3,7 @@
     <f7-navbar>
       <oh-nav-content title="Health Checks"
                       back-link="Settings"
-                      back-link-url="/settings"
+                      back-link-url="/settings/"
                       :f7router />
     </f7-navbar>
 


### PR DESCRIPTION
Regression from #3350.