### PR TITLE
States store: Performance improvements for pages with many Items

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
@@ -12,7 +12,7 @@ export interface ItemState {
   type: string
 }
 
-const UndefinedItemState: ItemState = { state: '-', type: '-' } 
+const UndefinedItemState: ItemState = { state: '-', type: '-' }
 
 const PendingItemsProcessingInterval = 100
 
@@ -35,13 +35,13 @@ export const useStatesStore = defineStore('states', () => {
   let processingIntervalId: number | null = null
 
 
-  function ensureItemTracking(itemName: string): ItemState {
+  function ensureItemTracking (itemName: string): ItemState {
     if (itemName === 'undefined') return UndefinedItemState
-    
+
     let itemState = itemStates.value.get(itemName)
     if (!isItemTracked(itemName)) {
       pendingNewItems.add(itemName)
-      
+
       if (!itemState) {
         itemState = UndefinedItemState
         setItemState(itemName, itemState)
@@ -54,7 +54,7 @@ export const useStatesStore = defineStore('states', () => {
         }, PendingItemsProcessingInterval)
       }
     }
-    
+
     return itemState!
   }
 


### PR DESCRIPTION
Fixes #1746.

### Issue

When loading pages with many (e.g. >= 100 Items), opening the page takes a lot of time.
This is because for every Item in that page, the `trackedItems` proxy adds that Item to the tracking list, causing a ton of reactivity to be triggered (e.g. widget rerendering, expression evaluation).
For 200 Items, the reactivity caused by this is so bad that the following error is thrown:

```
Uncaught (in promise) Maximum recursive updates exceeded. This means you have a reactive effect that is mutating 
its own dependencies and thus recursively triggering itself. Possible sources include component 
template, render function, updated hook or watcher source function.
```

### Solution

To fix the issue, batch processing for wanted tracking list Items is introduced.
(Making trackingList non-reactive is no option, as this causes problems with missing states.)

When a new page is loaded now, there will still be many Item states missing. But instead of directly adding them to the tracking list, now they are added to the pending new Items Set. This Set is then processed by a interval at most 100 ms later.

Further optimizations include not publishing internal state (such as EventSource) and using reactivity only where needed.

### Benchmarking

Without these changes, switching from an overview page that only contains a single colorpicker widget to the page provided in the above issue causes about 2 seconds of scripting accord. to the Chromium profiler.
With the changes from this PR, overall scripting time is reduced to 600 ms.
It feels the speedup is even better than that.