### PR TITLE
oh-masonry: Fix missing oh-placeholder-widget

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-masonry.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-masonry.vue
@@ -119,6 +119,7 @@ import { useWidgetContext } from '@/components/widgets/useWidgetContext'
 import { OhMasonryDefinition } from '@/assets/definitions/widgets/layout'
 import { MasonryGrid, MasonryGridItem } from '../../../components/vue3-masonry-css'
 import type { WidgetContext } from '@/components/widgets/types'
+import OhPlaceholderWidget from './oh-placeholder-widget.vue'
 
 const props = defineProps<{
   context: WidgetContext


### PR DESCRIPTION
Regression from #3969.