### PR TITLE
generic-widget-component: Don't inherit attributes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -66,6 +66,7 @@ import OhContext from './system/oh-context.vue'
 import mixin from './widget-mixin'
 
 export default {
+  inheritAttrs: false,
   mixins: [mixin],
   components: {
     ...SystemWidgets,


### PR DESCRIPTION
Added `inheritAtts: false` to generic-widget-component in order to eliminate:

```
[Vue warn]: Extraneous non-props attributes (class) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes.
```