### PR TITLE
Script/Code editor: Fix search panel closes on click

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -66,6 +66,9 @@
     // This affects the buttons in the search form
     .cm-button
       width auto
+    // Display the close button in the search form in upper right corner, not full width
+    .cm-panel.cm-search [name=close]
+      width unset
 </style>
 
 <script>


### PR DESCRIPTION
Fixes #3597.

This was caused by the close button being 100% width and overlaying other buttons.