### PR TITLE
Upgrade Karaf tooling to 4.4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <eea.version>2.4.0</eea.version>
     <jackson.annotations.version>2.20</jackson.annotations.version>
     <karaf.version>4.4.10</karaf.version>
-    <karaf.maven.plugin.version>4.4.8</karaf.maven.plugin.version>
+    <karaf.maven.plugin.version>4.4.10</karaf.maven.plugin.version>
     <ohc.version>5.2.0-SNAPSHOT</ohc.version>
     <sat.version>0.18.0</sat.version>
     <spotless.version>2.44.3</spotless.version>


### PR DESCRIPTION
I overlooked this in #3877 (and upgrades karaf-maven-plugin to 4.4.10).