### PR TITLE
Set searchbar height in Aurora theme to subnavbar height

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -6,6 +6,7 @@ html
 .aurora
   --f7-label-line-height 1.3
   --f7-searchbar-input-font-size 13px
+  --f7-searchbar-height var(--f7-subnavbar-height)
   --f7-button-font-size 14px
   --f7-chip-height 24px
   --f7-chip-font-size 13px

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -7,7 +7,7 @@
                       back-link="Settings"
                       back-link-url="/settings/"
                       :f7router />
-      <f7-subnavbar :inner="false" v-show="initSearchbar" style="height: var(--f7-searchbar-height)">
+      <f7-subnavbar :inner="false" v-show="initSearchbar">
         <f7-searchbar
           v-if="initSearchbar"
           ref="searchbar"


### PR DESCRIPTION
Regression from #3350.

This fixes CSS issues where the searchbar was higher than the subnavbar, e.g. on the model page.