### PR TITLE
oh-input: Fix reference to getVariableScope method

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-input.vue
@@ -71,7 +71,7 @@ export default {
     value () {
       let variableLocation = this.context.vars
       if (this.config.variable) {
-        const variableScope = this.getVariableScope(this.context.ctxVars, this.context.varScope, this.config.variable)
+        const variableScope = getVariableScope(this.context.ctxVars, this.context.varScope, this.config.variable)
         if (variableScope) variableLocation = this.context.ctxVars[variableScope]
       }
       if (this.config.variable && this.config.variableKey) {


### PR DESCRIPTION
Issue raised in forum: https://community.openhab.org/t/openhab-5-1-release-discussion/167620/406?u=jsjames

Fixes #3755. 

should be backported