### PR TITLE
Script editor: Allow return outside functions/global return

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -294,6 +294,11 @@ export default {
               globals: { ...globals.node },
               parserOptions: { ecmaVersion: 2024, sourceType: 'module' }
             },
+            parserOptions: {
+              ecmaFeatures: {
+                globalReturn: true // allow return outside functions
+              }
+            },
             rules: {
               semi: 'off' // allow both with and without semicolons
             }


### PR DESCRIPTION
JS Scripting supports global return thanks to the wrapper, but ESLint displays a parser error.

Reported on the community:
https://community.openhab.org/t/openhab-5-1-release-discussion/167620/53