### PR TITLE
Config params: Accept either "step" or "stepsize"

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-datetime.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-datetime.vue
@@ -35,8 +35,7 @@ export default {
   },
   computed: {
     step () {
-      if (this.configDescription.stepsize !== undefined) return this.configDescription.stepsize
-      return 60
+      return this.configDescription.step || this.configDescription.stepsize || 60
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-number.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-number.vue
@@ -34,8 +34,8 @@ export default {
       return (this.configDescription.type === 'DECIMAL') ? parseFloat(this.value) : parseInt(this.value)
     },
     step () {
-      if (this.configDescription.stepsize === 0) return 'any'
-      return this.configDescription.stepsize
+      let result = this.configDescription.step || this.configDescription.stepsize
+      return result === 0 ? 'any' : result
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-time.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-time.vue
@@ -78,7 +78,8 @@ export default {
         {
           values: (() => {
             let arr = []
-            for (let i = 0; i <= 59; i = i + this.configDescription.stepsize % 60) { arr.push(i < 10 ? `0${i}` : i) }
+            let step = this.configDescription.step | this.configDescription.stepsize
+            for (let i = 0; i <= 59; i = i + step % 60) { arr.push(i < 10 ? `0${i}` : i) }
             return arr
           })()
         })
@@ -122,7 +123,8 @@ export default {
   },
   computed: {
     hasSeconds () {
-      return this.configDescription.stepsize !== undefined && this.configDescription.stepsize % 60 !== 0
+      let result = this.configDescription.step || this.configDescription.stepsize
+      return result !== undefined && result % 60 !== 0
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -99,7 +99,7 @@ export default function itemDefaultCellComponent (item, itemNameAsFooter) {
           config: {
             min: stateDescription.minimum,
             max: stateDescription.maximum,
-            stepSize: stateDescription.step
+            step: stateDescription.step
           }
         }
       }


### PR DESCRIPTION
As discussed in #3457, I propose to make MainUI "agnostic" in regard to configuration description/parameter property `stepsize` and `step`.  The reason is that this is the only property that doesn't match the name of those used in [XML configuration files](https://www.openhab.org/docs/developer/addons/config-xml.html#xml-structure-for-configuration-descriptions), causing unnecessary confusion.

The idea is to also submit a Core PR if this is merged, to make Core agnostic too.