### PR TITLE
Fix oh-knob not working with Vue 3

### DIFF
--- a/bundles/org.openhab.ui/web/package-lock.json
+++ b/bundles/org.openhab.ui/web/package-lock.json
@@ -87,7 +87,7 @@
         "vue-i18n": "^11.1.10",
         "vue-magic-grid": "0.0.4",
         "vue-qrcode": "^2.2.2",
-        "vue-round-slider": "^1.0.1",
+        "vue-three-round-slider": "^1.2.7",
         "vue3-clipboard": "^1.0.0",
         "vuex": "^4.1.0",
         "yaml": "^2.8.0"
@@ -188,6 +188,7 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -766,6 +767,7 @@
     "node_modules/@codemirror/language": {
       "version": "6.11.3",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -803,6 +805,7 @@
     "node_modules/@codemirror/state": {
       "version": "6.5.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
       }
@@ -810,6 +813,7 @@
     "node_modules/@codemirror/view": {
       "version": "6.38.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -919,6 +923,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -940,6 +945,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1044,6 +1050,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -1449,6 +1456,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -2988,7 +2996,6 @@
       "version": "0.3.11",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -4356,7 +4363,6 @@
       "version": "3.7.7",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint": "*",
         "@types/estree": "*"
@@ -4435,6 +4441,7 @@
       "version": "8.46.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.1",
         "@typescript-eslint/types": "8.46.1",
@@ -5510,6 +5517,7 @@
     "node_modules/@vue/runtime-core": {
       "version": "3.5.22",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/reactivity": "3.5.22",
         "@vue/shared": "3.5.22"
@@ -5578,7 +5586,6 @@
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/helper-numbers": "1.13.2",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
@@ -5587,26 +5594,22 @@
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
       "version": "1.13.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
       "version": "1.13.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
       "version": "1.14.1",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
       "version": "1.13.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/floating-point-hex-parser": "1.13.2",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5616,14 +5619,12 @@
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
       "version": "1.13.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5635,7 +5636,6 @@
       "version": "1.13.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
@@ -5644,7 +5644,6 @@
       "version": "1.13.2",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
@@ -5652,14 +5651,12 @@
     "node_modules/@webassemblyjs/utf8": {
       "version": "1.13.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5675,7 +5672,6 @@
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
@@ -5688,7 +5684,6 @@
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-buffer": "1.14.1",
@@ -5700,7 +5695,6 @@
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@webassemblyjs/helper-api-error": "1.13.2",
@@ -5714,7 +5708,6 @@
       "version": "1.14.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
@@ -5730,14 +5723,12 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -5760,6 +5751,7 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5771,7 +5763,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       },
@@ -6028,6 +6019,7 @@
     "node_modules/blockly": {
       "version": "10.4.3",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "jsdom": "22.1.0"
       }
@@ -6144,6 +6136,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.9",
         "caniuse-lite": "^1.0.30001746",
@@ -6161,8 +6154,7 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/buffer-xor": {
       "version": "1.0.3",
@@ -6311,7 +6303,6 @@
       "version": "1.0.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.0"
       }
@@ -6446,6 +6437,7 @@
     "node_modules/codemirror": {
       "version": "6.0.2",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.0.0",
         "@codemirror/commands": "^6.0.0",
@@ -6755,6 +6747,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -7319,6 +7312,7 @@
       "version": "0.25.10",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -7401,6 +7395,7 @@
       "version": "9.37.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7863,6 +7858,7 @@
       "version": "10.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "natural-compare": "^1.4.0",
@@ -8518,8 +8514,7 @@
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "dev": true,
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
       "version": "2.0.2",
@@ -9149,7 +9144,6 @@
       "version": "27.5.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "merge-stream": "^2.0.0",
@@ -9169,6 +9163,8 @@
     },
     "node_modules/jquery": {
       "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
       "license": "MIT"
     },
     "node_modules/js-beautify": {
@@ -9265,6 +9261,7 @@
     "node_modules/jsep": {
       "version": "1.4.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -9333,6 +9330,7 @@
       "version": "2.4.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -9437,7 +9435,8 @@
     },
     "node_modules/leaflet": {
       "version": "1.9.4",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/leaflet-providers": {
       "version": "2.0.0",
@@ -9721,7 +9720,6 @@
       "version": "4.3.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6.11.5"
       },
@@ -9857,8 +9855,7 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -10136,8 +10133,7 @@
     "node_modules/neo-async": {
       "version": "2.6.2",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.23",
@@ -12632,6 +12628,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13367,6 +13364,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -14019,6 +14017,7 @@
       "version": "7.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -14303,6 +14302,7 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -14404,6 +14404,7 @@
     "node_modules/qrcode": {
       "version": "1.5.4",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dijkstrajs": "^1.0.1",
         "pngjs": "^5.0.0",
@@ -14756,6 +14757,7 @@
       "version": "1.0.0-beta.42",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.94.0",
         "@rolldown/pluginutils": "1.0.0-beta.42",
@@ -14793,6 +14795,7 @@
       "version": "4.52.4",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -15048,6 +15051,8 @@
     },
     "node_modules/round-slider": {
       "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/round-slider/-/round-slider-1.6.1.tgz",
+      "integrity": "sha512-yRVcksg/wUP6TUWoNrnGRkbvfWuir73+ZgVhYBQaMHXwq2Z2c2MyVZav6p0voIqMZNPbELuYF0UFkg+5d5dNgg==",
       "license": "MIT",
       "dependencies": {
         "jquery": ">= 1.10.2"
@@ -15172,6 +15177,7 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -15265,7 +15271,6 @@
       "version": "6.0.2",
       "dev": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "randombytes": "^2.1.0"
       }
@@ -15416,7 +15421,6 @@
       "version": "0.5.21",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
@@ -15670,6 +15674,7 @@
       "version": "0.64.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@adobe/css-tools": "~4.3.3",
         "debug": "^4.3.2",
@@ -15738,7 +15743,6 @@
       "version": "8.1.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -15854,7 +15858,6 @@
       "version": "5.44.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -15872,7 +15875,6 @@
       "version": "5.3.14",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.25",
         "jest-worker": "^27.4.5",
@@ -15905,8 +15907,7 @@
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tiny-emitter": {
       "version": "2.1.0",
@@ -16170,6 +16171,7 @@
       "version": "5.8.3",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16393,6 +16395,7 @@
       "version": "7.1.16",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.92.0",
         "fdir": "^6.5.0",
@@ -16774,6 +16777,7 @@
     "node_modules/vue": {
       "version": "3.5.22",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",
@@ -16878,6 +16882,7 @@
       "version": "10.2.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -16957,8 +16962,10 @@
         "vue": "^2.7.0 || ^3.0.0"
       }
     },
-    "node_modules/vue-round-slider": {
-      "version": "1.0.1",
+    "node_modules/vue-three-round-slider": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/vue-three-round-slider/-/vue-three-round-slider-1.2.7.tgz",
+      "integrity": "sha512-sYXvvYieuQ6859PZPcm0dq4YgXKZM/P83NmQMt1DbxrU/3gq7lkqvzzTecKdCfjNAkiKZfSSf53RLRjZal+HkQ==",
       "license": "MIT",
       "dependencies": {
         "round-slider": "^1.6.1"
@@ -17044,7 +17051,6 @@
       "version": "2.4.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
@@ -17125,7 +17131,6 @@
       "version": "3.3.3",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
@@ -17139,7 +17144,6 @@
       "version": "5.1.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
@@ -17152,7 +17156,6 @@
       "version": "4.3.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -17413,6 +17416,7 @@
       "version": "1.3.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.0.0",
         "yaml": "^2.0.0"

--- a/bundles/org.openhab.ui/web/package.json
+++ b/bundles/org.openhab.ui/web/package.json
@@ -132,7 +132,7 @@
     "vue-i18n": "^11.1.10",
     "vue-magic-grid": "0.0.4",
     "vue-qrcode": "^2.2.2",
-    "vue-round-slider": "^1.0.1",
+    "vue-three-round-slider": "^1.2.7",
     "vue3-clipboard": "^1.0.0",
     "vuex": "^4.1.0",
     "yaml": "^2.8.0"

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.js
@@ -93,7 +93,7 @@ export const OhGaugeCardDefinition = () => new WidgetDefinition('oh-gauge-card',
 import KnobParameters from '../system/knob.js'
 export const OhKnobCardDefinition = () => new WidgetDefinition('oh-knob-card', 'Knob & Rounded Slider Card', 'Display a knob or a rounded slider in a card to visualize and control a quantifiable item')
   .paramGroup(CardParameterGroup(), CardParameters())
-  .paramGroup(pg('knob', 'Knob & Rounded Slider', 'Parameters are passed to the underlying <a target="_blank" class="external text-color-blue" href="https://github.com/soundar24/vue-round-slider#props">round-slider control</a>'), KnobParameters())
+  .paramGroup(pg('knob', 'Knob & Rounded Slider', 'Parameters are passed to the underlying <a target="_blank" class="external text-color-blue" href="https://github.com/Artem9989/vue-three-round-slider?tab=readme-ov-file#props">round-slider control</a>'), KnobParameters())
 
 // OhStepperCard
 import StepperParameters from '../system/stepper.js'

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-knob.vue
@@ -19,7 +19,7 @@ export default {
   mixins: [mixin, slideMixin],
   components: {
     // See https://roundsliderui.com/document.html for docs
-    RoundSlider: defineAsyncComponent(() => import(/* webpackChunkName: "vue-round-slider" */ 'vue-round-slider'))
+    RoundSlider: defineAsyncComponent(() => import(/* webpackChunkName: "vue-round-slider" */ 'vue-three-round-slider'))
   },
   widget: OhKnobDefinition,
   computed: {


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/discussions/3381#discussioncomment-14931658.

vue-round-slider wasn't compatible with Vue 3,
switching to vue-three-round-slider.