### PR TITLE
Support keywords in Add-on Store

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -413,7 +413,7 @@ export default {
         results = results.filter((a) => a.type === this.currentTab)
       }
       query = query.toLowerCase()
-      results = results.filter((a) => a.id.includes(query) || a.label.toLowerCase().includes(query) || a.description?.toLowerCase()?.includes(query) || (query !== ',' && a.keywords?.toLowerCase()?.includes(query)))
+      results = results.filter((a) => query !== ',' && (a.id.includes(query) || a.label.toLowerCase().includes(query) || a.description?.toLowerCase()?.includes(query) || a.keywords?.toLowerCase()?.includes(query)))
 
       this.query = query
       this.searchResults = results


### PR DESCRIPTION
This is the UI counterpart of https://github.com/openhab/openhab-core/pull/5352

<img width="887" height="649" alt="image" src="https://github.com/user-attachments/assets/f3dd8095-4f9f-4b51-b8e5-7f1d75878821" />

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>
