### PR TITLE
useStatesStore: Fix error in expression tester with =items formula

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
@@ -63,6 +63,7 @@ export const useStatesStore = defineStore('states', () => {
     get(obj: Record<string, ItemState>, prop: string | symbol): ItemState {
       if (prop === '_keys') return Object.keys(itemStates.value) as any
       if (prop === '__ob__') return (obj as any).__ob__
+      if (prop === 'toString') return (() => '[object TrackedItems]') as any
 
       // to avoid the Vue devtools requesting invalid items in development
       if (INVALID_PROPS.has(prop.toString())) return {} as any


### PR DESCRIPTION
Fixes #3876

Adds `toString()` function to `trackedItems` proxy.