### PR TITLE
Widgets: Enhance <label> with stylesheet support of other components

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/Label.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/Label.vue
@@ -1,0 +1,11 @@
+<template>
+  <div v-bind="config">{{ config.text }}</div>
+</template>
+
+<script>
+import mixin from './widget-mixin'
+
+export default {
+    mixins: [mixin]
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/generic-widget-component.vue
@@ -54,14 +54,12 @@
       :context="context"
       :class="scopedCssUid" />
     <!-- Label renders text inside <div> element -->
-    <div
+    <Label
       v-else-if="componentType && componentType === 'Label'"
       ref="component"
       v-bind="$attrs"
-      :class="[...(Array.isArray(config.class) ? config.class : []), scopedCssUid]"
-      :style="config.style">
-      {{ config.text }}
-    </div>
+      :context="context"
+      :class="scopedCssUid" />
     <!-- Content renders text without any additional container -->
     <template v-else-if="componentType && componentType === 'Content'">
       {{ config.text }}
@@ -91,6 +89,7 @@ import * as StandardListWidgets from './standard/list'
 import * as StandardCellWidgets from './standard/cell'
 import * as LayoutWidgets from './layout/index'
 import OhContext from './system/oh-context.vue'
+import Label from './Label.vue'
 </script>
 
 <script>


### PR DESCRIPTION
Currently a label `<div>` is a special cased and implements only basic styling - causing some confusion as to what works and what doesn't. This PR adds standard widget configuration capabilities, including expressions and stylesheets - to the standard "label" component.

As an aside, to get a stylesheet applied to a "label" component, one must use :host { ... } - in this case the scope-css library replaces :host identity with the .scoped-#### directly vs. prepending it. In this way, the stylesheet can be applied to the top element in a component (in the "label" case - `<div>`).