### PR TITLE
Items: EQUALITY aggregation function is default for Groups with type

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/item-types.js
+++ b/bundles/org.openhab.ui/web/src/assets/item-types.js
@@ -18,35 +18,35 @@ export const GroupTypes = ['None'].concat(SharedTypes)
 
 export const CommonFunctions = [
   {
-    name: '',
-    value: 'None'
+    name: 'EQUALITY',
+    value: 'Equal or UNDEF'
   }
 ]
 
 export const ArithmeticFunctions = [
   {
     name: 'AVG',
-    value: 'AVG'
+    value: 'Average'
   },
   {
     name: 'MEDIAN',
-    value: 'MEDIAN'
+    value: 'Median'
   },
   {
     name: 'MAX',
-    value: 'MAX'
+    value: 'Maximum'
   },
   {
     name: 'MIN',
-    value: 'MIN'
+    value: 'Minimum'
   },
   {
     name: 'SUM',
-    value: 'SUM'
+    value: 'Sum'
   },
   {
     name: 'COUNT',
-    value: 'COUNT'
+    value: 'Count'
   }
 ]
 

--- a/bundles/org.openhab.ui/web/src/components/item/group-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-form.vue
@@ -133,8 +133,10 @@ export default {
           if (newType !== 'None') {
             this.item.groupType = newType
             if (previousAggregationFunctions !== this.aggregationFunctions) {
-              this.item.functionKey = 'None'
+              this.groupFunctionKey = 'EQUALITY'
             }
+          } else {
+            this.groupFunctionKey = null
           }
         })
       }
@@ -202,7 +204,7 @@ export default {
       }
     },
     aggregationFunctions () {
-      if (this.groupType === 'None') return null
+      if (!this.groupType || this.groupType === 'None' || this.groupType === '') return null
 
       const specificAggregationFunctions = (groupType) => {
         switch (this.groupType) {
@@ -231,7 +233,7 @@ export default {
         this.item.functionKey += '_' + this.item.function.params.join('_')
       }
     } else {
-      this.item.functionKey = 'None'
+      this.item.functionKey = 'EQUALITY'
     }
   },
   methods: {


### PR DESCRIPTION
Group aggregations with function 'None' selected from the UI are not what it seems. This is using the EQUALITY aggregation function which sets the group state to the member Items state if all member Items have the same state. This leads to confusion, as pointed out in a few community discussion, e.g. see here: https://community.openhab.org/t/mixed-items-group-status-aggregation-improvement/168400/12

This PR renames the 'None' aggregation function to 'Equal or UNDEF' to make that clearer. And rather then using the key in the smart select (EQUALITY, MIN, MAX...) a short label is used.

Some changes to the update logic were required as well to make updating group type or aggregation function propagate properly.