### PR TITLE
item-persistence-detail: Fix error when no persistence config is defined for a service

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
@@ -114,7 +114,7 @@ const loadService = async (service: api.PersistenceService): Promise<Persistence
 
   let itemsPersisted: api.PersistenceItemInfo | 'not_persisted' | 'unsupported' = 'unsupported'
   try {
-    itemsPersisted = (await api.getItemsForPersistenceService({ serviceId: service.id, itemName: props.item.name }))![0] || 'not_persisted'
+    itemsPersisted = (await api.getItemsForPersistenceService({ serviceId: service.id, itemName: props.item.name }))![0] ?? 'not_persisted'
   } catch (err: unknown) {
     if (err instanceof ApiError && err.response.status === 404) {
       itemsPersisted = 'not_persisted'


### PR DESCRIPTION
Fixes error when no persistence is set for a service

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'count')
    at item-persistence-details.vue:77:26
```