### PR TITLE
useThingEditStore: Fix firmware data no reset if not available

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useThingEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useThingEditStore.ts
@@ -75,9 +75,9 @@ export const useThingEditStore = defineStore('thingEditStore', () => {
         .filter((a) => a.inputConfigDescriptions !== undefined)
         .sort((a: ThingAction, b: ThingAction) => a.label.localeCompare(b.label))
     } catch (e: any) {
+      thingActions.value = []
       if (e === 'Not Found' || e === 404) {
         console.log('No actions available for this Thing')
-        thingActions.value = []
         return
       }
       console.error('Error loading thing actions: ' + e)
@@ -103,6 +103,7 @@ export const useThingEditStore = defineStore('thingEditStore', () => {
       firmwares.value = await api.get('/rest/things/' + thingUID + '/firmwares')
     } catch (e: any) {
       console.debug(`Firmware info not available for Thing ${thingUID}`)
+      firmwares.value = []
     }
   }
 


### PR DESCRIPTION
Fixes #3774

@florian-h05 - I also reset the thingActions on any failure - which seemed the right place.

Note, I don't have any things in my system which returns firmware, so I wasn't able to test, but pretty sure this is the fix.