### PR TITLE
Fix missing nav title in about page & add-ons store

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
+++ b/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
@@ -11,10 +11,15 @@
              :href="backLinkUrl"
              @click="back" />
   </f7-nav-left>
-  <component :is="titleComponent">
+  <!-- if large is enabled, we need both the normal and the large title, as the navbar might collapse when scrolling down -->
+  <f7-nav-title>
     {{ title }}
     <span v-if="subtitle" class="subtitle">{{ subtitle }}</span>
-  </component>
+  </f7-nav-title>
+  <f7-nav-title-large v-if="large">
+    {{ title }}
+    <span v-if="subtitle" class="subtitle">{{ subtitle }}</span>
+  </f7-nav-title-large>
   <f7-nav-right>
     <developer-dock-icon />
     <f7-link v-if="editable === false"
@@ -45,10 +50,9 @@
  *
  * To use it, simply put it as the first component into the f7-navbar.
  */
-import { f7, theme, f7NavTitle, f7NavTitleLarge } from 'framework7-vue'
+import { f7, theme } from 'framework7-vue'
 import type { Router } from 'framework7'
 import DeveloperDockIcon from '@/components/developer/developer-dock-icon.vue'
-import { computed } from 'vue'
 
 const props = withDefaults(defineProps<{
   title: string,
@@ -71,14 +75,6 @@ defineEmits(['save'])
 defineSlots<{
   right: void,
 }>()
-
-const titleComponent = computed(() => {
-  if (props.large) {
-    return f7NavTitleLarge
-  } else {
-    return f7NavTitle
-  }
-})
 
 function back () {
   if (props.backLinkUrl) return

--- a/bundles/org.openhab.ui/web/src/pages/about.vue
+++ b/bundles/org.openhab.ui/web/src/pages/about.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page name="about" class="page-about" @page:beforein="beforePageIn">
     <f7-navbar large>
-      <oh-nav-content :title="t('about.title')" :f7router />
+      <oh-nav-content :title="t('about.title')" :large="true" :f7router />
     </f7-navbar>
     <f7-block class="block-narrow after-big-title">
       <f7-row>

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -6,7 +6,7 @@
     <f7-navbar large
                :large-transparent="false"
                class="store-nav">
-      <oh-nav-content :title="AddonTitles[currentTab] || 'Add-on Store'" :f7router />
+      <oh-nav-content :title="AddonTitles[currentTab] || 'Add-on Store'" :large="true" :f7router />
     </f7-navbar>
     <f7-toolbar v-show="$f7dim.width < 1024 || !leftPanelOpened" tabbar bottom>
       <f7-link tab-link="#main"


### PR DESCRIPTION
Regression from #3350.