### PR TITLE
Redirect /overview to /overview/

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -115,6 +115,10 @@ export default [
         }
       },
       {
+        path: 'overview',
+        redirect: '/overview/'
+      },
+      {
         path: 'locations/',
         component: HomePage,
         options: {


### PR DESCRIPTION
Fixes https://github.com/openhab/openhab-webui/discussions/3381#discussioncomment-15108531.