### PR TITLE
[basicui] Fix stale state when tab returns to foreground

### DIFF
--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -3816,6 +3816,17 @@
 			_t.closeConnection();
 			_t.paused = true;
 		};
+		// Resume from hidden state: re-establish subscription via POST so that
+		// connectionRestored -> startSubscriber flow is used (reload + SSE reopen)
+		_t.resume = function() {
+			_t.paused = false;
+			ajax({
+				url: _t.subscribeRequestURL,
+				type: "POST",
+				callback: _t.connectionRestored,
+				error: _t.subscriberError
+			});
+		};
 	}
 
 	function ChangeListenerLongpolling() {
@@ -4080,19 +4091,17 @@
 				clearInterval(_t.reconnectInterval);
 				_t.reconnectInterval = null;
 			}
+			// Call resume() which is implemented by both
+			// ChangeListenerLongpolling and ChangeListenerEventsource.
+			// Long-polling resume restarts the polling loop; SSE resume
+			// triggers the subscribe POST and the normal recovery flow.
+			if (typeof _t.resume === "function") {
+				_t.resume();
+				return;
+			}
 			if (typeof _t.paused !== "undefined") {
 				_t.paused = false;
 			}
-			// A new subscribe POST gives us a fresh subscription ID.  The
-			// connectionRestored callback then reloads the page HTML (full state
-			// re-sync) and opens the new SSE stream – exactly the same flow used
-			// after a normal connection-error recovery.
-			ajax({
-				url: _t.subscribeRequestURL,
-				type: "POST",
-				callback: _t.connectionRestored,
-				error: _t.subscriberError
-			});
 		};
 
 		ajax({

--- a/bundles/org.openhab.ui.basic/web-src/smarthome.js
+++ b/bundles/org.openhab.ui.basic/web-src/smarthome.js
@@ -3809,6 +3809,13 @@
 			_t.closeConnection();
 			_t.connectionError();
 		};
+
+		// Override base pause: actually close the SSE stream so the server
+		// connection is freed while the page is not visible.
+		_t.pause = function() {
+			_t.closeConnection();
+			_t.paused = true;
+		};
 	}
 
 	function ChangeListenerLongpolling() {
@@ -4050,6 +4057,44 @@
 
 		_t.closeConnection = function(){};
 
+		// Called when the page becomes hidden (tab switched, browser minimised, etc.).
+		// Closes any open server connection to save resources while the page is idle.
+		_t.handlePageHidden = function() {
+			if (typeof _t.pause === "function") {
+				_t.pause();
+			}
+			// Stop any in-progress reconnect loop – it will be restarted on
+			// visibility-restore which does a full re-sync anyway.
+			if (_t.reconnectInterval !== null) {
+				clearInterval(_t.reconnectInterval);
+				_t.reconnectInterval = null;
+			}
+		};
+
+		// Called when the page becomes visible again.
+		// Re-subscribes to the event stream and reloads the current sitemap page so
+		// that all widget states are immediately up-to-date without the user having
+		// to refresh manually.
+		_t.handlePageVisible = function() {
+			if (_t.reconnectInterval !== null) {
+				clearInterval(_t.reconnectInterval);
+				_t.reconnectInterval = null;
+			}
+			if (typeof _t.paused !== "undefined") {
+				_t.paused = false;
+			}
+			// A new subscribe POST gives us a fresh subscription ID.  The
+			// connectionRestored callback then reloads the page HTML (full state
+			// re-sync) and opens the new SSE stream – exactly the same flow used
+			// after a normal connection-error recovery.
+			ajax({
+				url: _t.subscribeRequestURL,
+				type: "POST",
+				callback: _t.connectionRestored,
+				error: _t.subscriberError
+			});
+		};
+
 		ajax({
 			url: _t.subscribeRequestURL,
 			type: "POST",
@@ -4082,6 +4127,18 @@
 		}
 
 		window.addEventListener("storage", handleStorageEvent);
+
+		// Pause the event stream when the page is hidden (background tab, minimised
+		// browser) and transparently re-sync when it becomes visible again.
+		if (typeof document.hidden !== "undefined") {
+			document.addEventListener("visibilitychange", function() {
+				if (document.hidden) {
+					smarthome.changeListener.handlePageHidden();
+				} else {
+					smarthome.changeListener.handlePageVisible();
+				}
+			});
+		}
 
 		window.addEventListener("beforeunload", function() {
 			smarthome.changeListener.suppressErrors();


### PR DESCRIPTION
When a browser tab is backgrounded, item state changes received via SSE are displayed correctly while the stream is alive, but the page becomes stale if the SSE connection drops (the 10-second reconnect setInterval is heavily throttled by browsers for background tabs). More importantly, even when the SSE connection stays alive throughout, the page never back-fills the changes that occurred while it was hidden, so the user always had to manually refresh to re-sync.

Fix using the Page Visibility API:

- On 'hidden':   close the SSE connection immediately (frees the server- side subscription socket) and cancel any in-flight reconnect interval.
- On 'visible':  POST a fresh subscription, then use the existing connectionRestored() path to reload the current sitemap page HTML and open a new SSE stream.  This gives an unconditional full state re-sync the moment the user returns to the tab, regardless of whether the SSE was alive or dead while the page was hidden.

ChangeListenerEventsource.pause() is overridden to actually close the EventSource (the base AbstractChangeListener.pause() only set a flag). ChangeListenerLongpolling.pause() already aborted its XHR correctly.
