### PR TITLE
Various CSS fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -72,9 +72,11 @@ html
     --f7-typography-margin 0
     --f7-list-item-padding-vertical 10px
   // actions modal
-  --f7-actions-button-height 40px
-  --f7-actions-button-height-landscape 44px
-  --f7-actions-group-margin 24px
+  --f7-actions-button-height 44px
+  --f7-actions-button-height-landscape 48px
+  .actions-modal > .actions-group
+    margin-left 28px
+    margin-right 28px
 
 /* Adjustments for cards */
 :root
@@ -92,7 +94,7 @@ html
   .title
     left 0 !important
     right 0 !important
-    max-width calc(100% - var(--f7-navbar-inner-padding-left) - 50px - 50px - var(--f7-navbar-inner-padding-right))
+    max-width calc(100% - var(--f7-navbar-inner-padding-left) - 140px - var(--f7-navbar-inner-padding-right))
   .right
     position absolute
     right var(--f7-navbar-inner-padding-right)

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-action-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-action-popup.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-popup ref="modulePopup" class="moduleconfig-popup">
+  <f7-popup ref="modulePopup" class="thing-action-popup">
     <f7-page>
       <f7-navbar>
         <f7-nav-left>
@@ -94,7 +94,7 @@
                 </f7-list-item>
               </template>
               <f7-list-item accordion-item title="Raw Output Value">
-                <f7-accordion-content class="thing-type-description">
+                <f7-accordion-content class="raw-value">
                   <div class="margin">
                     <code> {{ actionOutput }} </code>
                   </div>
@@ -107,6 +107,14 @@
     </f7-page>
   </f7-popup>
 </template>
+
+<style lang="stylus">
+.thing-action-popup
+  .raw-value
+    padding-left calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-left) - var(--menu-list-offset))
+    div
+      padding-bottom calc(var(--f7-list-item-padding-vertical))
+</style>
 
 <script>
 import { defineAsyncComponent } from 'vue'


### PR DESCRIPTION
Regression from #3050.

- Adjust actions modal buttons on mobile to look more like in F7 v5.
- Reduce title max-width further to avoid overflowing on iOS
- Thing Action popup: Fix raw value accordion styling