### PR TITLE
Widget expressions: Fix invalid screen.viewArea dimensions in modals

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popover.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popover.vue
@@ -11,8 +11,12 @@
 
 <script>
 import modal from './modal-mixin'
+import { useViewArea } from '@/composables/useViewArea.ts'
 
 export default {
-  mixins: [modal]
+  mixins: [modal],
+  setup () {
+    useViewArea()
+  }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-popup.vue
@@ -48,6 +48,7 @@
 <script>
 import modal from './modal-mixin'
 import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
+import { useViewArea } from '@/composables/useViewArea.ts'
 
 export default {
   mixins: [modal],
@@ -58,7 +59,9 @@ export default {
   },
   components: {
     EmptyStatePlaceholder
-
+  },
+  setup () {
+    useViewArea()
   }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/modals/oh-sheet.vue
@@ -30,11 +30,15 @@
 <script>
 import modal from './modal-mixin'
 import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
+import { useViewArea } from '@/composables/useViewArea.ts'
 
 export default {
   mixins: [modal],
   components: {
     EmptyStatePlaceholder
+  },
+  setup () {
+    useViewArea()
   }
 }
 </script>


### PR DESCRIPTION
Fixes `null` for `screenAreaWidth` & `screenAreaHeight` values inside popup, popover & sheet,
causing user widgets using those props from the `screen` object not rendering as supposed to.