### PR TITLE
Add name to all markers in charts

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/markers.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/markers.js
@@ -16,9 +16,7 @@ export default (series) => {
       }
     }
     if (series.markers.includes('avg')) {
-      series.markLine.data.push({
-        type: 'average'
-      })
+      series.markLine.data.push({ type: 'average', name: 'avg' })
     }
     if (series.markers.includes('time')) {
       series.markLine.data.push({
@@ -30,6 +28,7 @@ export default (series) => {
           type: 'solid',
           width: 1
         },
+        name: 'now',
         symbol: 'none',
         xAxis: dayjs().format()
       })


### PR DESCRIPTION
- Add name to all markers in charts

Results in
<img width="1844" height="952" alt="grafik" src="https://github.com/user-attachments/assets/0d2eb729-54f5-41a9-a633-8903c6f60769" />

Does anybody know how to get rid of the `NaN` value in the tooltip for the current time mark line? 

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>