### PR TITLE
[basicUI] Set source for commands

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -3045,7 +3045,10 @@
 			type: "POST",
 			url: "/rest/items/" + event.detail.item,
 			data: event.detail.value,
-			headers: {"Content-Type": "text/plain"}
+			headers: {
+								"Content-Type": "text/plain",
+								"X-OpenHAB-Source": "org.openhab.ui.basic$" + smarthome.UI.sitemap + ":" + smarthome.UI.page
+							}
 		});
 	}
 


### PR DESCRIPTION
Actor is set to `<sitemap name>:<page>`

While this PR isn't strictly dependent on https://github.com/openhab/openhab-core/pull/5131, it won't do anything useful without it.