### PR TITLE
oh-slider: Protect against posting errant slider updates

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-slider.vue
@@ -66,7 +66,7 @@ export default {
       return parseFloat(Number(value).toFixed(nbDecimals ?? 0))
     },
     onChange (newValue) {
-      if (isNaN(this.value)) return
+      if (isNaN(this.value) || isNaN(newValue)) return
       const tsf = this.toStepFixed(newValue)
       // Do NOT send command if sliderValue is smaller than real value +-step
       if (Math.abs(tsf - this.value) < (this.config.step || 1)) {


### PR DESCRIPTION
Some of my sliders would occasionally be sending a NaN value back to openHAB when the position was updating.  I'm not sure if this was present before the big refactor, but i have noticed we now pop up an error dialog anytime a command receives a non `2xx` response, so its a lot more apparent when there are issues (we may want to tune this a bit); 