### PR TITLE
Revert "Bump org.eclipse.jdt:ecj from 3.43.0 to 3.44.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@ Import-Package: \\
             <dependency>
               <groupId>org.eclipse.jdt</groupId>
               <artifactId>ecj</artifactId>
-              <version>3.44.0</version>
+              <version>3.43.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Reverts openhab/openhab-webui#3559.
See https://github.com/openhab/openhab-webui/pull/3559#issuecomment-3643910863 for reason.