### PR TITLE
parameter-text: Fix extraneous props and use of f7-popover-inner

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul v-if="multiple" ref="inputs">
+  <ul v-if="multiple" ref="inputs" class="parameter-text">
     <f7-block-header class="no-margin">
       <div class="margin-horizontal item-label" style="padding-top: var(--f7-list-item-padding-vertical); color: var(--f7-text-color)">
         {{ configDescription.label }}
@@ -30,7 +30,7 @@
       @focus="gotFocus"
       :placeholder="configDescription.placeholder" />
   </ul>
-  <ul v-else>
+  <ul v-else class="parameter-text">
     <f7-list-input
       ref="input"
       :floating-label="theme.md"
@@ -60,7 +60,7 @@
       </template>
       <template v-if="softInvalid && !disableValidation" #error-message>
         <div>
-          <span class="text-color-red" @click="showNetworkAddressPopover">{{ NETWORK_ADDRESS_WARNING_TEXT }}</span>
+          <span class="network-address-text text-color-red" @click="showNetworkAddressPopover">{{ NETWORK_ADDRESS_WARNING_TEXT }}</span>
           <span @mousedown.prevent="disableValidation = true; validateSoft(value)" class="link" style="margin-left: 6px;">Use anyway</span>
         </div>
       </template>
@@ -73,6 +73,13 @@
     </f7-block>
   </f7-popover>
 </template>
+
+<style lang="stylus">
+.parameter-text
+  .network-address-text
+    &:hover
+      cursor pointer
+</style>
 
 <script>
 const NETWORK_ADDRESS_WARNING_TEXT = `⚠ This is not a standard URL, IP address, or host name.`


### PR DESCRIPTION
Regression from #3918 

Addresses:
```
[Vue warn]: Failed to resolve component: f7-popover-inner
If this is a native custom element, make sure to exclude it from component resolution via compilerOptions.isCustomElement. 
  at <ParameterText read-only=false config-description= {context: 'ip-address', label: 'IP', name: 'ip', required: true, type: 'TEXT'} value=undefined  ... > 
  at <F7ListGroup key=0 > 
  at <F7List ref="parameter" class="config-parameter" no-hairlines-md=true  ... > 
```
and

```
[Vue warn]: Extraneous non-props attributes (parameters, configuration, title, f7router) were passed to component but could not be automatically inherited because component renders fragment or text or teleport root nodes. 
  at <ParameterText read-only=false config-description= {context: 'week', label: 'Week', name: 'week', required: true, type: 'TEXT'} value=undefined  ... > 
  at <F7ListGroup key=0 >
```
