### PR TITLE
oh-nav-content: Fix back navigation navigates to subpage

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
+++ b/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
@@ -91,8 +91,8 @@ function back () {
   }
 
   if (previousPath === null) {
-    console.warn('No previous path found in history, cannot navigate back.')
-    return
+    console.warn('No previous path found in history, falling back to root path.')
+    previousPath = '/'
   }
   console.debug('Navigating back to previous path:', previousPath)
   f7router.navigate(previousPath, { force: true })


### PR DESCRIPTION
The back button should always return to a previous page that is not a subpage of the current page. This fixes an issue where: Settings Menu -> Items -> Settings Menu and then clicking back on Settings Menu navigated back to Items.