### PR TITLE
Z-Wave network map: Use bidirectional edges for controller

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/network/providers/zwave-provider.ts
+++ b/bundles/org.openhab.ui/web/src/components/thing/network/providers/zwave-provider.ts
@@ -31,9 +31,24 @@ export class ZWaveNetworkProvider implements NetworkGraphProvider {
 
   private static readonly LEGEND: NetworkLegend = {
     nodeRoles: [
-      { id: 'controller', label: 'Controller', color: RoleColors.controller, size: RoleSizes.controller },
-      { id: 'listening', label: 'Always Listening', color: RoleColors.listening, size: RoleSizes.listening },
-      { id: 'sleeping', label: 'Battery/Sleeping', color: RoleColors.sleeping, size: RoleSizes.sleeping }
+      {
+        id: 'controller',
+        label: 'Controller',
+        color: RoleColors.controller,
+        size: RoleSizes.controller
+      },
+      {
+        id: 'listening',
+        label: 'Always Listening',
+        color: RoleColors.listening,
+        size: RoleSizes.listening
+      },
+      {
+        id: 'sleeping',
+        label: 'Battery/Sleeping',
+        color: RoleColors.sleeping,
+        size: RoleSizes.sleeping
+      }
     ],
     linkQualities: [],
     linkTypes: [
@@ -50,11 +65,16 @@ export class ZWaveNetworkProvider implements NetworkGraphProvider {
 
     const nodes: NetworkNode[] = []
     const linkData: Array<[string, string]> = []
+    const controllerIds = new Set<string>()
 
     zWaveNodes.forEach((thing) => {
       const nodeId = thing.properties.zwave_nodeid
       const isController = !thing.bridgeUID
       const listening = thing.properties.zwave_listening === 'true'
+
+      if (isController) {
+        controllerIds.add(nodeId)
+      }
 
       let role: string
       if (isController) {
@@ -80,7 +100,7 @@ export class ZWaveNetworkProvider implements NetworkGraphProvider {
       linkData.push([nodeId, thing.properties.zwave_neighbours || ''])
     })
 
-    const links = this.createLinks(linkData)
+    const links = this.createLinks(linkData, controllerIds)
 
     return {
       networkType: 'zwave',
@@ -105,7 +125,7 @@ export class ZWaveNetworkProvider implements NetworkGraphProvider {
     }
   }
 
-  private createLinks(linkData: Array<[string, string]>): NetworkLink[] {
+  private createLinks(linkData: Array<[string, string]>, controllerIds: Set<string>): NetworkLink[] {
     const links: NetworkLink[] = []
     const linkMap = new Map<string, NetworkLink>()
 
@@ -122,16 +142,39 @@ export class ZWaveNetworkProvider implements NetworkGraphProvider {
         if (existingReverse) {
           // Found reverse link - make it bidirectional (peer)
           existingReverse.type = 'peer'
-        } else {
-          // Create new unidirectional link
+          const backLink: NetworkLink = {
+            source: nodeId,
+            target: n,
+            type: 'peer'
+          }
+          linkMap.set(forwardKey, backLink)
+          links.push(backLink)
+          return
+        }
+
+        // SPECIAL CASE: controller never reports neighbors
+        const isControllerPair = !controllerIds.has(nodeId) && controllerIds.has(n)
+
+        if (isControllerPair) {
+          // Force bidirectional links
           const link: NetworkLink = {
             source: nodeId,
             target: n,
-            type: 'asymmetric'
+            type: 'peer'
           }
           linkMap.set(forwardKey, link)
           links.push(link)
+          return
         }
+
+        // Create new unidirectional link
+        const link: NetworkLink = {
+          source: nodeId,
+          target: n,
+          type: 'asymmetric'
+        }
+        linkMap.set(forwardKey, link)
+        links.push(link)
       })
     })
 


### PR DESCRIPTION
With support for 700 zwave controllers (as of OH4.1), the find neighbors routine for controllers was dropped to avoid an endless loop. 
```
        // Set controller properties for Network Map since it will not be healed
        getThing().setProperty(ZWaveBindingConstants.PROPERTY_NEIGHBOURS, sucNode.toString());
        getThing().setProperty(ZWaveBindingConstants.PROPERTY_NODEID, sucNode.toString());
```
To keep the controller on the map, the ID and neighbor for the controller was set to itself. This PR applies the assumption that if a node "sees" the controller it must be bidirectional, otherwise the map implies the controller has no connection to any node. 
Test data
<img width="463" height="339" alt="ZWavemap2026-02-11 155641" src="https://github.com/user-attachments/assets/190c4af7-fe47-4d97-b4d1-e65e7e21ec5b" />
<img width="590" height="79" alt="controller prop 2026-02-11 155550" src="https://github.com/user-attachments/assets/29c50acc-aca2-4c81-a872-5ec04559b221" />

Before version
<img width="345" height="275" alt="ZWavemapold2026-02-11 155641" src="https://github.com/user-attachments/assets/0ee1bc96-b05f-456f-88a5-29b42486ead4" />

Second try had formatting issue, hopefully solved. This is an enhancement