### PR TITLE
Refactor config sheet advanced toggle

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -13,16 +13,11 @@
                  :f7router
                  @input="updateValue" />
     </f7-list-group>
-    <f7-list-item v-else-if="readOnly && configDescription.context === 'password'"
-                  :is="passwords"
-                  :config-description="configDescription"
-                  :value="value"
-                  :parameters="parameters"
-                  :configuration="configuration"
-                  :title="configDescription.title" />
-    <f7-list-item v-else :after="value !== undefined && value !== null ? value.toString() : 'N/A'" />
+    <f7-list-item v-else
+                  :title="configDescription.label"
+                  :after="value !== undefined && value !== null ? (configDescription.context === 'password' ? '•'.repeat(20) : value.toString()) : 'N/A'" />
     <template #after-list>
-      <f7-block-footer class="config-parameter-description">
+      <f7-block-footer class="param-description">
         <div v-if="status" class="param-status-info">
           <f7-chip v-if="status.type !== 'INFORMATION'"
                    :color="status.type === 'WARNING' ? 'orange' : status.type === 'ERROR' ? 'red' : 'gray'"
@@ -31,27 +26,11 @@
           <span v-if="status.statusCode">Status Code: &nbsp;{{ status.statusCode }}&nbsp;&nbsp;</span>
           <span v-if="status.message">{{ status.message }}</span>
         </div>
-        <small v-html="`${configDescription.required ? '<strong>Required</strong>&nbsp;' : ''}${description || (showNonDefaultBadge ? ' ' : '')}`" />
-        <f7-badge v-if="showNonDefaultBadge"
-                  style="margin-left:2px"
-                  color="blue"
-                  class="count-badge"
-                  tooltip="Non-default parameter">
-          1
-        </f7-badge>
+        <small v-html="`${configDescription.required ? '<strong>Required</strong>&nbsp;' : ''}${description || ''}`" />
       </f7-block-footer>
     </template>
   </f7-list>
 </template>
-
-<style lang="stylus">
-.config-parameter .config-parameter-description
-  padding-left calc(var(--f7-block-padding-horizontal) + var(--f7-safe-area-left))
-  padding-right calc(var(--f7-block-padding-horizontal) + var(--f7-safe-area-right))
-  display flex
-  justify-content space-between
-
-</style>
 
 <script>
 import { f7 } from 'framework7-vue'
@@ -85,8 +64,7 @@ export default {
     parameters: Array,
     configuration: Object,
     readOnly: Boolean,
-    status: Array,
-    showNonDefaultBadge: Boolean
+    status: Array
   },
   emits: ['update'],
   setup () {
@@ -98,10 +76,8 @@ export default {
     }
   },
   computed: {
-    passwords () {
-      const configDescription = this.configDescription
-      configDescription.readOnly = true
-      return ParameterText
+    maskedPassword () {
+      return '•'.repeat(20)
     },
     control () {
       const configDescription = this.configDescription

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -26,7 +26,6 @@
               :configuration="configurationWithDefaults"
               :read-only="readOnly"
               :status="parameterStatus(parameter)"
-              :showNonDefaultBadge="parameter.advanced && isNonDefault(parameter)"
               :f7router
               @update="(value) => updateParameter(parameter, value)" />
           </f7-col>
@@ -56,7 +55,6 @@
               :configuration="configurationWithDefaults"
               :read-only="readOnly"
               :status="parameterStatus(parameter)"
-              :showNonDefaultBadge="parameter.advanced && isNonDefault(parameter)"
               :f7router
               @update="(value) => updateParameter(parameter, value)" />
           </f7-col>


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/3480

As described in the issue, it is sometimes confusing advanced parameters with a non-default value are shown also when the show advanced toggle is off.

This refactors that behaviour:
- make the 'Show advanced' checkbox clearly toggle between showing the advanced parameters or not (and hide the option if there are no advanced options).
- put a badge next to the 'Show advanced' toggle that shows the number of advanced parameters with a non-default value (not shown if all have default values).
- the badges have tooltips clarifying their meaning.