### PR TITLE
[blockly] Fix oh_context_info block "as {type}" not working

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -276,13 +276,13 @@ export default function defineOHBlocks_Scripts (f7, transformationServices) {
     if (contextInfo === 'eventAvailable') return ['(event !== undefined)', javascriptGenerator.ORDER_ATOMIC]
     if (contextInfo === 'ruleUID') return ['ctx.ruleUID', javascriptGenerator.ORDER_ATOMIC]
 
-    if (contextInfo === 'itemState' || contextInfo === 'oldState' || contextInfo === 'itemCommand') {
+    if (oldContextInfoName === 'itemState' || oldContextInfoName === 'oldItemState' || oldContextInfoName === 'itemCommand') {
       if (type === 'asNumber') {
-        return [`((${contextInfo} !== undefined) ? parseFloat(${contextInfo}.toString()) : undefined)`, javascriptGenerator.ORDER_ATOMIC]
+        return [`((${contextInfo} !== undefined) ? parseFloat(${contextInfo}) : undefined)`, javascriptGenerator.ORDER_ATOMIC]
       } else if (type === 'asQuantity') {
-        return [`((${contextInfo} !== undefined) ? Quantity(${contextInfo}.toString()) : undefined)`, javascriptGenerator.ORDER_ATOMIC]
+        return [`((${contextInfo} !== undefined) ? Quantity(${contextInfo}) : undefined)`, javascriptGenerator.ORDER_ATOMIC]
       } else {
-        return [`${contextInfo}?.toString()`, javascriptGenerator.ORDER_ATOMIC]
+        return [`${contextInfo}`, javascriptGenerator.ORDER_ATOMIC]
       }
     }
     return [`${contextInfo}`, javascriptGenerator.ORDER_ATOMIC]


### PR DESCRIPTION
Regression from #3376.
Also simplifies the generated code (the members of the event object are now JS strings).