### PR TITLE
Model tab: Fix attempted modification of readonly model Items

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/home/homecards-grouping.js
+++ b/bundles/org.openhab.ui/web/src/pages/home/homecards-grouping.js
@@ -5,13 +5,14 @@ export default (model, type, page) => {
       ? page.slots[type][0].config.cardOrder
       : []
   const elements = [...model[type]].map((e) => {
-    if (e.separator) return e
+    const item = { ...e }
+    if (item.separator) return item
     const card =
-      page && page.slots && page.slots[type] && page.slots[type][0] && page.slots[type][0].slots && page.slots[type][0].slots[e.key]
-        ? page.slots[type][0].slots[e.key][0]
+      page && page.slots && page.slots[type] && page.slots[type][0] && page.slots[type][0].slots && page.slots[type][0].slots[item.key]
+        ? page.slots[type][0].slots[item.key][0]
         : null
-    if (card) e.card = card
-    return e
+    if (card) item.card = card
+    return item
   })
   let groups = []
   let currentGroup = []

--- a/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/model-tab.vue
@@ -112,7 +112,7 @@ export default {
     ready () {
       return useModelStore().ready
     },
-    groups (state) {
+    groups () {
       return cardGroups(useModelStore(), this.type, this.page)
     }
   },


### PR DESCRIPTION
This caused images to not be displayed for model cards. Regression from #3763.