### PR TITLE
oh-masonry: Fix style leak & Clean-up unused class from home

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-masonry.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-masonry.vue
@@ -131,7 +131,6 @@ export default {
       z-index inherit
     &.placeholder
       width calc(100% - 16px)
-
-.menu
-  z-index 6000 !important
+  .menu
+    z-index 6000 !important
 </style>

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -138,10 +138,6 @@
     top -6px
     letter-spacing 1px
     color var(--f7-list-item-footer-text-color)
-.edit-home-button
-  float right
-  display absolute
-  z-index 9000
 </style>
 
 <script>


### PR DESCRIPTION
Fixes issues where dropdown menu items where displayed behind menu buttons.