### PR TITLE
Link details: Fix reactivity when invalid link removed

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -115,7 +115,10 @@ export default {
                 destroyOnClose: true,
                 closeTimeout: 2000
               }).open()
-              delete this.enrichedLinks[this.enrichedLinks.indexOf(link)]
+              const index = this.enrichedLinks.indexOf(link)
+              if (index > -1) {
+                this.enrichedLinks.splice(index, 1)
+              }
             }).catch((err) => {
               f7.toast.create({
                 text: 'Link not deleted (links defined in a .items file are not editable from this screen): ' + err,


### PR DESCRIPTION
Fixes #3801 

original code used delete to remove a list item, this is not reactive and caused undefined when rendering
converted to using splice which is reactive

Should be backported