### PR TITLE
[blockly] Adjusted comment text style to black to be visible on yellow background

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1199,6 +1199,9 @@ textarea.blocklyHtmlTextAreaInput
 
 .blocklyComment .blocklyText
   color black
+
+.blocklyTextInputBubble .blocklyTextarea
+  color black
 </style>
 
 <script>


### PR DESCRIPTION
Fixes #3314