### PR TITLE
Fix broken `thing` context for widget parameters

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-thing.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-thing.vue
@@ -2,7 +2,7 @@
   <thing-picker :title="configDescription.label"
                 :value="value"
                 @input="updateValue"
-                :filter-uid="configDescription.options.map((o) => o.value)"
+                :filter-uid="configDescription.options ? configDescription.options.map((o) => o.value) : undefined"
                 :multiple="configDescription.multiple"
                 :required="configDescription.required" />
 </template>


### PR DESCRIPTION
This fixes one of the bugs reported in #3457, where the `thing` context for parameters doesn't render.

I'm not 100% sure if the fix is "the ideal way to do it", so reviewer: Please evaluate that.