### PR TITLE
Thing inbox: Fix "Add as Thing" dialog width to adjust to button text size

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -424,10 +424,6 @@ html
       margin-left 8px
       color var(--f7-input-text-color)
 
-// Increase width of Thing Inbox Approve Dialog
-.thing-inbox-approve-dialog
-  --f7-dialog-width 320px
-
 // Fix safe area issues inside f7-card components, where safe areas are already respected by the f7-card itself
 .card
   .block

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -94,6 +94,8 @@
   .scan-input
     .list
       margin-top 0
+.thing-inbox-approve-dialog
+  width auto
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -210,6 +210,8 @@
   @media (min-width 960px)
     padding-left 0 !important
     padding-right 0 !important
+.thing-inbox-approve-dialog
+  width auto
 </style>
 
 <script>


### PR DESCRIPTION
Fixes #3895