### PR TITLE
oh-context: Properly inherit attributes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
@@ -1,5 +1,6 @@
 <template>
   <generic-widget-component v-for="(slotComponent, idx) in children"
+                            v-bind="$attrs"
                             :key="'default-' + idx"
                             :context="childrenContext(slotComponent)" />
 </template>
@@ -11,6 +12,7 @@ import mixin from '../widget-mixin'
 import { OhContextDefinition } from '@/assets/definitions/widgets/system'
 
 export default {
+  inheritAttrs: false,
   mixins: [mixin],
   widget: OhContextDefinition,
   data () {


### PR DESCRIPTION
This addresses a 'Extraneous non-props attributes (class) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes' error.