### PR TITLE
Add performance metrics

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -812,6 +812,9 @@ export default {
         }).then(() => {
         // finished with loading
           this.ready = true
+          performance.mark('loadDataEnd')
+          const measure = performance.measure('loadData', 'loadDataStart', 'loadDataEnd')
+          console.info(`Init data loading: ${measure.duration.toFixed(2)} ms`)
           return Promise.resolve()
         })
     },
@@ -1003,7 +1006,6 @@ export default {
       this.$f7dim.width = f7.width
       this.$f7dim.height = f7.height
 
-      performance.mark('f7ready')
       this.updateThemeOptions()
 
       this.tryExchangeAuthorizationCode().then((user) => {

--- a/bundles/org.openhab.ui/web/src/main.ts
+++ b/bundles/org.openhab.ui/web/src/main.ts
@@ -1,3 +1,5 @@
+performance.mark('main-start')
+
 import '@/js/compatibility'
 import '@/js/logging'
 import '@/js/monkeypatch'
@@ -76,3 +78,8 @@ app.component('GenericWidgetComponent', GenericWidgetComponent)
 app.component('DeveloperDockIcon', DeveloperDockIcon)
 
 app.mount('#app')
+
+performance.mark('app-mounted')
+
+const measure = performance.measure('main', 'main-start', 'app-mounted')
+console.info(`App initialization: ${measure.duration.toFixed(2)} ms`)


### PR DESCRIPTION
I added 2 performance metrics so we can look at where bottlenecks are and measure any changes. The 2 I added and logged are the time for main, then the time for the loadData in App to execute.