### PR TITLE
zwave: Fix zwave network map display in 5.1.x

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -201,6 +201,7 @@
               </f7-block-title>
               <f7-list class="margin-top" media-list>
                 <f7-list-item
+                  key="zwave-network-map"
                   v-if="thingType?.UID?.startsWith('zwave:')"
                   title="View Network Map"
                   link=""


### PR DESCRIPTION
reference: https://community.openhab.org/t/z-wave-network-map-empty-after-hardware-upgrade/167672/9

Fix zwave network map display in 5.1.x Tested locally on 5.1.2

Add AI explanation; Ah, this is a classic Vue reactivity + conditional‑rendering interaction bug, and the symptoms you’re describing line up perfectly with one specific root cause:
🎯 The  item (v-if="thingType?.UID?.startsWith('zwave:')"disappears when the list is filtered. 
🔧 The fix: Give the v-if item a stable key. This forces Vue to treat the “View Network Map” item as a distinct, non-reusable DOM node, so its click handler stays intact.