### PR TITLE
oh-plan-page: Make marker tooltips non interactive

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -7,8 +7,7 @@
             @update:lat-lng="onMove"
             @click="onClick">
     <l-tooltip v-if="tooltip && !config.useTooltipAsLabel"
-               :options="tooltipOptions"
-               @click="() => {}">
+               :options="tooltipOptions">
       <div style="white-space: nowrap" :style="tooltipStyle">
         {{ tooltip }}
       </div>

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
@@ -97,6 +97,10 @@ dark-tooltip()
   background: unset
   border: unset
 
+// Make tooltips non-interactive so touch events pass through to markers on mobile
+.oh-plan-page-lmap .leaflet-tooltip
+  pointer-events none
+
 </style>
 
 <script>


### PR DESCRIPTION
Since our Vue 3 upgrade, i have noticed that on mobile devices the plan markers are very hard to interact with as the label pops up on touch events, and prevents the plan marker from reacting to the event.  This means you have to try and touch around it, or zoom in and touch which is not ideal.  This PR makes the labels non interactive (they still appear on touch or hover).