### PR TITLE
oh-swiper: Only unset width if slidesPerView set to auto

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-swiper.vue
@@ -5,7 +5,7 @@
       v-for="(slide, idx) in slides"
       :key="'editmode-' + idx"
       class="oh-swiper-slide"
-      :class="{ 'edit-mode': context.editmode }">
+      :class="{ 'unset-width': mergedConfig.slidesPerView === 'auto', 'edit-mode': context.editmode }">
       <f7-menu v-if="context.editmode" class="configure-layout-menu padding-horizontal">
         <f7-menu-item style="margin-left: auto" icon-f7="rectangle_on_rectangle" dropdown>
           <f7-menu-dropdown right>
@@ -65,8 +65,8 @@
 </template>
 
 <style lang="stylus">
-.oh-swiper-slide
-  width unset !important
+.oh-swiper-slide.unset-width
+    width unset !important
 </style>
 
 <script>


### PR DESCRIPTION
Regression from #3653.

When setting a fixed size per slide, it is not applied anymore as !important overwrites it.
When setting slidesPerView to auto, however width is calculated improperly, so only apply the fix from #3653 if slidesPerView is actually set to auto.
Reported on the community: https://community.openhab.org/t/universal-toggle/115500/29