### PR TITLE
Link edit: Fix link profile dirty issue

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -325,6 +325,7 @@ export default {
             destroyOnClose: true,
             closeTimeout: 2000
           }).open()
+          this.dirty = false
           this.f7router.back()
         })
       }).catch((err) => {


### PR DESCRIPTION
Fixes #3922 

Dirty flag was not cleared on link update prior to going navigation back.