### PR TITLE
Migrate UI bundles to Jakarta EE 10 whiteboard APIs

### DIFF
--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/CmdServlet.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/CmdServlet.java
@@ -14,12 +14,6 @@ package org.openhab.ui.basic.internal.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.GroupItem;
@@ -34,12 +28,18 @@ import org.openhab.core.types.TypeParser;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardResource;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardResource;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * This servlet receives events from the web app and sends these as

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/ManifestServlet.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/ManifestServlet.java
@@ -14,13 +14,6 @@ package org.openhab.ui.basic.internal.servlet;
 
 import java.io.IOException;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.ui.basic.internal.render.PageRenderer;
@@ -28,11 +21,18 @@ import org.openhab.ui.basic.render.RenderException;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * This is the manifest servlet for the Basic UI. It dynamically generates a

--- a/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/WebAppServlet.java
+++ b/bundles/org.openhab.ui.basic/src/main/java/org/openhab/ui/basic/internal/servlet/WebAppServlet.java
@@ -16,13 +16,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.ServletResponse;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.io.rest.sitemap.SitemapSubscriptionService;
@@ -40,11 +33,18 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletAsyncSupported;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * This is the main servlet for the Basic UI.

--- a/bundles/org.openhab.ui.cometvisu/pom.xml
+++ b/bundles/org.openhab.ui.cometvisu/pom.xml
@@ -16,21 +16,21 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.apache.servicemix.bundles</groupId>
-      <artifactId>org.apache.servicemix.bundles.jaxb-impl</artifactId>
-      <version>2.2.11_1</version>
+      <groupId>jakarta.activation</groupId>
+      <artifactId>jakarta.activation-api</artifactId>
+      <version>2.1.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.activation-api-1.1</artifactId>
-      <version>2.9.0</version>
+      <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.servicemix.specs</groupId>
-      <artifactId>org.apache.servicemix.specs.jaxb-api-2.2</artifactId>
-      <version>2.9.0</version>
+      <groupId>org.glassfish.jaxb</groupId>
+      <artifactId>jaxb-runtime</artifactId>
+      <version>4.0.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -85,19 +85,14 @@
         <version>3.2.0</version>
         <dependencies>
           <dependency>
-            <groupId>org.jvnet.jaxb2_commons</groupId>
-            <artifactId>jaxb2-basics</artifactId>
-            <version>0.12.0</version>
-          </dependency>
-          <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.8</version>
+            <version>4.0.5</version>
           </dependency>
           <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-xjc</artifactId>
-            <version>2.3.6</version>
+            <version>4.0.5</version>
           </dependency>
         </dependencies>
         <executions>
@@ -148,6 +143,7 @@
                 <java8>true</java8>
                 <dateLibrary>java8</dateLibrary>
                 <generatePom>false</generatePom>
+                <useJakartaEe>true</useJakartaEe>
                 <useSwaggerAnnotations>false</useSwaggerAnnotations>
                 <useBeanValidation>false</useBeanValidation>
                 <hideGenerationTimestamp>true</hideGenerationTimestamp>

--- a/bundles/org.openhab.ui.cometvisu/src/main/feature/feature.xml
+++ b/bundles/org.openhab.ui.cometvisu/src/main/feature/feature.xml
@@ -7,6 +7,7 @@
 		<feature>openhab-core-model-sitemap</feature>
 		<feature>openhab-core-ui-icon</feature>
 		<feature>openhab-core-ui</feature>
+		<feature dependency="true">openhab.tp-jax-rs-whiteboard</feature>
 		<feature dependency="true">openhab.tp-jaxb</feature>
 		<feature dependency="true">openhab.tp-jackson</feature>
 		<bundle dependency="true">mvn:org.rrd4j/rrd4j/3.8.2</bundle>

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/AdapterCDATA.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/AdapterCDATA.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.ui.cometvisu.internal.backend.model.config.pure;
 
-import javax.xml.bind.annotation.adapters.XmlAdapter;
+import jakarta.xml.bind.annotation.adapters.XmlAdapter;
 
 /**
  * Adapter for marshaling CDATA content

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/CDataLabel.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/CDataLabel.java
@@ -12,11 +12,11 @@
  */
 package org.openhab.ui.cometvisu.internal.backend.model.config.pure;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.XmlValue;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlValue;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * Adapter for marshaling label with CDATA content

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/CDataStatus.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/CDataStatus.java
@@ -12,10 +12,10 @@
  */
 package org.openhab.ui.cometvisu.internal.backend.model.config.pure;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlType;
-import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * Adapter for marshaling status with CDATA content

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/SchemaPages.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/model/config/pure/SchemaPages.java
@@ -12,8 +12,8 @@
  */
 package org.openhab.ui.cometvisu.internal.backend.model.config.pure;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
 
 /**
  * add two attributes to the pages element that are not defined in the XSD

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/CheckResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/CheckResource.java
@@ -17,11 +17,6 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.rest.RESTConstants;
 import org.openhab.core.io.rest.RESTResource;
@@ -30,17 +25,21 @@ import org.openhab.ui.cometvisu.internal.ManagerSettings;
 import org.openhab.ui.cometvisu.internal.backend.model.rest.CheckResponse;
 import org.openhab.ui.cometvisu.internal.backend.model.rest.EnvironmentState;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Check filesystem backend for the cometvisu manager.
@@ -50,9 +49,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/fs/check")
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/fs/check")
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/fs/check")
 @Tag(name = Config.COMETVISU_BACKEND_ALIAS + "/fs/check")

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ConfigResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ConfigResource.java
@@ -19,19 +19,6 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Role;
 import org.openhab.core.io.rest.RESTConstants;
@@ -43,11 +30,11 @@ import org.openhab.ui.cometvisu.internal.backend.model.rest.HiddenConfig;
 import org.openhab.ui.cometvisu.internal.util.ClientInstaller;
 import org.openhab.ui.cometvisu.internal.util.FsUtil;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +46,18 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * Allows certain actions to configure the CometVisu backend through the REST api.
@@ -68,9 +67,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_CONFIG_ALIAS)
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/" + Config.COMETVISU_BACKEND_CONFIG_ALIAS)
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @RolesAllowed({ Role.ADMIN })
 @SecurityRequirement(name = "oauth2", scopes = { "admin" })

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/DataProviderResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/DataProviderResource.java
@@ -19,13 +19,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.io.rest.RESTConstants;
 import org.openhab.core.io.rest.RESTResource;
@@ -46,11 +39,11 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,6 +53,12 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 /**
  * DataProvider backend for the cometvisu manager.
@@ -69,9 +68,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/data")
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/data")
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/data")
 @Tag(name = Config.COMETVISU_BACKEND_ALIAS + "/data")

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/EnvironmentResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/EnvironmentResource.java
@@ -12,12 +12,6 @@
  */
 package org.openhab.ui.cometvisu.internal.backend.rest;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jetty.server.Server;
 import org.openhab.core.io.rest.RESTConstants;
@@ -25,17 +19,22 @@ import org.openhab.core.io.rest.RESTResource;
 import org.openhab.ui.cometvisu.internal.Config;
 import org.openhab.ui.cometvisu.internal.backend.model.rest.RestBackendEnvironmentState;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 /**
  * Check CometVisu rest backend environment.
@@ -43,9 +42,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Tobias Bräutigam - Initial contribution
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/environment")
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/environment")
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/environment")
 @Produces(MediaType.APPLICATION_JSON)

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/FsResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/FsResource.java
@@ -19,23 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 
-import javax.annotation.security.RolesAllowed;
-import javax.servlet.http.HttpServletRequest;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.FormParam;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Context;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Role;
 import org.openhab.core.io.rest.RESTConstants;
@@ -47,11 +30,11 @@ import org.openhab.ui.cometvisu.internal.util.FileOperationException;
 import org.openhab.ui.cometvisu.internal.util.FsUtil;
 import org.openhab.ui.cometvisu.internal.util.MountedFile;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +44,22 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * Filesystem backend for the cometvisu manager.
@@ -70,9 +69,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/fs")
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/fs")
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/fs")
 @Tag(name = Config.COMETVISU_BACKEND_ALIAS + "/fs")

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/MoveResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/MoveResource.java
@@ -15,15 +15,6 @@ package org.openhab.ui.cometvisu.internal.backend.rest;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Role;
 import org.openhab.core.io.rest.RESTConstants;
@@ -33,11 +24,11 @@ import org.openhab.ui.cometvisu.internal.util.FileOperationException;
 import org.openhab.ui.cometvisu.internal.util.FsUtil;
 import org.openhab.ui.cometvisu.internal.util.MountedFile;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +36,14 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * Move/renames files for the CometVisu manager.
@@ -54,9 +53,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/fs/move")
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/fs/move")
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @RolesAllowed({ Role.USER, Role.ADMIN })
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/fs/move")

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/MultipartRequestMap.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/MultipartRequestMap.java
@@ -24,9 +24,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.Part;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.Part;
 
 /**
  * Helper object for getting files from multi-part {@link HttpServletRequest}s.

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ProxyResource.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/rest/ProxyResource.java
@@ -25,14 +25,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.io.rest.RESTConstants;
@@ -42,11 +34,11 @@ import org.openhab.ui.cometvisu.internal.backend.model.rest.ConfigSection;
 import org.openhab.ui.cometvisu.internal.backend.model.rest.HiddenConfig;
 import org.openhab.ui.cometvisu.internal.util.FsUtil;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,6 +50,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * Provides the options to proxy network requests for the CometVisu to avoid CORS errors.
@@ -65,9 +64,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Tobias Bräutigam - Initial contribution
  */
 @Component
-@JaxrsResource
-@JaxrsName(Config.COMETVISU_BACKEND_ALIAS + "/proxy")
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(Config.COMETVISU_BACKEND_ALIAS + "/proxy")
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(Config.COMETVISU_BACKEND_ALIAS + "/proxy")
 @Tag(name = Config.COMETVISU_BACKEND_ALIAS + "/proxy")

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/sitemap/ConfigHelper.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/sitemap/ConfigHelper.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.xml.bind.JAXBElement;
-
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.openhab.core.items.Item;
 import org.openhab.core.library.types.DecimalType;
@@ -70,6 +68,8 @@ import org.openhab.ui.cometvisu.internal.backend.model.config.pure.Widgetinfo;
 import org.openhab.ui.cometvisu.internal.servlet.CometVisuApp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.xml.bind.JAXBElement;
 
 /**
  * a set of helper methods to convert an openHAB sitemap to a CometVisu config

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/sitemap/VisuConfig.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/backend/sitemap/VisuConfig.java
@@ -19,11 +19,7 @@ import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
@@ -69,6 +65,11 @@ import org.rrd4j.ConsolFun;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
 
 /**
  * Generates a CometVisu visu_config.xml settings file from an openHAB sitemap

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/servlet/CometVisuApp.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/servlet/CometVisuApp.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.servlet.ServletException;
-
 import org.openhab.core.config.core.ConfigurableService;
 import org.openhab.core.events.EventPublisher;
 import org.openhab.core.items.ItemRegistry;
@@ -35,6 +33,7 @@ import org.openhab.ui.cometvisu.internal.Config;
 import org.openhab.ui.cometvisu.internal.util.ClientInstaller;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.Constants;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -43,10 +42,11 @@ import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
 import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.http.HttpService;
-import org.osgi.service.http.NamespaceException;
+import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
 
 /**
  * registers the CometVisuServlet-Service
@@ -64,7 +64,9 @@ public class CometVisuApp {
 
     protected static final String CONFIG_URI = "ui:cometvisu";
 
-    protected HttpService httpService;
+    private BundleContext bundleContext;
+
+    private ServiceRegistration<Servlet> servletRegistration;
 
     private ItemUIRegistry itemUIRegistry;
 
@@ -176,15 +178,6 @@ public class CometVisuApp {
         return sitemapProviders;
     }
 
-    @Reference
-    protected void setHttpService(HttpService httpService) {
-        this.httpService = httpService;
-    }
-
-    protected void unsetHttpService(HttpService httpService) {
-        this.httpService = null;
-    }
-
     private void readConfiguration(final Map<String, Object> properties) {
         if (properties != null) {
             setProperties(properties);
@@ -244,7 +237,9 @@ public class CometVisuApp {
      *            ConfigAdmin service
      */
     @Activate
-    protected void activate(Map<String, Object> configProps) throws ConfigurationException {
+    protected void activate(BundleContext bundleContext, Map<String, Object> configProps)
+            throws ConfigurationException {
+        this.bundleContext = bundleContext;
         readConfiguration(configProps);
         registerServlet();
         logger.info("Started CometVisu UI at {} serving {}", Config.cometvisuWebappAlias, Config.cometvisuWebfolder);
@@ -253,6 +248,7 @@ public class CometVisuApp {
     @Deactivate
     public void deactivate(BundleContext componentContext) {
         unregisterServlet();
+        this.bundleContext = null;
         logger.info("Stopped CometVisu UI");
     }
 
@@ -268,17 +264,23 @@ public class CometVisuApp {
                     Config.cometvisuWebappAlias.length() - 1);
         }
 
-        Dictionary<String, String> servletParams = new Hashtable<>();
+        Dictionary<String, Object> servletParams = new Hashtable<>();
+        servletParams.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_NAME, "org.openhab.ui.cometvisu");
+        servletParams.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_SERVLET_PATTERN,
+                new String[] { Config.cometvisuWebappAlias, Config.cometvisuWebappAlias + "/*" });
         servlet = new CometVisuServlet(Config.cometvisuWebfolder, this);
-        try {
-            httpService.registerServlet(Config.cometvisuWebappAlias, servlet, servletParams, null);
-        } catch (ServletException | NamespaceException e) {
-            logger.error("Error during servlet startup", e);
+        if (bundleContext == null) {
+            logger.warn("Cannot register CometVisu servlet because the bundle context is unavailable");
+            return;
         }
+        servletRegistration = bundleContext.registerService(Servlet.class, servlet, servletParams);
     }
 
     private void unregisterServlet() {
-        httpService.unregister(Config.cometvisuWebappAlias);
+        if (servletRegistration != null) {
+            servletRegistration.unregister();
+            servletRegistration = null;
+        }
     }
 
     /**

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/servlet/CometVisuServlet.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/servlet/CometVisuServlet.java
@@ -35,15 +35,6 @@ import java.util.Map.Entry;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletContext;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.MediaType;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.OpenHAB;
@@ -66,6 +57,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.gson.Gson;
+
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletOutputStream;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Servlet for CometVisu files
@@ -135,9 +135,10 @@ public class CometVisuServlet extends HttpServlet {
     /**
      * {@inheritDoc}
      *
-     * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest,
-     *      javax.servlet.http.HttpServletResponse)
+     * @see jakarta.servlet.http.HttpServlet#doGet(jakarta.servlet.http.HttpServletRequest,
+     *      jakarta.servlet.http.HttpServletResponse)
      */
+    @NonNullByDefault({})
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         File requestedFile = getRequestedFile(req);

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/util/FileOperationException.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/util/FileOperationException.java
@@ -12,7 +12,7 @@
  */
 package org.openhab.ui.cometvisu.internal.util;
 
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * Exception on file system operations that return a status code for the rest response

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/util/FsUtil.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/util/FsUtil.java
@@ -31,10 +31,6 @@ import java.util.zip.CRC32;
 import java.util.zip.CheckedInputStream;
 import java.util.zip.CheckedOutputStream;
 
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.openhab.ui.cometvisu.internal.ManagerSettings;
 import org.openhab.ui.cometvisu.internal.MountPoint;
 import org.openhab.ui.cometvisu.internal.backend.model.rest.FsEntry;
@@ -42,6 +38,10 @@ import org.openhab.ui.cometvisu.internal.backend.model.rest.FsEntry.TypeEnum;
 import org.openhab.ui.cometvisu.internal.backend.model.rest.ReadResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * Filesystem helper that supports all file operation in the installed CometVisus config folder

--- a/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/util/MountedFile.java
+++ b/bundles/org.openhab.ui.cometvisu/src/main/java/org/openhab/ui/cometvisu/internal/util/MountedFile.java
@@ -15,10 +15,10 @@ package org.openhab.ui.cometvisu.internal.util;
 import java.io.File;
 import java.nio.file.Path;
 
-import javax.ws.rs.core.Response.Status;
-
 import org.openhab.ui.cometvisu.internal.ManagerSettings;
 import org.openhab.ui.cometvisu.internal.MountPoint;
+
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * A File that can be places in a MountPoint

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/notification/internal/NotificationService.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/notification/internal/NotificationService.java
@@ -31,8 +31,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.Response;
-
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
@@ -51,6 +49,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.BaseEncoding;
+
+import jakarta.ws.rs.core.Response;
 
 /**
  * Handles the web push notifications.

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/notification/internal/webpush/PushService.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/notification/internal/webpush/PushService.java
@@ -28,15 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Variant;
-
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.interfaces.ECPublicKey;
 import org.bouncycastle.jce.spec.ECNamedCurveParameterSpec;
@@ -47,6 +38,15 @@ import org.jose4j.jwt.JwtClaims;
 import org.jose4j.lang.JoseException;
 
 import com.google.common.io.BaseEncoding;
+
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Variant;
 
 /**
  * This code in this package is mostly borrowed from

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/rest/internal/HABotResource.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/rest/internal/HABotResource.java
@@ -20,20 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Role;
 import org.openhab.core.io.rest.LocaleService;
@@ -54,11 +40,11 @@ import org.openhab.ui.habot.notification.internal.webpush.Subscription;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,6 +57,19 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * This class describes the /habot resource of the REST API.
@@ -80,9 +79,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(HABotResource.PATH_HABOT)
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(HABotResource.PATH_HABOT)
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @RolesAllowed({ Role.USER, Role.ADMIN })
 @Path(HABotResource.PATH_HABOT)

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/tile/internal/HABotHttpContext.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/tile/internal/HABotHttpContext.java
@@ -16,35 +16,35 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.ws.rs.core.HttpHeaders;
-
-import org.osgi.service.http.HttpContext;
-import org.osgi.service.http.HttpService;
+import org.osgi.framework.Bundle;
+import org.osgi.service.servlet.context.ServletContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.ws.rs.core.HttpHeaders;
+
 /**
- * An implementation of {@link HttpContext} which will handle the gzip-compressed assets.
+ * A custom {@link ServletContextHelper} which handles gzip-compressed assets and SPA fallbacks.
  *
  * @author Yannick Schaus - Initial contribution
  */
-public class HABotHttpContext implements HttpContext {
+public class HABotHttpContext extends ServletContextHelper {
     private final Logger logger = LoggerFactory.getLogger(HABotHttpContext.class);
 
-    private HttpContext defaultHttpContext;
-    private String resourcesBase;
-    private boolean useGzipCompression;
+    private final String resourcesBase;
+    private final boolean useGzipCompression;
 
     /**
-     * Constructs an {@link HABotHttpContext} with will another {@link HttpContext} as a base.
+     * Constructs an {@link HABotHttpContext}.
      *
-     * @param defaultHttpContext the base {@link HttpContext} - use {@link HttpService#createDefaultHttpContext()} to
-     *            create a default one
+     * @param bundle the bundle providing the resources
+     * @param resourcesBase the base folder for web resources
+     * @param useGzipCompression whether to serve pre-compressed gzip assets when available
      */
-    public HABotHttpContext(HttpContext defaultHttpContext, String resourcesBase, boolean useGzipCompression) {
-        this.defaultHttpContext = defaultHttpContext;
+    public HABotHttpContext(Bundle bundle, String resourcesBase, boolean useGzipCompression) {
+        super(bundle);
         this.resourcesBase = resourcesBase;
         this.useGzipCompression = useGzipCompression;
     }
@@ -56,31 +56,40 @@ public class HABotHttpContext implements HttpContext {
         if (useGzipCompression && isGzipVersionAvailable(request.getRequestURI())) {
             response.addHeader(HttpHeaders.CONTENT_ENCODING, "gzip");
         }
-        return defaultHttpContext.handleSecurity(request, response);
+        return super.handleSecurity(request, response);
     }
 
     @Override
     public URL getResource(String name) {
         logger.debug("Requesting resource: {}", name);
         // Get the gzipped version for selected resources, built as static resources by webpack
-        URL defaultResource = defaultHttpContext.getResource(name);
-        if (useGzipCompression && isGzipVersionAvailable(name)) {
+        URL defaultResource = super.getResource(name);
+        if (useGzipCompression && defaultResource != null && isGzipVersionAvailable(name)) {
             try {
                 return new URL(defaultResource.toString() + ".gz");
             } catch (MalformedURLException e) {
                 return defaultResource;
             }
         } else {
-            if (name.equals(resourcesBase) || (resourcesBase + "/").equals(name) || !name.contains(".")) {
-                return defaultHttpContext.getResource(resourcesBase + "/index.html");
+            if (defaultResource != null) {
+                if (name.equals(resourcesBase) || name.equals("/" + resourcesBase) || (resourcesBase + "/").equals(name)
+                        || ("/" + resourcesBase + "/").equals(name) || !name.contains(".")) {
+                    URL index = super.getResource("/" + resourcesBase + "/index.html");
+                    return index != null ? index : defaultResource;
+                }
+                return defaultResource;
             }
-            return defaultResource;
+
+            if (!name.contains(".")) {
+                return super.getResource("/" + resourcesBase + "/index.html");
+            }
+            return null;
         }
     }
 
     @Override
     public String getMimeType(String name) {
-        return defaultHttpContext.getMimeType(name);
+        return super.getMimeType(name);
     }
 
     private boolean isGzipVersionAvailable(String name) {

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/tile/internal/HABotTile.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/tile/internal/HABotTile.java
@@ -12,19 +12,20 @@
  */
 package org.openhab.ui.habot.tile.internal;
 
+import java.util.Dictionary;
+import java.util.Hashtable;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.core.ui.tiles.Tile;
 import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.http.HttpContext;
-import org.osgi.service.http.HttpService;
-import org.osgi.service.http.NamespaceException;
+import org.osgi.service.servlet.context.ServletContextHelper;
+import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,29 +40,48 @@ public class HABotTile implements Tile {
 
     public static final String HABOT_ALIAS = "/habot";
     public static final String RESOURCES_BASE = "web/dist/pwa-mat";
+    private static final String CONTEXT_NAME = "org.openhab.ui.habot.context";
 
     private final Logger logger = LoggerFactory.getLogger(HABotTile.class);
 
-    private final HttpService httpService;
+    private final BundleContext bundleContext;
+    private @Nullable ServiceRegistration<ServletContextHelper> contextRegistration;
+    private @Nullable ServiceRegistration<Object> resourceRegistration;
 
     @Activate
-    public HABotTile(Map<String, Object> configProps, BundleContext context, final @Reference HttpService httpService) {
-        this.httpService = httpService;
-        try {
-            Object useGzipCompression = configProps.get("useGzipCompression");
-            HttpContext httpContext = new HABotHttpContext(httpService.createDefaultHttpContext(), RESOURCES_BASE,
-                    (useGzipCompression != null && Boolean.parseBoolean(useGzipCompression.toString())));
+    public HABotTile(Map<String, Object> configProps, BundleContext context) {
+        this.bundleContext = context;
 
-            httpService.registerResources(HABOT_ALIAS, RESOURCES_BASE, httpContext);
-            logger.info("Started HABot at " + HABOT_ALIAS);
-        } catch (NamespaceException e) {
-            logger.error("Error during HABot startup: {}", e.getMessage());
-        }
+        Object useGzipCompression = configProps.get("useGzipCompression");
+        boolean gzipEnabled = useGzipCompression != null && Boolean.parseBoolean(useGzipCompression.toString());
+
+        Dictionary<String, Object> contextProps = new Hashtable<>();
+        contextProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME, CONTEXT_NAME);
+        contextProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_PATH, HABOT_ALIAS);
+
+        HABotHttpContext httpContext = new HABotHttpContext(context.getBundle(), RESOURCES_BASE, gzipEnabled);
+        contextRegistration = bundleContext.registerService(ServletContextHelper.class, httpContext, contextProps);
+
+        Dictionary<String, Object> resourceProps = new Hashtable<>();
+        resourceProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PATTERN, "/*");
+        resourceProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_RESOURCE_PREFIX, "/" + RESOURCES_BASE);
+        resourceProps.put(HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_SELECT,
+                "(" + HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_NAME + "=" + CONTEXT_NAME + ")");
+
+        resourceRegistration = bundleContext.registerService(Object.class, new Object(), resourceProps);
+        logger.info("Started HABot at {}", HABOT_ALIAS);
     }
 
     @Deactivate
     protected void deactivate() {
-        httpService.unregister(HABOT_ALIAS);
+        if (resourceRegistration != null) {
+            resourceRegistration.unregister();
+            resourceRegistration = null;
+        }
+        if (contextRegistration != null) {
+            contextRegistration.unregister();
+            contextRegistration = null;
+        }
         logger.info("Stopped HABot");
     }
 

--- a/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/HABPanelTile.java
+++ b/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/HABPanelTile.java
@@ -18,7 +18,7 @@ import org.openhab.core.ui.tiles.Tile;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Deactivate;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardResource;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/rest/HABPanelResource.java
+++ b/bundles/org.openhab.ui.habpanel/src/main/java/org/openhab/ui/habpanel/internal/rest/HABPanelResource.java
@@ -14,15 +14,6 @@ package org.openhab.ui.habpanel.internal.rest;
 
 import java.util.stream.Stream;
 
-import javax.annotation.security.RolesAllowed;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.openhab.core.auth.Role;
 import org.openhab.core.io.rest.JSONResponse;
@@ -34,11 +25,11 @@ import org.openhab.ui.habpanel.internal.gallery.GalleryProviderFactory;
 import org.openhab.ui.habpanel.internal.gallery.GalleryWidgetProvider;
 import org.openhab.ui.habpanel.internal.gallery.GalleryWidgetsListItem;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.jaxrs.whiteboard.JaxrsWhiteboardConstants;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JSONRequired;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsApplicationSelect;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsName;
-import org.osgi.service.jaxrs.whiteboard.propertytypes.JaxrsResource;
+import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JSONRequired;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsApplicationSelect;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsName;
+import org.osgi.service.jakartars.whiteboard.propertytypes.JakartarsResource;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -47,6 +38,14 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.security.RolesAllowed;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 
 /**
  * This class describes the /habpanel resource of the REST API, currently holding facilities for browsing widget
@@ -56,9 +55,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
  * @author Wouter Born - Migrated to OpenAPI annotations
  */
 @Component
-@JaxrsResource
-@JaxrsName(HABPanelResource.PATH_HABPANEL)
-@JaxrsApplicationSelect("(" + JaxrsWhiteboardConstants.JAX_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
+@JakartarsResource
+@JakartarsName(HABPanelResource.PATH_HABPANEL)
+@JakartarsApplicationSelect("(" + JakartarsWhiteboardConstants.JAKARTA_RS_NAME + "=" + RESTConstants.JAX_RS_NAME + ")")
 @JSONRequired
 @Path(HABPanelResource.PATH_HABPANEL)
 @Tag(name = HABPanelResource.PATH_HABPANEL)

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
@@ -30,6 +30,6 @@ import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "redirectWelcome=false",
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "preCompressed=true",
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX
-                + "etags=true" }, service = ServletContextHelper.class)
+                + "etags=true" }, service = { ServletContextHelper.class, UIContext.class })
 public class UIContext extends ServletContextHelper {
 }

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
@@ -14,8 +14,8 @@ package org.openhab.ui.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.http.context.ServletContextHelper;
-import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+import org.osgi.service.servlet.context.ServletContextHelper;
+import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
 
 /**
  * The {@link UIContext} is the shared context for Main UI servlets

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
@@ -13,9 +13,11 @@
 package org.openhab.ui.internal;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.http.context.ServletContextHelper;
-import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
+import org.osgi.service.servlet.context.ServletContextHelper;
+import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
 
 /**
  * The {@link UIContext} is the shared context for Main UI servlets
@@ -30,6 +32,10 @@ import org.osgi.service.http.whiteboard.HttpWhiteboardConstants;
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "redirectWelcome=false",
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "preCompressed=true",
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX
-                + "etags=true" }, service = ServletContextHelper.class)
+                + "etags=true" }, service = { ServletContextHelper.class, UIContext.class })
 public class UIContext extends ServletContextHelper {
+    @Activate
+    public UIContext(BundleContext bundleContext) {
+        super(bundleContext.getBundle());
+    }
 }

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIContext.java
@@ -31,8 +31,8 @@ import org.osgi.service.servlet.whiteboard.HttpWhiteboardConstants;
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "dirAllowed=false",
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "redirectWelcome=false",
         HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "preCompressed=true",
-        HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX
-                + "etags=true" }, service = { ServletContextHelper.class, UIContext.class })
+        HttpWhiteboardConstants.HTTP_WHITEBOARD_CONTEXT_INIT_PARAM_PREFIX + "etags=true" }, service = {
+                ServletContextHelper.class, UIContext.class })
 public class UIContext extends ServletContextHelper {
     @Activate
     public UIContext(BundleContext bundleContext) {

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIErrorPageServlet.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIErrorPageServlet.java
@@ -16,18 +16,18 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletErrorPage;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletErrorPage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Returns the index file whenever pages cannot be found. This allows the UI to route to a page based on the URL or
@@ -58,7 +58,7 @@ public class UIErrorPageServlet extends HttpServlet {
                 logger.warn("The index file ({}) does not exist", INDEX_FILE);
                 return;
             }
-            String requestURI = (String) req.getAttribute("javax.servlet.error.request_uri");
+            String requestURI = (String) req.getAttribute("jakarta.servlet.error.request_uri");
             int status = isValidRoute(requestURI) ? 200 : 404;
             logger.debug("Returning index file as response with status {} for request URI: {}", status, requestURI);
             resp.setContentType("text/html");

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIErrorPageServlet.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIErrorPageServlet.java
@@ -16,18 +16,19 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletErrorPage;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletErrorPage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Returns the index file whenever pages cannot be found. This allows the UI to route to a page based on the URL or
@@ -38,6 +39,7 @@ import org.slf4j.LoggerFactory;
  */
 @Component(immediate = true, service = Servlet.class)
 @HttpWhiteboardServletErrorPage(errorPage = { "404" })
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=org.openhab.ui.context)")
 @NonNullByDefault
 public class UIErrorPageServlet extends HttpServlet {
 
@@ -58,7 +60,7 @@ public class UIErrorPageServlet extends HttpServlet {
                 logger.warn("The index file ({}) does not exist", INDEX_FILE);
                 return;
             }
-            String requestURI = (String) req.getAttribute("javax.servlet.error.request_uri");
+            String requestURI = (String) req.getAttribute("jakarta.servlet.error.request_uri");
             int status = isValidRoute(requestURI) ? 200 : 404;
             logger.debug("Returning index file as response with status {} for request URI: {}", status, requestURI);
             resp.setContentType("text/html");

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIServlet.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIServlet.java
@@ -17,31 +17,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.channels.ReadableByteChannel;
-import java.util.Arrays;
-
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.UnavailableException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.net.URLConnection;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.server.handler.ContextHandler;
-import org.eclipse.jetty.servlet.DefaultServlet;
-import org.eclipse.jetty.util.resource.Resource;
 import org.openhab.core.OpenHAB;
-import org.ops4j.pax.web.service.WebContainer;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.http.HttpContext;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContext;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardContext;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet that serves files from both the filesystem and the local bundle. Supports general file caching as well as
@@ -55,7 +50,7 @@ import org.slf4j.LoggerFactory;
 @HttpWhiteboardServletName(UIServlet.SERVLET_PATH)
 @HttpWhiteboardServletPattern(UIServlet.SERVLET_PATH + "*")
 @HttpWhiteboardContext(name = "=org.openhab.ui.context", path = "=/")
-public class UIServlet extends DefaultServlet {
+public class UIServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
@@ -65,64 +60,16 @@ public class UIServlet extends DefaultServlet {
     public static final String SERVLET_PATH = "/";
     private static final String STATIC_PATH = "/static";
     private static final String STATIC_BASE = OpenHAB.getConfigFolder() + "/html";
-    private static final String[] COMPRESS_EXT = { "gz", "br" };
+    private static final List<String> COMPRESS_EXT = List.of("br", "gz");
 
-    private final HttpContext defaultHttpContext;
+    private final UIContext uiContext;
     private final long bundleModifiedTime;
-    private @Nullable ContextHandler contextHandler;
 
     @Activate
-    public UIServlet(final @Reference WebContainer webContainer) {
-        this.defaultHttpContext = webContainer.createDefaultHttpContext();
+    public UIServlet(final @Reference UIContext uiContext) {
+        this.uiContext = uiContext;
         logger.debug("Starting up {} at {}", getClass().getSimpleName(), SERVLET_PATH);
         bundleModifiedTime = (System.currentTimeMillis() / 1000) * 1000; // round milliseconds
-    }
-
-    @Override
-    public void init() throws UnavailableException {
-        contextHandler = ContextHandler.getCurrentContext().getContextHandler();
-        super.init();
-    }
-
-    @Override
-    public @Nullable Resource getResource(@NonNullByDefault({}) String name) {
-        logger.debug("getResource: {}", name);
-        ContextHandler contextHandler = this.contextHandler;
-        if (contextHandler == null) {
-            return null;
-        }
-
-        if (name.startsWith(STATIC_PATH) && !name.endsWith("/")) {
-            URL url = null;
-            try {
-                url = new File(STATIC_BASE + name.substring(STATIC_PATH.length())).toURI().toURL();
-            } catch (MalformedURLException e) {
-                logger.error("Error while serving static content: {}", e.getMessage());
-                url = defaultHttpContext.getResource(APP_BASE + name);
-            }
-            try {
-                logger.debug("getResource static file returning {}", url);
-                return contextHandler.newResource(url);
-            } catch (IOException e) {
-                logger.error("Error while serving content: {}", e.getMessage());
-                return null;
-            }
-        } else {
-            URL url = defaultHttpContext.getResource(APP_BASE + name);
-            // if we don't find a resource, and it's not a check for a compressed version,
-            // let the UIErrorPageServlet return the app base with a proper response code that lets
-            // the Vue.js main UI handle routing
-            if (url == null && Arrays.stream(COMPRESS_EXT).noneMatch(name::endsWith)) {
-                return null;
-            }
-            try {
-                logger.debug("getResource bundle file returning {}", url);
-                return url == null ? null : new ResourceWrapper(contextHandler.newResource(url));
-            } catch (IOException e) {
-                logger.error("Error while serving content: {}", e.getMessage());
-                return null;
-            }
-        }
     }
 
     @Override
@@ -131,113 +78,127 @@ public class UIServlet extends DefaultServlet {
         if (request == null || response == null) {
             return;
         }
-        if (!defaultHttpContext.handleSecurity(request, response)) {
+
+        if (!uiContext.handleSecurity(request, response)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
-        super.doGet(request, response);
+
+        String requestPath = request.getRequestURI().substring(request.getContextPath().length());
+        if (requestPath.isEmpty()) {
+            requestPath = SERVLET_PATH;
+        }
+        if (SERVLET_PATH.equals(requestPath)) {
+            requestPath = "/index.html";
+        }
+
+        ResourceDescriptor resource = resolveResource(requestPath, request.getHeader("Accept-Encoding"));
+        if (resource == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        if (resource.contentType != null) {
+            response.setContentType(resource.contentType);
+        }
+        if (resource.contentEncoding != null) {
+            response.setHeader("Content-Encoding", resource.contentEncoding);
+            response.setHeader("Vary", "Accept-Encoding");
+        }
+        if (resource.lastModified > 0) {
+            response.setDateHeader("Last-Modified", resource.lastModified);
+        }
+        if (resource.contentLength >= 0) {
+            response.setContentLengthLong(resource.contentLength);
+        }
+
+        try (InputStream is = resource.url.openStream()) {
+            is.transferTo(response.getOutputStream());
+        }
     }
 
-    @Override
-    public @Nullable String getWelcomeFile(@Nullable String pathInContext) {
-        logger.debug("getWelcomeFile {}", pathInContext);
-        if (pathInContext != null && pathInContext.startsWith(STATIC_PATH)) {
+    private @Nullable ResourceDescriptor resolveResource(String requestPath, @Nullable String acceptEncoding) {
+        logger.debug("Resolving UI resource: {}", requestPath);
+
+        if (requestPath.startsWith(STATIC_PATH) && !requestPath.endsWith("/")) {
+            return resolveStaticResource(requestPath, acceptEncoding);
+        }
+
+        if (requestPath.endsWith("/")) {
             return null;
         }
-        return "/index.html";
+
+        return resolveBundleResource(APP_BASE + requestPath, requestPath, acceptEncoding);
     }
 
-    /**
-     *
-     * Wraps a resource and returns a consistent time for bundled files
-     *
-     */
-    class ResourceWrapper extends Resource {
-
-        private final Resource baseResource;
-
-        public ResourceWrapper(Resource baseResource) {
-            this.baseResource = baseResource;
+    private @Nullable ResourceDescriptor resolveStaticResource(String requestPath, @Nullable String acceptEncoding) {
+        String relativePath = requestPath.substring(STATIC_PATH.length());
+        File file = new File(STATIC_BASE + relativePath);
+        if (file.isDirectory() || !file.exists()) {
+            return null;
         }
 
-        @Override
-        public long lastModified() {
-            return bundleModifiedTime;
+        if (acceptEncoding != null) {
+            for (String ext : COMPRESS_EXT) {
+                if (acceptEncoding.contains(ext)) {
+                    File compressed = new File(file.getPath() + "." + ext);
+                    if (compressed.exists()) {
+                        URL compressedUrl = fileUrl(compressed);
+                        if (compressedUrl != null) {
+                            return new ResourceDescriptor(compressedUrl, contentType(requestPath), ext,
+                                    compressed.length(), compressed.lastModified());
+                        }
+                    }
+                }
+            }
         }
 
-        @Override
-        public boolean isContainedIn(@Nullable Resource r) throws MalformedURLException {
-            return baseResource.isContainedIn(r);
+        URL fileUrl = fileUrl(file);
+        return fileUrl == null ? null
+                : new ResourceDescriptor(fileUrl, contentType(requestPath), null, file.length(), file.lastModified());
+    }
+
+    private @Nullable URL fileUrl(File file) {
+        try {
+            return file.toURI().toURL();
+        } catch (MalformedURLException e) {
+            logger.debug("Failed to create URL for static resource {}", file, e);
+            return null;
+        }
+    }
+
+    private @Nullable ResourceDescriptor resolveBundleResource(String bundlePath, String requestPath,
+            @Nullable String acceptEncoding) {
+        if (acceptEncoding != null) {
+            for (String ext : COMPRESS_EXT) {
+                if (acceptEncoding.contains(ext)) {
+                    URL compressed = uiContext.getResource(bundlePath + "." + ext);
+                    if (compressed != null) {
+                        return new ResourceDescriptor(compressed, contentType(requestPath), ext, -1,
+                                bundleModifiedTime);
+                    }
+                }
+            }
         }
 
-        @Override
-        public void close() {
-            baseResource.close();
+        URL resource = uiContext.getResource(bundlePath);
+        if (resource == null && COMPRESS_EXT.stream().noneMatch(requestPath::endsWith)) {
+            // Missing resources should return 404 so the error page servlet can handle SPA routes.
+            return null;
         }
+        return resource == null ? null
+                : new ResourceDescriptor(resource, contentType(requestPath), null, -1, bundleModifiedTime);
+    }
 
-        @Override
-        public boolean exists() {
-            return baseResource.exists();
+    private @Nullable String contentType(String path) {
+        String contentType = getServletContext().getMimeType(path);
+        if (contentType == null) {
+            contentType = URLConnection.guessContentTypeFromName(path);
         }
+        return contentType;
+    }
 
-        @Override
-        public boolean isDirectory() {
-            return baseResource.isDirectory();
-        }
-
-        @Override
-        public long length() {
-            return baseResource.length();
-        }
-
-        @Override
-        public URL getURL() {
-            return baseResource.getURL();
-        }
-
-        @Override
-        public File getFile() throws IOException {
-            return baseResource.getFile();
-        }
-
-        @Override
-        public String getName() {
-            return baseResource.getName();
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            return baseResource.getInputStream();
-        }
-
-        @Override
-        public ReadableByteChannel getReadableByteChannel() throws IOException {
-            return baseResource.getReadableByteChannel();
-        }
-
-        @Override
-        public boolean delete() throws SecurityException {
-            return baseResource.delete();
-        }
-
-        @Override
-        public boolean renameTo(@Nullable Resource dest) throws SecurityException {
-            return baseResource.renameTo(dest);
-        }
-
-        @Override
-        public String[] list() {
-            return baseResource.list();
-        }
-
-        @Override
-        public Resource addPath(@Nullable String path) throws IOException {
-            return baseResource.addPath(path);
-        }
-
-        @Override
-        public String toString() {
-            return getURL().toString();
-        }
+    private record ResourceDescriptor(URL url, @Nullable String contentType, @Nullable String contentEncoding,
+            long contentLength, long lastModified) {
     }
 }

--- a/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIServlet.java
+++ b/bundles/org.openhab.ui/src/main/java/org/openhab/ui/internal/UIServlet.java
@@ -17,31 +17,26 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.channels.ReadableByteChannel;
-import java.util.Arrays;
-
-import javax.servlet.Servlet;
-import javax.servlet.ServletException;
-import javax.servlet.UnavailableException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import java.net.URLConnection;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
-import org.eclipse.jetty.server.handler.ContextHandler;
-import org.eclipse.jetty.servlet.DefaultServlet;
-import org.eclipse.jetty.util.resource.Resource;
 import org.openhab.core.OpenHAB;
-import org.ops4j.pax.web.service.WebContainer;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.http.HttpContext;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardContext;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletName;
-import org.osgi.service.http.whiteboard.propertytypes.HttpWhiteboardServletPattern;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardContextSelect;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletName;
+import org.osgi.service.servlet.whiteboard.propertytypes.HttpWhiteboardServletPattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import jakarta.servlet.Servlet;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Servlet that serves files from both the filesystem and the local bundle. Supports general file caching as well as
@@ -54,8 +49,8 @@ import org.slf4j.LoggerFactory;
 @NonNullByDefault
 @HttpWhiteboardServletName(UIServlet.SERVLET_PATH)
 @HttpWhiteboardServletPattern(UIServlet.SERVLET_PATH + "*")
-@HttpWhiteboardContext(name = "=org.openhab.ui.context", path = "=/")
-public class UIServlet extends DefaultServlet {
+@HttpWhiteboardContextSelect("(osgi.http.whiteboard.context.name=org.openhab.ui.context)")
+public class UIServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
 
@@ -65,64 +60,16 @@ public class UIServlet extends DefaultServlet {
     public static final String SERVLET_PATH = "/";
     private static final String STATIC_PATH = "/static";
     private static final String STATIC_BASE = OpenHAB.getConfigFolder() + "/html";
-    private static final String[] COMPRESS_EXT = { "gz", "br" };
+    private static final List<String> COMPRESS_EXT = List.of("br", "gz");
 
-    private final HttpContext defaultHttpContext;
+    private final UIContext uiContext;
     private final long bundleModifiedTime;
-    private @Nullable ContextHandler contextHandler;
 
     @Activate
-    public UIServlet(final @Reference WebContainer webContainer) {
-        this.defaultHttpContext = webContainer.createDefaultHttpContext();
+    public UIServlet(final @Reference UIContext uiContext) {
+        this.uiContext = uiContext;
         logger.debug("Starting up {} at {}", getClass().getSimpleName(), SERVLET_PATH);
         bundleModifiedTime = (System.currentTimeMillis() / 1000) * 1000; // round milliseconds
-    }
-
-    @Override
-    public void init() throws UnavailableException {
-        contextHandler = ContextHandler.getCurrentContext().getContextHandler();
-        super.init();
-    }
-
-    @Override
-    public @Nullable Resource getResource(@NonNullByDefault({}) String name) {
-        logger.debug("getResource: {}", name);
-        ContextHandler contextHandler = this.contextHandler;
-        if (contextHandler == null) {
-            return null;
-        }
-
-        if (name.startsWith(STATIC_PATH) && !name.endsWith("/")) {
-            URL url = null;
-            try {
-                url = new File(STATIC_BASE + name.substring(STATIC_PATH.length())).toURI().toURL();
-            } catch (MalformedURLException e) {
-                logger.error("Error while serving static content: {}", e.getMessage());
-                url = defaultHttpContext.getResource(APP_BASE + name);
-            }
-            try {
-                logger.debug("getResource static file returning {}", url);
-                return contextHandler.newResource(url);
-            } catch (IOException e) {
-                logger.error("Error while serving content: {}", e.getMessage());
-                return null;
-            }
-        } else {
-            URL url = defaultHttpContext.getResource(APP_BASE + name);
-            // if we don't find a resource, and it's not a check for a compressed version,
-            // let the UIErrorPageServlet return the app base with a proper response code that lets
-            // the Vue.js main UI handle routing
-            if (url == null && Arrays.stream(COMPRESS_EXT).noneMatch(name::endsWith)) {
-                return null;
-            }
-            try {
-                logger.debug("getResource bundle file returning {}", url);
-                return url == null ? null : new ResourceWrapper(contextHandler.newResource(url));
-            } catch (IOException e) {
-                logger.error("Error while serving content: {}", e.getMessage());
-                return null;
-            }
-        }
     }
 
     @Override
@@ -131,113 +78,127 @@ public class UIServlet extends DefaultServlet {
         if (request == null || response == null) {
             return;
         }
-        if (!defaultHttpContext.handleSecurity(request, response)) {
+
+        if (!uiContext.handleSecurity(request, response)) {
             response.sendError(HttpServletResponse.SC_FORBIDDEN);
             return;
         }
-        super.doGet(request, response);
+
+        String requestPath = request.getRequestURI().substring(request.getContextPath().length());
+        if (requestPath.isEmpty()) {
+            requestPath = SERVLET_PATH;
+        }
+        if (SERVLET_PATH.equals(requestPath)) {
+            requestPath = "/index.html";
+        }
+
+        ResourceDescriptor resource = resolveResource(requestPath, request.getHeader("Accept-Encoding"));
+        if (resource == null) {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        if (resource.contentType != null) {
+            response.setContentType(resource.contentType);
+        }
+        if (resource.contentEncoding != null) {
+            response.setHeader("Content-Encoding", resource.contentEncoding);
+            response.setHeader("Vary", "Accept-Encoding");
+        }
+        if (resource.lastModified > 0) {
+            response.setDateHeader("Last-Modified", resource.lastModified);
+        }
+        if (resource.contentLength >= 0) {
+            response.setContentLengthLong(resource.contentLength);
+        }
+
+        try (InputStream is = resource.url.openStream()) {
+            is.transferTo(response.getOutputStream());
+        }
     }
 
-    @Override
-    public @Nullable String getWelcomeFile(@Nullable String pathInContext) {
-        logger.debug("getWelcomeFile {}", pathInContext);
-        if (pathInContext != null && pathInContext.startsWith(STATIC_PATH)) {
+    private @Nullable ResourceDescriptor resolveResource(String requestPath, @Nullable String acceptEncoding) {
+        logger.debug("Resolving UI resource: {}", requestPath);
+
+        if (requestPath.startsWith(STATIC_PATH) && !requestPath.endsWith("/")) {
+            return resolveStaticResource(requestPath, acceptEncoding);
+        }
+
+        if (requestPath.endsWith("/")) {
             return null;
         }
-        return "/index.html";
+
+        return resolveBundleResource(APP_BASE + requestPath, requestPath, acceptEncoding);
     }
 
-    /**
-     *
-     * Wraps a resource and returns a consistent time for bundled files
-     *
-     */
-    class ResourceWrapper extends Resource {
-
-        private final Resource baseResource;
-
-        public ResourceWrapper(Resource baseResource) {
-            this.baseResource = baseResource;
+    private @Nullable ResourceDescriptor resolveStaticResource(String requestPath, @Nullable String acceptEncoding) {
+        String relativePath = requestPath.substring(STATIC_PATH.length());
+        File file = new File(STATIC_BASE + relativePath);
+        if (file.isDirectory() || !file.exists()) {
+            return null;
         }
 
-        @Override
-        public long lastModified() {
-            return bundleModifiedTime;
+        if (acceptEncoding != null) {
+            for (String ext : COMPRESS_EXT) {
+                if (acceptEncoding.contains(ext)) {
+                    File compressed = new File(file.getPath() + "." + ext);
+                    if (compressed.exists()) {
+                        URL compressedUrl = fileUrl(compressed);
+                        if (compressedUrl != null) {
+                            return new ResourceDescriptor(compressedUrl, contentType(requestPath), ext,
+                                    compressed.length(), compressed.lastModified());
+                        }
+                    }
+                }
+            }
         }
 
-        @Override
-        public boolean isContainedIn(@Nullable Resource r) throws MalformedURLException {
-            return baseResource.isContainedIn(r);
+        URL fileUrl = fileUrl(file);
+        return fileUrl == null ? null
+                : new ResourceDescriptor(fileUrl, contentType(requestPath), null, file.length(), file.lastModified());
+    }
+
+    private @Nullable URL fileUrl(File file) {
+        try {
+            return file.toURI().toURL();
+        } catch (MalformedURLException e) {
+            logger.debug("Failed to create URL for static resource {}", file, e);
+            return null;
+        }
+    }
+
+    private @Nullable ResourceDescriptor resolveBundleResource(String bundlePath, String requestPath,
+            @Nullable String acceptEncoding) {
+        if (acceptEncoding != null) {
+            for (String ext : COMPRESS_EXT) {
+                if (acceptEncoding.contains(ext)) {
+                    URL compressed = uiContext.getResource(bundlePath + "." + ext);
+                    if (compressed != null) {
+                        return new ResourceDescriptor(compressed, contentType(requestPath), ext, -1,
+                                bundleModifiedTime);
+                    }
+                }
+            }
         }
 
-        @Override
-        public void close() {
-            baseResource.close();
+        URL resource = uiContext.getResource(bundlePath);
+        if (resource == null && COMPRESS_EXT.stream().noneMatch(requestPath::endsWith)) {
+            // Missing resources should return 404 so the error page servlet can handle SPA routes.
+            return null;
         }
+        return resource == null ? null
+                : new ResourceDescriptor(resource, contentType(requestPath), null, -1, bundleModifiedTime);
+    }
 
-        @Override
-        public boolean exists() {
-            return baseResource.exists();
+    private @Nullable String contentType(String path) {
+        String contentType = getServletContext().getMimeType(path);
+        if (contentType == null) {
+            contentType = URLConnection.guessContentTypeFromName(path);
         }
+        return contentType;
+    }
 
-        @Override
-        public boolean isDirectory() {
-            return baseResource.isDirectory();
-        }
-
-        @Override
-        public long length() {
-            return baseResource.length();
-        }
-
-        @Override
-        public URL getURL() {
-            return baseResource.getURL();
-        }
-
-        @Override
-        public File getFile() throws IOException {
-            return baseResource.getFile();
-        }
-
-        @Override
-        public String getName() {
-            return baseResource.getName();
-        }
-
-        @Override
-        public InputStream getInputStream() throws IOException {
-            return baseResource.getInputStream();
-        }
-
-        @Override
-        public ReadableByteChannel getReadableByteChannel() throws IOException {
-            return baseResource.getReadableByteChannel();
-        }
-
-        @Override
-        public boolean delete() throws SecurityException {
-            return baseResource.delete();
-        }
-
-        @Override
-        public boolean renameTo(@Nullable Resource dest) throws SecurityException {
-            return baseResource.renameTo(dest);
-        }
-
-        @Override
-        public String[] list() {
-            return baseResource.list();
-        }
-
-        @Override
-        public Resource addPath(@Nullable String path) throws IOException {
-            return baseResource.addPath(path);
-        }
-
-        @Override
-        public String toString() {
-            return getURL().toString();
-        }
+    private record ResourceDescriptor(URL url, @Nullable String contentType, @Nullable String contentEncoding,
+            long contentLength, long lastModified) {
     }
 }

--- a/bundles/pom.xml
+++ b/bundles/pom.xml
@@ -51,6 +51,18 @@
       <type>pom</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.http</artifactId>
+      <version>1.2.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.service.jakartars</artifactId>
+      <version>2.0.0</version>
+      <scope>provided</scope>
+    </dependency>
     <!-- Distribution -->
     <dependency>
       <groupId>org.apache.karaf.features</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <bnd.version>7.2.1</bnd.version>
     <eea.version>2.4.0</eea.version>
     <jackson.annotations.version>2.20</jackson.annotations.version>
-    <karaf.version>4.4.10</karaf.version>
-    <karaf.maven.plugin.version>4.4.10</karaf.maven.plugin.version>
+    <karaf.version>4.5.0-SNAPSHOT</karaf.version>
+    <karaf.maven.plugin.version>4.5.0-SNAPSHOT</karaf.maven.plugin.version>
     <ohc.version>5.2.0-SNAPSHOT</ohc.version>
     <sat.version>0.18.0</sat.version>
     <spotless.version>2.44.3</spotless.version>
@@ -92,24 +92,24 @@
           <configuration>
             <bnd><![CDATA[Bundle-SymbolicName: ${project.artifactId}
 Automatic-Module-Name: ${def;bsn}
-Import-Package: \\
-  io.swagger.v3.oas.annotations.*;resolution:=optional,\\
-  javax.annotation.security.*;resolution:=optional,\\
-  org.eclipse.jdt.annotation.*;resolution:=optional,\\
-  org.openhab.core.automation.annotation.*;resolution:=optional;version=!,\\
-  org.openhab.*;version=!,\\
-  com.google.common.*;version="14.0",\\
+Import-Package: \
+  io.swagger.v3.oas.annotations.*;resolution:=optional,\
+  jakarta.annotation.security.*;resolution:=optional,\
+  org.eclipse.jdt.annotation.*;resolution:=optional,\
+  org.openhab.core.automation.annotation.*;resolution:=optional;version=!,\
+  org.openhab.*;version=!,\
+  com.google.common.*;version="14.0",\
   *
--exportcontents: \\
-  !*.internal.*,\\
-  !*.impl.*, \\
+-exportcontents: \
+  !*.internal.*,\
+  !*.impl.*, \
   org.openhab.*
 -noimportjava: true
 -sources: false
 -contract: *
 -includeresource: -${.}/NOTICE, -${.}/*.xsd
--fixupmessages: \\
-  'Unused Import-Package instructions';is:=ignore,\\
+-fixupmessages: \
+  'Unused Import-Package instructions';is:=ignore,\
   'Unused Export-Package instructions';is:=ignore]]></bnd>
             <!--
               -dsannotations-options: norequirements

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <bnd.version>7.3.0</bnd.version>
     <eea.version>2.4.0</eea.version>
     <jackson.annotations.version>2.20</jackson.annotations.version>
-    <karaf.version>4.4.11</karaf.version>
-    <karaf.maven.plugin.version>4.4.11</karaf.maven.plugin.version>
+    <karaf.version>4.5.0-SNAPSHOT</karaf.version>
+    <karaf.maven.plugin.version>4.5.0-SNAPSHOT</karaf.maven.plugin.version>
     <ohc.version>5.3.0-SNAPSHOT</ohc.version>
     <sat.version>0.18.0</sat.version>
     <spotless.version>2.44.3</spotless.version>
@@ -92,24 +92,24 @@
           <configuration>
             <bnd><![CDATA[Bundle-SymbolicName: ${project.artifactId}
 Automatic-Module-Name: ${def;bsn}
-Import-Package: \\
-  io.swagger.v3.oas.annotations.*;resolution:=optional,\\
-  javax.annotation.security.*;resolution:=optional,\\
-  org.eclipse.jdt.annotation.*;resolution:=optional,\\
-  org.openhab.core.automation.annotation.*;resolution:=optional;version=!,\\
-  org.openhab.*;version=!,\\
-  com.google.common.*;version="14.0",\\
+Import-Package: \
+  io.swagger.v3.oas.annotations.*;resolution:=optional,\
+  jakarta.annotation.security.*;resolution:=optional,\
+  org.eclipse.jdt.annotation.*;resolution:=optional,\
+  org.openhab.core.automation.annotation.*;resolution:=optional;version=!,\
+  org.openhab.*;version=!,\
+  com.google.common.*;version="14.0",\
   *
--exportcontents: \\
-  !*.internal.*,\\
-  !*.impl.*, \\
+-exportcontents: \
+  !*.internal.*,\
+  !*.impl.*, \
   org.openhab.*
 -noimportjava: true
 -sources: false
 -contract: *
 -includeresource: -${.}/NOTICE, -${.}/*.xsd
--fixupmessages: \\
-  'Unused Import-Package instructions';is:=ignore,\\
+-fixupmessages: \
+  'Unused Import-Package instructions';is:=ignore,\
   'Unused Export-Package instructions';is:=ignore]]></bnd>
             <!--
               -dsannotations-options: norequirements


### PR DESCRIPTION
Refs: openhab/openhab-core#5479

Servlet / HTTP:
- Migrate affected UI servlet/context classes to jakarta.servlet.* based APIs
- Replace legacy HttpService/HttpContext registration in HABot tile with Servlet Whiteboard registration

JAX-RS:
- Switch UI REST resources from org.osgi.service.jaxrs.whiteboard to org.osgi.service.jakartars.whiteboard (OSGi R8)
- Update whiteboard annotations/constants from Jaxrs* to Jakartars*
- Keep RESTConstants.JAX_RS_NAME usage where required for openHAB REST integration
- Add openhab.tp-jax-rs-whiteboard feature dependency for CometVisu runtime resolution

Dependencies:
- Replace provided osgi.service.jaxrs with osgi.service.jakartars in bundles dependency management

Build:
- Verify focused compilation for CometVisu, HABot, and HABPanel after migration