### PR TITLE
oh-map-/oh-plan-marker: Fix incorrect marker/tooltip positioning

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/map/oh-map-marker.vue
@@ -3,7 +3,7 @@
     <l-tooltip v-if="config.label">
       {{ config.label }}
     </l-tooltip>
-    <l-icon v-if="icon" :icon-size="icon.iconSize" :icon-url="icon.iconUrl" :shadow-url="icon?.shadowUrl" />
+    <l-icon v-if="icon" :icon-size="icon.iconSize" :icon-url="icon.iconUrl" />
   </l-marker>
 </template>
 
@@ -16,7 +16,6 @@ import { actionsMixin } from '../widget-actions'
 import { OhMapMarkerDefinition } from '@/assets/definitions/widgets/map'
 
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
-import markerShadow from 'leaflet/dist/images/marker-shadow.png'
 
 export default {
   mixins: [mixin, actionsMixin],
@@ -52,8 +51,7 @@ export default {
         this.markerKey = f7.utils.id()
         return {
           iconUrl: markerIcon,
-          shadowUrl: markerShadow,
-          iconSize: null
+          iconSize: [25,41],
         }
       }
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -25,7 +25,7 @@
         :height="config.iconHeight || config.iconSize || 40"
         :state="config.iconUseState ? state : undefined" />
     </l-icon>
-    <l-icon v-else :icon-url="DefaultIcon.iconUrl" :shadow-url="DefaultIcon.shadowUrl" />
+    <l-icon v-else :icon-url="DefaultIcon.iconUrl" :icon-size="DefaultIcon.iconSize" />
     <l-popup v-if="context.editmode && !dragging">
       <div class="display-flex">
         <f7-link
@@ -70,7 +70,6 @@ import { actionsMixin } from '../widget-actions'
 import { OhPlanMarkerDefinition } from '@/assets/definitions/widgets/plan'
 
 import markerIcon from 'leaflet/dist/images/marker-icon.png'
-import markerShadow from 'leaflet/dist/images/marker-shadow.png'
 
 export default {
   mixins: [mixin, actionsMixin],
@@ -91,7 +90,7 @@ export default {
   created () {
     this.DefaultIcon = {
       iconUrl: markerIcon,
-      shadowUrl: markerShadow
+      iconSize: [25, 41],
     }
   },
   computed: {
@@ -102,7 +101,6 @@ export default {
       return this.config.useTooltipAsLabel || this.config.icon
     },
     iconSize () {
-      if (this.hasCustomIcon) return null
       const iconSize = this.config.iconSize || 40
       return [iconSize, iconSize]
     },


### PR DESCRIPTION
Regression from #3687.

This ensures icon size is always set explicitly.
I decided to remove the icon shadow as I didn't figure out how to place the shadow correctly and displaying shadow for the default icon, but not for custom icons is inconsistent.