### PR TITLE
Analyzer: Hide permanent menu icon

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
+++ b/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-nav-left class="oh-nav-content">
-    <f7-link class="menu-icon" icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
+    <f7-link v-if="menuIcon" class="menu-icon" icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
     <f7-link v-if="!theme.md && backLink" icon-f7="chevron_left" :href="backLinkUrl" @click="back">
       {{ backLink }}
     </f7-link>
@@ -58,6 +58,7 @@ import DeveloperDockIcon from '@/components/developer/developer-dock-icon.vue'
 const props = withDefaults(defineProps<{
   title: string,
   subtitle?: string,
+  menuIcon?: boolean,
   backLink?: string,
   backLinkUrl?: string,
   editable?: boolean,
@@ -66,6 +67,7 @@ const props = withDefaults(defineProps<{
   large?: boolean,
   f7router?: Router.Router,
 }>(), {
+  menuIcon: true,
   backLink: 'Back',
   editable: undefined,
   large: false

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -3,6 +3,7 @@
     <f7-navbar>
       <oh-nav-content
         :title="titleDisplayText"
+        :menu-icon="false"
         :back-link="t('analyzer.back')"
         :save-link="userStore.isAdmin() ? t('analyzer.save') : undefined"
         @save="savePage"


### PR DESCRIPTION
Consistent with viewing pages.
Saves valuable space in the top-navbar on mobile device.