### PR TITLE
[mainui] Fix floor plan markers not rendering in production build

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-page.vue
@@ -27,7 +27,7 @@
       <l-feature-group v-if="context.component.slots" ref="featureGroup">
         <template v-for="(marker, idx) in defaultSlots" :key="idx">
           <component
-            :is="markerComponent(marker)"
+            :is="markerComponent"
             v-if="isMarkerVisible(marker)"
             :context="childContext(marker)"
             @update="onMarkerUpdate" />
@@ -94,7 +94,7 @@ dark-tooltip()
     dark-tooltip()
 
 // override leaflet style
-.leaflet-div-icon
+.oh-plan-page-lmap .leaflet-div-icon
   background: unset
   border: unset
 
@@ -112,7 +112,7 @@ import { Icon, CRS } from 'leaflet'
 import { LMap, LImageOverlay, LFeatureGroup, LControl } from '@vue-leaflet/vue-leaflet'
 import 'leaflet/dist/leaflet.css'
 
-import OhPlanMarker from './oh-plan-marker.vue'
+import { widget } from '@/components/oh-component-registry'
 import { OhPlanPageDefinition } from '@/assets/definitions/widgets/plan'
 
 // Do NOT remove: required for Leaflet to render in prod build
@@ -131,8 +131,7 @@ export default {
     LMap,
     LImageOverlay,
     LControl,
-    LFeatureGroup,
-    OhPlanMarker
+    LFeatureGroup
   },
   widget: OhPlanPageDefinition,
   setup(props) {
@@ -151,25 +150,13 @@ export default {
     }
   },
   computed: {
+    markerComponent () {
+      return widget('oh-plan-marker')
+    },
     bounds () {
       const lat = this.config.imageHeight || 1000
       const lng = this.config.imageWidth || 1000
       return [[0, 0], [lat, lng]]
-    },
-    markerComponent() {
-      return (marker) => {
-        return OhPlanMarker
-      }
-    },
-    isMarkerVisible() {
-      return (marker) => {
-        if (this.context.editmode != null) return true
-        const zoomVisibilityMin = parseFloat(marker.config.zoomVisibilityMin)
-        const zoomVisibilityMax = parseFloat(marker.config.zoomVisibilityMax)
-        const isVisibleMin = isNaN(zoomVisibilityMin) || zoomVisibilityMin < this.currentZoom
-        const isVisibleMax = isNaN(zoomVisibilityMax) || zoomVisibilityMax > this.currentZoom
-        return isVisibleMin && isVisibleMax
-      }
     },
     mapOptions () {
       return Object.assign({
@@ -201,6 +188,14 @@ export default {
   methods: {
     zoomUpdate (zoom) {
       this.currentZoom = zoom
+    },
+    isMarkerVisible (marker) {
+      if (this.context.editmode != null) return true
+      const zoomVisibilityMin = parseFloat(marker.config.zoomVisibilityMin)
+      const zoomVisibilityMax = parseFloat(marker.config.zoomVisibilityMax)
+      const isVisibleMin = isNaN(zoomVisibilityMin) || zoomVisibilityMin < this.currentZoom
+      const isVisibleMax = isNaN(zoomVisibilityMax) || zoomVisibilityMax > this.currentZoom
+      return isVisibleMin && isVisibleMax
     },
     centerUpdate (center) {
       this.currentCenter = center


### PR DESCRIPTION
This is a follow up to #3993  .   That fix worked when running under the Vue dev server, but when i deployed the UI bundle, the markers remained hidden, which was really baffling.  I assumed at first this was a caching issue or i was not loading the right bundle, but after lots of troubleshooting, it become clear it was a vue issue.  I have to admit, i then used claude quite a bit to resolve this as i was a bit out of my league.  I would suggest we try to get this in our milestone release. 

Here's what it came up with, which does now work when running under the dev server and deployed.

The static import of oh-plan-marker.vue caused Rolldown's code-splitting (via import.meta.glob in the component registry) to place the marker in a separate chunk where its vue-leaflet imports (LMarker, LTooltip, LIcon) failed to resolve, rendering as raw HTML elements instead of Vue components.

Fix by resolving the marker through the component registry using defineAsyncComponent, matching the pattern used by all other widgets.

Also fix CSS specificity for .leaflet-div-icon override, which was being overridden by leaflet.css loading after the plan page's CSS chunk.

Additionally simplify zoom-based marker visibility by using a per-marker v-if with an isMarkerVisible method instead of imperatively filtering into a markers data array.