### PR TITLE
Fix navbar title overflows if screen to narrow and title too long

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -92,6 +92,7 @@ html
   .title
     left 0 !important
     right 0 !important
+    max-width calc(100% - var(--f7-navbar-inner-padding-left) - 50px - 50px - var(--f7-navbar-inner-padding-right))
   .right
     position absolute
     right var(--f7-navbar-inner-padding-right)


### PR DESCRIPTION
Regression from #3350.