### PR TITLE
Increase delay for "Communication failure" toast

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/connection-health-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/connection-health-mixin.js
@@ -24,7 +24,7 @@ export default {
       const { sseConnected } = storeToRefs(useStatesStore())
 
       watch(sseConnected, (newValue) => {
-        if(newValue === false) {
+        if (newValue === false) {
           if (this.communicationFailureToast === null) {
             this.communicationFailureTimeoutId = setTimeout(() => {
               if (this.communicationFailureToast !== null) return
@@ -34,12 +34,13 @@ export default {
                 false
               )
               this.communicationFailureTimeoutId = null
-            }, 1000)
+            }, 2000)
           }
         } else if (newValue === true) {
-          if (this.communicationFailureTimeoutId !== null)
+          if (this.communicationFailureTimeoutId !== null) {
             clearTimeout(this.communicationFailureTimeoutId)
-          if (this.communicationFailureToast) {
+          }
+          if (this.communicationFailureToast !== null) {
             this.communicationFailureToast.close()
             this.communicationFailureToast = null
           }


### PR DESCRIPTION
Fixes an issue where the popup always appeared when opening the iOS app.