### PR TITLE
[MainUI] Persistence configuration UI update

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/persistence.js
@@ -35,6 +35,7 @@ export const FilterTypes = [
   {
     name: 'thresholdFilters',
     label: 'Threshold',
+    icon: 'arrow_up_right_circle',
     configDescriptionParameters: [
       {
         advanced: false,
@@ -66,6 +67,7 @@ export const FilterTypes = [
   {
     name: 'timeFilters',
     label: 'Time',
+    icon: 'clock',
     configDescriptionParameters: [
       {
         advanced: false,
@@ -97,6 +99,7 @@ export const FilterTypes = [
   {
     name: 'equalsFilters',
     label: 'Equals/Not Equals',
+    icon: 'equal_circle',
     configDescriptionParameters: [
       {
         advanced: false,
@@ -114,6 +117,7 @@ export const FilterTypes = [
   {
     name: 'includeFilters',
     label: 'Include/Exclude',
+    icon: 'arrow_left_right_square',
     configDescriptionParameters: [
       {
         advanced: false,

--- a/bundles/org.openhab.ui/web/src/assets/definitions/persistence.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/persistence.js
@@ -112,7 +112,7 @@ export const FilterTypes = [
       },
       filterInvertedParameter
     ],
-    footerFn: (f) => (f.inverted === true ? 'not ' : '') + 'equals ' + f.values.join(', ')
+    footerFn: (f) => (f.inverted === true ? 'not ' : '') + 'equals ' + f.values?.join(', ')
   },
   {
     name: 'includeFilters',

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -226,7 +226,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 4 ? true : null"
                 @click="day.cronEvery = 4">
-                <select multiple @change="week.specificSpecific = getSmartSelectValue('specificDayOfWeek').map((v) => v)"> 
+                <select multiple @change="week.specificSpecific = getSmartSelectValue('specificDayOfWeek').map((v) => v)">
                   <option
                     v-for="val in 7"
                     :key="val"
@@ -731,11 +731,11 @@ export default {
     updateSmartSelectOptions (refName, selectedValues) {
       const selectEl = this.$refs[refName]?.$el?.querySelector('select')
       if (!selectEl) return
-      
+
       Array.from(selectEl.options).forEach(option => {
         option.selected = selectedValues.includes(option.value) || selectedValues.includes(parseInt(option.value))
       })
-      
+
       // Trigger change to update smart-select UI
       selectEl.dispatchEvent(new Event('change', { bubbles: true }))
     },

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -9,23 +9,15 @@
         </f7-nav-right>
       </f7-navbar>
       <f7-toolbar tabbar position="top">
-        <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'seconds'" @click="currentTab = 'seconds'">
-          Seconds
-        </f7-link>
-        <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'minutes'" @click="currentTab = 'minutes'">
-          Minutes
-        </f7-link>
-        <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'hours'" @click="currentTab = 'hours'">
-          Hours
-        </f7-link>
-        <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'days'" @click="currentTab = 'days'"> Days </f7-link>
-        <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'month'" @click="currentTab = 'month'">
-          Month
-        </f7-link>
-        <f7-link class="padding-left padding-right" :tab-link-active="currentTab === 'year'" @click="currentTab = 'year'"> Year </f7-link>
+        <f7-link class="padding-left padding-right" tab-link="#seconds" tab-link-active> Seconds </f7-link>
+        <f7-link class="padding-left padding-right" tab-link="#minutes"> Minutes </f7-link>
+        <f7-link class="padding-left padding-right" tab-link="#hours"> Hours </f7-link>
+        <f7-link class="padding-left padding-right" tab-link="#days"> Days </f7-link>
+        <f7-link class="padding-left padding-right" tab-link="#month"> Month </f7-link>
+        <f7-link class="padding-left padding-right" tab-link="#year"> Year </f7-link>
       </f7-toolbar>
       <f7-tabs type="border-card">
-        <f7-tab :tab-active="currentTab === 'seconds'">
+        <f7-tab id="seconds" tab-active>
           <template #label>
             <span>
               <i class="el-icon-date" />
@@ -58,12 +50,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="second.cronEvery === 3 ? true : null"
                 @click="second.cronEvery = 3">
-                <select multiple @change="second.specificSpecific = getSmartSelectValue('specificSecond').map((v) => parseInt(v))">
-                  <option
-                    v-for="val in 60"
-                    :key="val"
-                    :value="val - 1"
-                    :selected="second.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
+                <select multiple v-model="second.specificSpecfic">
+                  <option v-for="val in 60" :key="val" :value="val - 1">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -78,7 +66,7 @@
             </f7-list>
           </f7-block>
         </f7-tab>
-        <f7-tab :tab-active="currentTab === 'minutes'">
+        <f7-tab id="minutes">
           <template #label>
             <span>
               <i class="el-icon-date" />
@@ -111,12 +99,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="minute.cronEvery === 3 ? true : null"
                 @click="minute.cronEvery = 3">
-                <select multiple @change="minute.specificSpecific = getSmartSelectValue('specificMinute').map((v) => parseInt(v))">
-                  <option
-                    v-for="val in 60"
-                    :key="val"
-                    :value="val - 1"
-                    :selected="minute.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
+                <select multiple v-model="minute.specificSpecific">
+                  <option v-for="val in 60" :key="val" :value="val - 1">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -131,7 +115,7 @@
             </f7-list>
           </f7-block>
         </f7-tab>
-        <f7-tab :tab-active="currentTab === 'hours'">
+        <f7-tab id="hours">
           <template #label>
             <span>
               <i class="el-icon-date" />
@@ -164,12 +148,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="hour.cronEvery === 3 ? true : null"
                 @click="hour.cronEvery = 3">
-                <select multiple @change="hour.specificSpecific = getSmartSelectValue('specificHour').map((v) => parseInt(v))">
-                  <option
-                    v-for="val in 24"
-                    :key="val"
-                    :value="val - 1"
-                    :selected="hour.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
+                <select multiple v-model="hour.specificSpecific">
+                  <option v-for="val in 24" :key="val" :value="val - 1">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -184,7 +164,7 @@
             </f7-list>
           </f7-block>
         </f7-tab>
-        <f7-tab :tab-active="currentTab === 'days'">
+        <f7-tab id="days">
           <template #label>
             <span>
               <i class="el-icon-date" />
@@ -226,12 +206,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 4 ? true : null"
                 @click="day.cronEvery = 4">
-                <select multiple @change="week.specificSpecific = getSmartSelectValue('specificDayOfWeek').map((v) => v)">
-                  <option
-                    v-for="val in 7"
-                    :key="val"
-                    :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]"
-                    :selected="week.specificSpecific.indexOf( ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]) >= 0 ? true : null">
+                <select multiple v-model="week.specficSpecific">
+                  <option v-for="val in 7" :key="val" :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]">
                     {{ text.Week[val - 1] }}
                   </option>
                 </select>
@@ -246,8 +222,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 5 ? true : null"
                 @click="day.cronEvery = 5">
-                <select multiple @change="day.specificSpecific = getSmartSelectValue('specificDayOfMonth').map((v) => parseInt(v))">
-                  <option v-for="val in 31" :key="val" :value="val" :selected="day.specificSpecific.indexOf(val) >= 0 ? true : null">
+                <select multiple v-model="day.specificSpecific">
+                  <option v-for="val in 31" :key="val" :value="val">
                     {{ val }}
                   </option>
                 </select>
@@ -301,7 +277,7 @@
             </f7-list>
           </f7-block>
         </f7-tab>
-        <f7-tab :tab-active="currentTab === 'month'">
+        <f7-tab id="month">
           <f7-block>
             <f7-list>
               <f7-list-item radio :checked="month.cronEvery === 1 ? true : null" @change="month.cronEvery = 1">
@@ -328,8 +304,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="month.cronEvery === 3 ? true : null"
                 @click="month.cronEvery = 3">
-                <select multiple @change="month.specificSpecific = getSmartSelectValue('specificMonth').map((v) => parseInt(v))">
-                  <option v-for="val in 12" :key="val" :value="val" :selected="month.specificSpecific.indexOf(val) >= 0 ? true : null">
+                <select multiple v-model="month.specificSpecific">
+                  <option v-for="val in 12" :key="val" :value="val">
                     {{ val }}
                   </option>
                 </select>
@@ -344,7 +320,7 @@
             </f7-list>
           </f7-block>
         </f7-tab>
-        <f7-tab :tab-active="currentTab === 'year'">
+        <f7-tab id="year">
           <f7-block>
             <f7-list>
               <f7-list-item radio :checked="year.cronEvery === 1 ? true : null" @change="year.cronEvery = 1">
@@ -376,12 +352,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="year.cronEvery === 3 ? true : null"
                 @click="year.cronEvery = 3">
-                <select multiple @change="year.specificSpecific = getSmartSelectValue('specificYear').map((v) => parseInt(v))">
-                  <option
-                    v-for="val in 100"
-                    :key="val"
-                    :value="val + year.currentYear - 1"
-                    :selected="year.specificSpecific.indexOf(val + year.currentYear - 1) >= 0 ? true : null">
+                <select multiple v-model="year.specficSpecific">
+                  <option v-for="val in 100" :key="val" :value="val + year.currentYear - 1">
                     {{ val + year.currentYear - 1 }}
                   </option>
                 </select>
@@ -424,9 +396,9 @@
 </style>
 
 <script>
+import { f7 } from 'framework7-vue'
 import Labels from '@/assets/i18n/cron/en.js'
 import { toString } from 'cronstrue'
-import { f7 } from 'framework7-vue'
 
 export default {
   name: 'vueCron',
@@ -443,7 +415,6 @@ export default {
     const currentMonth = date.getMonth() + 1
     const currentYear = date.getFullYear()
     return {
-      currentTab: 'seconds',
       second: {
         cronEvery: 3,
         incrementStart: 0,
@@ -714,30 +685,9 @@ export default {
     },
     open () {
       this.restore(this.value)
-      this.$nextTick(() => {
-        // Manually update select elements to reflect restored data
-        this.updateSmartSelectOptions('specificSecond', this.second.specificSpecific)
-        this.updateSmartSelectOptions('specificMinute', this.minute.specificSpecific)
-        this.updateSmartSelectOptions('specificHour', this.hour.specificSpecific)
-        this.updateSmartSelectOptions('specificDayOfWeek', this.week.specificSpecific)
-        this.updateSmartSelectOptions('specificDayOfMonth', this.day.specificSpecific)
-        this.updateSmartSelectOptions('specificMonth', this.month.specificSpecific)
-        this.updateSmartSelectOptions('specificYear', this.year.specificSpecific)
-      })
     },
     close () {
       f7.emit('cronEditorClosed')
-    },
-    updateSmartSelectOptions (refName, selectedValues) {
-      const selectEl = this.$refs[refName]?.$el?.querySelector('select')
-      if (!selectEl) return
-
-      Array.from(selectEl.options).forEach(option => {
-        option.selected = selectedValues.includes(option.value) || selectedValues.includes(parseInt(option.value))
-      })
-
-      // Trigger change to update smart-select UI
-      selectEl.dispatchEvent(new Event('change', { bubbles: true }))
     },
     restore (val) {
       if (!val) return
@@ -825,10 +775,6 @@ export default {
         this.day.cronEvery = 5
         this.day.specificSpecific = dayExpr.split(',')
       }
-    },
-    getSmartSelectValue (refName) {
-      const ref = this.$refs[refName]
-      return ref?.$el?.children[0]?.f7SmartSelect?.getValue() || []
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -1,7 +1,7 @@
 <!-- Adapted from https://github.com/1615450788/vue-cron - license: MIT -->
 
 <template>
-  <f7-popup class="cron-select" close-on-escape @popup:opened="open" @popup:closed="close">
+  <f7-popup class="cron-select" close-on-escape @popup:closed="close">
     <f7-page class="cron-select-content">
       <f7-navbar :title="'Cron: ' + cron" :subtitle="translation">
         <f7-nav-right>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -749,7 +749,7 @@ export default {
         newVal.incrementStart = parseInt(increment[0])
         newVal.incrementIncrement = parseInt(increment[1])
       } else if (expr.includes('-')) {
-        this.second.cronEvery = 4
+        newVal.cronEvery = 4
         const range = expr.split('-')
         newVal.rangeStart = parseInt(range[0])
         newVal.rangeEnd = parseInt(range[1])
@@ -763,13 +763,13 @@ export default {
       if (weekExpr.includes('/')) {
         this.day.cronEvery = 2
         const weekIncrement = weekExpr.split('/')
-        this.week.incrementStart = weekIncrement[0]
-        this.week.incrementEnd = weekIncrement[1]
+        this.week.incrementStart = parseInt(weekIncrement[0])
+        this.week.incrementIncrement = parseInt(weekIncrement[1])
       } else if (dayExpr.includes('/')) {
         this.day.cronEvery = 3
         const dayIncrement = dayExpr.split('/')
-        this.day.incrementStart = dayIncrement[0]
-        this.day.incrementEnd = dayIncrement[1]
+        this.day.incrementStart = parseInt(dayIncrement[0])
+        this.day.incrementIncrement = parseInt(dayIncrement[1])
       } else if (dayExpr === 'L') {
         this.day.cronEvery = 6
       } else if (dayExpr === 'LW') {

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -1,7 +1,7 @@
 <!-- Adapted from https://github.com/1615450788/vue-cron - license: MIT -->
 
 <template>
-  <f7-popup class="cron-select" close-on-escape @popup:closed="close">
+  <f7-popup class="cron-select" close-on-escape @popup:opened="open" @popup:closed="close">
     <f7-page class="cron-select-content">
       <f7-navbar :title="'Cron: ' + cron" :subtitle="translation">
         <f7-nav-right>
@@ -29,7 +29,7 @@
           <template #label>
             <span>
               <i class="el-icon-date" />
-              {{ text.seconds.name }}
+              {{ text.Seconds.name }}
             </span>
           </template>
           <f7-block>
@@ -58,7 +58,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="second.cronEvery === 3 ? true : null"
                 @click="second.cronEvery = 3">
-                <select multiple @change="second.specificSpecific = $refs.specificSecond.$el.children[0].f7SmartSelect.getValue()">
+                <select multiple @change="second.specificSpecific = getSmartSelectValue('specificSecond').map((v) => parseInt(v))">
                   <option
                     v-for="val in 60"
                     :key="val"
@@ -111,7 +111,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="minute.cronEvery === 3 ? true : null"
                 @click="minute.cronEvery = 3">
-                <select multiple @change="minute.specificSpecific = $refs.specificMinute.f7SmartSelect.getValue()">
+                <select multiple @change="minute.specificSpecific = getSmartSelectValue('specificMinute').map((v) => parseInt(v))">
                   <option
                     v-for="val in 60"
                     :key="val"
@@ -164,7 +164,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="hour.cronEvery === 3 ? true : null"
                 @click="hour.cronEvery = 3">
-                <select multiple @change="hour.specificSpecific = $refs.specificHour.$el.children[0].f7SmartSelect.getValue()">
+                <select multiple @change="hour.specificSpecific = getSmartSelectValue('specificHour').map((v) => parseInt(v))">
                   <option
                     v-for="val in 24"
                     :key="val"
@@ -226,12 +226,12 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 4 ? true : null"
                 @click="day.cronEvery = 4">
-                <select multiple @change="week.specificSpecific = $refs.specificDayOfWeek.$el.children[0].f7SmartSelect.getValue()">
+                <select multiple @change="week.specificSpecific = getSmartSelectValue('specificDayOfWeek').map((v) => v)"> 
                   <option
                     v-for="val in 7"
                     :key="val"
                     :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]"
-                    :selected=" week.specificSpecific.indexOf( ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]) >= 0 ? true : null">
+                    :selected="week.specificSpecific.indexOf( ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]) >= 0 ? true : null">
                     {{ text.Week[val - 1] }}
                   </option>
                 </select>
@@ -246,7 +246,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 5 ? true : null"
                 @click="day.cronEvery = 5">
-                <select multiple @change="day.specificSpecific = $refs.specificDayOfMonth.$el.children[0].f7SmartSelect.getValue()">
+                <select multiple @change="day.specificSpecific = getSmartSelectValue('specificDayOfMonth').map((v) => parseInt(v))">
                   <option v-for="val in 31" :key="val" :value="val" :selected="day.specificSpecific.indexOf(val) >= 0 ? true : null">
                     {{ val }}
                   </option>
@@ -328,7 +328,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="month.cronEvery === 3 ? true : null"
                 @click="month.cronEvery = 3">
-                <select multiple @change="month.specificSpecific = $refs.specificMonth.$el.children[0].f7SmartSelect.getValue()">
+                <select multiple @change="month.specificSpecific = getSmartSelectValue('specificMonth').map((v) => parseInt(v))">
                   <option v-for="val in 12" :key="val" :value="val" :selected="month.specificSpecific.indexOf(val) >= 0 ? true : null">
                     {{ val }}
                   </option>
@@ -359,7 +359,12 @@
                   :min="1"
                   :max="99" />
                 {{ text.Year.interval[1] || '' }}
-                <f7-stepper small :value="year.incrementStart" @stepper:change="(v) => year.incrementStart = v" :min="2019" :max="2119" />
+                <f7-stepper
+                  small
+                  :value="year.incrementStart"
+                  @stepper:change="(v) => year.incrementStart = v"
+                  :min="year.currentYear"
+                  :max="year.currentYear + 100" />
                 {{ text.Year.interval[2] || '' }}
               </f7-list-item>
               <f7-list-item
@@ -371,21 +376,31 @@
                 :smart-select-params="smartSelectParams"
                 :checked="year.cronEvery === 3 ? true : null"
                 @click="year.cronEvery = 3">
-                <select multiple @change="year.specificSpecific = $refs.specificYear.$el.children[0].f7SmartSelect.getValue()">
+                <select multiple @change="year.specificSpecific = getSmartSelectValue('specificYear').map((v) => parseInt(v))">
                   <option
                     v-for="val in 100"
                     :key="val"
-                    :value="val + 2018"
-                    :selected="year.specificSpecific.indexOf(val + 2018) >= 0 ? true : null">
-                    {{ val + 2018 }}
+                    :value="val + year.currentYear - 1"
+                    :selected="year.specificSpecific.indexOf(val + year.currentYear - 1) >= 0 ? true : null">
+                    {{ val + year.currentYear - 1 }}
                   </option>
                 </select>
               </f7-list-item>
               <f7-list-item radio :checked="year.cronEvery === 4 ? true : null" @change="year.cronEvery = 4">
                 {{ text.Year.cycle[0] }}
-                <f7-stepper small :value="year.rangeStart" @stepper:change="v => (year.rangeStart = v)" :min="2019" :max="2119" />
+                <f7-stepper
+                  small
+                  :value="year.rangeStart"
+                  @stepper:change="v => (year.rangeStart = v)"
+                  :min="year.currentYear"
+                  :max="year.currentYear + 100" />
                 {{ text.Year.cycle[1] || '' }}
-                <f7-stepper small :value="year.rangeEnd" @stepper:change="v => (year.rangeEnd = v)" :min="2019" :max="2119" />
+                <f7-stepper
+                  small
+                  :value="year.rangeEnd"
+                  @stepper:change="v => (year.rangeEnd = v)"
+                  :min="year.currentYear"
+                  :max="year.currentYear + 100" />
                 {{ text.Year.cycle[2] || '' }}
               </f7-list-item>
             </f7-list>
@@ -424,6 +439,9 @@ export default {
     ]
   },
   data () {
+    const date = new Date()
+    const currentMonth = date.getMonth() + 1
+    const currentYear = date.getFullYear()
     return {
       currentTab: 'seconds',
       second: {
@@ -462,7 +480,6 @@ export default {
         cronDaysNearestWeekday: 1
       },
       week: {
-        cronEvery: 1,
         incrementStart: 1,
         incrementIncrement: 1,
         specificSpecific: [],
@@ -471,34 +488,21 @@ export default {
       },
       month: {
         cronEvery: 1,
-        incrementStart: 3,
-        incrementIncrement: 5,
-        rangeStart: 1,
-        rangeEnd: 1,
+        incrementStart: currentMonth,
+        incrementIncrement: 2,
+        rangeStart: currentMonth,
+        rangeEnd: currentMonth,
         specificSpecific: []
       },
       year: {
         cronEvery: 1,
-        incrementStart: 2019,
+        incrementStart: currentYear,
         incrementIncrement: 1,
-        rangeStart: 2019,
-        rangeEnd: 2019,
-        specificSpecific: []
-      },
-      output: {
-        second: 1,
-        minute: 1,
-        hour: 1,
-        day: 1,
-        month: 1,
-        Week: 1,
-        year: 1
+        rangeStart: currentYear,
+        rangeEnd: currentYear,
+        specificSpecific: [],
+        currentYear: currentYear
       }
-    }
-  },
-  watch: {
-    value () {
-      this.rest(this.$data)
     }
   },
   computed: {
@@ -511,10 +515,7 @@ export default {
     secondsText () {
       let seconds = ''
       let cronEvery = this.second.cronEvery
-      switch (cronEvery.toString(), {
-        use24HourTimeFormat: true,
-        dayOfWeekStartIndexZero: false
-      }) {
+      switch (cronEvery.toString()) {
         case '1':
           seconds = '*'
           break
@@ -584,7 +585,6 @@ export default {
       let cronEvery = this.day.cronEvery
       switch (cronEvery.toString()) {
         case '1':
-          break
         case '2':
         case '4':
         case '11':
@@ -621,6 +621,8 @@ export default {
       let cronEvery = this.day.cronEvery
       switch (cronEvery.toString()) {
         case '1':
+          weeks = '*'
+          break
         case '3':
         case '5':
           weeks = '?'
@@ -677,7 +679,7 @@ export default {
       let cronEvery = this.year.cronEvery
       switch (cronEvery.toString()) {
         case '1':
-          years = '*'
+          years = ''
           break
         case '2':
           years = this.year.incrementStart + '/' + this.year.incrementIncrement
@@ -696,8 +698,8 @@ export default {
     },
     cron () {
       return `${this.secondsText || '*'} ${this.minutesText || '*'} ${this
-        .hoursText || '*'} ${this.daysText || '*'} ${this.monthsText ||
-        '*'} ${this.weeksText || '?'} ${this.yearsText || '*'}`
+        .hoursText || '*'} ${this.daysText || '?'} ${this.monthsText ||
+        '*'} ${this.weeksText || '?'} ${this.yearsText.length ? ' ' : ''}${this.yearsText || ''}`
     },
     translation () {
       return toString(this.cron, {
@@ -707,33 +709,127 @@ export default {
     }
   },
   methods: {
-    getValue () {
-      return this.cron
-    },
     change () {
       f7.emit('cronEditorUpdate', this.cron)
+    },
+    open () {
+      this.restore(this.value)
+      this.$nextTick(() => {
+        // Manually update select elements to reflect restored data
+        this.updateSmartSelectOptions('specificSecond', this.second.specificSpecific)
+        this.updateSmartSelectOptions('specificMinute', this.minute.specificSpecific)
+        this.updateSmartSelectOptions('specificHour', this.hour.specificSpecific)
+        this.updateSmartSelectOptions('specificDayOfWeek', this.week.specificSpecific)
+        this.updateSmartSelectOptions('specificDayOfMonth', this.day.specificSpecific)
+        this.updateSmartSelectOptions('specificMonth', this.month.specificSpecific)
+        this.updateSmartSelectOptions('specificYear', this.year.specificSpecific)
+      })
     },
     close () {
       f7.emit('cronEditorClosed')
     },
-    rest (data) {
-      for (let i in data) {
-        if (i === 'currentTab') continue
-        if (data[i] instanceof Object) {
-          this.rest(data[i])
-        } else {
-          switch (typeof data[i]) {
-            case 'object':
-              data[i] = []
-              break
-            case 'string':
-              data[i] = ''
-              break
-          }
+    updateSmartSelectOptions (refName, selectedValues) {
+      const selectEl = this.$refs[refName]?.$el?.querySelector('select')
+      if (!selectEl) return
+      
+      Array.from(selectEl.options).forEach(option => {
+        option.selected = selectedValues.includes(option.value) || selectedValues.includes(parseInt(option.value))
+      })
+      
+      // Trigger change to update smart-select UI
+      selectEl.dispatchEvent(new Event('change', { bubbles: true }))
+    },
+    restore (val) {
+      if (!val) return
+      const cronExpr = val.trim().split(' ')
+      this.second.cronEvery = 1
+      this.minute.cronEvery = 1
+      this.hour.cronEvery = 1
+      this.day.cronEvery = 1
+      this.month.cronEvery = 1
+      this.year.cronEvery = 1
+      cronExpr.forEach((expr, ndx) => {
+        switch (ndx) {
+          case 0:
+            this.second = this.restoreBase(this.second, expr)
+            break
+          case 1:
+            this.minute = this.restoreBase(this.minute, expr)
+            break
+          case 2:
+            this.hour = this.restoreBase(this.hour, expr)
+            break
+          case 4:
+            this.month = this.restoreBase(this.month, expr)
+            break
+          case 6:
+            this.year = this.restoreBase(this.year, expr)
+            break
         }
+      })
+      this.restoreDayAndWeek(cronExpr[3] || '', cronExpr[5] || '')
+    },
+    restoreBase (val, expr) {
+      const newVal = val
+      if (expr === '*') {
+        newVal.cronEvery = 1
+      } else if (expr.includes('/')) {
+        newVal.cronEvery = 2
+        const increment = expr.split('/')
+        newVal.incrementStart = parseInt(increment[0])
+        newVal.incrementIncrement = parseInt(increment[1])
+      } else if (expr.includes('-')) {
+        this.second.cronEvery = 4
+        const range = expr.split('-')
+        newVal.rangeStart = parseInt(range[0])
+        newVal.rangeEnd = parseInt(range[1])
+      } else {
+        newVal.cronEvery = 3
+        newVal.specificSpecific = expr.split(',').map((v) => parseInt(v))
       }
+      return newVal
+    },
+    restoreDayAndWeek (dayExpr, weekExpr) {
+      if (weekExpr.includes('/')) {
+        this.day.cronEvery = 2
+        const weekIncrement = weekExpr.split('/')
+        this.week.incrementStart = weekIncrement[0]
+        this.week.incrementEnd = weekIncrement[1]
+      } else if (dayExpr.includes('/')) {
+        this.day.cronEvery = 3
+        const dayIncrement = dayExpr.split('/')
+        this.day.incrementStart = dayIncrement[0]
+        this.day.incrementEnd = dayIncrement[1]
+      } else if (dayExpr === 'L') {
+        this.day.cronEvery = 6
+      } else if (dayExpr === 'LW') {
+        this.day.cronEvery = 7
+      } else if (weekExpr.endsWith('L')) {
+        this.day.cronEvery = 8
+        this.day.cronLastSpecificDomDay = weekExpr.slice(0, -1)
+      } else if (dayExpr.startsWith('L-')) {
+        this.day.cronEvery = 9
+        this.day.cronDaysBeforeEomMinus = dayExpr.slice(2)
+      } else if (dayExpr.endsWith('W')) {
+        this.day.cronEvery = 10
+        this.day.cronDaysNearestWeekday = dayExpr.slice(0, -1)
+      } else if (weekExpr.includes('#')) {
+        this.day.cronEvery = 11
+        const weekNthDay = weekExpr.split('#')
+        this.week.cronNthDayDay = weekNthDay[0]
+        this.week.cronNthDayNth = weekNthDay[1]
+      } else if (weekExpr?.length) {
+        this.day.cronEvery = 4
+        this.week.specificSpecific = weekExpr.split(',')
+      } else {
+        this.day.cronEvery = 5
+        this.day.specificSpecific = dayExpr.split(',')
+      }
+    },
+    getSmartSelectValue (refName) {
+      const ref = this.$refs[refName]
+      return ref?.$el?.children[0]?.f7SmartSelect?.getValue() || []
     }
-  },
-  mounted () {}
+  }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -50,12 +50,8 @@
                 :smart-select-params="smartSelectParams"
                 :checked="second.cronEvery === 3 ? true : null"
                 @click="second.cronEvery = 3">
-                <select multiple v-model="second.specificSpecfic">
-                  <option
-                    v-for="val in 60"
-                    :key="val"
-                    :value="val - 1"
-                    :selected="second.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
+                <select multiple v-model="second.specificSpecific">
+                  <option v-for="val in 60" :key="val" :value="val - 1">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -104,11 +100,7 @@
                 :checked="minute.cronEvery === 3 ? true : null"
                 @click="minute.cronEvery = 3">
                 <select multiple v-model="minute.specificSpecific">
-                  <option
-                    v-for="val in 60"
-                    :key="val"
-                    :value="val - 1"
-                    :selected="minute.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
+                  <option v-for="val in 60" :key="val" :value="val - 1">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -157,11 +149,7 @@
                 :checked="hour.cronEvery === 3 ? true : null"
                 @click="hour.cronEvery = 3">
                 <select multiple v-model="hour.specificSpecific">
-                  <option
-                    v-for="val in 24"
-                    :key="val"
-                    :value="val - 1"
-                    :selected="hour.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
+                  <option v-for="val in 24" :key="val" :value="val - 1">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -219,11 +207,7 @@
                 :checked="day.cronEvery === 4 ? true : null"
                 @click="day.cronEvery = 4">
                 <select multiple v-model="week.specificSpecific">
-                  <option
-                    v-for="val in 7"
-                    :key="val"
-                    :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]"
-                    :selected="week.specificSpecific.indexOf( ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]) >= 0 ? true : null">
+                  <option v-for="val in 7" :key="val" :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]">
                     {{ text.Week[val - 1] }}
                   </option>
                 </select>
@@ -321,7 +305,7 @@
                 :checked="month.cronEvery === 3 ? true : null"
                 @click="month.cronEvery = 3">
                 <select multiple v-model="month.specificSpecific">
-                  <option v-for="val in 12" :key="val" :value="val" :selected="month.specificSpecific.indexOf(val) >= 0 ? true : null">
+                  <option v-for="val in 12" :key="val" :value="val">
                     {{ val }}
                   </option>
                 </select>
@@ -369,11 +353,7 @@
                 :checked="year.cronEvery === 3 ? true : null"
                 @click="year.cronEvery = 3">
                 <select multiple v-model="year.specificSpecific">
-                  <option
-                    v-for="val in 100"
-                    :key="val"
-                    :value="val + year.currentYear - 1"
-                    :selected="year.specificSpecific.indexOf(val + year.currentYear - 1) >= 0 ? true : null">
+                  <option v-for="val in 100" :key="val" :value="val + year.currentYear - 1">
                     {{ val + year.currentYear - 1 }}
                   </option>
                 </select>
@@ -493,6 +473,16 @@ export default {
         rangeEnd: currentYear,
         specificSpecific: [],
         currentYear: currentYear
+      }
+    }
+  },
+  watch: {
+    value: {
+      immediate: true,
+      handler (newVal) {
+        if (!newVal) return
+
+        this.restore(newVal)
       }
     }
   },
@@ -703,9 +693,6 @@ export default {
     change () {
       f7.emit('cronEditorUpdate', this.cron)
     },
-    open () {
-      this.restore(this.value)
-    },
     close () {
       f7.emit('cronEditorClosed')
     },
@@ -749,7 +736,7 @@ export default {
         newVal.incrementStart = parseInt(increment[0])
         newVal.incrementIncrement = parseInt(increment[1])
       } else if (expr.includes('-')) {
-        this.second.cronEvery = 4
+        newVal.cronEvery = 4
         const range = expr.split('-')
         newVal.rangeStart = parseInt(range[0])
         newVal.rangeEnd = parseInt(range[1])
@@ -790,10 +777,10 @@ export default {
         this.week.cronNthDayNth = weekNthDay[1]
       } else if (weekExpr?.length) {
         this.day.cronEvery = 4
-        this.week.specificSpecific = weekExpr.split(',')
+        this.week.specificSpecific = weekExpr.split(',').map((v) => v.trim())
       } else {
         this.day.cronEvery = 5
-        this.day.specificSpecific = dayExpr.split(',')
+        this.day.specificSpecific = dayExpr.split(',').map((v) => parseInt(v))
       }
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -51,7 +51,11 @@
                 :checked="second.cronEvery === 3 ? true : null"
                 @click="second.cronEvery = 3">
                 <select multiple v-model="second.specificSpecfic">
-                  <option v-for="val in 60" :key="val" :value="val - 1">
+                  <option
+                    v-for="val in 60"
+                    :key="val"
+                    :value="val - 1"
+                    :selected="second.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -100,7 +104,11 @@
                 :checked="minute.cronEvery === 3 ? true : null"
                 @click="minute.cronEvery = 3">
                 <select multiple v-model="minute.specificSpecific">
-                  <option v-for="val in 60" :key="val" :value="val - 1">
+                  <option
+                    v-for="val in 60"
+                    :key="val"
+                    :value="val - 1"
+                    :selected="minute.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -149,7 +157,11 @@
                 :checked="hour.cronEvery === 3 ? true : null"
                 @click="hour.cronEvery = 3">
                 <select multiple v-model="hour.specificSpecific">
-                  <option v-for="val in 24" :key="val" :value="val - 1">
+                  <option
+                    v-for="val in 24"
+                    :key="val"
+                    :value="val - 1"
+                    :selected="hour.specificSpecific.indexOf(val - 1) >= 0 ? true : null">
                     {{ val - 1 }}
                   </option>
                 </select>
@@ -206,8 +218,12 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 4 ? true : null"
                 @click="day.cronEvery = 4">
-                <select multiple v-model="week.specficSpecific">
-                  <option v-for="val in 7" :key="val" :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]">
+                <select multiple v-model="week.specificSpecific">
+                  <option
+                    v-for="val in 7"
+                    :key="val"
+                    :value="['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]"
+                    :selected="week.specificSpecific.indexOf( ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'][val - 1]) >= 0 ? true : null">
                     {{ text.Week[val - 1] }}
                   </option>
                 </select>
@@ -305,7 +321,7 @@
                 :checked="month.cronEvery === 3 ? true : null"
                 @click="month.cronEvery = 3">
                 <select multiple v-model="month.specificSpecific">
-                  <option v-for="val in 12" :key="val" :value="val">
+                  <option v-for="val in 12" :key="val" :value="val" :selected="month.specificSpecific.indexOf(val) >= 0 ? true : null">
                     {{ val }}
                   </option>
                 </select>
@@ -352,8 +368,12 @@
                 :smart-select-params="smartSelectParams"
                 :checked="year.cronEvery === 3 ? true : null"
                 @click="year.cronEvery = 3">
-                <select multiple v-model="year.specficSpecific">
-                  <option v-for="val in 100" :key="val" :value="val + year.currentYear - 1">
+                <select multiple v-model="year.specificSpecific">
+                  <option
+                    v-for="val in 100"
+                    :key="val"
+                    :value="val + year.currentYear - 1"
+                    :selected="year.specificSpecific.indexOf(val + year.currentYear - 1) >= 0 ? true : null">
                     {{ val + year.currentYear - 1 }}
                   </option>
                 </select>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/cronexpression-editor.vue
@@ -58,7 +58,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="second.cronEvery === 3 ? true : null"
                 @click="second.cronEvery = 3">
-                <select multiple @change="second.specificSpecific = getSmartSelectValue('specificSecond').map((v) => parseInt(v))">
+                <select multiple v-model="second.specificSpecific">
                   <option
                     v-for="val in 60"
                     :key="val"
@@ -111,7 +111,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="minute.cronEvery === 3 ? true : null"
                 @click="minute.cronEvery = 3">
-                <select multiple @change="minute.specificSpecific = getSmartSelectValue('specificMinute').map((v) => parseInt(v))">
+                <select multiple v-model="minute.specificSpecific">
                   <option
                     v-for="val in 60"
                     :key="val"
@@ -164,7 +164,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="hour.cronEvery === 3 ? true : null"
                 @click="hour.cronEvery = 3">
-                <select multiple @change="hour.specificSpecific = getSmartSelectValue('specificHour').map((v) => parseInt(v))">
+                <select multiple v-model="hour.specificSpecific">
                   <option
                     v-for="val in 24"
                     :key="val"
@@ -226,7 +226,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 4 ? true : null"
                 @click="day.cronEvery = 4">
-                <select multiple @change="week.specificSpecific = getSmartSelectValue('specificDayOfWeek').map((v) => v)">
+                <select multiple v-model="week.specificSpecific">
                   <option
                     v-for="val in 7"
                     :key="val"
@@ -246,7 +246,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="day.cronEvery === 5 ? true : null"
                 @click="day.cronEvery = 5">
-                <select multiple @change="day.specificSpecific = getSmartSelectValue('specificDayOfMonth').map((v) => parseInt(v))">
+                <select multiple v-model="day.specificSpecific">
                   <option v-for="val in 31" :key="val" :value="val" :selected="day.specificSpecific.indexOf(val) >= 0 ? true : null">
                     {{ val }}
                   </option>
@@ -328,7 +328,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="month.cronEvery === 3 ? true : null"
                 @click="month.cronEvery = 3">
-                <select multiple @change="month.specificSpecific = getSmartSelectValue('specificMonth').map((v) => parseInt(v))">
+                <select multiple v-model="month.specificSpecific">
                   <option v-for="val in 12" :key="val" :value="val" :selected="month.specificSpecific.indexOf(val) >= 0 ? true : null">
                     {{ val }}
                   </option>
@@ -376,7 +376,7 @@
                 :smart-select-params="smartSelectParams"
                 :checked="year.cronEvery === 3 ? true : null"
                 @click="year.cronEvery = 3">
-                <select multiple @change="year.specificSpecific = getSmartSelectValue('specificYear').map((v) => parseInt(v))">
+                <select multiple v-model="year.specificSpecific">
                   <option
                     v-for="val in 100"
                     :key="val"
@@ -825,10 +825,6 @@ export default {
         this.day.cronEvery = 5
         this.day.specificSpecific = dayExpr.split(',')
       }
-    },
-    getSmartSelectValue (refName) {
-      const ref = this.$refs[refName]
-      return ref?.$el?.children[0]?.f7SmartSelect?.getValue() || []
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -49,9 +49,8 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
         console.log('Getting persistence strategy suggestions failed for serviceId:', serviceId, '- default to no suggestions')
         suggestedStrategies.value = []
       })
-      .then(() => {
-        return api.getPersistenceServiceConfiguration({ serviceId })
-      })
+    api
+      .getPersistenceServiceConfiguration({ serviceId })
       .then((data) => {
         persistence.value = data || null
         savedPersistence.value = cloneDeep(persistence.value)

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -15,7 +15,6 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
   const loading = ref(false)
   const persistenceDirty = ref(false)
   const newPersistence = ref(false)
-  const skipLoadOnReturn = ref(false)
 
   // Store both the current (potentially dirty) and saved (clean) persistence data
   const persistence = ref<api.PersistenceServiceConfiguration | null>(null)
@@ -39,11 +38,6 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
 
   function loadPersistence(serviceId: string, loadingFinishedCallback: (success: boolean) => void) {
     if (loading.value) return
-    if (skipLoadOnReturn.value) {
-      loadingFinishedCallback(true)
-      skipLoadOnReturn.value = false
-      return
-    }
     loading.value = true
 
     api
@@ -62,7 +56,6 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
         persistence.value = data || null
         savedPersistence.value = cloneDeep(persistence.value)
         loadingFinishedCallback(true)
-        skipLoadOnReturn.value = false
         loading.value = false
       })
       .catch((err) => {
@@ -71,7 +64,6 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
           console.log('Persistence configuration not found (404) for serviceId:', serviceId, '- creating new configuration')
           newPersistence.value = true
           loadingFinishedCallback(true)
-          skipLoadOnReturn.value = false
           loading.value = false
         } else {
           console.error('Error loading persistence configuration for serviceId:', serviceId, '- Error:', err)
@@ -83,7 +75,6 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
             })
             .open()
           loadingFinishedCallback(false)
-          skipLoadOnReturn.value = false
           loading.value = false
         }
       })
@@ -153,7 +144,6 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
 
   return {
     persistenceDirty,
-    skipLoadOnReturn,
 
     persistence,
     suggestedStrategies,

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -44,7 +44,8 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
     loading = true
 
     // Load suggestions in parallel (don't await, failure is OK)
-    api.getPersistenceServiceStrategySuggestions({ serviceId })
+    api
+      .getPersistenceServiceStrategySuggestions({ serviceId })
       .then((suggestions) => {
         suggestedStrategies.value = suggestions || []
       })

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -3,7 +3,7 @@ import { watch, computed, ref } from 'vue'
 import fastDeepEqual from 'fast-deep-equal/es6'
 import cloneDeep from 'lodash/cloneDeep'
 
-import api from '@/js/openhab/api'
+import * as api from '@/api'
 import { f7 } from 'framework7-vue'
 
 /**
@@ -18,9 +18,9 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
   const skipLoadOnReturn = ref(false)
 
   // Store both the current (potentially dirty) and saved (clean) persistence data
-  const persistence = ref<any>({})
-  const savedPersistence = ref<any>({})
-  const suggestedStrategies = ref<string[]>([])
+  const persistence = ref<api.PersistenceServiceConfiguration>({})
+  const savedPersistence = ref<api.PersistenceServiceConfiguration>({})
+  const suggestedStrategies = ref<Array<api.PersistenceStrategy>>([])
 
   // watch
   watch(
@@ -47,7 +47,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
     loading.value = true
 
     api
-      .get('/rest/persistence/strategysuggestions?serviceId=' + serviceId)
+      .getPersistenceServiceStrategySuggestions({ serviceId })
       .then((suggestions) => {
         suggestedStrategies.value = suggestions
       })
@@ -56,7 +56,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
         suggestedStrategies.value = []
       })
       .then(() => {
-        return api.get('/rest/persistence/' + serviceId)
+        return api.getPersistenceServiceConfiguration({ serviceId })
       })
       .then((data) => {
         persistence.value = data
@@ -94,7 +94,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
 
     const serviceId = persistence.value.serviceId
     api
-      .put('/rest/persistence/' + serviceId, persistence.value)
+      .updatePersistenceServiceConfiguration({ serviceId: serviceId, body: persistence.value})
       .then(() => {
         persistence.value.editable = true
         newPersistence.value = false
@@ -122,7 +122,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
   async function deletePersistence() {
     const serviceId = persistence.value.serviceId
     api
-      .delete('/rest/persistence/' + serviceId, null)
+      .deletePersistenceServiceConfiguration({serviceId: serviceId})
       .then(() => {
         persistence.value = {}
         savedPersistence.value = {}

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -55,15 +55,22 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
       })
 
     try {
+      savedPersistence.value = null
+      newPersistence.value = false
       const data = await api.getPersistenceServiceConfiguration({ serviceId })
       persistence.value = data || null
+      if (!persistence.value || Object.keys(persistence.value).length === 0) {
+        // Empty object would be because of a 204
+        console.log('Persistence configuration not found (204) for serviceId:', serviceId, '- creating new configuration')
+        newPersistence.value = true
+      }
       savedPersistence.value = cloneDeep(persistence.value)
       loading = false
       return true
     } catch (err) {
       // Only handle 404 from persistence endpoint as "new persistence"
-      if (err instanceof ApiError && (err.response.status === 204 || err.response.status === 404)) {
-        console.log('Persistence configuration not found (204) for serviceId:', serviceId, '- creating new configuration')
+      if (err instanceof ApiError && (err.response.status === 404)) {
+        console.log('Persistence configuration not found (404) for serviceId:', serviceId, '- creating new configuration')
         newPersistence.value = true
         loading = false
         return true

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -69,7 +69,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
       return true
     } catch (err) {
       // Only handle 404 from persistence endpoint as "new persistence"
-      if (err instanceof ApiError && (err.response.status === 404)) {
+      if (err instanceof ApiError && err.response.status === 404) {
         console.log('Persistence configuration not found (404) for serviceId:', serviceId, '- creating new configuration')
         newPersistence.value = true
         loading = false

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -1,0 +1,163 @@
+import { defineStore } from 'pinia'
+import { watch, computed, ref } from 'vue'
+import fastDeepEqual from 'fast-deep-equal/es6'
+import cloneDeep from 'lodash/cloneDeep'
+
+import api from '@/js/openhab/api'
+import { f7 } from 'framework7-vue'
+
+/**
+ * The persistence edit store is used by persistence-edit.vue to store data independent of the component's lifecycle.
+ */
+
+export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
+  // data
+  const loading = ref(false)
+  const persistenceDirty = ref(false)
+  const newPersistence = ref(false)
+  const skipLoadOnReturn = ref(false)
+
+  // Store both the current (potentially dirty) and saved (clean) persistence data
+  const persistence = ref<any>({})
+  const savedPersistence = ref<any>({})
+  const suggestedStrategies = ref<string[]>([])
+
+  // watch
+  watch(
+    persistence,
+    () => {
+      if (!loading.value) {
+        // ignore changes during loading
+        persistenceDirty.value = !fastDeepEqual(persistence.value, savedPersistence.value)
+      }
+    },
+    { deep: true }
+  )
+
+  // computed
+  const editable = computed(() => newPersistence.value || persistence.value?.editable)
+
+  function loadPersistence(serviceId: string, loadingFinishedCallback: (success: boolean) => void) {
+    if (loading.value) return
+    if (skipLoadOnReturn.value) {
+      loadingFinishedCallback(true)
+      skipLoadOnReturn.value = false
+      return
+    }
+    loading.value = true
+
+    api
+      .get('/rest/persistence/strategysuggestions?serviceId=' + serviceId)
+      .then((suggestions) => {
+        suggestedStrategies.value = suggestions
+      })
+      .catch(() => {
+        console.log('Getting persistence strategy suggestions failed for serviceId:', serviceId, '- default to no suggestions')
+        suggestedStrategies.value = []
+      })
+      .then(() => {
+        return api.get('/rest/persistence/' + serviceId)
+      })
+      .then((data) => {
+        persistence.value = data
+        savedPersistence.value = cloneDeep(persistence.value)
+        loadingFinishedCallback(true)
+        skipLoadOnReturn.value = false
+        loading.value = false
+      })
+      .catch((err) => {
+        // Only handle 404 from persistence endpoint as "new persistence"
+        if (err === 404 || err === 'Not Found') {
+          console.log('Persistence configuration not found (404) for serviceId:', serviceId, '- creating new configuration')
+          newPersistence.value = true
+          loadingFinishedCallback(true)
+          skipLoadOnReturn.value = false
+          loading.value = false
+        } else {
+          console.error('Error loading persistence configuration for serviceId:', serviceId, '- Error:', err)
+          f7.toast
+            .create({
+              text: 'Error loading persistence configuration',
+              destroyOnClose: true,
+              closeTimeout: 2000
+            })
+            .open()
+          loadingFinishedCallback(false)
+          skipLoadOnReturn.value = false
+          loading.value = false
+        }
+      })
+  }
+
+  async function savePersistence() {
+    if (!editable.value) return
+
+    const serviceId = persistence.value.serviceId
+    api
+      .put('/rest/persistence/' + serviceId, persistence.value)
+      .then(() => {
+        persistence.value.editable = true
+        newPersistence.value = false
+        savedPersistence.value = cloneDeep(persistence.value)
+        persistenceDirty.value = false
+        f7.toast
+          .create({
+            text: 'Persistence configuration saved',
+            destroyOnClose: true,
+            closeTimeout: 2000
+          })
+          .open()
+      })
+      .catch((err) => {
+        f7.toast
+          .create({
+            text: 'Error saving persistence configuration: ' + err,
+            destroyOnClose: true,
+            closeTimeout: 2000
+          })
+          .open()
+      })
+  }
+
+  async function deletePersistence() {
+    const serviceId = persistence.value.serviceId
+    api
+      .delete('/rest/persistence/' + serviceId, null)
+      .then(() => {
+        persistence.value = {}
+        savedPersistence.value = {}
+        newPersistence.value = true
+        persistenceDirty.value = false
+      })
+      .catch((err) => {
+        f7.toast
+          .create({
+            text: 'Error deleting persistence configuration: ' + err,
+            destroyOnClose: true,
+            closeTimeout: 2000
+          })
+          .open()
+      })
+  }
+
+  function revertPersistence() {
+    persistence.value = cloneDeep(savedPersistence.value)
+    persistenceDirty.value = false
+  }
+
+  return {
+    persistenceDirty,
+    skipLoadOnReturn,
+
+    persistence,
+    suggestedStrategies,
+
+    editable,
+    newPersistence,
+
+    loadPersistence,
+    savePersistence,
+    deletePersistence,
+    revertPersistence
+  }
+})

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -95,7 +95,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
 
     const serviceId = persistence.value.serviceId
     api
-      .putPersistenceServiceConfiguration({ serviceId: serviceId, persistenceServiceConfiguration: persistence.value})
+      .putPersistenceServiceConfiguration({ serviceId: serviceId, persistenceServiceConfiguration: persistence.value })
       .then(() => {
         if (persistence.value) {
           persistence.value.editable = true
@@ -128,7 +128,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
 
     const serviceId = persistence.value.serviceId
     api
-      .deletePersistenceServiceConfiguration({serviceId: serviceId})
+      .deletePersistenceServiceConfiguration({ serviceId: serviceId })
       .then(() => {
         persistence.value = null
         savedPersistence.value = null

--- a/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/usePersistenceEditStore.ts
@@ -59,7 +59,7 @@ export const usePersistenceEditStore = defineStore('persistenceEdit', () => {
       })
       .catch((err) => {
         // Only handle 404 from persistence endpoint as "new persistence"
-        if (err === 404 || err === 'Not Found') {
+        if (err.status === 404 || err.statusCode === 404 || err === 404 || err === 'Not Found' || err.message === 'Not Found') {
           console.log('Persistence configuration not found (404) for serviceId:', serviceId, '- creating new configuration')
           newPersistence.value = true
           loadingFinishedCallback(true)

--- a/bundles/org.openhab.ui/web/src/pages/settings/dirty-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/dirty-mixin.js
@@ -48,7 +48,7 @@ export default {
     void nextTick(() => {
       const pageEl = this.$el
       if (!pageEl) return
-      if (!pageEl.classList.contains('page')) return
+      if (!pageEl.classList?.contains('page')) return
 
       // store a wrapped function so `this` inside beforeLeave is the Vue component instance
       pageEl.beforeLeave = (args) => this.beforeLeave(args)

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/COMPONENT_ARCHITECTURE.md
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/COMPONENT_ARCHITECTURE.md
@@ -68,142 +68,152 @@
 ## Data Flow Details
 
 ### 1. **persistence-edit.vue** (Root/Main Component)
-   - **Owns**: `persistence` (ref from Pinia store)
-   - **Creates**: All child popup components
-   - **Role**: Orchestrates the main UI and popups
+
+- **Owns**: `persistence` (ref from Pinia store)
+- **Creates**: All child popup components
+- **Role**: Orchestrates the main UI and popups
 
 ### 2. **configuration-popup.vue** (Child of persistence-edit)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to root's persistence object
-     - `:configurationIndex` - which config to edit
-     - `:suggestedStrategies` - read-only
-   
-   - **Data Flow**:
-     - Creates **LOCAL CLONE**: `persistenceLocal` in data() **for `persistence.configs` editing**
-     - Watches prop `persistence` to update local copy
-     - Passes `persistence` (root) to pickers for **definitions** (strategies/filters)
-     - **DOES NOT mutate** `persistence.configs` directly
-     - **EMITS** `@configuration-update` event with modified `persistenceLocal` (configs only)
-     - Parent handler: `saveConfiguration($event)` merges configs back into root persistence
-   
-   - **Impact**: Changes are emitted only, parent merges back
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to root's persistence object
+  - `:configurationIndex` - which config to edit
+  - `:suggestedStrategies` - read-only
+
+- **Data Flow**:
+  - Creates **LOCAL CLONE**: `persistenceLocal` in data() **for `persistence.configs` editing**
+  - Watches prop `persistence` to update local copy
+  - Passes `persistence` (root) to pickers for **definitions** (strategies/filters)
+  - **DOES NOT mutate** `persistence.configs` directly
+  - **EMITS** `@configuration-update` event with modified `persistenceLocal` (configs only)
+  - Parent handler: `saveConfiguration($event)` merges configs back into root persistence
+
+- **Impact**: Changes are emitted only, parent merges back
 
 ### 3. **strategy-picker.vue** (Child of configuration-popup)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to root's persistence object (NOT the clone!)
-     - `:strategies` - available strategy names (computed from persistenceLocal)
-     - `:value` - currently selected strategies
-   
-   - **Data Flow**:
-     - Creates local copy: `localValue` (selected strategies)
-     - Creates local copy: `localStrategies` (available strategies)
-     - Has nested `cron-strategy-popup`
-     - **EMITS** `@strategies-selected` when Done clicked
-     - Parent (configuration-popup) handles via `onStrategiesSelected()`
-   
-   - **Impact**: Does NOT mutate persistence directly at this level
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to root's persistence object (NOT the clone!)
+  - `:strategies` - available strategy names (computed from persistenceLocal)
+  - `:value` - currently selected strategies
+
+- **Data Flow**:
+  - Creates local copy: `localValue` (selected strategies)
+  - Creates local copy: `localStrategies` (available strategies)
+  - Has nested `cron-strategy-popup`
+  - **EMITS** `@strategies-selected` when Done clicked
+  - Parent (configuration-popup) handles via `onStrategiesSelected()`
+
+- **Impact**: Does NOT mutate persistence directly at this level
 
 ### 4. **filter-picker.vue** (Child of configuration-popup)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to root's persistence object (NOT the clone!)
-     - `:filters` - available filter names (computed from persistenceLocal)
-     - `:value` - currently selected filters
-   
-   - **Data Flow**:
-     - Creates local copy: `localValue` (selected filters)
-     - Creates local copy: `localFilters` (available filters)
-     - Has nested `filter-popup`
-     - **EMITS** `@filters-selected` when Done clicked
-     - Parent (configuration-popup) handles via `onFiltersSelected()`
-   
-   - **Impact**: Does NOT mutate persistence directly at this level
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to root's persistence object (NOT the clone!)
+  - `:filters` - available filter names (computed from persistenceLocal)
+  - `:value` - currently selected filters
+
+- **Data Flow**:
+  - Creates local copy: `localValue` (selected filters)
+  - Creates local copy: `localFilters` (available filters)
+  - Has nested `filter-popup`
+  - **EMITS** `@filters-selected` when Done clicked
+  - Parent (configuration-popup) handles via `onFiltersSelected()`
+
+- **Impact**: Does NOT mutate persistence directly at this level
 
 ### 5. **cron-strategy-popup.vue** (Called from strategy-picker)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to root's persistence object
-     - `:cronStrategy` - strategy being edited (or undefined for new)
-   
-   - **Data Flow**:
-     - Creates local `currentCronStrategy` from prop
-     - Watches prop to sync changes
-     - On updateCronStrategy():
-       - **MUTATES** `persistence.cronStrategies` array directly
-       - **EMITS** `@cronStrategyConfigUpdate` event with strategy
-       - Parent (strategy-picker) handles via `handleCronStrategyUpdate($event)`
-       - Updates picker's local state to show new strategy
-   
-  - **Direct Mutations**: ✅ YES - mutates ROOT persistence object (intended)
-  - **Impact**: Changes are IMMEDIATE to root persistence object
-  - **Why emit?** Picker maintains its own `localValue`/`localStrategies` and does not auto-sync from root; the event updates the open picker UI.
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to root's persistence object
+  - `:cronStrategy` - strategy being edited (or undefined for new)
+
+- **Data Flow**:
+  - Creates local `currentCronStrategy` from prop
+  - Watches prop to sync changes
+  - On updateCronStrategy():
+    - **MUTATES** `persistence.cronStrategies` array directly
+    - **EMITS** `@cronStrategyConfigUpdate` event with strategy
+    - Parent (strategy-picker) handles via `handleCronStrategyUpdate($event)`
+    - Updates picker's local state to show new strategy
+
+- **Direct Mutations**: ✅ YES - mutates ROOT persistence object (intended)
+- **Impact**: Changes are IMMEDIATE to root persistence object
+- **Why emit?** Picker maintains its own `localValue`/`localStrategies` and does not auto-sync from root; the event updates the open picker UI.
 
 ### 6. **filter-popup.vue** (Called from filter-picker)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to root's persistence object
-     - `:filter` - filter being edited (or undefined for new)
-     - `:filterType` - what type of filter
-   
-   - **Data Flow**:
-     - Similar pattern to cron-strategy-popup from strategy-picker
-     - **MUTATES** `persistence[filterType.name]` array directly
-     - **EMITS** `@filter-config-update` event with filter
-     - Parent (filter-picker) handles via `handleFilterUpdate($event)`
-     - Updates picker's local state to show new filter
-   
-  - **Direct Mutations**: ✅ YES - mutates ROOT persistence object (intended)
-  - **Impact**: Changes are IMMEDIATE to root persistence object
-  - **Why emit?** Picker maintains its own `localValue`/`localFilters` and does not auto-sync from root; the event updates the open picker UI.
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to root's persistence object
+  - `:filter` - filter being edited (or undefined for new)
+  - `:filterType` - what type of filter
+
+- **Data Flow**:
+  - Similar pattern to cron-strategy-popup from strategy-picker
+  - **MUTATES** `persistence[filterType.name]` array directly
+  - **EMITS** `@filter-config-update` event with filter
+  - Parent (filter-picker) handles via `handleFilterUpdate($event)`
+  - Updates picker's local state to show new filter
+
+- **Direct Mutations**: ✅ YES - mutates ROOT persistence object (intended)
+- **Impact**: Changes are IMMEDIATE to root persistence object
+- **Why emit?** Picker maintains its own `localValue`/`localFilters` and does not auto-sync from root; the event updates the open picker UI.
 
 ### 7. **definitions-popup.vue** (Child of persistence-edit)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to root's persistence object
-     - `:editable` - read-only boolean
-   
-   - **Data Flow**:
-     - Creates **LOCAL CLONE**: `persistenceLocal` in data()
-     - Watches prop `persistence` to update local copy
-     - Passes `persistenceLocal` to nested popups (cron-strategy, filter)
-     - On back/close: reverts `persistenceLocal` back to original
-     - On Done: **EMITS** `@definitions-update` with modified copy
-     - Parent handler: `saveDefinitions($event)` merges changes back
-   
-   - **Impact**: Changes are NOT immediate; only applied on "Done"
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to root's persistence object
+  - `:editable` - read-only boolean
+
+- **Data Flow**:
+  - Creates **LOCAL CLONE**: `persistenceLocal` in data()
+  - Watches prop `persistence` to update local copy
+  - Passes `persistenceLocal` to nested popups (cron-strategy, filter)
+  - On back/close: reverts `persistenceLocal` back to original
+  - On Done: **EMITS** `@definitions-update` with modified copy
+  - Parent handler: `saveDefinitions($event)` merges changes back
+
+- **Impact**: Changes are NOT immediate; only applied on "Done"
 
 ### 8. **cron-strategy-popup.vue** (Called from definitions-popup)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to `persistenceLocal` (the clone)
-     - `:cronStrategy` - current strategy being edited
-   
-   - **Data Flow**:
-     - Creates local `currentCronStrategy` from prop
-     - Watches prop to sync changes
-     - On updateCronStrategy():
-       - **MUTATES** `persistence.cronStrategies` array directly
-       - **EMITS** `@cronStrategyConfigUpdate` event
-       - Parent (definitions-popup) handles via `handleCronStrategyUpdate()`
-   
-   - **Direct Mutations**: ✅ YES - but safe
-     - Since persistence is actually `persistenceLocal` (a clone), mutations don't affect root
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to `persistenceLocal` (the clone)
+  - `:cronStrategy` - current strategy being edited
+
+- **Data Flow**:
+  - Creates local `currentCronStrategy` from prop
+  - Watches prop to sync changes
+  - On updateCronStrategy():
+    - **MUTATES** `persistence.cronStrategies` array directly
+    - **EMITS** `@cronStrategyConfigUpdate` event
+    - Parent (definitions-popup) handles via `handleCronStrategyUpdate()`
+
+- **Direct Mutations**: ✅ YES - but safe
+  - Since persistence is actually `persistenceLocal` (a clone), mutations don't affect root
 
 ### 9. **filter-popup.vue** (Called from definitions-popup)
-   - **Props Received**:
-     - `:persistence` - **Direct reference** to `persistenceLocal` (the clone)
-     - `:filter` - current filter being edited
-     - `:filterType` - what type of filter
-   
-   - **Data Flow**:
-     - Similar pattern to cron-strategy-popup from definitions-popup
-     - **MUTATES** `persistence[filterType.name]` array directly
-     - **EMITS** `@filter-config-update` event
-     - Parent (definitions-popup) handles via `handleFilterUpdate()`
-   
-   - **Direct Mutations**: ✅ YES - but safe
-     - Since persistence is actually `persistenceLocal` (a clone), mutations don't affect root
+
+- **Props Received**:
+  - `:persistence` - **Direct reference** to `persistenceLocal` (the clone)
+  - `:filter` - current filter being edited
+  - `:filterType` - what type of filter
+
+- **Data Flow**:
+  - Similar pattern to cron-strategy-popup from definitions-popup
+  - **MUTATES** `persistence[filterType.name]` array directly
+  - **EMITS** `@filter-config-update` event
+  - Parent (definitions-popup) handles via `handleFilterUpdate()`
+
+- **Direct Mutations**: ✅ YES - but safe
+  - Since persistence is actually `persistenceLocal` (a clone), mutations don't affect root
 
 ---
 
 ## Key Data Flow Patterns
 
 ### Pattern A: Picker-Nested Popup (Intended direct ROOT mutations)
+
 ```
 persistence-edit.persistence (ROOT OBJECT)
     ↓
@@ -219,13 +229,14 @@ configuration-popup :persistence (direct ref, also has persistenceLocal clone)
         └─→ filter-popup :persistence (DIRECT REF TO ROOT)
             └─→ MUTATES persistence[filterType] IMMEDIATELY
                 Changes appear INSTANTLY in ROOT object
-    
+
 ✅ Intended: Mutations bypass configuration-popup's local copy
 Result: Changes to strategies/filters are IMMEDIATE, even if user cancels config dialog
 Note: This is by design so strategy/filter definitions persist globally.
 ```
 
 ### Pattern B: Definitions-Nested Popup (SAFE - Clone Mutations)
+
 ```
 persistence-edit.persistence (ROOT OBJECT)
     ↓
@@ -240,11 +251,11 @@ definitions-popup :persistence (creates persistenceLocal clone)
     └─→ filter-popup :persistence (reference to CLONE)
         ├─→ MUTATES persistenceLocal[type]
         └─→ Changes stay in clone
-    
+
     On "Done":
         EMITS @definitions-update with persistenceLocal
         Parent merges back into ROOT persistence
-    
+
 ✅ SAFE: Changes isolated until user confirms
 Result: Changes are DELAYED until "Done" is clicked
 ```
@@ -253,25 +264,27 @@ Result: Changes are DELAYED until "Done" is clicked
 
 ## Direct Mutation Impact Matrix
 
-| Component | Mutates | Target | Reference Type | Immediate? | Impact Radius | Risk Level |
-|-----------|---------|--------|----------------|-----------|---------------|------------|
-| configuration-popup | NO | N/A | Has both | N/A | Emits only | ✅ Safe |
-| strategy-picker | NO | N/A | Direct to root | N/A | Emits only | ✅ Safe |
-| filter-picker | NO | N/A | Direct to root | N/A | Emits only | ✅ Safe |
-| **cron-strategy-popup** (from picker) | **persistence.cronStrategies** | **ROOT object** | **Direct to root** | **YES** | **ROOT persistence** | ✅ **INTENDED** |
-| **filter-popup** (from picker) | **persistence[type]** | **ROOT object** | **Direct to root** | **YES** | **ROOT persistence** | ✅ **INTENDED** |
-| definitions-popup | NO | N/A | Direct + clone | N/A | Emits only | ✅ Safe |
-| cron-strategy-popup (from definitions) | persistenceLocal.cronStrategies | LOCAL clone | Via definitions | NO | definitions-popup only | ✅ Safe |
-| filter-popup (from definitions) | persistenceLocal[type] | LOCAL clone | Via definitions | NO | definitions-popup only | ✅ Safe |
+| Component                              | Mutates                         | Target          | Reference Type     | Immediate? | Impact Radius          | Risk Level      |
+| -------------------------------------- | ------------------------------- | --------------- | ------------------ | ---------- | ---------------------- | --------------- |
+| configuration-popup                    | NO                              | N/A             | Has both           | N/A        | Emits only             | ✅ Safe         |
+| strategy-picker                        | NO                              | N/A             | Direct to root     | N/A        | Emits only             | ✅ Safe         |
+| filter-picker                          | NO                              | N/A             | Direct to root     | N/A        | Emits only             | ✅ Safe         |
+| **cron-strategy-popup** (from picker)  | **persistence.cronStrategies**  | **ROOT object** | **Direct to root** | **YES**    | **ROOT persistence**   | ✅ **INTENDED** |
+| **filter-popup** (from picker)         | **persistence[type]**           | **ROOT object** | **Direct to root** | **YES**    | **ROOT persistence**   | ✅ **INTENDED** |
+| definitions-popup                      | NO                              | N/A             | Direct + clone     | N/A        | Emits only             | ✅ Safe         |
+| cron-strategy-popup (from definitions) | persistenceLocal.cronStrategies | LOCAL clone     | Via definitions    | NO         | definitions-popup only | ✅ Safe         |
+| filter-popup (from definitions)        | persistenceLocal[type]          | LOCAL clone     | Via definitions    | NO         | definitions-popup only | ✅ Safe         |
 
 ---
 
 ## Design Notes
 
 ### ✅ Intended: Definitions are separate from configurations
+
 The configuration popup’s local clone exists to isolate edits to `persistence.configs`. Strategy/filter **definitions** created from the pickers should bypass the config clone and update root persistence immediately, because definitions are global and not tied to saving a single configuration.
 
 ### ✅ Events are intentional (not redundant)
+
 The nested popups mutate root persistence, but the pickers keep their own local state (`localValue`, `localStrategies`, `localFilters`). Emitted events are required to update the picker UI while the picker popup is still open.
 
 ---
@@ -282,7 +295,6 @@ The nested popups mutate root persistence, but the pickers keep their own local 
   - `persistence` (ref) - the main data object
   - `savePersistence()` - called by root to persist to API
   - `loadPersistence()` - called by root to load from API
-  
 - **Components use store data** but handle updates locally via refs and props
 
 ---
@@ -290,13 +302,17 @@ The nested popups mutate root persistence, but the pickers keep their own local 
 ## Recommendations
 
 ### Keep the current hybrid design (intended)
+
 The current behavior is intentional:
+
 - `persistenceLocal` in configuration-popup is scoped to `persistence.configs`
 - Strategy/filter definitions created from pickers update root persistence immediately
 - Events from nested popups are required to refresh picker-local state
 
 ### Alternative designs (not intended here)
+
 If future requirements change, consider one of these broader patterns:
+
 - **All immediate mutations**: remove clones entirely and accept global, immediate changes
 - **All clone + emit**: isolate all edits behind explicit confirmation and merge
 
@@ -305,6 +321,7 @@ If future requirements change, consider one of these broader patterns:
 ## Summary
 
 **Current State**: Hybrid approach with two different patterns (intended)
+
 - **definitions-popup path**: Uses clones for definition edits until "Done"
 - **configuration-popup path**: Uses a clone for `persistence.configs`, while definition creation (strategies/filters) updates root immediately
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/COMPONENT_ARCHITECTURE.md
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/COMPONENT_ARCHITECTURE.md
@@ -1,0 +1,311 @@
+# Persistence Configuration Component Architecture
+
+## Component Hierarchy
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    persistence-edit.vue                          │
+│                    (Main Component)                              │
+│                                                                   │
+│  State:                                                          │
+│  - persistence (from store, writable)                           │
+│  - ready, currentTab                                            │
+│  - configurationPopupOpen, definitionsPopupOpen                 │
+└────────────────────────────────────────────────────────────────┬┘
+         │
+         ├─────────────────────┬──────────────────────────────────┐
+         │                     │                                  │
+         ▼                     ▼                                  ▼
+    ┌─────────────┐   ┌──────────────────┐        ┌────────────────────┐
+    │configuration│   │ definitions-popup│        │ other components   │
+    │   -popup    │   │                  │        │ (config pickers)   │
+    └──────┬──────┘   └────────┬─────────┘        └────────────────────┘
+           │                    │
+           │ @configuration     │ @definitions
+           │ -update            │ -update
+           │                    │
+           │ :persistence       │ :persistence (direct ref)
+           │ (direct ref)       │ :persistenceLocal (cloned copy)
+           │ :persistenceLocal  │
+           │ (cloned copy)      │
+           │                    │
+           │                    └────────────────────┬──────────────────┐
+           │                                         │                  │
+           │                                         ▼                  ▼
+           ├────────────────┬──────────────     ┌──────────────┐  ┌────────────┐
+           │                │                   │cron-strategy │  │ filter-    │
+           ▼                ▼                   │   -popup     │  │   popup    │
+    ┌─────────────┐  ┌─────────────┐           │ (definitions)│  │ (definitions)│
+    │strategy-    │  │filter-      │           └──────────────┘  └────────────┘
+    │  picker     │  │  picker     │                MUTATES            MUTATES
+    └──────┬──────┘  └──────┬──────┘           persistenceLocal   persistenceLocal
+           │                │
+           │ :persistence   │ :persistence
+           │ (direct ref)   │ (direct ref)
+           │                │
+           ├────────────────┼────────────────┐
+           │                │                │
+           ▼                ▼                │
+    ┌──────────────┐  ┌────────────┐        │
+    │cron-strategy │  │ filter-    │        │
+    │   -popup     │  │   popup    │        │
+    │ (picker)     │  │ (picker)   │        │
+    └──────────────┘  └────────────┘        │
+         MUTATES           MUTATES           │
+        persistence       persistence        │
+     (ROOT OBJECT)     (ROOT OBJECT)         │
+                                             │
+           │                │                │
+           │ @cron-strategy │ @filter        │
+           │ -config-update │ -config-update │
+           │                │                │
+           └────────┬───────┴────────────────┘
+                    │
+                    └─> Updates picker's local state
+                        Then emits to parent
+```
+
+## Data Flow Details
+
+### 1. **persistence-edit.vue** (Root/Main Component)
+   - **Owns**: `persistence` (ref from Pinia store)
+   - **Creates**: All child popup components
+   - **Role**: Orchestrates the main UI and popups
+
+### 2. **configuration-popup.vue** (Child of persistence-edit)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to root's persistence object
+     - `:configurationIndex` - which config to edit
+     - `:suggestedStrategies` - read-only
+   
+   - **Data Flow**:
+     - Creates **LOCAL CLONE**: `persistenceLocal` in data() **for `persistence.configs` editing**
+     - Watches prop `persistence` to update local copy
+     - Passes `persistence` (root) to pickers for **definitions** (strategies/filters)
+     - **DOES NOT mutate** `persistence.configs` directly
+     - **EMITS** `@configuration-update` event with modified `persistenceLocal` (configs only)
+     - Parent handler: `saveConfiguration($event)` merges configs back into root persistence
+   
+   - **Impact**: Changes are emitted only, parent merges back
+
+### 3. **strategy-picker.vue** (Child of configuration-popup)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to root's persistence object (NOT the clone!)
+     - `:strategies` - available strategy names (computed from persistenceLocal)
+     - `:value` - currently selected strategies
+   
+   - **Data Flow**:
+     - Creates local copy: `localValue` (selected strategies)
+     - Creates local copy: `localStrategies` (available strategies)
+     - Has nested `cron-strategy-popup`
+     - **EMITS** `@strategies-selected` when Done clicked
+     - Parent (configuration-popup) handles via `onStrategiesSelected()`
+   
+   - **Impact**: Does NOT mutate persistence directly at this level
+
+### 4. **filter-picker.vue** (Child of configuration-popup)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to root's persistence object (NOT the clone!)
+     - `:filters` - available filter names (computed from persistenceLocal)
+     - `:value` - currently selected filters
+   
+   - **Data Flow**:
+     - Creates local copy: `localValue` (selected filters)
+     - Creates local copy: `localFilters` (available filters)
+     - Has nested `filter-popup`
+     - **EMITS** `@filters-selected` when Done clicked
+     - Parent (configuration-popup) handles via `onFiltersSelected()`
+   
+   - **Impact**: Does NOT mutate persistence directly at this level
+
+### 5. **cron-strategy-popup.vue** (Called from strategy-picker)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to root's persistence object
+     - `:cronStrategy` - strategy being edited (or undefined for new)
+   
+   - **Data Flow**:
+     - Creates local `currentCronStrategy` from prop
+     - Watches prop to sync changes
+     - On updateCronStrategy():
+       - **MUTATES** `persistence.cronStrategies` array directly
+       - **EMITS** `@cronStrategyConfigUpdate` event with strategy
+       - Parent (strategy-picker) handles via `handleCronStrategyUpdate($event)`
+       - Updates picker's local state to show new strategy
+   
+  - **Direct Mutations**: ✅ YES - mutates ROOT persistence object (intended)
+  - **Impact**: Changes are IMMEDIATE to root persistence object
+  - **Why emit?** Picker maintains its own `localValue`/`localStrategies` and does not auto-sync from root; the event updates the open picker UI.
+
+### 6. **filter-popup.vue** (Called from filter-picker)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to root's persistence object
+     - `:filter` - filter being edited (or undefined for new)
+     - `:filterType` - what type of filter
+   
+   - **Data Flow**:
+     - Similar pattern to cron-strategy-popup from strategy-picker
+     - **MUTATES** `persistence[filterType.name]` array directly
+     - **EMITS** `@filter-config-update` event with filter
+     - Parent (filter-picker) handles via `handleFilterUpdate($event)`
+     - Updates picker's local state to show new filter
+   
+  - **Direct Mutations**: ✅ YES - mutates ROOT persistence object (intended)
+  - **Impact**: Changes are IMMEDIATE to root persistence object
+  - **Why emit?** Picker maintains its own `localValue`/`localFilters` and does not auto-sync from root; the event updates the open picker UI.
+
+### 7. **definitions-popup.vue** (Child of persistence-edit)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to root's persistence object
+     - `:editable` - read-only boolean
+   
+   - **Data Flow**:
+     - Creates **LOCAL CLONE**: `persistenceLocal` in data()
+     - Watches prop `persistence` to update local copy
+     - Passes `persistenceLocal` to nested popups (cron-strategy, filter)
+     - On back/close: reverts `persistenceLocal` back to original
+     - On Done: **EMITS** `@definitions-update` with modified copy
+     - Parent handler: `saveDefinitions($event)` merges changes back
+   
+   - **Impact**: Changes are NOT immediate; only applied on "Done"
+
+### 8. **cron-strategy-popup.vue** (Called from definitions-popup)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to `persistenceLocal` (the clone)
+     - `:cronStrategy` - current strategy being edited
+   
+   - **Data Flow**:
+     - Creates local `currentCronStrategy` from prop
+     - Watches prop to sync changes
+     - On updateCronStrategy():
+       - **MUTATES** `persistence.cronStrategies` array directly
+       - **EMITS** `@cronStrategyConfigUpdate` event
+       - Parent (definitions-popup) handles via `handleCronStrategyUpdate()`
+   
+   - **Direct Mutations**: ✅ YES - but safe
+     - Since persistence is actually `persistenceLocal` (a clone), mutations don't affect root
+
+### 9. **filter-popup.vue** (Called from definitions-popup)
+   - **Props Received**:
+     - `:persistence` - **Direct reference** to `persistenceLocal` (the clone)
+     - `:filter` - current filter being edited
+     - `:filterType` - what type of filter
+   
+   - **Data Flow**:
+     - Similar pattern to cron-strategy-popup from definitions-popup
+     - **MUTATES** `persistence[filterType.name]` array directly
+     - **EMITS** `@filter-config-update` event
+     - Parent (definitions-popup) handles via `handleFilterUpdate()`
+   
+   - **Direct Mutations**: ✅ YES - but safe
+     - Since persistence is actually `persistenceLocal` (a clone), mutations don't affect root
+
+---
+
+## Key Data Flow Patterns
+
+### Pattern A: Picker-Nested Popup (Intended direct ROOT mutations)
+```
+persistence-edit.persistence (ROOT OBJECT)
+    ↓
+configuration-popup :persistence (direct ref, also has persistenceLocal clone)
+    ├─→ persistenceLocal (clone for display purposes)
+    │
+    ├─→ strategy-picker :persistence (DIRECT REF TO ROOT, not the clone!)
+    │   └─→ cron-strategy-popup :persistence (DIRECT REF TO ROOT)
+    │       └─→ MUTATES persistence.cronStrategies IMMEDIATELY
+    │           Changes appear INSTANTLY in ROOT object
+    │
+    └─→ filter-picker :persistence (DIRECT REF TO ROOT, not the clone!)
+        └─→ filter-popup :persistence (DIRECT REF TO ROOT)
+            └─→ MUTATES persistence[filterType] IMMEDIATELY
+                Changes appear INSTANTLY in ROOT object
+    
+✅ Intended: Mutations bypass configuration-popup's local copy
+Result: Changes to strategies/filters are IMMEDIATE, even if user cancels config dialog
+Note: This is by design so strategy/filter definitions persist globally.
+```
+
+### Pattern B: Definitions-Nested Popup (SAFE - Clone Mutations)
+```
+persistence-edit.persistence (ROOT OBJECT)
+    ↓
+definitions-popup :persistence (creates persistenceLocal clone)
+    ├─→ persistenceLocal != persistence (separate copy)
+    ├─→ Passes persistenceLocal to children
+    │
+    ├─→ cron-strategy-popup :persistence (reference to CLONE)
+    │   ├─→ MUTATES persistenceLocal.cronStrategies
+    │   └─→ Changes stay in clone
+    │
+    └─→ filter-popup :persistence (reference to CLONE)
+        ├─→ MUTATES persistenceLocal[type]
+        └─→ Changes stay in clone
+    
+    On "Done":
+        EMITS @definitions-update with persistenceLocal
+        Parent merges back into ROOT persistence
+    
+✅ SAFE: Changes isolated until user confirms
+Result: Changes are DELAYED until "Done" is clicked
+```
+
+---
+
+## Direct Mutation Impact Matrix
+
+| Component | Mutates | Target | Reference Type | Immediate? | Impact Radius | Risk Level |
+|-----------|---------|--------|----------------|-----------|---------------|------------|
+| configuration-popup | NO | N/A | Has both | N/A | Emits only | ✅ Safe |
+| strategy-picker | NO | N/A | Direct to root | N/A | Emits only | ✅ Safe |
+| filter-picker | NO | N/A | Direct to root | N/A | Emits only | ✅ Safe |
+| **cron-strategy-popup** (from picker) | **persistence.cronStrategies** | **ROOT object** | **Direct to root** | **YES** | **ROOT persistence** | ✅ **INTENDED** |
+| **filter-popup** (from picker) | **persistence[type]** | **ROOT object** | **Direct to root** | **YES** | **ROOT persistence** | ✅ **INTENDED** |
+| definitions-popup | NO | N/A | Direct + clone | N/A | Emits only | ✅ Safe |
+| cron-strategy-popup (from definitions) | persistenceLocal.cronStrategies | LOCAL clone | Via definitions | NO | definitions-popup only | ✅ Safe |
+| filter-popup (from definitions) | persistenceLocal[type] | LOCAL clone | Via definitions | NO | definitions-popup only | ✅ Safe |
+
+---
+
+## Design Notes
+
+### ✅ Intended: Definitions are separate from configurations
+The configuration popup’s local clone exists to isolate edits to `persistence.configs`. Strategy/filter **definitions** created from the pickers should bypass the config clone and update root persistence immediately, because definitions are global and not tied to saving a single configuration.
+
+### ✅ Events are intentional (not redundant)
+The nested popups mutate root persistence, but the pickers keep their own local state (`localValue`, `localStrategies`, `localFilters`). Emitted events are required to update the picker UI while the picker popup is still open.
+
+---
+
+## Store Involvement
+
+- **usePersistenceEditStore.ts** provides:
+  - `persistence` (ref) - the main data object
+  - `savePersistence()` - called by root to persist to API
+  - `loadPersistence()` - called by root to load from API
+  
+- **Components use store data** but handle updates locally via refs and props
+
+---
+
+## Recommendations
+
+### Keep the current hybrid design (intended)
+The current behavior is intentional:
+- `persistenceLocal` in configuration-popup is scoped to `persistence.configs`
+- Strategy/filter definitions created from pickers update root persistence immediately
+- Events from nested popups are required to refresh picker-local state
+
+### Alternative designs (not intended here)
+If future requirements change, consider one of these broader patterns:
+- **All immediate mutations**: remove clones entirely and accept global, immediate changes
+- **All clone + emit**: isolate all edits behind explicit confirmation and merge
+
+---
+
+## Summary
+
+**Current State**: Hybrid approach with two different patterns (intended)
+- **definitions-popup path**: Uses clones for definition edits until "Done"
+- **configuration-popup path**: Uses a clone for `persistence.configs`, while definition creation (strategies/filters) updates root immediately
+
+**Intent**: Strategy/filter definitions are global and should persist even if the configuration popup is canceled, while configuration edits remain local until saved.

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -10,94 +10,94 @@
           <f7-link v-show="currentConfiguration.items.length > 0" @click="updateConfiguration"> Done </f7-link>
         </f7-nav-right>
       </f7-navbar>
-        <f7-block class="no-margin no-padding">
-          <f7-col>
-            <f7-block-title medium class="padding-bottom"> Items </f7-block-title>
-            <f7-list>
-              <f7-list-item title="Persist all Items">
-                <template #after>
-                  <f7-toggle :checked="allItemsSelected ? true : null" @toggle:change="allItemsSelected = $event" />
-                </template>
-              </f7-list-item>
-            </f7-list>
-            <f7-list>
-              <f7-list-group>
-                <item-picker
-                  key="groups"
-                  label="Select groups"
-                  name="groupItems"
-                  :multiple="true"
-                  filterType="Group"
-                  :disabled="allItemsSelected ? true : null"
-                  :value="groupItems"
-                  @input="groupItems = $event" />
-              </f7-list-group>
-              <f7-list-item>... whose members are to be persisted.</f7-list-item>
-            </f7-list>
-            <f7-list>
-              <f7-list-group>
-                <item-picker
-                  key="items"
-                  label="Select Items"
-                  name="items"
-                  :multiple="true"
-                  :disabled="allItemsSelected ? true : null"
-                  :value="items"
-                  @input="items = $event" />
-              </f7-list-group>
-              <f7-list-item>... to be persisted.</f7-list-item>
-            </f7-list>
-            <f7-list>
-              <f7-list-group>
-                <item-picker
-                  key="exclude-groups"
-                  label="Select exclude groups"
-                  name="excludeGroupItems"
-                  :multiple="true"
-                  filterType="Group"
-                  :disabled="!anySelected ? true : null"
-                  :value="excludeGroupItems"
-                  @input="excludeGroupItems = $event" />
-              </f7-list-group>
-              <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
-            </f7-list>
-            <f7-list>
-              <f7-list-group>
-                <item-picker
-                  key="exclude-items"
-                  label="Select exclude Items"
-                  name="excludeItems"
-                  :multiple="true"
-                  :disabled="!anySelected ? true : null"
-                  :value="excludeItems"
-                  @input="excludeItems = $event" />
-              </f7-list-group>
-              <f7-list-item>... to be excluded from persistence.</f7-list-item>
-            </f7-list>
-          </f7-col>
-          <f7-col>
-            <f7-block-title medium class="padding-bottom"> Strategies </f7-block-title>
-            <strategy-picker
-              ref="strategyPicker"
-              title="Select strategies"
-              :strategies="strategies"
-              :value="currentConfiguration.strategies || []"
-              :persistence="persistenceLocal"
-              @strategies-selected="onStrategiesSelected" />
-          </f7-col>
-          <f7-col>
-            <f7-block-title medium class="padding-bottom"> Filters </f7-block-title>
-            <filter-picker
-              ref="filterPicker"
-              title="Select filters"
-              :filters="filters"
-              :value="currentConfiguration.filters || []"
-              :persistence="persistenceLocal"
-              @filters-selected="onFiltersSelected" />
-          </f7-col>
-        </f7-block>
-      </f7-page>
-    </f7-popup>
+      <f7-block class="no-margin no-padding">
+        <f7-col>
+          <f7-block-title medium class="padding-bottom"> Items </f7-block-title>
+          <f7-list>
+            <f7-list-item title="Persist all Items">
+              <template #after>
+                <f7-toggle :checked="allItemsSelected ? true : null" @toggle:change="allItemsSelected = $event" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+          <f7-list>
+            <f7-list-group>
+              <item-picker
+                key="groups"
+                label="Select groups"
+                name="groupItems"
+                :multiple="true"
+                filterType="Group"
+                :disabled="allItemsSelected ? true : null"
+                :value="groupItems"
+                @input="groupItems = $event" />
+            </f7-list-group>
+            <f7-list-item>... whose members are to be persisted.</f7-list-item>
+          </f7-list>
+          <f7-list>
+            <f7-list-group>
+              <item-picker
+                key="items"
+                label="Select Items"
+                name="items"
+                :multiple="true"
+                :disabled="allItemsSelected ? true : null"
+                :value="items"
+                @input="items = $event" />
+            </f7-list-group>
+            <f7-list-item>... to be persisted.</f7-list-item>
+          </f7-list>
+          <f7-list>
+            <f7-list-group>
+              <item-picker
+                key="exclude-groups"
+                label="Select exclude groups"
+                name="excludeGroupItems"
+                :multiple="true"
+                filterType="Group"
+                :disabled="!anySelected ? true : null"
+                :value="excludeGroupItems"
+                @input="excludeGroupItems = $event" />
+            </f7-list-group>
+            <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
+          </f7-list>
+          <f7-list>
+            <f7-list-group>
+              <item-picker
+                key="exclude-items"
+                label="Select exclude Items"
+                name="excludeItems"
+                :multiple="true"
+                :disabled="!anySelected ? true : null"
+                :value="excludeItems"
+                @input="excludeItems = $event" />
+            </f7-list-group>
+            <f7-list-item>... to be excluded from persistence.</f7-list-item>
+          </f7-list>
+        </f7-col>
+        <f7-col>
+          <f7-block-title medium class="padding-bottom"> Strategies </f7-block-title>
+          <strategy-picker
+            ref="strategyPicker"
+            title="Select strategies"
+            :strategies="strategies"
+            :value="currentConfiguration.strategies || []"
+            :persistence="persistenceLocal"
+            @strategies-selected="onStrategiesSelected" />
+        </f7-col>
+        <f7-col>
+          <f7-block-title medium class="padding-bottom"> Filters </f7-block-title>
+          <filter-picker
+            ref="filterPicker"
+            title="Select filters"
+            :filters="filters"
+            :value="currentConfiguration.filters || []"
+            :persistence="persistenceLocal"
+            @filters-selected="onFiltersSelected" />
+        </f7-col>
+      </f7-block>
+    </f7-page>
+  </f7-popup>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-popup :opened="opened" class="moduleconfig-popup" @popup:open="onPopupOpen">
-    <f7-page>
+    <f7-page v-if="opened">
       <f7-navbar>
         <f7-nav-left>
           <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -109,6 +109,8 @@ import ItemPicker from '@/components/config/controls/item-picker.vue'
 import StrategyPicker from '@/pages/settings/persistence/strategy-picker.vue'
 import FilterPicker from '@/pages/settings/persistence/filter-picker.vue'
 
+import { PredefinedStrategies } from '@/assets/definitions/persistence'
+
 export default {
   components: { FilterPicker, StrategyPicker, ItemPicker },
   emits: ['close', 'configurationUpdate'],
@@ -116,7 +118,6 @@ export default {
     opened: Boolean,
     persistence: Object,
     configurationIndex: Number,
-    predefinedStrategies: Array,
     suggestedStrategies: Array
   },
   data () {
@@ -141,7 +142,7 @@ export default {
   },
   computed: {
     strategies () {
-      const predefinedNames = this.predefinedStrategies || []
+      const predefinedNames = PredefinedStrategies
       const cronStrategyNames = (this.persistenceLocal.cronStrategies || []).map(cs => cs.name)
       return [...predefinedNames, ...cronStrategyNames]
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -1,104 +1,109 @@
 <template>
-  <f7-popup ref="modulePopup" class="moduleconfig-popup">
+  <f7-popup :opened="opened" class="moduleconfig-popup" @popup:open="onPopupOpen">
     <f7-page>
       <f7-navbar>
         <f7-nav-left>
-          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />
         </f7-nav-left>
         <f7-nav-title> Configure strategies and filters for Item(s) </f7-nav-title>
         <f7-nav-right>
-          <f7-link v-show="currentConfiguration.items.length > 0" @click="updateModuleConfig"> Done </f7-link>
+          <f7-link v-show="currentConfiguration.items.length > 0" @click="updateConfiguration"> Done </f7-link>
         </f7-nav-right>
       </f7-navbar>
-      <f7-block class="no-margin no-padding">
-        <f7-col>
-          <f7-block-title medium class="padding-bottom"> Items </f7-block-title>
-          <f7-list>
-            <f7-list-item title="Persist all Items">
-              <template #after>
-                <f7-toggle :checked="allItemsSelected ? true : null" @toggle:change="allItemsSelected = $event" />
-              </template>
-            </f7-list-item>
-          </f7-list>
-          <f7-list>
-            <f7-list-group>
-              <item-picker
-                key="groups"
-                label="Select groups"
-                name="groupItems"
-                :multiple="true"
-                filterType="Group"
-                :disabled="allItemsSelected ? true : null"
-                :value="groupItems"
-                @input="groupItems = $event" />
-            </f7-list-group>
-            <f7-list-item>... whose members are to be persisted.</f7-list-item>
-          </f7-list>
-          <f7-list>
-            <f7-list-group>
-              <item-picker
-                key="items"
-                label="Select Items"
-                name="items"
-                :multiple="true"
-                :disabled="allItemsSelected ? true : null"
-                :value="items"
-                @input="items = $event" />
-            </f7-list-group>
-            <f7-list-item>... to be persisted.</f7-list-item>
-          </f7-list>
-          <f7-list>
-            <f7-list-group>
-              <item-picker
-                key="exclude-groups"
-                label="Select exclude groups"
-                name="excludeGroupItems"
-                :multiple="true"
-                filterType="Group"
-                :disabled="!anySelected ? true : null"
-                :value="excludeGroupItems"
-                @input="excludeGroupItems = $event" />
-            </f7-list-group>
-            <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
-          </f7-list>
-          <f7-list>
-            <f7-list-group>
-              <item-picker
-                key="exclude-items"
-                label="Select exclude Items"
-                name="excludeItems"
-                :multiple="true"
-                :disabled="!anySelected ? true : null"
-                :value="excludeItems"
-                @input="excludeItems = $event" />
-            </f7-list-group>
-            <f7-list-item>... to be excluded from persistence.</f7-list-item>
-          </f7-list>
-        </f7-col>
-        <f7-col>
-          <f7-block-title medium class="padding-bottom"> Strategies </f7-block-title>
-          <strategy-picker
-            title="Select strategies"
-            name="strategies"
-            :strategies="strategies"
-            :value="currentConfiguration.strategies"
-            :suggested="suggestedStrategies"
-            @strategies-selected="currentConfiguration.strategies = $event" />
-        </f7-col>
-        <f7-col>
-          <f7-block-title medium class="padding-bottom"> Filters </f7-block-title>
-          <filter-picker
-            :filters="filters"
-            :value="currentConfiguration.filters"
-            @filters-selected="currentConfiguration.filters = $event" />
-        </f7-col>
-      </f7-block>
-    </f7-page>
-  </f7-popup>
+        <f7-block class="no-margin no-padding">
+          <f7-col>
+            <f7-block-title medium class="padding-bottom"> Items </f7-block-title>
+            <f7-list>
+              <f7-list-item title="Persist all Items">
+                <template #after>
+                  <f7-toggle :checked="allItemsSelected ? true : null" @toggle:change="allItemsSelected = $event" />
+                </template>
+              </f7-list-item>
+            </f7-list>
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="groups"
+                  label="Select groups"
+                  name="groupItems"
+                  :multiple="true"
+                  filterType="Group"
+                  :disabled="allItemsSelected ? true : null"
+                  :value="groupItems"
+                  @input="groupItems = $event" />
+              </f7-list-group>
+              <f7-list-item>... whose members are to be persisted.</f7-list-item>
+            </f7-list>
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="items"
+                  label="Select Items"
+                  name="items"
+                  :multiple="true"
+                  :disabled="allItemsSelected ? true : null"
+                  :value="items"
+                  @input="items = $event" />
+              </f7-list-group>
+              <f7-list-item>... to be persisted.</f7-list-item>
+            </f7-list>
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="exclude-groups"
+                  label="Select exclude groups"
+                  name="excludeGroupItems"
+                  :multiple="true"
+                  filterType="Group"
+                  :disabled="!anySelected ? true : null"
+                  :value="excludeGroupItems"
+                  @input="excludeGroupItems = $event" />
+              </f7-list-group>
+              <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
+            </f7-list>
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="exclude-items"
+                  label="Select exclude Items"
+                  name="excludeItems"
+                  :multiple="true"
+                  :disabled="!anySelected ? true : null"
+                  :value="excludeItems"
+                  @input="excludeItems = $event" />
+              </f7-list-group>
+              <f7-list-item>... to be excluded from persistence.</f7-list-item>
+            </f7-list>
+          </f7-col>
+          <f7-col>
+            <f7-block-title medium class="padding-bottom"> Strategies </f7-block-title>
+            <strategy-picker
+              ref="strategyPicker"
+              title="Select strategies"
+              :strategies="strategies"
+              :value="currentConfiguration.strategies || []"
+              :persistence="persistenceLocal"
+              @strategies-selected="onStrategiesSelected" />
+          </f7-col>
+          <f7-col>
+            <f7-block-title medium class="padding-bottom"> Filters </f7-block-title>
+            <filter-picker
+              ref="filterPicker"
+              title="Select filters"
+              :filters="filters"
+              :value="currentConfiguration.filters || []"
+              :persistence="persistenceLocal"
+              @filters-selected="onFiltersSelected" />
+          </f7-col>
+        </f7-block>
+      </f7-page>
+    </f7-popup>
 </template>
 
 <script>
 import { f7 } from 'framework7-vue'
+
+import cloneDeep from 'lodash/cloneDeep'
 
 import ItemPicker from '@/components/config/controls/item-picker.vue'
 import StrategyPicker from '@/pages/settings/persistence/strategy-picker.vue'
@@ -106,23 +111,46 @@ import FilterPicker from '@/pages/settings/persistence/filter-picker.vue'
 
 export default {
   components: { FilterPicker, StrategyPicker, ItemPicker },
+  emits: ['close', 'configurationUpdate'],
   props: {
-    configuration: Object,
-    strategies: Array,
-    filters: Array,
-    suggestedStrategies: Array
+    opened: Boolean,
+    persistence: Object,
+    configurationIndex: Number,
+    predefinedStrategies: Array
   },
-  emits: ['configurationUpdate'],
   data () {
     return {
-      currentConfiguration: this.configuration || {
-        items: [],
-        strategies: this.suggestedStrategies,
+      persistenceLocal: {},
+      currentConfiguration: {
+        items: ['*'],
+        strategies: [],
         filters: []
       }
     }
   },
+  watch: {
+    persistence: {
+      handler (newPersistence) {
+        if (newPersistence) {
+          this.persistenceLocal = cloneDeep(newPersistence)
+        }
+      },
+      deep: true
+    }
+  },
   computed: {
+    strategies () {
+      const predefinedNames = this.predefinedStrategies || []
+      const cronStrategyNames = (this.persistenceLocal.cronStrategies || []).map(cs => cs.name)
+      return [...predefinedNames, ...cronStrategyNames]
+    },
+    filters () {
+      return (this.persistenceLocal.equalsFilters || [])
+        .concat(this.persistenceLocal.includeFilters || [])
+        .concat(this.persistenceLocal.thresholdFilters || [])
+        .concat(this.persistenceLocal.timeFilters || [])
+        .map(f => f.name)
+    },
     groupItems: {
       get () {
         return this.currentConfiguration.items.filter((i) => i.length > 1 && !i.startsWith('!') && i.endsWith('*')).map((i) => i.slice(0, -1))
@@ -170,17 +198,36 @@ export default {
     }
   },
   methods: {
+    onPopupOpen () {
+      this.persistenceLocal = cloneDeep(this.persistence || {})
+      this.currentConfiguration = this.persistenceLocal?.configs?.[this.configurationIndex] || {
+        items: ['*'],
+        strategies: [],
+        filters: []
+      }
+    },
     itemConfig (allItemsSelected, groupItems, items, excludeGroupItems, excludeItems) {
       return (allItemsSelected ? ['*'] : []).concat(groupItems.map((i) => i + '*')).concat(items).concat(excludeGroupItems.map((i) => '!' + i + '*')).concat(excludeItems.map((i) => '!' + i))
     },
-    updateModuleConfig () {
+    onStrategiesSelected (strategies) {
+      this.currentConfiguration.strategies = strategies
+    },
+    onFiltersSelected (filters) {
+      this.currentConfiguration.filters = filters
+    },
+    updateConfiguration () {
       if (!this.anySelected) {
         f7.dialog.alert('Please select Items')
         return
       }
       this.currentConfiguration.items = this.itemConfig(this.allItemsSelected, this.allItemsSelected ? [] : this.groupItems, this.allItemsSelected ? [] : this.items, this.excludeGroupItems, this.excludeItems)
-      f7.emit('configurationUpdate', this.currentConfiguration)
-      this.$refs.modulePopup.$el.f7Modal.close()
+      if (this.configurationIndex !== null) {
+        this.persistenceLocal.configs[this.configurationIndex] = this.currentConfiguration
+      } else {
+        this.persistenceLocal.configs.push(this.currentConfiguration)
+      }
+      // Emit the modified persistence object with updated configuration
+      this.$emit('configurationUpdate', this.persistenceLocal)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -116,14 +116,15 @@ export default {
     opened: Boolean,
     persistence: Object,
     configurationIndex: Number,
-    predefinedStrategies: Array
+    predefinedStrategies: Array,
+    suggestedStrategies: Array
   },
   data () {
     return {
       persistenceLocal: {},
       currentConfiguration: {
         items: ['*'],
-        strategies: [],
+        strategies: this.suggestedStrategies,
         filters: []
       }
     }
@@ -202,7 +203,7 @@ export default {
       this.persistenceLocal = cloneDeep(this.persistence || {})
       this.currentConfiguration = this.persistenceLocal?.configs?.[this.configurationIndex] || {
         items: ['*'],
-        strategies: [],
+        strategies: this.suggestedStrategies,
         filters: []
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/cron-strategy-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/cron-strategy-popup.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-popup :opened="opened" class="moduleconfig-popup">
-    <f7-page>
+    <f7-page v-if="opened">
       <f7-navbar>
         <f7-nav-left>
           <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/cron-strategy-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/cron-strategy-popup.vue
@@ -96,24 +96,24 @@ export default {
         f7.dialog.alert('Please review the configuration and correct validation errors')
         return
       }
-      
+
       // Modify persistence directly and save the strategy
       if (!this.persistence.cronStrategies) this.persistence.cronStrategies = []
-      
+
       // Check for duplicates (unless editing existing)
       const existingIndex = this.persistence.cronStrategies.findIndex((cs) => cs.name === this.currentCronStrategy.name)
       if (this.createMode && existingIndex !== -1) {
         f7.dialog.alert('A (cron) strategy with the same name already exists!')
         return
       }
-      
+
       // Add or update in persistence
       if (this.createMode) {
         this.persistence.cronStrategies.push(cloneDeep(this.currentCronStrategy))
       } else if (existingIndex !== -1) {
         this.persistence.cronStrategies[existingIndex] = cloneDeep(this.currentCronStrategy)
       }
-      
+
       // Emit via Vue event system so parent can listen directly
       this.$emit('cronStrategyConfigUpdate', this.currentCronStrategy)
       this.$emit('close')

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/cron-strategy-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/cron-strategy-popup.vue
@@ -1,13 +1,13 @@
 <template>
-  <f7-popup ref="modulePopup" class="moduleconfig-popup">
+  <f7-popup :opened="opened" class="moduleconfig-popup">
     <f7-page>
       <f7-navbar>
         <f7-nav-left>
-          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />
         </f7-nav-left>
         <f7-nav-title> Configure cron strategy </f7-nav-title>
         <f7-nav-right>
-          <f7-link v-show="currentCronStrategy.name && currentCronStrategy.cronExpression" @click="updateModuleConfig"> Done </f7-link>
+          <f7-link v-show="currentCronStrategy.name && currentCronStrategy.cronExpression" @click="updateCronStrategy"> Done </f7-link>
         </f7-nav-right>
       </f7-navbar>
       <f7-block class="no-margin no-padding">
@@ -47,20 +47,21 @@
 
 <script>
 import { f7 } from 'framework7-vue'
-
+import cloneDeep from 'lodash/cloneDeep'
 import ParameterCronexpression from '@/components/config/controls/parameter-cronexpression.vue'
 
 export default {
   components: {
     ParameterCronexpression
   },
+  emits: ['close', 'cronStrategyConfigUpdate'],
   props: {
+    opened: Boolean,
+    persistence: Object,
     cronStrategy: Object
   },
-  emits: ['cronStrategyConfigUpdate'],
   data () {
     return {
-      createMode: !this.cronStrategy,
       currentCronStrategy: this.cronStrategy || {
         name: null,
         cronExpression: null
@@ -73,14 +74,49 @@ export default {
       }
     }
   },
+  computed: {
+    createMode () {
+      return !this.cronStrategy
+    }
+  },
+  watch: {
+    cronStrategy: {
+      handler (newVal) {
+        this.currentCronStrategy = newVal || {
+          name: null,
+          cronExpression: null
+        }
+      },
+      immediate: true
+    }
+  },
   methods: {
-    updateModuleConfig () {
-      if (!f7.input.validateInputs(this.$refs.name.$el) && !f7.input.validateInputs(this.$refs.cronExpression.$el)) {
+    updateCronStrategy () {
+      if (!f7.input.validateInputs(this.$refs.name.$el) || !f7.input.validateInputs(this.$refs.cronExpression.$el)) {
         f7.dialog.alert('Please review the configuration and correct validation errors')
         return
       }
-      f7.emit('cronStrategyConfigUpdate', this.currentCronStrategy)
-      this.$refs.modulePopup.$el.f7Modal.close()
+      
+      // Modify persistence directly and save the strategy
+      if (!this.persistence.cronStrategies) this.persistence.cronStrategies = []
+      
+      // Check for duplicates (unless editing existing)
+      const existingIndex = this.persistence.cronStrategies.findIndex((cs) => cs.name === this.currentCronStrategy.name)
+      if (this.createMode && existingIndex !== -1) {
+        f7.dialog.alert('A (cron) strategy with the same name already exists!')
+        return
+      }
+      
+      // Add or update in persistence
+      if (this.createMode) {
+        this.persistence.cronStrategies.push(cloneDeep(this.currentCronStrategy))
+      } else if (existingIndex !== -1) {
+        this.persistence.cronStrategies[existingIndex] = cloneDeep(this.currentCronStrategy)
+      }
+      
+      // Emit via Vue event system so parent can listen directly
+      this.$emit('cronStrategyConfigUpdate', this.currentCronStrategy)
+      this.$emit('close')
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
@@ -1,21 +1,21 @@
 <template>
   <f7-popup :opened="opened" class="persistence-definitions-popup">
     <f7-page>
-        <f7-navbar title="Manage Definitions">
+      <f7-navbar title="Manage Definitions">
         <f7-nav-left>
-            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="onClose" />
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="onClose" />
         </f7-nav-left>
         <f7-nav-right>
-            <f7-link v-if="hasChanges" @click="onDone"> Done </f7-link>
+          <f7-link v-if="hasChanges" @click="onDone"> Done </f7-link>
         </f7-nav-right>
-        </f7-navbar>
-        <f7-block>
+      </f7-navbar>
+      <f7-block>
         <f7-block-title medium> Definitions </f7-block-title>
         <f7-block-header> Cron strategy and filter definitions used in a persistence configuration. </f7-block-header>
         <!-- Cron Strategies -->
         <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Cron Strategies </f7-block-title>
         <f7-list media-list swipeout>
-            <f7-list-item
+          <f7-list-item
             v-for="(cs, index) in (persistenceLocal.cronStrategies || [])"
             :key="cs.name"
             :title="cs.name"
@@ -24,7 +24,7 @@
             @click="editCronStrategy(cs)"
             swipeout>
             <template #media>
-                <f7-link
+              <f7-link
                 v-if="editable"
                 icon-color="red"
                 icon-aurora="f7:minus_circle_filled"
@@ -33,16 +33,16 @@
                 @click="showSwipeout" />
             </template>
             <f7-swipeout-actions right v-if="editable">
-                <f7-swipeout-button
+              <f7-swipeout-button
                 @click="(ev) => deleteCronStrategy(ev, index)"
                 style="background-color: var(--f7-swipeout-delete-button-bg-color)">
                 Delete
-                </f7-swipeout-button>
+              </f7-swipeout-button>
             </f7-swipeout-actions>
-            </f7-list-item>
+          </f7-list-item>
         </f7-list>
         <f7-list>
-            <f7-list-item
+          <f7-list-item
             link
             no-chevron
             media-item
@@ -50,14 +50,14 @@
             subtitle="Add cron strategy"
             @click="addCronStrategy">
             <template #media>
-                <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+              <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
             </template>
-            </f7-list-item>
+          </f7-list-item>
         </f7-list>
         <!-- Filters -->
         <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
         <f7-list v-for="ft in FilterTypes" :key="ft.name" :media-list="editable" swipeout>
-            <f7-list-item
+          <f7-list-item
             v-for="(f, index) in (persistenceLocal[ft.name] || [])"
             :key="f.name"
             :title="f.name"
@@ -66,7 +66,7 @@
             @click="editFilter(ft, f)"
             swipeout>
             <template #media>
-                <f7-link
+              <f7-link
                 v-if="editable"
                 icon-color="red"
                 icon-aurora="f7:minus_circle_filled"
@@ -75,33 +75,27 @@
                 @click="showSwipeout" />
             </template>
             <f7-swipeout-actions right v-if="editable">
-                <f7-swipeout-button
+              <f7-swipeout-button
                 @click="(ev) => deleteFilter(ev, ft, index)"
                 style="background-color: var(--f7-swipeout-delete-button-bg-color)">
                 Delete
-                </f7-swipeout-button>
+              </f7-swipeout-button>
             </f7-swipeout-actions>
-            </f7-list-item>
+          </f7-list-item>
         </f7-list>
         <f7-list>
-            <f7-list-item
-            link
-            no-chevron
-            media-item
-            :color="(theme.dark) ? 'black' : 'white'"
-            subtitle="Add filter"
-            @click="addFilter">
+          <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add filter" @click="addFilter">
             <template #media>
-                <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+              <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
             </template>
-            </f7-list-item>
+          </f7-list-item>
         </f7-list>
-        </f7-block>
+      </f7-block>
     </f7-page>
   </f7-popup>
 
   <!-- Cron Strategy Popup -->
-<cron-strategy-popup
+  <cron-strategy-popup
     v-model:opened="cronStrategyPopupOpen"
     :persistence="persistenceLocal"
     :cronStrategy="currentCronStrategy"
@@ -109,7 +103,7 @@
     @cron-strategy-config-update="handleCronStrategyUpdate" />
 
   <!-- Filter Popup -->
-<filter-popup
+  <filter-popup
     v-model:opened="filterPopupOpen"
     :persistence="persistenceLocal"
     :filter="currentFilter"

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
@@ -1,0 +1,279 @@
+<template>
+  <f7-popup :opened="opened" class="persistence-definitions-popup">
+    <f7-page>
+        <f7-navbar title="Manage Definitions">
+        <f7-nav-left>
+            <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="onClose" />
+        </f7-nav-left>
+        <f7-nav-right>
+            <f7-link v-if="hasChanges" @click="onDone"> Done </f7-link>
+        </f7-nav-right>
+        </f7-navbar>
+        <f7-block>
+        <f7-block-title medium> Definitions </f7-block-title>
+        <f7-block-header> Cron strategy and filter definitions used in a persistence configuration. </f7-block-header>
+        <!-- Cron Strategies -->
+        <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Cron Strategies </f7-block-title>
+        <f7-list media-list swipeout>
+            <f7-list-item
+            v-for="(cs, index) in (persistenceLocal.cronStrategies || [])"
+            :key="cs.name"
+            :title="cs.name"
+            :footer="cs.cronExpression"
+            :link="editable"
+            @click="editCronStrategy(cs)"
+            swipeout>
+            <template #media>
+                <f7-link
+                v-if="editable"
+                icon-color="red"
+                icon-aurora="f7:minus_circle_filled"
+                icon-ios="f7:minus_circle_filled"
+                icon-md="material:remove_circle_outline"
+                @click="showSwipeout" />
+            </template>
+            <f7-swipeout-actions right v-if="editable">
+                <f7-swipeout-button
+                @click="(ev) => deleteCronStrategy(ev, index)"
+                style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                Delete
+                </f7-swipeout-button>
+            </f7-swipeout-actions>
+            </f7-list-item>
+        </f7-list>
+        <f7-list>
+            <f7-list-item
+            link
+            no-chevron
+            media-item
+            :color="(theme.dark) ? 'black' : 'white'"
+            subtitle="Add cron strategy"
+            @click="addCronStrategy">
+            <template #media>
+                <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+            </template>
+            </f7-list-item>
+        </f7-list>
+        <!-- Filters -->
+        <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
+        <f7-list v-for="ft in FilterTypes" :key="ft.name" :media-list="editable" swipeout>
+            <f7-list-item
+            v-for="(f, index) in (persistenceLocal[ft.name] || [])"
+            :key="f.name"
+            :title="f.name"
+            :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
+            :link="editable"
+            @click="editFilter(ft, f)"
+            swipeout>
+            <template #media>
+                <f7-link
+                v-if="editable"
+                icon-color="red"
+                icon-aurora="f7:minus_circle_filled"
+                icon-ios="f7:minus_circle_filled"
+                icon-md="material:remove_circle_outline"
+                @click="showSwipeout" />
+            </template>
+            <f7-swipeout-actions right v-if="editable">
+                <f7-swipeout-button
+                @click="(ev) => deleteFilter(ev, ft, index)"
+                style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                Delete
+                </f7-swipeout-button>
+            </f7-swipeout-actions>
+            </f7-list-item>
+        </f7-list>
+        <f7-list>
+            <f7-list-item
+            link
+            no-chevron
+            media-item
+            :color="(theme.dark) ? 'black' : 'white'"
+            subtitle="Add filter"
+            @click="addFilter">
+            <template #media>
+                <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+            </template>
+            </f7-list-item>
+        </f7-list>
+        </f7-block>
+    </f7-page>
+  </f7-popup>
+
+  <!-- Cron Strategy Popup -->
+<cron-strategy-popup
+    v-model:opened="cronStrategyPopupOpen"
+    :persistence="persistenceLocal"
+    :cronStrategy="currentCronStrategy"
+    @close="cronStrategyPopupOpen = false; currentCronStrategy = null"
+    @cron-strategy-config-update="handleCronStrategyUpdate" />
+
+  <!-- Filter Popup -->
+<filter-popup
+    v-model:opened="filterPopupOpen"
+    :persistence="persistenceLocal"
+    :filter="currentFilter"
+    :filterType="currentFilterType"
+    @close="filterPopupOpen = false; currentFilterType = null; currentFilter = null"
+    @filter-config-update="handleFilterUpdate" />
+</template>
+
+<style lang="stylus">
+.persistence-definitions-popup
+  .block
+    padding-left var(--f7-safe-area-left)
+    padding-right var(--f7-safe-area-right)
+  .media-list
+    margin-bottom 0
+  .list
+    margin-top 0
+    margin-bottom 0
+</style>
+
+<script>
+import { theme, f7 } from 'framework7-vue'
+import cloneDeep from 'lodash/cloneDeep'
+import fastDeepEqual from 'fast-deep-equal/es6'
+
+import { FilterTypes } from '@/assets/definitions/persistence'
+import CronStrategyPopup from '@/pages/settings/persistence/cron-strategy-popup.vue'
+import FilterPopup from '@/pages/settings/persistence/filter-popup.vue'
+
+export default {
+  emits: ['close', 'definitionsUpdate'],
+  props: {
+    opened: Boolean,
+    persistence: Object,
+    editable: Boolean
+  },
+  components: {
+    CronStrategyPopup,
+    FilterPopup
+  },
+  data () {
+    return {
+      theme,
+      FilterTypes,
+      persistenceLocal: cloneDeep(this.persistence || {}),
+
+      // popup visibility
+      cronStrategyPopupOpen: false,
+      filterPopupOpen: false,
+
+      currentCronStrategy: null,
+      currentFilterType: null,
+      currentFilter: null
+    }
+  },
+  watch: {
+    persistence: {
+      handler (newPersistence) {
+        if (newPersistence) {
+          this.persistenceLocal = cloneDeep(newPersistence)
+        }
+      },
+      deep: true
+    }
+  },
+  computed: {
+    hasChanges () {
+      if (!fastDeepEqual(this.persistence.cronStrategies, this.persistenceLocal.cronStrategies)) return true
+      for (const filterType of FilterTypes.map((ft) => ft.name)) {
+        if (!fastDeepEqual(this.persistence[filterType], this.persistenceLocal[filterType])) return true
+      }
+        return false
+    },
+  },
+  methods: {
+    addCronStrategy () {
+      this.editCronStrategy(null)
+    },
+    editCronStrategy (cronStrategy) {
+      this.currentCronStrategy = cronStrategy || undefined
+      this.cronStrategyPopupOpen = true
+    },
+    handleCronStrategyUpdate () {
+      // Nested popup modified persistenceLocal directly, just close it
+      this.cronStrategyPopupOpen = false
+      this.currentCronStrategy = null
+    },
+    deleteCronStrategy (ev, index) {
+      const csName = this.persistenceLocal.cronStrategies[index].name
+      // Check if strategy is used in configurations
+      if (this.isCronStrategyUsed(csName)) {
+        f7.dialog.confirm(
+          'Cron strategy used in configuration(s), delete anyway?',
+          () => {
+            this.deleteModule(ev, 'cronStrategies', index)
+          }
+        )
+      } else {
+        this.deleteModule(ev, 'cronStrategies', index)
+      }
+    },
+    isCronStrategyUsed (csName) {
+      return this.persistenceLocal.configs?.findIndex((cfg) => cfg.strategies?.findIndex((cs) => cs === csName) >= 0) >= 0
+    },
+    addFilter () {
+      this.editFilter(null, null)
+    },
+    editFilter (filterType, filter) {
+      this.currentFilterType = filterType
+      this.currentFilter = filter || undefined
+      this.filterPopupOpen = true
+    },
+    handleFilterUpdate () {
+      // Nested popup modified persistenceLocal directly, just close it
+      this.filterPopupOpen = false
+      this.currentFilterType = null
+      this.currentFilter = null
+    },
+    deleteFilter (ev, filterType, index) {
+      const filterName = this.persistenceLocal[filterType.name][index].name
+      // Check if filter is used in configurations
+      if (this.isFilterUsed(filterName)) {
+        f7.dialog.confirm(
+          'Filter used in configuration(s), delete anyway?',
+          () => {
+            this.deleteModule(ev, filterType.name, index)
+          }
+        )
+      } else {
+        this.deleteModule(ev, filterType.name, index)
+      }
+    },
+    isFilterUsed (filterName) {
+      return this.persistenceLocal.configs?.findIndex((cfg) => cfg.filters?.findIndex((f) => f === filterName) >= 0) >= 0
+    },
+    deleteModule (ev, module, index) {
+      if (!this.editable) return
+      let swipeoutElement = ev.target
+      ev.cancelBubble = true
+      while (!swipeoutElement.classList.contains('swipeout')) {
+        swipeoutElement = swipeoutElement.parentElement
+      }
+      f7.swipeout.delete(swipeoutElement, () => {
+        this.persistenceLocal[module].splice(index, 1)
+      })
+    },
+    showSwipeout (event) {
+      let swipeoutElement = event.target
+      event.cancelBubble = true
+      while (!swipeoutElement.classList.contains('swipeout')) {
+        swipeoutElement = swipeoutElement.parentElement
+      }
+
+      if (swipeoutElement) {
+        f7.swipeout.open(swipeoutElement)
+      }
+    },
+    onClose () {
+        this.persistenceLocal = cloneDeep(this.persistence)
+        this.$emit('close')
+    },
+    onDone () {
+      this.$emit('definitionsUpdate', this.persistenceLocal)
+    }
+  }
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-popup :opened="opened" class="persistence-definitions-popup">
-    <f7-page>
+    <f7-page v-if="opened">
       <f7-navbar title="Manage Definitions">
         <f7-nav-left>
           <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="onClose" />
@@ -167,6 +167,7 @@ export default {
   },
   computed: {
     hasChanges () {
+      if (!this.persistence || !this.persistenceLocal) return false
       if (!fastDeepEqual(this.persistence.cronStrategies, this.persistenceLocal.cronStrategies)) return true
       for (const filterType of FilterTypes.map((ft) => ft.name)) {
         if (!fastDeepEqual(this.persistence[filterType], this.persistenceLocal[filterType])) return true

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
@@ -175,7 +175,7 @@ export default {
       for (const filterType of FilterTypes.map((ft) => ft.name)) {
         if (!fastDeepEqual(this.persistence[filterType], this.persistenceLocal[filterType])) return true
       }
-        return false
+      return false
     },
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
@@ -46,7 +46,7 @@
             link
             no-chevron
             media-item
-            :color="(theme.dark) ? 'black' : 'white'"
+            :color="uiOptionsStore.darkMode"
             subtitle="Add cron strategy"
             @click="addCronStrategy">
             <template #media>
@@ -84,7 +84,7 @@
           </f7-list-item>
         </f7-list>
         <f7-list>
-          <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add filter" @click="addFilter">
+          <f7-list-item link no-chevron media-item :color="uiOptionsStore.darkMode" subtitle="Add filter" @click="addFilter">
             <template #media>
               <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
             </template>
@@ -125,10 +125,13 @@
 </style>
 
 <script>
-import { theme, f7 } from 'framework7-vue'
+import { f7 } from 'framework7-vue'
 import cloneDeep from 'lodash/cloneDeep'
 import fastDeepEqual from 'fast-deep-equal/es6'
+import { mapStores } from 'pinia'
 
+
+import { useUIOptionsStore } from  '@/js/stores/useUIOptionsStore'
 import { FilterTypes } from '@/assets/definitions/persistence'
 import CronStrategyPopup from '@/pages/settings/persistence/cron-strategy-popup.vue'
 import FilterPopup from '@/pages/settings/persistence/filter-popup.vue'
@@ -146,7 +149,6 @@ export default {
   },
   data () {
     return {
-      theme,
       FilterTypes,
       persistenceLocal: cloneDeep(this.persistence || {}),
 
@@ -177,6 +179,7 @@ export default {
       }
       return false
     },
+    ...mapStores(useUIOptionsStore)
   },
   methods: {
     addCronStrategy () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/definitions-popup.vue
@@ -42,13 +42,7 @@
           </f7-list-item>
         </f7-list>
         <f7-list>
-          <f7-list-item
-            link
-            no-chevron
-            media-item
-            :color="uiOptionsStore.darkMode"
-            subtitle="Add cron strategy"
-            @click="addCronStrategy">
+          <f7-list-item link no-chevron media-item :color="uiOptionsStore.darkMode" subtitle="Add cron strategy" @click="addCronStrategy">
             <template #media>
               <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
             </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
@@ -21,13 +21,7 @@
         <f7-list-item v-for="s in localFilters" :key="s" checkbox :checked="localValue.includes(s)" @change="toggleFilter(s)">
           {{ s }}
         </f7-list-item>
-        <f7-list-item
-          link
-          no-chevron
-          media-item
-          :color="uiOptionsStore.darkMode"
-          subtitle="Add filter definition"
-          @click="openFilterPopup">
+        <f7-list-item link no-chevron media-item :color="uiOptionsStore.darkMode" subtitle="Add filter definition" @click="openFilterPopup">
           <template #media>
             <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
           </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
@@ -21,7 +21,7 @@
         <f7-list-item v-for="s in localFilters" :key="s" checkbox :checked="localValue.includes(s)" @change="toggleFilter(s)">
           {{ s }}
         </f7-list-item>
-        <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add filter" @click="openFilterPopup">
+        <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add filter definition" @click="openFilterPopup">
           <template #media>
             <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
           </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
@@ -25,7 +25,7 @@
           link
           no-chevron
           media-item
-          :color="(theme.dark) ? 'black' : 'white'"
+          :color="uiOptionsStore.darkMode"
           subtitle="Add filter definition"
           @click="openFilterPopup">
           <template #media>
@@ -44,8 +44,9 @@
 </template>
 
 <script>
-import { theme } from 'framework7-vue'
+import { mapStores } from 'pinia'
 import FilterPopup from '@/pages/settings/persistence/filter-popup.vue'
+import { useUIOptionsStore } from  '@/js/stores/useUIOptionsStore'
 
 export default {
   components: { FilterPopup },
@@ -66,9 +67,7 @@ export default {
     }
   },
   computed: {
-    theme () {
-      return theme
-    }
+    ...mapStores(useUIOptionsStore),
   },
   watch: {
     value: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
@@ -21,7 +21,13 @@
         <f7-list-item v-for="s in localFilters" :key="s" checkbox :checked="localValue.includes(s)" @change="toggleFilter(s)">
           {{ s }}
         </f7-list-item>
-        <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add filter definition" @click="openFilterPopup">
+        <f7-list-item
+          link
+          no-chevron
+          media-item
+          :color="(theme.dark) ? 'black' : 'white'"
+          subtitle="Add filter definition"
+          @click="openFilterPopup">
           <template #media>
             <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
           </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-picker.vue
@@ -1,59 +1,108 @@
 <template>
-  <f7-list class="strategy-picker-container" v-if="filters">
-    <f7-list-item
-      title="Select filters"
-      :smart-select="disabled !== true && filters.length > 0"
-      :smart-select-params="smartSelectParams"
-      ref="smartSelect"
-      class="defaults-picker">
-      <select v-if="disabled !== true && filters.length > 0" name="filters" multiple @change="select">
-        <option v-for="s in filters" :key="s" :value="s" :selected="value.includes(s) ? true : null">
-          {{ s }}
-        </option>
-      </select>
-      <div v-else-if="disabled === true">
-        {{ value.join(', ') }}
-      </div>
-      <div v-else-if="disabled !== true && filters.length === 0">No filters available. Please add them first.</div>
+  <f7-list class="module-picker-container">
+    <f7-list-item :title="title" class="defaults-picker" @click="popupOpened = true">
+      <template #after>
+        <div>{{ localValue.join(', ') }}<f7-icon f7="chevron_right" style="margin-left: 8px;"></f7-icon></div>
+      </template>
     </f7-list-item>
   </f7-list>
+
+  <f7-popup v-model:opened="popupOpened">
+    <f7-page>
+      <f7-navbar :title="title">
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="popupOpened = false" />
+        </f7-nav-left>
+        <f7-nav-right>
+          <f7-link @click="onDone">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-list class="module-picker-container popup-list">
+        <f7-list-item v-for="s in localFilters" :key="s" checkbox :checked="localValue.includes(s)" @change="toggleFilter(s)">
+          {{ s }}
+        </f7-list-item>
+        <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add filter" @click="openFilterPopup">
+          <template #media>
+            <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+          </template>
+        </f7-list-item>
+      </f7-list>
+    </f7-page>
+  </f7-popup>
+
+  <filter-popup
+    v-model:opened="filterPopupOpen"
+    :persistence="persistence"
+    @close="filterPopupOpen = false"
+    @filter-config-update="handleFilterUpdate($event)" />
 </template>
 
-<style lang="stylus">
-.strategy-picker-container
-  .item-content
-    padding-left calc(var(--f7-list-item-padding-horizontal) / 2 + var(--f7-safe-area-left))
-
-  .item-media
-    padding 0
-
-  .item-inner:after
-    display none
-</style>
-
 <script>
-import { f7 } from 'framework7-vue'
+import { theme } from 'framework7-vue'
+import FilterPopup from '@/pages/settings/persistence/filter-popup.vue'
 
 export default {
+  components: { FilterPopup },
   props: {
+    title: String,
     filters: Array,
     value: Array,
-    disabled: Boolean
+    persistence: Object
   },
-  emits: ['filters-selected'],
+  emits: ['filtersSelected'],
   data () {
     return {
-      smartSelectParams: {
-        view: f7.view.main,
-        openIn: 'popup'
-      }
+      popupOpened: false,
+      filterPopupOpen: false,
+
+      localFilters: this.filters || [],
+      localValue: [...this.value],
+    }
+  },
+  computed: {
+    theme () {
+      return theme
+    }
+  },
+  watch: {
+    value: {
+      handler (newVal) {
+        this.localValue = [...newVal]
+      },
+      immediate: true
+    },
+    filters: {
+      handler (newVal) {
+        this.localFilters = newVal || []
+      },
+      immediate: true
     }
   },
   methods: {
-    select () {
-      f7.input.validateInputs(this.$refs.smartSelect.$el)
-      const value = this.$refs.smartSelect.$el.children[0].f7SmartSelect.getValue()
-      this.$emit('filters-selected', value)
+    toggleFilter (filter) {
+      if (this.localValue.includes(filter)) {
+        this.localValue = this.localValue.filter(s => s !== filter)
+      } else {
+        this.localValue = [...this.localValue, filter]
+      }
+    },
+    openFilterPopup () {
+      this.filterPopupOpen = true
+    },
+    handleFilterUpdate (ev) {
+      const filterName = ev.name
+      // Update localValue FIRST so the new item will be checked when the list re-renders
+      if (!this.localValue.includes(filterName)) {
+        this.localValue = [...this.localValue, filterName]
+      }
+      // Then add to available filters
+      if (!this.localFilters.includes(filterName)) {
+        this.localFilters = [...this.localFilters, filterName]
+      }
+    },
+    onDone () {
+      this.$emit('filtersSelected', this.localValue)
+      this.popupOpened = false
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-popup :opened="opened && !!currentFilterType" class="moduleconfig-popup">
-    <f7-page>
+    <f7-page v-if="opened">
       <f7-navbar>
         <f7-nav-left>
           <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
@@ -111,30 +111,30 @@ export default {
           return
         }
       }
-      
+
       // Modify persistence directly and save the filter
       if (!this.persistence[this.currentFilterType.name]) this.persistence[this.currentFilterType.name] = []
-      
+
       // Check for duplicates (unless editing existing)
       const existingIndex = this.persistence[this.currentFilterType.name].findIndex((f) => f.name === this.currentFilter.name)
       if (this.createMode && existingIndex !== -1) {
         f7.dialog.alert('A filter with the same name already exists!')
         return
       }
-      
+
       // Handle comma-separated values for equalsFilters
       let filterToSave = cloneDeep(this.currentFilter)
       if (this.currentFilterType.name === 'equalsFilters' && typeof filterToSave.values === 'string') {
         filterToSave.values = filterToSave.values.split(',').map((v) => v.trim())
       }
-      
+
       // Add or update in persistence
       if (this.createMode) {
         this.persistence[this.currentFilterType.name].push(filterToSave)
       } else if (existingIndex !== -1) {
         this.persistence[this.filterType.name][existingIndex] = filterToSave
       }
-      
+
       // Emit via Vue event system so parent can listen directly
       this.$emit('filterConfigUpdate', this.currentFilter)
       this.$emit('close')

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
@@ -1,13 +1,13 @@
 <template>
-  <f7-popup ref="modulePopup" class="moduleconfig-popup">
+  <f7-popup :opened="opened && !!currentFilterType" class="moduleconfig-popup">
     <f7-page>
       <f7-navbar>
         <f7-nav-left>
-          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />
         </f7-nav-left>
-        <f7-nav-title> Configure {{ filterType.label.toLowerCase() }} filter </f7-nav-title>
+        <f7-nav-title> Configure {{ filterTypeLabel }} filter </f7-nav-title>
         <f7-nav-right>
-          <f7-link v-show="currentFilter.name" @click="updateModuleConfig"> Done </f7-link>
+          <f7-link v-show="currentFilter.name" @click="updateFilter"> Done </f7-link>
         </f7-nav-right>
       </f7-navbar>
       <f7-block class="no-margin no-padding">
@@ -39,43 +39,105 @@
       </f7-block>
     </f7-page>
   </f7-popup>
+
+  <filter-type-picker :opened="opened && !currentFilterType" @close="$emit('close')" @filter-type-selected="currentFilterType = $event" />
 </template>
 
 <script>
 import { f7 } from 'framework7-vue'
-
+import cloneDeep from 'lodash/cloneDeep'
+import FilterTypePicker from '@/pages/settings/persistence/filter-type-picker.vue'
 import ConfigSheet from '@/components/config/config-sheet.vue'
 
 export default {
-  components: { ConfigSheet },
+  components: { ConfigSheet, FilterTypePicker },
   props: {
-    filter: Object,
+    opened: Boolean,
+    persistence: Object,
     filterType: Object,
-    filterConfigDescriptionParameters: Array
+    filter: Object
   },
-  emits: ['filterUpdate'],
+  emits: ['close', 'filterConfigUpdate'],
   data () {
+    const initialFilter = this.filter || { name: null }
+    // Initialize values property for equalsFilters if creating new
+    if (!this.filter && this.filterType?.name === 'equalsFilters') {
+      initialFilter.values = ''
+    }
     return {
-      createMode: !this.filter,
-      currentFilter: this.filter || {
-        name: null
-      }
+      currentFilterType: this.filterType,
+      currentFilter: initialFilter
+    }
+  },
+  computed: {
+    createMode () {
+      return !this.filter
+    },
+    filterConfigDescriptionParameters () {
+      return this.currentFilterType?.configDescriptionParameters
+    },
+    filterTypeLabel () {
+      return this.currentFilterType?.label?.toLowerCase() || ''
+    }
+  },
+  watch: {
+    filter: {
+      handler (newVal) {
+        const initialFilter = newVal || { name: null }
+        // Initialize values property for equalsFilters if creating new
+        if (!newVal && this.currentFilterType?.name === 'equalsFilters') {
+          initialFilter.values = ''
+        }
+        this.currentFilter = initialFilter
+      },
+      immediate: true
+    },
+    filterType: {
+      handler (newVal) {
+        this.currentFilterType = newVal
+      },
+      immediate: true
     }
   },
   methods: {
-    updateModuleConfig () {
+    updateFilter () {
       if (!this.$refs['config-sheet'].isValid()) {
         f7.dialog.alert('Please review the configuration and correct validation errors')
         return
       }
-      if (this.filterType.name === 'includeFilters') {
+      if (this.currentFilterType?.name === 'includeFilters') {
         if (this.currentFilter.upper <= this.currentFilter.lower) {
           f7.dialog.alert('The lower bound value must be less than the upper bound value')
           return
         }
       }
-      f7.emit('filterUpdate', this.currentFilter, this.filterType.name)
-      this.$refs.modulePopup.$el.f7Modal.close()
+      
+      // Modify persistence directly and save the filter
+      if (!this.persistence[this.currentFilterType.name]) this.persistence[this.currentFilterType.name] = []
+      
+      // Check for duplicates (unless editing existing)
+      const existingIndex = this.persistence[this.currentFilterType.name].findIndex((f) => f.name === this.currentFilter.name)
+      if (this.createMode && existingIndex !== -1) {
+        f7.dialog.alert('A filter with the same name already exists!')
+        return
+      }
+      
+      // Handle comma-separated values for equalsFilters
+      let filterToSave = cloneDeep(this.currentFilter)
+      if (this.currentFilterType.name === 'equalsFilters' && typeof filterToSave.values === 'string') {
+        filterToSave.values = filterToSave.values.split(',').map((v) => v.trim())
+      }
+      
+      // Add or update in persistence
+      if (this.createMode) {
+        this.persistence[this.currentFilterType.name].push(filterToSave)
+      } else if (existingIndex !== -1) {
+        this.persistence[this.filterType.name][existingIndex] = filterToSave
+      }
+      
+      // Emit via Vue event system so parent can listen directly
+      this.$emit('filterConfigUpdate', this.currentFilter)
+      this.$emit('close')
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-type-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-type-picker.vue
@@ -65,4 +65,3 @@ export default {
   }
 }
 </script>
-

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-type-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-type-picker.vue
@@ -1,0 +1,68 @@
+<template>
+  <f7-popup :opened="opened" class="filtertype-selection-popup">
+    <f7-page>
+      <f7-navbar title="Configure Filter">
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="$emit('close')" />
+        </f7-nav-left>
+      </f7-navbar>
+      <f7-block-title class="no-margin padding-horizontal margin-vertical" medium> Filter Type </f7-block-title>
+      <f7-block>
+        <f7-row v-for="ftRow in filterTypesMatrix" :key="ftRow" class="margin-bottom">
+          <f7-col
+            v-for="ft in ftRow"
+            :key="ft.name"
+            class="elevation-2 elevation-hover-6 elevation-pressed-1 persistence-filter-big-button"
+            width="50">
+            <f7-link class="display-flex flex-direction-column no-ripple" no-ripple @click="selectFilterType(ft)">
+              <f7-icon size="35" :f7="ft.icon" class="margin" />
+              {{ ft.label }}<br />Filter
+            </f7-link>
+          </f7-col>
+        </f7-row>
+      </f7-block>
+    </f7-page>
+  </f7-popup>
+</template>
+
+<style scoped lang="stylus">
+.persistence-filter-big-button
+  background var(--f7-card-bg-color)
+  text-align center
+  height 7.5rem
+  .link
+    color var(--f7-text-color)
+</style>
+
+<script>
+import { FilterTypes } from '@/assets/definitions/persistence'
+
+export default {
+  emits: ['close', 'filter-type-selected'],
+  props: {
+    opened: Boolean
+  },
+  data () {
+    return {
+      FilterTypes
+    }
+  },
+  computed: {
+    filterTypesMatrix () {
+      if (!this.FilterTypes) return []
+      const matrix = []
+      const columns = 2
+      for (let i = 0; i < this.FilterTypes.length; i += columns) {
+        matrix.push(this.FilterTypes.slice(i, i + columns))
+      }
+      return matrix
+    }
+  },
+  methods: {
+    selectFilterType (filterType) {
+      this.$emit('filter-type-selected', filterType)
+    }
+  }
+}
+</script>
+

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-type-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-type-picker.vue
@@ -8,7 +8,7 @@
       </f7-navbar>
       <f7-block-title class="no-margin padding-horizontal margin-vertical" medium> Filter Type </f7-block-title>
       <f7-block>
-        <f7-row v-for="ftRow in filterTypesMatrix" :key="ftRow" class="margin-bottom">
+        <f7-row v-for="(ftRow, rowIndex) in filterTypesMatrix" :key="rowIndex" class="margin-bottom">
           <f7-col
             v-for="ft in ftRow"
             :key="ft.name"

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -497,7 +497,9 @@ export default {
     saveConfiguration (persistenceWithUpdatedConfig) {
       // Merge the returned persistence back into our main persistence
       // The nested popups have already modified cronStrategies/filters in persistenceWithUpdatedConfig
-      const updatedConfig = persistenceWithUpdatedConfig.configs[this.currentConfigurationIndex || (persistenceWithUpdatedConfig.configs.length - 1)]
+      const updatedConfig = persistenceWithUpdatedConfig.configs[
+        this.currentConfigurationIndex ?? (persistenceWithUpdatedConfig.configs.length - 1)
+      ]
       if (updatedConfig) {
         // Update the configuration
         const idx = this.persistence.configs.findIndex((cfg) => cfg.items.join() === updatedConfig.items.join())

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -132,7 +132,8 @@
                       pattern="[A-Za-z_][A-Za-z0-9_]*"
                       error-message="Required. Must not start with a number. A-Z,a-z,0-9,_ only"
                       :value="persistence.aliases[i]"
-                      @input="editAlias($event, i, $event.target.value)"
+                      @input="editAlias(i, $event.target.value)"
+                      @blur="checkAliasForDuplicates(i, $event.target.value)"
                       @keydown="keyDown($event, index)" />
                   </div>
                   <f7-swipeout-actions right v-if="editable">
@@ -537,16 +538,18 @@ export default {
         }, {})
       this.persistence.aliases = newAliases
     },
-    editAlias (ev, item, alias) {
+    editAlias (item, alias) {
       if (!this.editable) return
+      this.persistence.aliases[item] = alias
+    },
+    checkAliasForDuplicates (item, alias) {
+      if (!this.editable || !alias) return
       // Warn when alias already exists
       const duplicate = Object.entries(this.persistence.aliases).find(([i, a]) => (item !== i) && (alias === a))
       if (duplicate) {
         f7.dialog.alert('Alias ' + alias + ' for item ' + item + ' already exists for item ' + duplicate[0])
         this.persistence.aliases[item] = ''
-        return
       }
-      this.persistence.aliases[item] = alias
     },
     deleteAlias (ev, item) {
       if (!this.editable) return
@@ -556,10 +559,7 @@ export default {
         swipeoutElement = swipeoutElement.parentElement
       }
       f7.swipeout.delete(swipeoutElement, () => {
-        const index = this.persistence.aliases.findIndex((k) => k === item)
-        if (index >= 0) {
-          this.persistence.aliases.splice(index, 1)
-        }
+        delete this.persistence.aliases[item]
       })
     },
     async validateAliases () {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -70,11 +70,11 @@
                       @click="showSwipeout" />
                   </template>
                   <template #title>
-                    <div v-if="configurationAllItemsTitle(cfg.items)">{{ configurationAllItemsTitle(cfg.items) }}</div>
-                    <div v-if="configurationGroupsTitle(cfg.items)">{{ configurationGroupsTitle(cfg.items) }}</div>
-                    <div v-if="configurationItemsTitle(cfg.items)">{{ configurationItemsTitle(cfg.items) }}</div>
-                    <div v-if="configurationGroupsTitle(cfg.items, true)">{{ configurationGroupsTitle(cfg.items, true) }}</div>
-                    <div v-if="configurationItemsTitle(cfg.items, true)">{{ configurationItemsTitle(cfg.items, true) }}</div>
+                    <div v-if="configurationAllItemsTitle(cfg.items)" v-text="configurationAllItemsTitle(cfg.items)" />
+                    <div v-if="configurationGroupsTitle(cfg.items)" v-text="configurationGroupsTitle(cfg.items)" />
+                    <div v-if="configurationItemsTitle(cfg.items)" v-text="configurationItemsTitle(cfg.items)" />
+                    <div v-if="configurationGroupsTitle(cfg.items, true)" v-text="configurationGroupsTitle(cfg.items, true)" />
+                    <div v-if="configurationItemsTitle(cfg.items, true)" v-text="configurationItemsTitle(cfg.items, true)" />
                   </template>
                   <template #footer>
                     <div v-if="cfg.strategies?.length">{{ configurationStrategiesTitle(cfg.strategies) }}</div>
@@ -97,7 +97,7 @@
                   link
                   no-chevron
                   media-item
-                  :color="(theme.dark) ? 'black' : 'white'"
+                  :color="useUiOptionsStore().darkMode"
                   subtitle="Add configuration"
                   @click="editConfiguration(undefined, null)">
                   <template #media>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -97,7 +97,7 @@
                   link
                   no-chevron
                   media-item
-                  :color="useUiOptionsStore().darkMode"
+                  :color="uiOptionsStore.darkMode"
                   subtitle="Add configuration"
                   @click="editConfiguration(undefined, null)">
                   <template #media>
@@ -305,6 +305,7 @@ import ConfigurationPopup from '@/pages/settings/persistence/configuration-popup
 import DefinitionsPopup from '@/pages/settings/persistence/definitions-popup.vue'
 
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
+import { useUIOptionsStore } from  '@/js/stores/useUIOptionsStore'
 import { usePersistenceEditStore } from '@/js/stores/usePersistenceEditStore'
 
 export default {
@@ -356,7 +357,7 @@ export default {
     suggestedStrategyNames () {
       return this.suggestedStrategies.map((ss) => ss.name)
     },
-    ...mapStores(useRuntimeStore),
+    ...mapStores(useRuntimeStore, useUIOptionsStore),
     ...mapState(usePersistenceEditStore, ['persistenceDirty', 'suggestedStrategies', 'editable', 'newPersistence']),
     ...mapWritableState(usePersistenceEditStore, ['persistence'])
   },

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -423,6 +423,7 @@ export default {
         `Are you sure you want to delete persistence configuration for ${this.serviceId}?`,
         'Delete persistence configuration',
         () => {
+          this.ready = false
           usePersistenceEditStore().deletePersistence()
           this.f7router.back({ force: true })
         }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -155,48 +155,46 @@
               </f7-list>
               <!-- Filters -->
               <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
-              <div v-for="ft in FilterTypes" :key="ft.name">
-                <f7-list :media-list="editable" swipeout>
-                  <f7-list-item
-                    v-for="(f, index) in persistence[ft.name]"
-                    :key="f.name"
-                    :title="f.name"
-                    :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
-                    :link="editable"
-                    @click="(ev) => editFilter(ev, ft, index, f)"
-                    swipeout>
-                    <template #media>
-                      <f7-link
-                        v-if="editable"
-                        icon-color="red"
-                        icon-aurora="f7:minus_circle_filled"
-                        icon-ios="f7:minus_circle_filled"
-                        icon-md="material:remove_circle_outline"
-                        @click="showSwipeout" />
-                    </template>
-                    <f7-swipeout-actions right v-if="editable">
-                      <f7-swipeout-button
-                        @click="(ev) => deleteFilter(ev, ft, index)"
-                        style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                        Delete
-                      </f7-swipeout-button>
-                    </f7-swipeout-actions>
-                  </f7-list-item>
-                </f7-list>
-                <f7-list v-if="editable">
-                  <f7-list-item
-                    link
-                    no-chevron
-                    media-item
-                    :color="(theme.dark) ? 'black' : 'white'"
-                    :subtitle="'Add ' + ft.label.toLowerCase() + ' filter'"
-                    @click="editFilter(undefined, ft, null)">
-                    <template #media>
-                      <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                    </template>
-                  </f7-list-item>
-                </f7-list>
-              </div>
+              <f7-list v-for="ft in FilterTypes" :key="ft.name" :media-list="editable" swipeout>
+                <f7-list-item
+                  v-for="(f, index) in persistence[ft.name]"
+                  :key="f.name"
+                  :title="f.name"
+                  :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
+                  :link="editable"
+                  @click="(ev) => editFilter(ev, ft, index, f)"
+                  swipeout>
+                  <template #media>
+                    <f7-link
+                      v-if="editable"
+                      icon-color="red"
+                      icon-aurora="f7:minus_circle_filled"
+                      icon-ios="f7:minus_circle_filled"
+                      icon-md="material:remove_circle_outline"
+                      @click="showSwipeout" />
+                  </template>
+                  <f7-swipeout-actions right v-if="editable">
+                    <f7-swipeout-button
+                      @click="(ev) => deleteFilter(ev, ft, index)"
+                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                      Delete
+                    </f7-swipeout-button>
+                  </f7-swipeout-actions>
+                </f7-list-item>
+              </f7-list>
+              <f7-list v-if="editable">
+                <f7-list-item
+                  link
+                  no-chevron
+                  media-item
+                  :color="(theme.dark) ? 'black' : 'white'"
+                  subtitle="Add filter"
+                  @click="openFilterTypePopup">
+                  <template #media>
+                    <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+                  </template>
+                </f7-list-item>
+              </f7-list>
             </f7-block>
             <f7-block>
               <!-- Aliases -->
@@ -283,6 +281,25 @@
       </f7-tab>
     </f7-tabs>
   </f7-page>
+
+  <f7-popup v-if="ready" v-model:opened="addFilterTypePopup"  class="filtertype-selection-popup">
+    <f7-page>
+      <f7-navbar title="Select Filter Type">
+        <f7-nav-right>
+          <f7-link popup-close>Close</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-list>
+        <f7-list-item
+          v-for="ft in FilterTypes"
+          :key="ft.name"
+          link
+          :title="ft.label"
+          @click="selectFilterType(ft)"
+        />
+      </f7-list>
+    </f7-page>
+  </f7-popup>
 </template>
 
 <style lang="stylus">
@@ -334,7 +351,7 @@
 </style>
 
 <script>
-import { defineAsyncComponent } from 'vue'
+import { nextTick, defineAsyncComponent } from 'vue'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
@@ -377,6 +394,7 @@ export default {
       currentConfiguration: null,
       currentCronStrategy: null,
       currentFilter: null,
+      addFilterTypePopup: false,
 
       notEditableMgs: 'This persistence configuration is not editable because it has been provisioned from a file.'
     }
@@ -601,6 +619,16 @@ export default {
         cfg.strategies.splice(i, 1)
       })
       this.deleteModule(ev, 'cronStrategies', index)
+    },
+    openFilterTypePopup () {
+      if (!this.editable) return
+      this.addFilterTypePopup = true
+    },
+    selectFilterType (filterType) {
+      this.addFilterTypePopup = false
+      nextTick(() => {
+        this.editFilter(undefined, filterType, null)
+      })
     },
     editFilter (ev, filterType, index, filter) {
       if (!this.editable) return

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -71,8 +71,6 @@
                 <f7-list-item
                   v-for="(cfg, index) in persistence.configs"
                   :key="cfg.items.join()"
-                  :title="cfg.items.join(', ')"
-                  :footer="cfg.strategies.join(', ') + (cfg.filters.length > 0 ? ' - ' + cfg.filters.join(', ') : '')"
                   :link="editable"
                   @click="(ev) => editConfiguration(ev, index, cfg)"
                   swipeout>
@@ -84,6 +82,17 @@
                       icon-ios="f7:minus_circle_filled"
                       icon-md="material:remove_circle_outline"
                       @click="showSwipeout" />
+                  </template>
+                  <template #title>
+                    <div v-if="configurationAllItemsTitle(cfg.items)">{{ configurationAllItemsTitle(cfg.items) }}</div>
+                    <div v-if="configurationGroupsTitle(cfg.items)">{{ configurationGroupsTitle(cfg.items) }}</div>
+                    <div v-if="configurationItemsTitle(cfg.items)">{{ configurationItemsTitle(cfg.items) }}</div>
+                    <div v-if="configurationGroupsTitle(cfg.items, true)">{{ configurationGroupsTitle(cfg.items, true) }}</div>
+                    <div v-if="configurationItemsTitle(cfg.items, true)">{{ configurationItemsTitle(cfg.items, true) }}</div>
+                  </template>
+                  <template #footer>
+                    <div v-if="cfg.strategies?.length">{{ configurationStrategiesTitle(cfg.strategies) }}</div>
+                    <div v-if="cfg.filters?.length">{{ configurationFiltersTitle(cfg.filters) }}</div>
                   </template>
                   <f7-swipeout-actions right v-if="editable">
                     <f7-swipeout-button
@@ -361,6 +370,7 @@ import ConfigurationPopup from '@/pages/settings/persistence/configuration-popup
 import FilterPopup from '@/pages/settings/persistence/filter-popup.vue'
 
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
+import { config } from 'blockly'
 
 export default {
   mixins: [DirtyMixin],
@@ -543,6 +553,39 @@ export default {
       if (swipeoutElement) {
         f7.swipeout.open(swipeoutElement)
       }
+    },
+    configurationAllItemsTitle (items) {
+      if (!items) return null
+      const itemList = items.filter((item) => item === '*')
+      return itemList.length ? 'All Items' : null
+    },
+    configurationGroupsTitle (items, exclude) {
+      if (!items) return null
+      let itemList = []
+      if (exclude) {
+        itemList = items.filter((item) => item.match(/^![^!*]+\*$/)).map((item) =>  item.slice(1, -1))
+      } else {
+        itemList = items.filter((item) => item.match(/^[^!*]+\*$/)).map((item) => item.slice(0, -1))
+      }
+      return itemList.length ? (exclude ? 'Not members of: ' : 'Members of: ') + itemList.join(', ') : null
+    },
+    configurationItemsTitle (items, exclude) {
+      if (!items) return null
+      let itemList = []
+      if (exclude) {
+        itemList = items.filter((item) => item.match(/^![^!*]+$/)).map((item) =>  item.slice(1))
+      } else {
+        itemList = items.filter((item) => item.match(/^[^!*]+$/))
+      }
+      return itemList.length ? (exclude ? 'Not : ' : '') + itemList.join(', ') : null
+    },
+    configurationStrategiesTitle (strategies) {
+      if (!(strategies && strategies.length)) return null
+      return strategies.join(', ')
+    },
+    configurationFiltersTitle (filters) {
+      if (!(filters && filters.length)) return null
+      return 'filters: ' + filters.join(', ')
     },
     editConfiguration (ev, index, configuration) {
       if (!this.editable) return

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -387,8 +387,7 @@ export default {
         serviceId: this.serviceId,
         configs: [],
         aliases: {},
-        cronStrategies: cronStrategies,
-        filters: []
+        cronStrategies: cronStrategies
       }
     },
     /**

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -357,7 +357,7 @@ export default {
       return this.suggestedStrategies.map((ss) => ss.name)
     },
     ...mapStores(useRuntimeStore),
-    ...mapState(usePersistenceEditStore, ['persistenceDirty', 'skipLoadOnReturn', 'suggestedStrategies', 'editable', 'newPersistence']),
+    ...mapState(usePersistenceEditStore, ['persistenceDirty', 'suggestedStrategies', 'editable', 'newPersistence']),
     ...mapWritableState(usePersistenceEditStore, ['persistence'])
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -396,7 +396,7 @@ export default {
         // Failed to load - go back or show error
         return
       }
-      
+
       // Success or new persistence - initialize if needed
       if (this.newPersistence) {
         this.initializeNewPersistence()

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -90,9 +90,7 @@
                 </f7-list-item>
               </f7-list>
               <f7-list v-else-if="!editable">
-                <f7-list-item>
-                  No configurations defined
-                </f7-list-item>
+                <f7-list-item> No configurations defined </f7-list-item>
               </f7-list>
               <f7-list v-if="editable">
                 <f7-list-item
@@ -147,9 +145,7 @@
                 </f7-list-item>
               </f7-list>
               <f7-list v-else-if="!editable">
-                <f7-list-item>
-                  No aliases defined
-                </f7-list-item>
+                <f7-list-item> No aliases defined </f7-list-item>
               </f7-list>
               <f7-list v-if="editable">
                 <f7-list-group>
@@ -511,7 +507,7 @@ export default {
           this.persistence.configs[this.currentConfigurationIndex] = updatedConfig
         }
       }
-      
+
       // Merge any new strategies/filters that were added in the nested popups
       if (persistenceWithUpdatedConfig.cronStrategies) {
         this.persistence.cronStrategies = persistenceWithUpdatedConfig.cronStrategies
@@ -607,7 +603,7 @@ export default {
           this.persistence[key] = persistenceWithUpdates[key]
         }
       })
-      
+
       this.dirty = true
     },
     onEditorInput (value) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -205,6 +205,7 @@
     :persistence="persistence"
     :configurationIndex="currentConfigurationIndex"
     :predefinedStrategies="PredefinedStrategies"
+    :suggestedStrategies="suggestedStrategyNames"
     @close="configurationPopupOpen = false"
     @configuration-update="saveConfiguration($event); configurationPopupOpen = false" />
 
@@ -351,10 +352,12 @@ export default {
     currentItemsWithAlias () {
       return Object.keys(this.persistence.aliases || {}).sort()
     },
+    suggestedStrategyNames () {
+      return this.suggestedStrategies.map((ss) => ss.name)
+    },
     ...mapStores(useRuntimeStore),
     ...mapState(usePersistenceEditStore, ['persistenceDirty', 'skipLoadOnReturn', 'suggestedStrategies', 'editable', 'newPersistence']),
     ...mapWritableState(usePersistenceEditStore, ['persistence'])
-
   },
   watch: {
     persistenceDirty: function () { this.dirty = this.persistenceDirty }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -293,14 +293,24 @@
 
   <f7-popup v-if="ready" v-model:opened="addFilterTypePopup" class="filtertype-selection-popup">
     <f7-page>
-      <f7-navbar title="Select Filter Type">
+      <f7-navbar title="Configure Filter">
         <f7-nav-right>
           <f7-link popup-close>Close</f7-link>
         </f7-nav-right>
       </f7-navbar>
-      <f7-list>
-        <f7-list-item v-for="ft in FilterTypes" :key="ft.name" link :title="ft.label" @click="selectFilterType(ft)" />
-      </f7-list>
+      <f7-block-title class="no-margin padding-horizontal margin-vertical" medium>
+        Filter Type
+      </f7-block-title>
+      <f7-block>
+        <f7-row v-for="ftRow in filtersMatrix" :key="ftRow" class="margin-bottom">
+          <f7-col v-for="ft in ftRow" :key="ft.name" class="elevation-2 elevation-hover-6 elevation-pressed-1 persistence-filter-big-button" width="50">
+            <f7-link class="display-flex flex-direction-column no-ripple" no-ripple @click="selectFilterType(ft)">
+              <f7-icon size="35" :f7="ft.icon" class="margin" />
+              {{ ft.label }}<br />Filter
+            </f7-link>
+          </f7-col>
+        </f7-row>
+      </f7-block>
     </f7-page>
   </f7-popup>
 </template>
@@ -349,6 +359,13 @@
   padding-left: calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-left))
   .item-inner::before
     visibility: hidden
+
+.persistence-filter-big-button
+  background var(--f7-card-bg-color)
+  text-align center
+  height 7.5rem
+  .link
+    color var(--f7-text-color)
 
 .persistence-code-editor.v-codemirror
   position absolute
@@ -425,6 +442,14 @@ export default {
         if (this.persistence[filterTypeName]) names = names.concat(this.persistence[filterTypeName].map((f) => f.name))
       }
       return names
+    },
+    filtersMatrix () {
+      const matrix = []
+      const columns = 2
+      for (let i = 0; i < FilterTypes.length; i += columns) {
+        matrix.push(FilterTypes.slice(i, i + columns))
+      }
+      return matrix
     },
     currentItemsWithAlias () {
       return Object.keys(this.persistence.aliases).sort()

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -701,13 +701,26 @@ export default {
       this.saveModule('cronStrategies', index, cronStrategy)
     },
     deleteCronStrategy (ev, index) {
-      // Remove cron strategy from configs, otherwise we get a 400
       const csName = this.persistence.cronStrategies[index].name
-      this.persistence.configs.forEach((cfg) => {
-        const i = cfg.strategies.findIndex((cs) => cs === csName)
-        cfg.strategies.splice(i, 1)
-      })
-      this.deleteModule(ev, 'cronStrategies', index)
+      // Check if filter is used and show dialog if so
+      if (this.isUsedCronStrategy(csName)) {
+        f7.dialog.confirm(
+          'Cron strategy used in configuration(s), delete usage and definition?',
+          () => {
+            // Remove cron strategy from configs, otherwise we get a 400
+            this.persistence.configs.forEach((cfg) => {
+              const i = cfg.strategies.findIndex((cs) => cs === csName)
+              cfg.strategies.splice(i, 1)
+            })
+            this.deleteModule(ev, 'cronStrategies', index)
+          }
+        )
+      } else {
+        this.deleteModule(ev, 'cronStrategies', index)
+      }
+    },
+    isUsedCronstrategy (csName) {
+      return this.persistence.configs.findIndex((cfg) => cfg.strategies.findIndex((cs) => cs === csName) >= 0) >= 0
     },
     openFilterTypePopup () {
       if (!this.editable) return
@@ -760,13 +773,26 @@ export default {
       this.saveModule(filterTypeName, index, filter)
     },
     deleteFilter (ev, module, index) {
-      // Remove filter from configs, otherwise we get a 400
       const filterName = this.persistence[module.name][index].name
-      this.persistence.configs.forEach((cfg) => {
-        const i = cfg.filters.findIndex((f) => f === filterName)
-        if (i > -1) cfg.filters.splice(i, 1)
-      })
-      this.deleteModule(ev, module.name, index)
+      // Check if filter is used and show dialog if so
+      if (this.isUsedFilter(filterName)) {
+        f7.dialog.confirm(
+          'Filter used in configuration(s), delete usage and definition?',
+          () => {
+            // Remove filter from configs, otherwise we get a 400
+            this.persistence.configs.forEach((cfg) => {
+              const i = cfg.filters.findIndex((f) => f === filterName)
+              if (i > -1) cfg.filters.splice(i, 1)
+            })
+            this.deleteModule(ev, module.name, index)
+          }
+        )
+      } else {
+        this.deleteModule(ev, module.name, index)
+      }
+    },
+    isUsedFilter (filterName) {
+      return this.persistence.configs.findIndex((cfg) => cfg.filters.findIndex((f) => f === filterName) >= 0) >= 0
     },
     updateAliasItems (items) {
       if (!this.editable) return

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -315,6 +315,8 @@
 .modules
   width 100%
   .block
+    padding-left var(--f7-safe-area-left)
+    padding-right var(--f7-safe-area-right)
     .block-title
       padding-left calc(var(--f7-block-padding-horizontal) + var(--f7-safe-area-left))
     .block-header

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -644,12 +644,12 @@ export default {
     },
     deleteFilter (ev, module, index) {
       // Remove filter from configs, otherwise we get a 400
-      const filterName = this.persistence[module][index].name
+      const filterName = this.persistence[module.name][index].name
       this.persistence.configs.forEach((cfg) => {
         const i = cfg.filters.findIndex((f) => f === filterName)
         if (i > -1) cfg.filters.splice(i, 1)
       })
-      this.deleteModule(ev, module, index)
+      this.deleteModule(ev, module.name, index)
     },
     updateAliasItems (items) {
       if (!this.editable) return

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -118,94 +118,6 @@
               </f7-list>
             </f7-block>
             <f7-block>
-              <f7-block-title medium> Definitions </f7-block-title>
-              <f7-block-header> Cron strategy and filter definitions used in a persistence configuration. </f7-block-header>
-              <!-- Cron Strategies -->
-              <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Cron Strategies </f7-block-title>
-              <f7-list :media-list="editable" swipeout>
-                <f7-list-item
-                  v-for="(cs, index) in persistence.cronStrategies"
-                  :key="cs.name"
-                  :title="cs.name"
-                  :footer="cs.cronExpression"
-                  :link="editable"
-                  @click="(ev) => editCronStrategy(ev, index, cs)"
-                  swipeout>
-                  <template #media>
-                    <f7-link
-                      v-if="editable"
-                      icon-color="red"
-                      icon-aurora="f7:minus_circle_filled"
-                      icon-ios="f7:minus_circle_filled"
-                      icon-md="material:remove_circle_outline"
-                      @click="showSwipeout" />
-                  </template>
-                  <f7-swipeout-actions right v-if="editable">
-                    <f7-swipeout-button
-                      @click="(ev) => deleteCronStrategy(ev, index)"
-                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                      Delete
-                    </f7-swipeout-button>
-                  </f7-swipeout-actions>
-                </f7-list-item>
-              </f7-list>
-              <f7-list v-if="editable">
-                <f7-list-item
-                  link
-                  no-chevron
-                  media-item
-                  :color="(theme.dark) ? 'black' : 'white'"
-                  subtitle="Add cron strategy"
-                  @click="editCronStrategy(undefined, null)">
-                  <template #media>
-                    <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                  </template>
-                </f7-list-item>
-              </f7-list>
-              <!-- Filters -->
-              <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
-              <f7-list v-for="ft in FilterTypes" :key="ft.name" :media-list="editable" swipeout>
-                <f7-list-item
-                  v-for="(f, index) in persistence[ft.name]"
-                  :key="f.name"
-                  :title="f.name"
-                  :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
-                  :link="editable"
-                  @click="(ev) => editFilter(ev, ft, index, f)"
-                  swipeout>
-                  <template #media>
-                    <f7-link
-                      v-if="editable"
-                      icon-color="red"
-                      icon-aurora="f7:minus_circle_filled"
-                      icon-ios="f7:minus_circle_filled"
-                      icon-md="material:remove_circle_outline"
-                      @click="showSwipeout" />
-                  </template>
-                  <f7-swipeout-actions right v-if="editable">
-                    <f7-swipeout-button
-                      @click="(ev) => deleteFilter(ev, ft, index)"
-                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                      Delete
-                    </f7-swipeout-button>
-                  </f7-swipeout-actions>
-                </f7-list-item>
-              </f7-list>
-              <f7-list v-if="editable">
-                <f7-list-item
-                  link
-                  no-chevron
-                  media-item
-                  :color="(theme.dark) ? 'black' : 'white'"
-                  subtitle="Add filter"
-                  @click="openFilterTypePopup">
-                  <template #media>
-                    <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                  </template>
-                </f7-list-item>
-              </f7-list>
-            </f7-block>
-            <f7-block>
               <!-- Aliases -->
               <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Aliases </f7-block-title>
               <f7-block-header style="padding-right: 16px">Item names mapped to aliases used in persistence store.</f7-block-header>
@@ -262,9 +174,10 @@
               </f7-list>
             </f7-block>
           </f7-col>
-          <f7-col v-if="editable && !newPersistence">
+          <f7-col v-if="editable" class="persistence-config-links">
             <f7-list>
-              <f7-list-button color="red" @click="deletePersistence"> Remove persistence configuration </f7-list-button>
+              <f7-list-button color="blue" @click="manageDefinitionsPopup = true"> Manage definitions </f7-list-button>
+              <f7-list-button v-if="!newPersistence" color="red" @click="deletePersistence"> Remove persistence configuration </f7-list-button>
             </f7-list>
           </f7-col>
         </f7-block>
@@ -290,6 +203,104 @@
       </f7-tab>
     </f7-tabs>
   </f7-page>
+
+  <f7-popup v-if="ready" v-model:opened="manageDefinitionsPopup" class="persistence-definitions-popup">
+    <f7-page>
+      <f7-navbar title="Manage Definitions">
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" popup-close />
+        </f7-nav-left>
+      </f7-navbar>
+      <f7-block>
+        <f7-block-title medium> Definitions </f7-block-title>
+        <f7-block-header> Cron strategy and filter definitions used in a persistence configuration. </f7-block-header>
+        <!-- Cron Strategies -->
+        <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Cron Strategies </f7-block-title>
+        <f7-list media-list swipeout>
+          <f7-list-item
+            v-for="(cs, index) in persistence.cronStrategies"
+            :key="cs.name"
+            :title="cs.name"
+            :footer="cs.cronExpression"
+            :link="editable"
+            @click="(ev) => editCronStrategy(ev, index, cs)"
+            swipeout>
+            <template #media>
+              <f7-link
+                v-if="editable"
+                icon-color="red"
+                icon-aurora="f7:minus_circle_filled"
+                icon-ios="f7:minus_circle_filled"
+                icon-md="material:remove_circle_outline"
+                @click="showSwipeout" />
+            </template>
+            <f7-swipeout-actions right v-if="editable">
+              <f7-swipeout-button
+                @click="(ev) => deleteCronStrategy(ev, index)"
+                style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                Delete
+              </f7-swipeout-button>
+            </f7-swipeout-actions>
+          </f7-list-item>
+        </f7-list>
+        <f7-list>
+          <f7-list-item
+            link
+            no-chevron
+            media-item
+            :color="(theme.dark) ? 'black' : 'white'"
+            subtitle="Add cron strategy"
+            @click="editCronStrategy(undefined, null)">
+            <template #media>
+              <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+            </template>
+          </f7-list-item>
+        </f7-list>
+        <!-- Filters -->
+        <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
+        <f7-list v-for="ft in FilterTypes" :key="ft.name" :media-list="editable" swipeout>
+          <f7-list-item
+            v-for="(f, index) in persistence[ft.name]"
+            :key="f.name"
+            :title="f.name"
+            :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
+            :link="editable"
+            @click="(ev) => editFilter(ev, ft, index, f)"
+            swipeout>
+            <template #media>
+              <f7-link
+                v-if="editable"
+                icon-color="red"
+                icon-aurora="f7:minus_circle_filled"
+                icon-ios="f7:minus_circle_filled"
+                icon-md="material:remove_circle_outline"
+                @click="showSwipeout" />
+            </template>
+            <f7-swipeout-actions right v-if="editable">
+              <f7-swipeout-button
+                @click="(ev) => deleteFilter(ev, ft, index)"
+                style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                Delete
+              </f7-swipeout-button>
+            </f7-swipeout-actions>
+          </f7-list-item>
+        </f7-list>
+        <f7-list>
+          <f7-list-item
+            link
+            no-chevron
+            media-item
+            :color="(theme.dark) ? 'black' : 'white'"
+            subtitle="Add filter"
+            @click="openFilterTypePopup">
+            <template #media>
+              <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+            </template>
+          </f7-list-item>
+        </f7-list>
+      </f7-block>
+    </f7-page>
+  </f7-popup>
 
   <f7-popup v-if="ready" v-model:opened="addFilterTypePopup" class="filtertype-selection-popup">
     <f7-page>
@@ -360,6 +371,19 @@
   .item-inner::before
     visibility: hidden
 
+.persistence-config-links
+  margin-top: 2.5rem
+
+.persistence-definitions-popup
+  .block
+    padding-left var(--f7-safe-area-left)
+    padding-right var(--f7-safe-area-right)
+  .media-list
+    margin-bottom 0
+  .list
+    margin-top 0
+    margin-bottom 0
+
 .persistence-filter-big-button
   background var(--f7-card-bg-color)
   text-align center
@@ -417,6 +441,7 @@ export default {
       currentConfiguration: null,
       currentCronStrategy: null,
       currentFilter: null,
+      manageDefinitionsPopup: false,
       addFilterTypePopup: false,
 
       notEditableMgs: 'This persistence configuration is not editable because it has been provisioned from a file.'

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -292,7 +292,7 @@
 
 <script>
 import { defineAsyncComponent } from 'vue'
-import { f7, theme } from 'framework7-vue'
+import { f7 } from 'framework7-vue'
 import { mapState, mapWritableState, mapStores } from 'pinia'
 
 import YAML from 'yaml'
@@ -318,9 +318,6 @@ export default {
   props: {
     serviceId: String,
     f7router: Object
-  },
-  setup () {
-    return { theme }
   },
   data () {
     return {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -462,7 +462,7 @@ export default {
       } else {
         itemList = items.filter((item) => item.match(/^[^!*]+$/))
       }
-      return itemList.length ? (exclude ? 'Not : ' : '') + itemList.join(', ') : null
+      return itemList.length ? (exclude ? 'Not: ' : '') + itemList.join(', ') : null
     },
     configurationStrategiesTitle (strategies) {
       if (!(strategies && strategies.length)) return null

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -282,7 +282,7 @@
     </f7-tabs>
   </f7-page>
 
-  <f7-popup v-if="ready" v-model:opened="addFilterTypePopup"  class="filtertype-selection-popup">
+  <f7-popup v-if="ready" v-model:opened="addFilterTypePopup" class="filtertype-selection-popup">
     <f7-page>
       <f7-navbar title="Select Filter Type">
         <f7-nav-right>
@@ -290,13 +290,7 @@
         </f7-nav-right>
       </f7-navbar>
       <f7-list>
-        <f7-list-item
-          v-for="ft in FilterTypes"
-          :key="ft.name"
-          link
-          :title="ft.label"
-          @click="selectFilterType(ft)"
-        />
+        <f7-list-item v-for="ft in FilterTypes" :key="ft.name" link :title="ft.label" @click="selectFilterType(ft)" />
       </f7-list>
     </f7-page>
   </f7-popup>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -368,6 +368,7 @@ export default {
       this.load()
     },
     onPageBeforeOut () {
+      this.ready = false
       if (window) {
         window.removeEventListener('keydown', this.keyDown)
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -27,37 +27,34 @@
         <!-- Skeletons for not ready -->
         <f7-block v-if="!ready" class="block-narrow">
           <f7-col class="modules">
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Configuration </f7-block-title>
+            <f7-block>
+              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Configurations </f7-block-title>
+              <f7-block-header style="padding-right: 16px"> Items to persist with strategies to use. </f7-block-header>
               <f7-list class="skeleton-text skeleton-effect-blink">
                 <f7-list-item />
               </f7-list>
-            </div>
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Strategies </f7-block-title>
+            </f7-block>
+            <f7-block>
+              <f7-block-title medium> Definitions </f7-block-title>
+              <f7-block-header> Cron strategy and filter definitions used in a persistence configuration. </f7-block-header>
+              <!-- Cron Strategies -->
+              <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Cron Strategies </f7-block-title>
               <f7-list class="skeleton-text skeleton-effect-blink">
                 <f7-list-item />
               </f7-list>
-              <!-- Default Strategies -->
-              <strategy-picker title="Default Strategies" class="skeleton-text skeleton-effect-blink" />
-            </div>
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
-              <div v-for="ft in FilterTypes" :key="ft.name">
-                <f7-block-title>
-                  {{ ft.label }}
-                </f7-block-title>
-                <f7-list class="skeleton-text skeleton-effect-blink">
-                  <f7-list-item />
-                </f7-list>
-              </div>
-            </div>
-            <div>
+              <!-- Filters -->
+              <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
+              <f7-list class="skeleton-text skeleton-effect-blink">
+                <f7-list-item />
+              </f7-list>
+            </f7-block>
+            <f7-block>
               <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Aliases </f7-block-title>
+              <f7-block-header style="padding-right: 16px">Item names mapped to aliases used in persistence store.</f7-block-header>
               <f7-list class="skeleton-text skeleton-effect-blink">
                 <f7-list-item />
               </f7-list>
-            </div>
+            </f7-block>
           </f7-col>
         </f7-block>
 
@@ -67,8 +64,9 @@
           </f7-col>
           <f7-col class="modules">
             <!-- Configuration -->
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Configuration </f7-block-title>
+            <f7-block>
+              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Configurations </f7-block-title>
+              <f7-block-header style="padding-right: 16px"> Items to persist with strategies to use. </f7-block-header>
               <f7-list :media-list="editable" swipeout>
                 <f7-list-item
                   v-for="(cfg, index) in persistence.configs"
@@ -109,11 +107,12 @@
                   </template>
                 </f7-list-item>
               </f7-list>
-            </div>
-            <!-- Strategies -->
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Strategies </f7-block-title>
+            </f7-block>
+            <f7-block>
+              <f7-block-title medium> Definitions </f7-block-title>
+              <f7-block-header> Cron strategy and filter definitions used in a persistence configuration. </f7-block-header>
               <!-- Cron Strategies -->
+              <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Cron Strategies </f7-block-title>
               <f7-list :media-list="editable" swipeout>
                 <f7-list-item
                   v-for="(cs, index) in persistence.cronStrategies"
@@ -155,58 +154,54 @@
                 </f7-list-item>
               </f7-list>
               <!-- Filters -->
-              <div>
-                <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
-                <div v-for="ft in FilterTypes" :key="ft.name">
-                  <f7-block-title>
-                    {{ ft.label }}
-                  </f7-block-title>
-                  <f7-list :media-list="editable" swipeout>
-                    <f7-list-item
-                      v-for="(f, index) in persistence[ft.name]"
-                      :key="f.name"
-                      :title="f.name"
-                      :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
-                      :link="editable"
-                      @click="(ev) => editFilter(ev, ft, index, f)"
-                      swipeout>
-                      <template #media>
-                        <f7-link
-                          v-if="editable"
-                          icon-color="red"
-                          icon-aurora="f7:minus_circle_filled"
-                          icon-ios="f7:minus_circle_filled"
-                          icon-md="material:remove_circle_outline"
-                          @click="showSwipeout" />
-                      </template>
-                      <f7-swipeout-actions right v-if="editable">
-                        <f7-swipeout-button
-                          @click="(ev) => deleteFilter(ev, ft.name, index)"
-                          style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                          Delete
-                        </f7-swipeout-button>
-                      </f7-swipeout-actions>
-                    </f7-list-item>
-                  </f7-list>
-                  <f7-list v-if="editable">
-                    <f7-list-item
-                      link
-                      no-chevron
-                      media-item
-                      :color="(theme.dark) ? 'black' : 'white'"
-                      :subtitle="'Add ' + ft.label.toLowerCase() + ' filter'"
-                      @click="editFilter(undefined, ft, null)">
-                      <template #media>
-                        <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                      </template>
-                    </f7-list-item>
-                  </f7-list>
-                </div>
+              <f7-block-title small style="margin-bottom: var(--f7-list-margin-vertical)"> Filters </f7-block-title>
+              <div v-for="ft in FilterTypes" :key="ft.name">
+                <f7-list :media-list="editable" swipeout>
+                  <f7-list-item
+                    v-for="(f, index) in persistence[ft.name]"
+                    :key="f.name"
+                    :title="f.name"
+                    :footer="(typeof ft.footerFn === 'function') ? ft.footerFn(f) : ''"
+                    :link="editable"
+                    @click="(ev) => editFilter(ev, ft, index, f)"
+                    swipeout>
+                    <template #media>
+                      <f7-link
+                        v-if="editable"
+                        icon-color="red"
+                        icon-aurora="f7:minus_circle_filled"
+                        icon-ios="f7:minus_circle_filled"
+                        icon-md="material:remove_circle_outline"
+                        @click="showSwipeout" />
+                    </template>
+                    <f7-swipeout-actions right v-if="editable">
+                      <f7-swipeout-button
+                        @click="(ev) => deleteFilter(ev, ft, index)"
+                        style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                        Delete
+                      </f7-swipeout-button>
+                    </f7-swipeout-actions>
+                  </f7-list-item>
+                </f7-list>
+                <f7-list v-if="editable">
+                  <f7-list-item
+                    link
+                    no-chevron
+                    media-item
+                    :color="(theme.dark) ? 'black' : 'white'"
+                    :subtitle="'Add ' + ft.label.toLowerCase() + ' filter'"
+                    @click="editFilter(undefined, ft, null)">
+                    <template #media>
+                      <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+                    </template>
+                  </f7-list-item>
+                </f7-list>
               </div>
-            </div>
-            <!-- Aliases -->
-            <div>
+            </f7-block>
+            <f7-block>
+              <!-- Aliases -->
               <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Aliases </f7-block-title>
+              <f7-block-header style="padding-right: 16px">Item names mapped to aliases used in persistence store.</f7-block-header>
               <f7-list :media-list="editable" swipeout no-swipeout-opened>
                 <f7-list-item v-for="(i, index) in currentItemsWithAlias" class="swipeout list-alias-item" :key="i">
                   <template #media>
@@ -258,7 +253,7 @@
                     @input="updateAliasItems($event)" />
                 </f7-list-group>
               </f7-list>
-            </div>
+            </f7-block>
           </f7-col>
           <f7-col v-if="editable && !newPersistence">
             <f7-list>
@@ -298,6 +293,13 @@
     margin-top 0 !important
 
 .modules
+  width 100%
+  .block
+    .block-title
+      padding-left calc(var(--f7-block-padding-horizontal) + var(--f7-safe-area-left))
+    .block-header
+      padding-left calc(var(--f7-block-padding-horizontal) + var(--f7-safe-area-left))
+      padding-right calc(var(--f7-block-padding-horizontal) + var(--f7-safe-area-right))
   .swipeout-opened
     .sortable-handler
       display none
@@ -307,6 +309,7 @@
     margin-bottom 0
   .list
     margin-top 0
+    margin-bottom 0
 
 .list-alias-item .item-content .item-inner
   display: flex
@@ -322,6 +325,8 @@
     text-align: right
 .alias-item-picker .item-picker .item-content
   padding-left: calc(var(--f7-list-item-padding-horizontal) + var(--f7-safe-area-left))
+  .item-inner::before
+    visibility: hidden
 
 .persistence-code-editor.v-codemirror
   position absolute
@@ -341,7 +346,6 @@ import DirtyMixin from '../dirty-mixin'
 import { FilterTypes, PredefinedStrategies, CommonCronStrategies } from '@/assets/definitions/persistence'
 import CronStrategyPopup from '@/pages/settings/persistence/cron-strategy-popup.vue'
 import ItemPicker from '@/components/config/controls/item-picker.vue'
-import StrategyPicker from '@/pages/settings/persistence/strategy-picker.vue'
 import ConfigurationPopup from '@/pages/settings/persistence/configuration-popup.vue'
 import FilterPopup from '@/pages/settings/persistence/filter-popup.vue'
 
@@ -351,7 +355,6 @@ export default {
   mixins: [DirtyMixin],
   components: {
     ItemPicker,
-    StrategyPicker,
     editor: defineAsyncComponent(() => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue'))
   },
   props: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -205,7 +205,6 @@
     v-model:opened="configurationPopupOpen"
     :persistence="persistence"
     :configurationIndex="currentConfigurationIndex"
-    :predefinedStrategies="PredefinedStrategies"
     :suggestedStrategies="suggestedStrategyNames"
     @close="configurationPopupOpen = false"
     @configuration-update="saveConfiguration($event); configurationPopupOpen = false" />
@@ -292,14 +291,14 @@
 </style>
 
 <script>
-import { nextTick, defineAsyncComponent } from 'vue'
+import { defineAsyncComponent } from 'vue'
 import { f7, theme } from 'framework7-vue'
 import { mapState, mapWritableState, mapStores } from 'pinia'
 
 import YAML from 'yaml'
 
 import DirtyMixin from '../dirty-mixin'
-import { FilterTypes, PredefinedStrategies, CommonCronStrategies } from '@/assets/definitions/persistence'
+import { FilterTypes, CommonCronStrategies } from '@/assets/definitions/persistence'
 import ItemPicker from '@/components/config/controls/item-picker.vue'
 import ConfigurationPopup from '@/pages/settings/persistence/configuration-popup.vue'
 import DefinitionsPopup from '@/pages/settings/persistence/definitions-popup.vue'
@@ -673,7 +672,6 @@ export default {
     }
   },
   created () {
-    this.PredefinedStrategies = PredefinedStrategies
     this.FilterTypes = FilterTypes
     this.CommonCronStrategies = CommonCronStrategies
   }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -395,23 +395,23 @@ export default {
     /**
      * Load required data from the REST API.
      */
-    load () {
-      const loadingFinished = (success) => {
-        if (!success) return
-
-        nextTick(() => {
-          if (this.newPersistence) {
-            this.initializeNewPersistence()
-          }
-          if (this.FilterTypes && this.persistence) {
-            this.FilterTypes.forEach((ft) => {
-              if (!this.persistence[ft.name]) this.persistence[ft.name] = []
-            })
-          }
-          this.ready = true
+    async load () {
+      const success = await usePersistenceEditStore().loadPersistence(this.serviceId)
+      if (!success) {
+        // Failed to load - go back or show error
+        return
+      }
+      
+      // Success or new persistence - initialize if needed
+      if (this.newPersistence) {
+        this.initializeNewPersistence()
+      }
+      if (this.FilterTypes && this.persistence) {
+        this.FilterTypes.forEach((ft) => {
+          if (!this.persistence[ft.name]) this.persistence[ft.name] = []
         })
       }
-      usePersistenceEditStore().loadPersistence(this.serviceId, loadingFinished)
+      this.ready = true
     },
     async save () {
       if (!this.editable) return

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -35,7 +35,7 @@
             link="/addons/persistence/"
             no-chevron
             media-item
-            :color="theme.dark ? 'black' : 'white'"
+            :color="uiOptionsStore.darkMode"
             subtitle="Install more persistence add-ons">
             <template #media>
               <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
@@ -72,7 +72,7 @@
 
 <script>
 import { nextTick } from 'vue'
-import { f7, theme } from 'framework7-vue'
+import { f7 } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
 import DirtyMixin from '../dirty-mixin'
@@ -80,6 +80,7 @@ import ConfigSheet from '@/components/config/config-sheet.vue'
 import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
 
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
+import { useUIOptionsStore } from  '@/js/stores/useUIOptionsStore'
 
 export default {
   mixins: [DirtyMixin],
@@ -89,9 +90,6 @@ export default {
   },
   props: {
     f7router: Object
-  },
-  setup () {
-    return { theme }
   },
   data () {
     return {
@@ -104,7 +102,7 @@ export default {
     }
   },
   computed: {
-    ...mapStores(useRuntimeStore)
+    ...mapStores(useRuntimeStore, useUIOptionsStore)
   },
   watch: {
     config: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
@@ -26,7 +26,7 @@
           no-chevron
           media-item
           :color="(theme.dark) ? 'black' : 'white'"
-          subtitle="Add cron strategy"
+          subtitle="Add cron strategy definition"
           @click="openCronPopup">
           <template #media>
             <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
@@ -25,7 +25,7 @@
           link
           no-chevron
           media-item
-          :color="(theme.dark) ? 'black' : 'white'"
+          :color="uiOptionsStore.darkMode"
           subtitle="Add cron strategy definition"
           @click="openCronPopup">
           <template #media>
@@ -44,8 +44,10 @@
 </template>
 
 <script>
-import { theme } from 'framework7-vue'
+import { mapStores } from 'pinia'
+
 import CronStrategyPopup from '@/pages/settings/persistence/cron-strategy-popup.vue'
+import { useUIOptionsStore } from  '@/js/stores/useUIOptionsStore'
 
 export default {
   components: { CronStrategyPopup },
@@ -66,9 +68,8 @@ export default {
     }
   },
   computed: {
-    theme () {
-      return theme
-    }
+    ...mapStores(useUIOptionsStore)
+
   },
   watch: {
     value: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
@@ -1,63 +1,108 @@
 <template>
-  <f7-list class="strategy-picker-container" v-if="strategies">
-    <f7-list-item
-      :title="title"
-      :smart-select="disabled !== true"
-      :smart-select-params="smartSelectParams"
-      ref="smartSelect"
-      class="defaults-picker">
-      <select v-if="disabled !== true" :name="name" multiple @change="select">
-        <option v-for="s in strategies" :key="s" :value="s" :selected="value.length ? value.includes(s) : null">
-          {{ s }}
-        </option>
-      </select>
-      <div v-else>
-        {{ value.join(', ') }}
-      </div>
+  <f7-list class="module-picker-container">
+    <f7-list-item :title="title" class="defaults-picker" @click="popupOpened = true">
+      <template #after>
+        <div>{{ localValue.join(', ') }}<f7-icon f7="chevron_right" style="margin-left: 8px;"></f7-icon></div>
+      </template>
     </f7-list-item>
   </f7-list>
+
+  <f7-popup v-model:opened="popupOpened">
+    <f7-page>
+      <f7-navbar :title="title">
+        <f7-nav-left>
+          <f7-link icon-ios="f7:arrow_left" icon-md="material:arrow_back" icon-aurora="f7:arrow_left" @click="popupOpened = false" />
+        </f7-nav-left>
+        <f7-nav-right>
+          <f7-link @click="onDone">Done</f7-link>
+        </f7-nav-right>
+      </f7-navbar>
+      <f7-list class="module-picker-container popup-list">
+        <f7-list-item v-for="s in localStrategies" :key="s" checkbox :checked="localValue.includes(s)" @change="toggleStrategy(s)">
+          {{ s }}
+        </f7-list-item>
+        <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add cron strategy" @click="openCronPopup">
+          <template #media>
+            <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+          </template>
+        </f7-list-item>
+      </f7-list>
+    </f7-page>
+  </f7-popup>
+
+  <cron-strategy-popup
+    v-model:opened="cronStrategyPopupOpen"
+    :persistence="persistence"
+    @close="cronStrategyPopupOpen = false"
+    @cron-strategy-config-update="handleCronStrategyUpdate($event)" />
 </template>
 
-<style lang="stylus">
-.strategy-picker-container
-  .item-content
-    padding-left calc(var(--f7-list-item-padding-horizontal) / 2 + var(--f7-safe-area-left))
-  .item-media
-    padding 0
-  .item-inner:after
-    display none
-  .item-title
-    padding-left 8px
-</style>
-
 <script>
-import { f7 } from 'framework7-vue'
+import { theme } from 'framework7-vue'
+import CronStrategyPopup from '@/pages/settings/persistence/cron-strategy-popup.vue'
 
 export default {
+  components: { CronStrategyPopup },
   props: {
     title: String,
-    name: String,
     strategies: Array,
     value: Array,
-    suggested: Array,
-    disabled: Boolean
+    persistence: Object
   },
-  emits: ['strategies-selected'],
+  emits: ['strategiesSelected'],
   data () {
     return {
-      smartSelectParams: {
-        view: f7.view.main,
-        openIn: 'popup'
-      }
+      popupOpened: false,
+      cronStrategyPopupOpen: false,
+
+      localStrategies: this.strategies || [],
+      localValue: [...this.value]
+    }
+  },
+  computed: {
+    theme () {
+      return theme
+    }
+  },
+  watch: {
+    value: {
+      handler (newVal) {
+        this.localValue = [...newVal]
+      },
+      immediate: true
+    },
+    strategies: {
+      handler (newVal) {
+        this.localStrategies = newVal || []
+      },
+      immediate: true
     }
   },
   methods: {
-    select () {
-      f7.input.validateInputs(this.$refs.smartSelect.$el)
-      const smartSelect = this.$refs.smartSelect.$el.children[0].f7SmartSelect
-      const value = smartSelect.getValue()
-      if (value === this.value || ((value.length === this.value.length) && value.reduce((av, cv) => { return av || this.value?.includes(cv) }, true))) return
-      this.$emit('strategies-selected', value)
+    toggleStrategy (strategy) {
+      if (this.localValue.includes(strategy)) {
+        this.localValue = this.localValue.filter(s => s !== strategy)
+      } else {
+        this.localValue = [...this.localValue, strategy]
+      }
+    },
+    openCronPopup () {
+      this.cronStrategyPopupOpen = true
+    },
+    handleCronStrategyUpdate (ev) {
+      const strategyName = ev.name
+      // Update localValue FIRST so the new item will be checked when the list re-renders
+      if (!this.localValue.includes(strategyName)) {
+        this.localValue = [...this.localValue, strategyName]
+      }
+      // Then add to available strategies
+      if (!this.localStrategies.includes(strategyName)) {
+        this.localStrategies = [...this.localStrategies, strategyName]
+      }
+    },
+    onDone () {
+      this.$emit('strategiesSelected', this.localValue)
+      this.popupOpened = false
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/strategy-picker.vue
@@ -21,7 +21,13 @@
         <f7-list-item v-for="s in localStrategies" :key="s" checkbox :checked="localValue.includes(s)" @change="toggleStrategy(s)">
           {{ s }}
         </f7-list-item>
-        <f7-list-item link no-chevron media-item :color="(theme.dark) ? 'black' : 'white'" subtitle="Add cron strategy" @click="openCronPopup">
+        <f7-list-item
+          link
+          no-chevron
+          media-item
+          :color="(theme.dark) ? 'black' : 'white'"
+          subtitle="Add cron strategy"
+          @click="openCronPopup">
           <template #media>
             <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
           </template>


### PR DESCRIPTION
There has been feedback on the forum that the persistence configuration UI is not very transparent, and one needs to read the manual to understand what is going on.

This PR amends the UI to make a distinction between real persistence configuration (item, strategy and filter selections that define what will be persisted + aliases) and definitions for cron strategies and filters that can afterwards be selected. The definitions are considered to be on an extra level and not presented to the user immediately in the same screen.

Below are a few screenshots.

Main persistence configuration screen:


<img width="526" height="892" alt="image" src="https://github.com/user-attachments/assets/efbdaf4e-c1b0-4d23-8e1e-f5d54d2506f9" />


Configurations screen for one configuration (no visual change from before):


<img width="523" height="941" alt="image" src="https://github.com/user-attachments/assets/96f34428-b414-483f-abc9-257f7537bd65" />


Select strategies and select filters options on the configuration screen will now have an option to create and immediately select a cron strategy definition or filter definition:


<img width="514" height="390" alt="image" src="https://github.com/user-attachments/assets/7d037cfa-38ef-43c6-9377-29dee706ff88" />


When creating a new filter, the filter type has to be selected first:


<img width="505" height="488" alt="image" src="https://github.com/user-attachments/assets/5c2f9ed3-9c07-4a38-9586-01ff0782c5b6" />


Only adding cron strategies or filters is possible directly from the selection pickers. Editing or removing is still possible, but has been put one level lower, behind the 'Manage Definitions' link. Separate management is still required as the definitions can be used in multiple configurations (and will be visibile in all, even when created from the selection pickers).


<img width="523" height="777" alt="image" src="https://github.com/user-attachments/assets/454a2db2-e556-4fd3-aa42-8f0dcda558cf" />



So far the cron builder only allowed building a cron expression and always started from a default expression. This has been enhanced to interpret the provided expressions, so it can be changed through the cron builder. There ware also a few bugs introduced in the cron builder that have been fixed (see https://community.openhab.org/t/struggling-with-cron-builder/168139).
