### PR TITLE
generic-widget-component: Fix critical regression for <Label> component

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -55,7 +55,7 @@
       v-else-if="componentType && componentType === 'Label'"
       ref="component"
       v-bind="$attrs"
-      :class="[...config.class, scopedCssUid]"
+      :class="[...(Array.isArray(config.class) ? config.class : []), scopedCssUid]"
       :style="config.style">
       {{ config.text }}
     </div>


### PR DESCRIPTION
Regression from #3595.