### PR TITLE
Script edit: Fix wrong alert message on script create & label missing

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -485,7 +485,7 @@ export default {
         return
       }
       if (!this.rule.name) {
-        f7.dialog.alert('Please give a name to the script')
+        f7.dialog.alert('Please give a label to the script')
         return
       }
 


### PR DESCRIPTION
Fixes #3447.