### PR TITLE
Items pages: Fix various CSS issues

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -1,5 +1,6 @@
 <template>
-  <f7-page class="item-details-page"
+  <!-- page-with-subnavbar class required on Android -->
+  <f7-page class="item-details-page page-with-subnavbar"
            @page:beforein="onPageBeforeIn"
            @page:beforeout="onPageBeforeOut">
     <f7-navbar>
@@ -161,8 +162,10 @@
       font-weight normal
       text-align center
       margin-top 0
-.after-item-header
-  margin-top 10rem !important
+.item-details-page
+  --f7-page-subnavbar-offset 170px
+  .after-item-header
+    margin-bottom 0 !important
 .tags-block
   margin-bottom 0
   text-align center

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -337,9 +337,9 @@ export default {
     },
     height (item) {
       let vlHeight
-      if (theme.ios) vlHeight = 73.15
+      if (theme.ios) vlHeight = 79.19
       if (theme.aurora) vlHeight = 66.37
-      if (theme.md) vlHeight = 73.37
+      if (theme.md) vlHeight = 79.39
       if (this.$device.macos) {
         if (window.navigator.userAgent.includes('Safari') && !window.navigator.userAgent.includes('Chrome')) vlHeight -= 0.77
       }


### PR DESCRIPTION
Regression from #3350.

- Fix subnavbar on Item detail page not visible on Material Design.
- Fix placement of Item details page content.
- Fix height of virtual list items.