### PR TITLE
generic-widget-component: Only bind $attrs to parent element

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -41,7 +41,8 @@
     </oh-card>
     <generic-widget-component v-else-if="componentType && componentType.startsWith('widget:')"
                               ref="component"
-                              v-bind="$attrs"
+                              v-bind="isChild ? null : $attrs"
+                              :is-child="true"
                               :context="childWidgetContext()"
                               :class="scopedCssUid" />
     <component v-else-if="componentType && componentType.startsWith('oh-')"
@@ -95,6 +96,12 @@ import mixin from './widget-mixin'
 export default {
   inheritAttrs: false,
   mixins: [mixin],
+  props: {
+    isChild: {
+      type: Boolean,
+      default: false
+    }
+  },
   components: {
     ...SystemWidgets,
     ...StandardWidgets,


### PR DESCRIPTION
Related to #3539.

Fixes issues with oh-grid-layout that were reported on the community:
https://community.openhab.org/t/openhab-5-1-release-discussion/167620/119