### PR TITLE
Item picker title fix

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="item-picker-container">
     <f7-list-item v-if="ready"
-                  :title="itemTitle || 'Item'"
+                  :title="label || 'Item'"
                   smart-select
                   :smart-select-params="smartSelectParams"
                   :disabled="disabled ? true : null"
@@ -37,7 +37,7 @@
     <!-- for placeholder purposes before items are loaded -->
     <f7-list-item v-else
                   link
-                  :title="itemTitle"
+                  :title="label"
                   disabled
                   no-chevron>
       <template #media>
@@ -74,7 +74,7 @@ import ModelPickerPopup from '@/components/model/model-picker-popup.vue'
 
 export default {
   props: {
-    itemTitle: String,
+    label: String,
     name: String,
     value: [String, Array],
     items: Array,
@@ -174,7 +174,7 @@ export default {
           value: this.value,
           multiple: this.multiple,
           allowEmpty: true,
-          popupTitle: this.itemTitle,
+          popupTitle: this.label,
           groupsOnly: this.filterType && this.filterType === 'Group',
           editableOnly: this.editableOnly
         }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-item.vue
@@ -1,5 +1,5 @@
 <template>
-  <item-picker :item-title="configDescription.label || 'Item'"
+  <item-picker :label="configDescription.label || 'Item'"
                :value="value"
                @input="updateValue"
                :multiple="configDescription.multiple"

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -15,7 +15,7 @@
           <item-picker :multiple="true"
                        name="groupMembers"
                        :value="pickedMemberNames"
-                       title="Members"
+                       label="Members"
                        :editableOnly="true"
                        @input="(members) => pickedMemberNames = members" />
         </f7-list-group>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -148,7 +148,7 @@
       </f7-list-item>
       <f7-list-group>
         <item-picker v-if="editable"
-                     title="Select"
+                     label="Select"
                      :value="item.groupNames"
                      :items="items"
                      @input="(value) => this.item.groupNames = value"

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -21,7 +21,7 @@
                        clear-button />
         <f7-list-group v-if="widget.component !== 'Sitemap' && widget.component !== 'Frame'">
           <item-picker
-            title="Item"
+            label="Item"
             :value="widget.config.item"
             @input="(value) => widget.config.item = value" />
         </f7-list-group>

--- a/bundles/org.openhab.ui/web/src/components/rule/action-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/action-module-wizard.vue
@@ -48,7 +48,7 @@
     <f7-list>
       <f7-list-group>
         <item-picker :value="currentModule.configuration.itemName"
-                     title="Item"
+                     label="Item"
                      @input="(val) => currentModule.configuration.itemName = val"
                      @item-selected="(value) => { this.currentItem = value; updateItemEventType('command') }" />
       </f7-list-group>

--- a/bundles/org.openhab.ui/web/src/components/rule/condition-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/condition-module-wizard.vue
@@ -35,7 +35,7 @@
   <f7-block class="no-margin no-padding" v-else-if="category === 'item'">
     <f7-list>
       <f7-list-group>
-        <item-picker :value="currentModule.configuration.itemName" title="Item" @input="(val) => currentModule.configuration.itemName = val" />
+        <item-picker :value="currentModule.configuration.itemName" label="Item" @input="(val) => currentModule.configuration.itemName = val" />
       </f7-list-group>
     </f7-list>
     <f7-list>

--- a/bundles/org.openhab.ui/web/src/components/rule/trigger-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/trigger-module-wizard.vue
@@ -37,7 +37,7 @@
       <f7-list-group>
         <item-picker :required="true"
                      :value="currentItem.name"
-                     title="Item"
+                     label="Item"
                      @input="(val) => currentModule.configuration.itemName = val"
                      @item-selected="(value) => { currentItem = value; updateItemEventType('command') }" />
       </f7-list-group>

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -100,7 +100,7 @@
           </f7-list-item>
           <f7-list-group>
             <item-picker
-              :title="t('about.miscellaneous.commandItem.title')"
+              :label="t('about.miscellaneous.commandItem.title')"
               :multiple="false"
               :value="commandItem"
               @input="setCommandItem" />

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -72,7 +72,7 @@
               </template>
               <template v-else-if="multipleLinksMode" #default="{ channelType, channel }">
                 <item-picker v-if="isChecked(channel) && hasLinks(channel)"
-                             :title="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
+                             :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
                              textColor="blue"
                              :hideIcon="true"
                              :items="items.filter((i) => channel.linkedItems.includes(i.name))"

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -70,7 +70,7 @@
                   <f7-list style="width: 100%">
                     <f7-list-group>
                       <item-picker :key="itemsPickerKey"
-                                   title="Items"
+                                   label="Items"
                                    name="items-to-analyze"
                                    :value="itemNames"
                                    @input="updateItems"

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -72,7 +72,7 @@
         <div v-else-if="selectedThing.UID && selectedThingType.UID">
           <f7-list v-if="createEquipment" media-list class="equipment-group-picker">
             <f7-list-group>
-              <item-picker :title="selectedGroup ? 'Change Selected Group' : 'Pick Existing Group'"
+              <item-picker :label="selectedGroup ? 'Change Selected Group' : 'Pick Existing Group'"
                            textColor="blue"
                            :hideIcon="true"
                            :items="selectableGroups"

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -32,7 +32,7 @@
           <f7-list>
             <f7-list-group>
               <item-picker key="groups"
-                           title="Select groups"
+                           label="Select groups"
                            name="groupItems"
                            :multiple="true"
                            filterType="Group"
@@ -45,7 +45,7 @@
           <f7-list>
             <f7-list-group>
               <item-picker key="items"
-                           title="Select Items"
+                           label="Select Items"
                            name="items"
                            :multiple="true"
                            :disabled="allItemsSelected ? true : null"
@@ -57,7 +57,7 @@
           <f7-list>
             <f7-list-group>
               <item-picker key="exclude-groups"
-                           title="Select exclude groups"
+                           label="Select exclude groups"
                            name="excludeGroupItems"
                            :multiple="true"
                            filterType="Group"
@@ -70,7 +70,7 @@
           <f7-list>
             <f7-list-group>
               <item-picker key="exclude-items"
-                           title="Select exclude Items"
+                           label="Select exclude Items"
                            name="excludeItems"
                            :multiple="true"
                            :disabled="!anySelected ? true : null"

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -273,7 +273,7 @@
               <f7-list v-if="editable">
                 <f7-list-group>
                   <item-picker class="alias-item-picker"
-                               title="Add alias"
+                               label="Add alias"
                                name="items"
                                :multiple="true"
                                :noModelPicker="true"

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -154,7 +154,7 @@
                   </template>
                 </f7-list-item> -->
                 <f7-list-group>
-                  <item-picker title="Select Items"
+                  <item-picker label="Select Items"
                                name="newItem"
                                :multiple="true"
                                :value="selectedItems"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -48,7 +48,7 @@
           <f7-list>
             <f7-list-group>
               <item-picker key="itemLink"
-                           title="Item to Link"
+                           label="Item to Link"
                            name="item"
                            :value="selectedItemName"
                            :multiple="false"


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/discussions/3381#discussioncomment-14861022.
Regression from #3350.

Fix for Vue 3 binding title to the DOM title vs. the component property in item-picker by renaming the prop from title -> label.