### PR TITLE
useModelStore: Ensure required elements are present when converting to ModelItem

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useModelStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useModelStore.ts
@@ -10,7 +10,7 @@ import { type Item } from '@/types/openhab'
 import type { Composer } from 'vue-i18n'
 
 interface ModelItem extends Item {
-  modelPath: Item[]
+  modelPath?: Item[]
   parent: ModelItem | null
   children: ModelItem[]
   points: ModelItem[]
@@ -181,7 +181,18 @@ export const useModelStore = defineStore('model', () => {
 
   async function loadSemanticModel () {
     api.get('/rest/items?staticDataOnly=true&metadata=semantics,listWidget,widgetOrder').then((data: Item[]) => {
-      let modelItems = data as ModelItem[]
+      let modelItems: ModelItem[] = data.map((item) => {
+        return {
+          ...item,
+          parent: null,
+          children: [],
+          points: [],
+          locations: [],
+          properties: [],
+          equipment: [],
+          equipmentOrPoints: []
+        } satisfies ModelItem
+      })
 
       let filteredItems: FilteredItems = {
         equipment: [],


### PR DESCRIPTION
Fixes an issue reported on the community:
https://community.openhab.org/t/openhab-5-1-release-discussion/167620/345