### PR TITLE
Hide nav bar background when nav bar is hidden

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -218,8 +218,15 @@ html
   --f7-navbar-large-collapse-progress 1
   opacity 0
 
-.navbar-large-hidden:not(.navbar-large-collapsed) .navbar-bg
-  opacity 0
+  .navbar-bg
+    opacity 0
+
+.navbar-hidden
+  .navbar-bg
+    opacity 0
+
+.navbar-bg
+  transition opacity 0.3s ease
 
 .toolbar.toolbar-bottom, .tabbar.tabbar-bottom
   --f7-theme-color #2196f3


### PR DESCRIPTION
This is related to #3676 , but this should be useful for all platforms i think (so not limiting to IOS)

This allows the use of the whole screen for viewing, while still keeping "safe" areas for the menu bar when visible. 

Apologies for the ugly red page, but was helpful for testing.

When menu shows

<img width="330" alt="image" src="https://github.com/user-attachments/assets/2563c130-71f2-44a9-9f29-fcde24a4a224" />

When scrolling

<img width="330" height="2868" alt="image" src="https://github.com/user-attachments/assets/9c072dc0-07f2-43a7-a2f4-6c94b9356692" />

How it looked before this change when scrolling

<img width="330" height="2868" alt="image" src="https://github.com/user-attachments/assets/258f9a23-cecf-418a-80e6-ead0f05bc19b" />

Personally i think this is a much better experience. 
