### PR TITLE
Charts: Fix freeze if tooltip with smartFormatter enabled

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/misc/oh-chart-tooltip.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/misc/oh-chart-tooltip.js
@@ -27,7 +27,7 @@ export default {
           if (s.seriesId) {
             const [seriesType, itemName] = s.seriesId.split('#')
             if (seriesType === 'oh-time-series') {
-              let item = chart.items[itemName]
+              let item = chart._items[itemName]
               let state = s.data[1]
               if (item) {
                 const stateDescription = item.stateDescription || {}


### PR DESCRIPTION
Regression from #3544.
Fix reference to chart.items -> chart._items.

Fixes https://community.openhab.org/t/5-1-0-m3-charts-load-slowly/167402/13.