### PR TITLE
[MainUI] Add thing link to link editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -29,7 +29,8 @@
                               :footer="channel.uid + ' (' + getItemType(channel) + ')'"
                               :subtitle="thing.label"
                               :badge="thingStatusBadgeText(thing.statusInfo)"
-                              :badge-color="thingStatusBadgeColor(thing.statusInfo)">
+                              :badge-color="thingStatusBadgeColor(thing.statusInfo)"
+                              :link="'/settings/things/' + thing.UID">
                   <template #media>
                     <span class="item-initial">{{ (channel.label) ? channel.label[0] : channelType.label ? channelType.label[0] : '?' }}</span>
                   </template>


### PR DESCRIPTION
Resolves https://github.com/openhab/openhab-webui/issues/846

This adds the thing link to the link editor.