### PR TITLE
Fix framework7 menu pointer styling

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -72,7 +72,7 @@ html
 
 /* Fixes for dropdown menus */
 .menu-dropdown
-  cursor: pointer
+  cursor pointer
   z-index 7000 !important
 
 /* Fixes and adjustments for list input */


### PR DESCRIPTION
Framework7 set cursor: auto on menu-dropdown, this PR forces cursor: pointer for menu-dropdown

FIxes #3983