### PR TITLE
Fix screen.viewAreaWidth and screen.viewAreaHeight not available in widget editor

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -114,6 +114,7 @@ import DirtyMixin from '@/pages/settings/dirty-mixin'
 import * as StandardListWidgets from '@/components/widgets/standard/list'
 
 import { useStatesStore } from '@/js/stores/useStatesStore'
+import { useViewArea } from '@/composables/useViewArea'
 
 const toStringOptions = { toStringDefaults: { lineWidth: 0 } }
 
@@ -130,6 +131,7 @@ export default {
     f7route: Object
   },
   setup () {
+    useViewArea()
     return { f7, theme }
   },
   data () {


### PR DESCRIPTION
When editing a widget, the screen property is not available - need to add useViewArea() to the top-level page window.