### PR TITLE
Charts: Fix duplicate REST requests

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -212,7 +212,10 @@ export default {
         }
         const key = `${neededItem}-${query.serviceId}-${query.starttime}-${query.endtime}-${query.boundary}-${query.itemState}`
         if (!this._persistencePromises[key]) {
-          this._persistencePromises[key] = this.$oh.api.get(url, query)
+          this._persistencePromises[key] = this.$oh.api.get(url, query).then((result) => {
+            delete this._persistencePromises[key]
+            return result
+          })
         }
 
         return Promise.all([this._itemPromises[neededItem], this._persistencePromises[key]])


### PR DESCRIPTION
Reported on the community: https://community.openhab.org/t/5-1-0-m3-charts-load-slowly/167402/6

Fixes an issue where the chart-mixin did the same requests multiple times due to a reactivity issues.
This fix makes the caching for items non-reactive by using underscore-prefixed properties, avoiding recomputation of `asyncComputed` `series` due to changes to the items store.
This fix also caches ongoing promises to `/rest/items/{itemname}` and `/rest/persistence/items/{itemname}` to reduce the number of requests.