### PR TITLE
Add thing: Add ignore & remove from inbox buttons

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -266,7 +266,11 @@ export default {
           ],
           [
             this.entryActionsAddAsThingButton(entry, this.loadInbox),
-            this.entryActionsCopyThingDefinitionButton(entry)
+            this.entryActionsCopyThingDefinitionButton(entry),
+            this.entryActionsIgnoreButton(entry, this.loadInbox)
+          ],
+          [
+            this.entryActionsRemoveButton(entry, this.loadInbox)
           ]
         ]
       })

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -383,84 +383,15 @@ export default {
           [
             this.entryActionsAddAsThingButton(entry, this.load),
             this.entryActionsCopyThingDefinitionButton(entry),
-            {
-              text: (!ignored) ? 'Ignore' : 'Unignore',
-              color: (!ignored) ? 'orange' : 'blue',
-              onClick: () => {
-                if (ignored) {
-                  this.unignoreEntry(entry)
-                } else {
-                  this.ignoreEntry(entry)
-                }
-              }
-            }
+            this.entryActionsIgnoreButton(entry, this.load, ignored)
           ],
           [
-            {
-              text: 'Remove',
-              color: 'red',
-              onClick: () => {
-                f7.dialog.confirm(`Remove ${entry.label} from the Inbox?`, 'Remove Entry', () => {
-                  this.removeEntry(entry)
-                })
-              }
-            }
+            this.entryActionsRemoveButton(entry, this.load)
           ]
         ]
       })
 
       actions.open()
-    },
-    ignoreEntry (entry) {
-      this.$oh.api.postPlain(`/rest/inbox/${entry.thingUID}/ignore`).then((res) => {
-        f7.toast.create({
-          text: 'Entry ignored',
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        this.load()
-      }).catch((err) => {
-        f7.toast.create({
-          text: 'Error while ignoring entry: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        this.load()
-      })
-    },
-    unignoreEntry (entry) {
-      this.$oh.api.postPlain(`/rest/inbox/${entry.thingUID}/unignore`).then((res) => {
-        f7.toast.create({
-          text: 'Entry unignored',
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        this.load()
-      }).catch((err) => {
-        f7.toast.create({
-          text: 'Error while unignoring entry: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        this.load()
-      })
-    },
-    removeEntry (entry) {
-      this.$oh.api.delete('/rest/inbox/' + entry.thingUID).then((res) => {
-        f7.toast.create({
-          text: 'Entry removed',
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        this.load()
-      }).catch((err) => {
-        f7.toast.create({
-          text: 'Error while removing entry: ' + err,
-          destroyOnClose: true,
-          closeTimeout: 2000
-        }).open()
-        this.load()
-      })
     },
     changeIgnored () {
       setTimeout(() => { this.$refs.listIndex.update() })

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
@@ -34,6 +34,57 @@ export default {
         return Promise.reject(err)
       })
     },
+    ignoreEntry (entry, loadFn) {
+      this.$oh.api.postPlain(`/rest/inbox/${entry.thingUID}/ignore`).then((res) => {
+        f7.toast.create({
+          text: 'Entry ignored',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        loadFn()
+      }).catch((err) => {
+        f7.toast.create({
+          text: 'Error while ignoring entry: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        loadFn()
+      })
+    },
+    unignoreEntry (entry, loadFn) {
+      this.$oh.api.postPlain(`/rest/inbox/${entry.thingUID}/unignore`).then((res) => {
+        f7.toast.create({
+          text: 'Entry unignored',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        loadFn()
+      }).catch((err) => {
+        f7.toast.create({
+          text: 'Error while unignoring entry: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        loadFn()
+      })
+    },
+    removeEntry (entry, loadFn) {
+      this.$oh.api.delete('/rest/inbox/' + entry.thingUID).then((res) => {
+        f7.toast.create({
+          text: 'Entry removed',
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        loadFn()
+      }).catch((err) => {
+        f7.toast.create({
+          text: 'Error while removing entry: ' + err,
+          destroyOnClose: true,
+          closeTimeout: 2000
+        }).open()
+        loadFn()
+      })
+    },
     entryActionsAddAsThingButton (entry, loadFn) {
       return {
         text: 'Add as Thing',
@@ -128,6 +179,30 @@ export default {
         color: 'blue',
         bold: true,
         onClick: () => this.copyFileDefinitionToClipboard(this.ObjectType.THING, [entry.thingUID])
+      }
+    },
+    entryActionsIgnoreButton (entry, loadFn, ignored) {
+      return {
+        text: (!ignored) ? 'Ignore' : 'Unignore',
+        color: (!ignored) ? 'orange' : 'blue',
+        onClick: () => {
+          if (ignored) {
+            this.unignoreEntry(entry, loadFn)
+          } else {
+            this.ignoreEntry(entry, loadFn)
+          }
+        }
+      }
+    },
+    entryActionsRemoveButton (entry, loadFn) {
+      return {
+        text: 'Remove',
+        color: 'red',
+        onClick: () => {
+          f7.dialog.confirm(`Remove ${entry.label} from the Inbox?`, 'Remove Entry', () => {
+            this.removeEntry(entry, loadFn)
+          })
+        }
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/openhab/openhab-webui/issues/416

This exposes the same buttons as when clicking on a discovery result directly from the inbox.
Note that it is not possible to unignore an entry from that screen, as ignored entries are never shown there (but can still be unignored from the inbox).