### PR TITLE
Charts: Fix oh-time-axis doesn't adjust begin/end for series with offset

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-time-axis.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-time-axis.js
@@ -20,7 +20,10 @@ export default {
       axis.max = (v) => {
         if (isNaN(v.min)) return endTime.toDate().getTime()
         if (!isFinite(v.max)) return v.max
-        return startOf(chartType, v.min).add(1, chartType === 'isoWeek' ? 'week' : chartType).toDate().getTime()
+        return startOf(chartType, v.min)
+          .add(1, chartType === 'isoWeek' ? 'week' : chartType)
+          .toDate()
+          .getTime()
       }
     } else {
       axis.min = startTime.toDate().getTime()

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/chart-mixin.js
@@ -56,9 +56,7 @@ export default {
     const config = this.context.component.config || {}
     const chartType = config.chartType
     const future = config.future === true ? 1 : (config.future ?? 0)
-    const endTime = (chartType)
-      ? this.addOrSubtractPeriod(startOf(chartType), 1 + future)
-      : this.addOrSubtractPeriod(dayjs(), future)
+    const endTime = chartType ? this.addOrSubtractPeriod(startOf(chartType), 1 + future) : this.addOrSubtractPeriod(dayjs(), future)
 
     return {
       speriod: config.period || DEFAULT_PERIOD,
@@ -261,7 +259,7 @@ export default {
     setDate(date) {
       const chartType = this.context.component.config.chartType
       const day = dayjs(date)
-      this.endTime = this.addOrSubtractPeriod((chartType) ? startOf(chartType) : day, 1)
+      this.endTime = this.addOrSubtractPeriod(chartType ? startOf(chartType) : day, 1)
     },
     earlierPeriod() {
       this.endTime = this.addOrSubtractPeriod(this.endTime, -1)

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/utils.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/utils.ts
@@ -14,7 +14,7 @@ dayjs.extend(DayDuration)
  * @param chartType
  * @param date
  */
-export function startOf (chartType: ChartType, date?: any): Dayjs {
+export function startOf(chartType: ChartType, date?: any): Dayjs {
   if (chartType === 'week') {
     // Week starting on Sunday & passed-in date is on Sunday: pass through to avoid shifting back by one week
     if (date && dayjs(date).day() === 0) return dayjs(date)


### PR DESCRIPTION
Regression from #3578.
Reported on the community.