### PR TITLE
Fix back button issue

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -1075,6 +1075,14 @@ export default {
       f7.on('pageAfterIn', (page) => {
         // console.log('pageAfterIn: current URL:', page.route.url)
         // console.log('Full route object:', page.route)
+
+        // Fix for back button issue: When redirected from '/' to '/overview/',
+        // sometimes F7's router history may be empty and the back button doesn't work at first.
+        const router = f7.views.main?.router
+        if (router && router.history.length === 0 && page.route?.url) {
+          router.history.push(page.route.url)
+        }
+
         nextTick(this.updateTitle)
       })
 


### PR DESCRIPTION
When loading "oh.foo.com" we route in F7 to "oh.foo.com/overview/" but in some cases this leaves the f7 route history empty, and the back button will have nothing to go back to after the first navigation item is clicked.