### PR TITLE
oh-list-item: Merge `component.slots.after[0]` & `$slots.after`

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -29,11 +29,13 @@
     <template #footer v-if="$slots.footer">
       <slot name="footer" />
     </template>
-    <template #after v-if="$slots.after">
-      <slot name="after" />
-    </template>
-    <template #after v-if="context.component.slots && context.component.slots.after && context.component.slots.after.length">
-      <generic-widget-component :context="childContext(context.component.slots.after[0])" />
+    <template #after v-if="$slots.after || context.component.slots?.after?.length">
+      <template v-if="context.component.slots?.after?.length">
+        <generic-widget-component :context="childContext(context.component.slots.after[0])" />
+      </template>
+      <template v-if="$slots.after">
+        <slot name="after" />
+      </template>
     </template>
     <f7-accordion-content v-if="context.parent.component.config.accordionList && !context.editmode">
       <generic-widget-component v-if="isRegularAccordion" :context="childContext(context.component.slots.accordion[0])" />


### PR DESCRIPTION
Restores Vue 2 behavior where slots were appended instead of being overwritten.