### PR TITLE
Make semantics not editable from metadata editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -165,6 +165,7 @@ export default {
       }
     },
     editable () {
+      if (this.namespace === 'semantics') return false
       return this.metadata.editable !== false
     }
   },


### PR DESCRIPTION
Semantics metadata is (correctly) excluded from the Metadata section menu on the Items page.

However, you can still use 'Add Metadata' and manually type 'semantics' as custom namespace. If there was no semantics metadata, that enables you to add semantics metadata to the managed provider. This should not be allowed.

This PR makes the semantics namespace non-editable in the editor. So it is still possible to see the semantics metadata when typing 'semantics' in the namespace, but it cannot be saved anymore.

The context of this is here: https://github.com/openhab/openhab-core/issues/5363#issuecomment-3938443492. Semantic metadata ended up in the managed metadata store because of the use of an LLM to create semantic metadata. That needs to be fixed in the REST API to not allow that (working on that). But I noticed the same is actually possible through the UI and even if I fix the REST API, the semantics editor may not give a meaningful error message without UI code changes anyway. So this change already avoids the issue in the UI.