### PR TITLE
useUIOptionsStore: Fix `themeOptions().dark` is Ref instead of string

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useUIOptionsStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useUIOptionsStore.ts
@@ -175,7 +175,7 @@ export const useUIOptionsStore = defineStore('uiOptions', () => {
 
   function themeOptions() {
     return {
-      dark: darkMode,
+      dark: darkMode.value,
       autoDarkMode: isAutoDarkMode(),
       bars: bars.value,
       homeNavBar: homeNavBar.value,


### PR DESCRIPTION
Regression from #3788.