### PR TITLE
Implement backwards compatibility for f7-swiper usage in widgets

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -1,50 +1,56 @@
 <template>
-  <component v-if="componentType && componentType.startsWith('f7-') && visible"
-             :is="componentType"
-             v-bind="config">
-    <!-- eslint-disable-next-line vue/no-unused-vars -->
-    <template v-for="(slotComponents, slotName) in context.component.slots" :key="slotName" #[slotName]>
-      <ul v-if="componentType === 'f7-list'">
-        <generic-widget-component v-for="(slotComponent, idx) in slotComponents"
-                                  :context="childContext(slotComponent)"
-                                  :key="slotName + '-' + idx" />
-      </ul>
-      <template v-else>
-        <generic-widget-component v-for="(slotComponent, idx) in slotComponents"
-                                  :context="childContext(slotComponent)"
-                                  :key="slotName + '-' + idx" />
+  <template v-if="visible">
+    <!-- Render oh-swiper instead of f7-swiper as f7-swiper changes from F7 v5 -> v7 would require changing widgets,
+    oh-swiper does the necessary adjustments so existing widgets continue to work fine -->
+    <oh-swiper v-if="componentType === 'f7-swiper'" :context="context" />
+
+    <component v-else-if="componentType && componentType.startsWith('f7-')"
+               :is="componentType"
+               v-bind="config">
+      <!-- eslint-disable-next-line vue/no-unused-vars -->
+      <template v-for="(slotComponents, slotName) in context.component.slots" :key="slotName" #[slotName]>
+        <ul v-if="componentType === 'f7-list'">
+          <generic-widget-component v-for="(slotComponent, idx) in slotComponents"
+                                    :context="childContext(slotComponent)"
+                                    :key="slotName + '-' + idx" />
+        </ul>
+        <template v-else>
+          <generic-widget-component v-for="(slotComponent, idx) in slotComponents"
+                                    :context="childContext(slotComponent)"
+                                    :key="slotName + '-' + idx" />
+        </template>
       </template>
+    </component>
+    <oh-card v-else-if="componentType && componentType === 'oh-card'" :context="context">
+      <template v-for="(slotComponents, slotName) in context.component.slots" :key="slotName" #[slotName]>
+        <generic-widget-component v-for="(slotComponent, idx) in slotComponents"
+                                  :context="childContext(slotComponent)"
+                                  :key="slotName + '-' + idx " />
+      </template>
+    </oh-card>
+    <generic-widget-component v-else-if="componentType && componentType.startsWith('widget:')"
+                              :context="childWidgetContext()" />
+    <component v-else-if="componentType && componentType.startsWith('oh-')"
+               :is="componentType"
+               :context="context" />
+    <!-- Label renders text inside <div> element -->
+    <div v-else-if="componentType && componentType === 'Label'" :class="config.class" :style="config.style">
+      {{ config.text }}
+    </div>
+    <!-- Content renders text without any additional container -->
+    <template v-else-if="componentType && componentType === 'Content'">
+      {{ config.text }}
     </template>
-  </component>
-  <oh-card v-else-if="componentType && componentType === 'oh-card' && visible" :context="context">
-    <template v-for="(slotComponents, slotName) in context.component.slots" :key="slotName" #[slotName]>
-      <generic-widget-component v-for="(slotComponent, idx) in slotComponents"
-                                :context="childContext(slotComponent)"
-                                :key="slotName + '-' + idx " />
-    </template>
-  </oh-card>
-  <generic-widget-component v-else-if="componentType && componentType.startsWith('widget:') && visible"
-                            :context="childWidgetContext()" />
-  <component v-else-if="componentType && componentType.startsWith('oh-') && visible"
-             :is="componentType"
-             :context="context" />
-  <!-- Label renders text inside <div> element -->
-  <div v-else-if="componentType && componentType === 'Label' && visible" :class="config.class" :style="config.style">
-    {{ config.text }}
-  </div>
-  <!-- Content renders text without any additional container -->
-  <template v-else-if="componentType && componentType === 'Content'">
-    {{ config.text }}
+    <pre v-else-if="componentType && componentType === 'Error'" class="text-color-red" style="white-space: pre-wrap">{{ config.error }}</pre>
+    <component v-else :is="componentType" v-bind="config">
+      {{ config.content }}
+      <template v-if="context.component.slots && context.component.slots.default">
+        <generic-widget-component v-for="(slotComponent, idx) in context.component.slots.default"
+                                  :context="childContext(slotComponent)"
+                                  :key="'default-' + idx" />
+      </template>
+    </component>
   </template>
-  <pre v-else-if="componentType && componentType === 'Error' && visible" class="text-color-red" style="white-space: pre-wrap">{{ config.error }}</pre>
-  <component v-else-if="visible" :is="componentType" v-bind="config">
-    {{ config.content }}
-    <template v-if="context.component.slots && context.component.slots.default">
-      <generic-widget-component v-for="(slotComponent, idx) in context.component.slots.default"
-                                :context="childContext(slotComponent)"
-                                :key="'default-' + idx" />
-    </template>
-  </component>
 </template>
 
 <script setup>

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-swiper v-bind="config" observer observe-parents>
+  <f7-swiper v-bind="mergedConfig" observer observe-parents>
     <!-- renders slides added through the add slide component below -->
     <f7-swiper-slide
       v-for="(slide, idx) in slides"
@@ -92,6 +92,15 @@ export default {
     repeater () {
       if (!this.context.component.slots || !this.context.component.slots.default) return []
       return this.context.component.slots.default.filter((c) => c.component === 'oh-repeater')
+    },
+    mergedConfig () {
+      const config = Object.assign({}, this.config)
+      // provide backwards compatibility for the params object as passed to f7-swiper in F7 v5
+      if (config.params) {
+        Object.assign(config, this.config.params)
+        delete config.params
+      }
+      return config
     }
   }
 }


### PR DESCRIPTION
This automatically transforms any use of f7-swiper in widgets to oh-swiper, which handles the swiper children properly.
Existing swiper widgets don't need to be changed, even though F7 changed the swiper behaviour very much.