### PR TITLE
Vite: Emit static assets to dedicated dirs & cache in service worker

### DIFF
--- a/bundles/org.openhab.ui/web/vite.config.ts
+++ b/bundles/org.openhab.ui/web/vite.config.ts
@@ -165,7 +165,7 @@ export default defineConfig({
             return 'fonts/[name][extname]'
           }
           // Move images to images/ folder
-          if (['png', 'jpg', 'jpeg', 'gif', 'svg'].includes(ext!)) {
+          if (['png', 'jpg', 'jpeg', 'gif', 'svg'].includes(ext)) {
             return 'images/[name][extname]'
           }
           // Move media to media/ folder


### PR DESCRIPTION
Fixes #3622.

Before #3350 switched to Vite, we were using Webpack.
Webpack was configured to move static assets (see https://github.com/openhab/openhab-webui/blob/7a0e0421e72b82570f11225a68206b8d34c5c050/bundles/org.openhab.ui/web/build/webpack.config.js#L195-L230) to different directories and included them in it's service worker cache.
This change takes over that Webpack config to Vite.