### PR TITLE
Fix Main UI load fails if implicit user role is disabled

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -713,9 +713,8 @@ export default {
           return request.json('/rest/')
         })
         .catch((err) => {
-          console.error('openHAB REST API connection failed with error:')
-          console.info(err)
           if (err.message === 'Unauthorized' || err.status === 401) {
+            console.info('openHAB REST API connection failed: 401 Unauthorized. Authorizing against reverse proxy ...')
             if (!useCredentials) {
               // try again with credentials
               this.loadData(true)
@@ -747,8 +746,9 @@ export default {
               )
             })
             return Promise.reject()
-            // Redirection handling (e.g. when using auth_request in nginx)
           } else if (err.message === 'Found' || err.status === 302) {
+            console.info('openHAB REST API connection failed: 302 (Found). Redirecting ...')
+            // Redirection handling (e.g. when using auth_request in nginx)
             // technically correct way, but unreliable because XhrHttpRequest follows the redirect itself and fails because of CORS policy
             if (err.xhr.HEADERS_RECEIVED > 0) {
               const headersObj = {}
@@ -766,6 +766,7 @@ export default {
               )
             }
           } else if (err.message === 0 || err.status === 0) {
+            console.info('openHAB REST API connection failed: 0 (unknown). Unloading service-worker and reloading PWA ...')
             // XhrHttpRequest has message & status 0 if the redirected request failed due to CORS policy
             // Follow the authentication redirect by unloading service-worker and reloading PWA
             if ('serviceWorker' in window.navigator) {
@@ -777,6 +778,7 @@ export default {
               })
             }
           } else {
+            console.error('openHAB REST API connection failed fatal:', err)
             // Make sure this is set to a value, otherwise the page won't show up
             this.communicationFailureMsg = err.message || err.status || 'Unknown Error'
             return Promise.reject(
@@ -791,7 +793,18 @@ export default {
           if (!useRuntimeStore().apiEndpoint('auth')) useUserStore().setNoAuth(true)
           return rootResponse
         })
-        .then((rootResponse) => {
+        .then(() => {
+          return useSemanticsStore().loadSemantics(i18n)
+        })
+        .catch((err) => {
+          if (err === 'Unauthorized' || err === 401) {
+            console.info('openHAB REST API implicit user role is disabled. Authorizing ...')
+            this.authorize(false) // will redirect to auth page, redirecting back to Main UI triggers new load
+          } else {
+            return Promise.reject(err)
+          }
+        })
+        .then(() => {
           const locale = useRuntimeStore().locale.toLocaleLowerCase()
           let dayjsLocalePromise = Promise.resolve(null)
           // try to resolve the dayjs file to load if it exists
@@ -818,8 +831,7 @@ export default {
             ...(useRuntimeStore().apiEndpoint('ui'))
               ? [this.$oh.api.get('/rest/ui/components/ui:page'), this.$oh.api.get('/rest/ui/components/ui:widget')]
               : [Promise.resolve([]), Promise.resolve([])],
-            dayjsLocalePromise,
-            useSemanticsStore().loadSemantics(i18n)
+            dayjsLocalePromise
           ])
         })
         .then((data) => {

--- a/bundles/org.openhab.ui/web/src/js/stores/useSemanticsStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useSemanticsStore.ts
@@ -89,10 +89,10 @@ export const useSemanticsStore = defineStore('semantics', () => {
           ready.value = true
         })
         .catch((e) => {
-          console.error('Failed to load semantic tags:')
-          console.error(e)
+          console.error('Failed to load semantic tags:', e)
           ready.value = false
-          return Promise.reject('Failed to load semantic tags: ' + e)
+          // Return the plain error so consumers can handle it; you must NOT modify it!
+          return Promise.reject(e)
         })
     } else {
       ready.value = true


### PR DESCRIPTION
If the implicit use role setting is disabled (API security setting), Main UI load fails because it doesn't authorize early enough and the first REST requests fail.

Reported on the community:
https://community.openhab.org/t/5-1-0-m3-main-ui-shows-blank-screen-on-android/167432/49