### PR TITLE
Display channel properties in channel-general-settings 

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <f7-block class="padding-vertical no-padding-horizontal">
+  <f7-block class="channel-general-settings padding-vertical no-padding-horizontal">
     <f7-col>
       <f7-list class="no-margin" inline-labels no-hairlines-md>
         <f7-list-input
@@ -81,14 +81,14 @@
 </template>
 
 <style lang="stylus">
-.list
-  .item-subtitle
-    overflow-wrap break-word
-    white-space inherit
-
-.property-key
-  display inline-block
-  padding-left 12px
+.channel-general-settings
+  .list
+    .item-subtitle
+      overflow-wrap break-word
+      white-space inherit
+  .property-key
+    display inline-block
+    padding-left 12px
 </style>
 
 <script>


### PR DESCRIPTION
Currently the Main UI channel general settings view does not display any channel properties.

This PR adds such a display (see screen shot below).

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>

---

<img width="600" alt="image" src="https://github.com/user-attachments/assets/84ec6e54-416c-4224-bda7-7b96af56cdb7" />

