### PR TITLE
oh-block/widget-mixin: Make code more robust to missing values

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-block.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-block.vue
@@ -28,7 +28,7 @@
         </f7-menu-dropdown>
       </f7-menu-item>
     </f7-menu>
-    <component v-for="(component, idx) in context.component.slots.default"
+    <component v-for="(component, idx) in context.component.slots?.default"
                :is="component.component"
                :key="idx"
                :context="childContext(component)" />

--- a/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/widget-mixin.js
@@ -32,6 +32,7 @@ export default {
   },
   computed: {
     componentType () {
+      if (!this.context?.component?.component) return null
       return this.evaluateExpression('type', this.context.component.component)
     },
     childWidgetComponentType () {
@@ -71,7 +72,7 @@ export default {
       }
     },
     visible () {
-      if (this.context.editmode || !this.context.component.config) return true
+      if (this.context?.editmode || !this.context?.component?.config) return true
       const visible = this.evaluateExpression('visible', this.context.component.config.visible)
       const visibleTo = this.context.component.config.visibleTo
       if (visible === undefined && visibleTo === undefined) return true


### PR DESCRIPTION
Fixes #3702.

- oh-block: Handle missing `config` gracefully.
- widget-mixin: Handle missing component gracefully.