### PR TITLE
oh-swiper: Don't set swiper-slide width to 100%

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
@@ -69,6 +69,11 @@
   </f7-swiper>
 </template>
 
+<style lang="stylus">
+.oh-swiper-slide
+  width unset !important
+</style>
+
 <script>
 import { defineAsyncComponent } from 'vue'
 


### PR DESCRIPTION
Fixes a style regression of #3350.

Reported on the community:
https://community.openhab.org/t/5-1-0-m3-main-ui-shows-blank-screen-on-android/167432/41