### PR TITLE
f7-list-group css: Fix style regression from grouped list indentation fix

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -443,8 +443,7 @@ html
 
 // Fix for grouped list indentation, e.g. Pages list
 .list:not(.accordion-list) ul .list-group ul
-  --f7-list-in-list-padding-left 0px
-  --f7-list-item-padding-horizontal 0px
+  padding-left 0
 
 .advanced-label
   font-size var(--f7-toolbar-font-size)


### PR DESCRIPTION
Fixes an issue where padding was missing as the CSS variables were set to 0 for elements in: f7-list > f7-list-group > f7-list-item

It is enough to remove the left padding for the list-group itself, we don't want to remove it for its list items as well.

Regression from #3350.