### PR TITLE
Widget expressions: Add access to global i18n translations

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-expression-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-expression-mixin.js
@@ -126,6 +126,7 @@ export default {
             JSON,
             dayjs,
             user: useUserStore().user,
+            translations: i18n.global.t,
             t: i18n.global.t
           })
         } catch (e) {


### PR DESCRIPTION
The naming of the function has to be discussed, this is just a PoC.
I would propose `translation`, so it is used like `=translation('Floor')`.