### PR TITLE
Fix developer-dock title width too narrow

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-dock.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-dock.vue
@@ -91,11 +91,14 @@
   .page-content
     scrollbar-width none /* Firefox */
     -ms-overflow-style none  /* IE 10+ */
+
+.navbar-inner.navbar-inner-centered-title
+  .title
+    max-width none
 </style>
 
 <script>
 import { f7 } from 'framework7-vue'
-import { nextTick } from 'vue'
 import { mapStores } from 'pinia'
 
 import DeveloperSidebar from './developer-sidebar.vue'


### PR DESCRIPTION
Fix css style width causing title block to be too narrow in development doc.

https://github.com/openhab/openhab-webui/discussions/3381#discussioncomment-15117083