### PR TITLE
Add Items from Thing: Fix expert mode code tab empty

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
@@ -207,6 +207,7 @@ watch(codeEditorType, () => {
 // methods
 const onPageAfterIn = () => {
   load()
+  if (props.textualDefinition) parseItems()
 }
 
 const load = async () => {


### PR DESCRIPTION
Fixes #4022
Signed-off-by: Dan Cunningham <dan@digitaldan.com>