### PR TITLE
Charts: Don't enable boundary & itemState for forecast charts

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/useChart.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/useChart.ts
@@ -217,10 +217,12 @@ export function useChart(
       dayjs(startTime.value).subtract(5, 'minutes').isBefore(now) && dayjs(endTime.value).add(5, 'minutes').isAfter(now)
     const isNotFuture = !(future.value > 0)
 
-    let boundary = seriesComponents[component.component]!.includeBoundary?.(chartContext.value, component) ?? (isBetweenStartAndEnd && isNotFuture)
+    let boundary =
+      seriesComponents[component.component]!.includeBoundary?.(chartContext.value, component) ?? (isBetweenStartAndEnd && isNotFuture)
     if (config.noBoundary === true) boundary = false
 
-    let itemState = seriesComponents[component.component]!.includeItemState?.(chartContext.value, component) ?? (isBetweenStartAndEnd && isNotFuture)
+    let itemState =
+      seriesComponents[component.component]!.includeItemState?.(chartContext.value, component) ?? (isBetweenStartAndEnd && isNotFuture)
     if (config.noItemState === true) itemState = false
 
     neededItems.forEach((neededItem) => {


### PR DESCRIPTION
This fixes an issue where forecasted charts with bar time-series only displayed very narrow bars because of to short minimum time intervals caused by current Item state and/or boundary manipulation.