### PR TITLE
oh-nav-content: Remove current page from history on back navigation

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
+++ b/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
@@ -82,7 +82,8 @@ defineSlots<{
 }>()
 
 function back () {
-  if (props.backLinkUrl || props.backLinkUrl === null) {
+  if (props.backLinkUrl) return
+  if (props.backLinkUrl === null) {
     emit('back')
     return
   }
@@ -103,6 +104,7 @@ function back () {
     previousPath = '/'
   }
   console.debug('Navigating back to previous path:', previousPath)
+  f7router.history.pop()
   f7router.navigate(previousPath, { force: true })
 }
 </script>


### PR DESCRIPTION
Regression from #3050.

This fixes issues where back navigation leaded to a circular navigation between two pages.