### PR TITLE
Link channel -> Item: Include channel group label in new item name

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -111,6 +111,7 @@ export default {
     channelId: String,
     channel: Object,
     thing: Object,
+    thingType: Object,
     opened: Boolean,
     extensible: Boolean,
     context: Object,
@@ -161,6 +162,7 @@ export default {
       }, {
         props: {
           thing: this.thing,
+          channelGroup: this.channelId.includes('#') ? this.thingType.channelGroups.find((cg) => cg.id === this.channelId.split('#', 1)[0]) : null,
           channel: this.thing.channels.find((c) => c.id === this.channelId),
           channelType: this.channelType
         }

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -62,6 +62,7 @@
                         #default="{ channelId, channelType, channel, extensible }">
                 <channel-link :opened="openedChannelId === channelId"
                               :thing="thing"
+                              :thingType="thingType"
                               :channelId="channelId"
                               :channelType="channelType"
                               :channel="channel"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -188,10 +188,11 @@ import { mapStores } from 'pinia'
 export default {
   mixins: [ItemMixin, uomMixin, LinkMixin],
   props: {
-    thing: String,
-    channel: String,
-    channelType: String,
-    item: String,
+    thing: Object,
+    channelGroup: Object,
+    channel: Object,
+    channelType: Object,
+    item: Object,
     f7router: Object
   },
   setup () {
@@ -243,6 +244,10 @@ export default {
       this.loadProfileTypes(this.channel)
       let newItemName = this.$oh.utils.normalizeLabel(this.thing.label)
       newItemName += '_'
+      if (this.channelGroup) {
+        newItemName += this.$oh.utils.normalizeLabel(this.channelGroup.label)
+        newItemName += '_'
+      }
       newItemName += this.$oh.utils.normalizeLabel(this.channel.label || this.channelType.label)
       const defaultTags = (this.channel.defaultTags.length > 0) ? this.channel.defaultTags : this.channelType.tags
       this.newItem = {


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/3272

When linking a new item to a channel, the proposed name does not consider the channel group. It therefore can lead to double item names.
With this code, if the channel is in a channel group, the channel group label is being included in the proposed name.

@hmerk You may want to have a look, as this changes the automatically generated item names and can have an impact on your widgets.