### PR TITLE
[BasicUI] Align handling of webaudio setting with Main UI

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/render/PageRenderer.java
@@ -377,7 +377,7 @@ public class PageRenderer extends AbstractWidgetRenderer {
 
         renderSwitchSetting(localizeText("@text/ui.config.basic.webAudio.label"),
                 localizeText("@text/ui.config.basic.webAudio.description"), "webAudio", "openhab.ui:webaudio.enable",
-                "enabled", "", false, sb);
+                "true", "false", false, sb);
 
         return getSnippet("main_static") //
                 .replace("%title%", localizeText("@text/preferences.title")) //

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -3295,7 +3295,7 @@
 
 			if (param === null || param === "openhab.ui:webaudio.enable") {
 				oldValue = _t.webAudioEnabled;
-				newValue = window.localStorage.getItem("openhab.ui:webaudio.enable") === "enabled";
+				newValue = window.localStorage.getItem("openhab.ui:webaudio.enable") === "true";
 				_t.webAudioEnabled = newValue;
 				if (oldValue !== newValue) {
 					if (newValue) {


### PR DESCRIPTION
Values for openhab.ui:webaudio.enable setting in local storage set by Main UI were changed in OH 5.1.

Fix #3669