### PR TITLE
Pages list: Separate sitemaps, Include unmanaged sitemaps & Copy file definition

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
@@ -48,5 +48,8 @@
   "page.unavailable.text": "You are not allowed to view this page because of visibility restrictions.",
 
   "persistence.title": "No persistence add-on installed",
-  "persistence.text": "With persistence you can store Item states over time, no matter they are historic or future values. To configure persistence, you need at least one persistence add-on to be installed."
+  "persistence.text": "With persistence you can store Item states over time, no matter they are historic or future values. To configure persistence, you need at least one persistence add-on to be installed.",
+
+  "sitemaps.title": "No sitemaps yet",
+  "sitemaps.text": "Sitemaps are a declarative way to define the structure of a user interface for UIs that support them (BasicUI, mobile apps...). They are made of widgets to display item states or send commands to items.<br><br>Click the button below to create your first sitemap."
 }

--- a/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
@@ -51,5 +51,5 @@
   "persistence.text": "With persistence you can store Item states over time, no matter they are historic or future values. To configure persistence, you need at least one persistence add-on to be installed.",
 
   "sitemaps.title": "No sitemaps yet",
-  "sitemaps.text": "Sitemaps are a declarative way to define the structure of a user interface for UIs that support them (BasicUI, mobile apps...). They are made of widgets to display item states or send commands to items.<br><br>Click the button below to create your first sitemap."
+  "sitemaps.text": "Sitemaps are a declarative way to define the structure of a user interface for UIs that support them (BasicUI, mobile apps...). They are made of widgets to display item states or send commands to items.<br><br>Use the + button to create your first sitemap."
 }

--- a/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/empty-states/en.json
@@ -51,5 +51,5 @@
   "persistence.text": "With persistence you can store Item states over time, no matter they are historic or future values. To configure persistence, you need at least one persistence add-on to be installed.",
 
   "sitemaps.title": "No sitemaps yet",
-  "sitemaps.text": "Sitemaps are a declarative way to define the structure of a user interface for UIs that support them (BasicUI, mobile apps...). They are made of widgets to display item states or send commands to items.<br><br>Use the + button to create your first sitemap."
+  "sitemaps.text": "Sitemaps are a declarative way to define the structure of a user interface for UIs that support them (Basic UI, mobile apps...). They are made of widgets to display item states or send commands to items.<br><br>Use the + button to create your first sitemap."
 }

--- a/bundles/org.openhab.ui/web/src/js/stores/useRuntimeStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useRuntimeStore.ts
@@ -30,7 +30,7 @@ export const useRuntimeStore = defineStore('runtime', () => {
   const modelSelectedItem = ref<object | null>(null)
   const modelExpandedTreeviewItems = ref<string[]>([])
   const pagesShowSitemaps = ref<boolean>(false)
-  const pagesGroupOrder = ref<'alphabetical' | 'default'>('default')
+  const pagesGroupOrder = ref<'alphabetical' | 'type'>('alphabetical')
   const ready = ref<boolean>(false)
 
   // Getters

--- a/bundles/org.openhab.ui/web/src/js/stores/useRuntimeStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useRuntimeStore.ts
@@ -29,6 +29,8 @@ export const useRuntimeStore = defineStore('runtime', () => {
   const modelPickerExpanded = ref<boolean>(false)
   const modelSelectedItem = ref<object | null>(null)
   const modelExpandedTreeviewItems = ref<string[]>([])
+  const pagesShowSitemaps = ref<boolean>(false)
+  const pagesGroupOrder = ref<'alphabetical' | 'default'>('default')
   const ready = ref<boolean>(false)
 
   // Getters
@@ -70,6 +72,8 @@ export const useRuntimeStore = defineStore('runtime', () => {
     modelPickerExpanded,
     modelSelectedItem,
     modelExpandedTreeviewItems,
+    pagesShowSitemaps,
+    pagesGroupOrder,
     ready,
 
     setRootResource

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -40,16 +40,18 @@ export default {
     // Define the ObjectType enum to be used when calling the copyFileDefinitionToClipboard method
     this.ObjectType = Object.freeze({
       THING: 'thing',
-      ITEM: 'item'
+      ITEM: 'item',
+      SITEMAP: 'sitemap'
     })
   },
   methods: {
     /**
      * Copies the file definitions of the given list of thingUIDs or item names to the clipboard.
      *
-     * @param {string} objectType - The type of the objects (`thing` or `item`). Use {ObjectType} enum for clarity.
+     * @param {string} objectType - The type of the objects (`thing`, `item`, or `sitemap`). Use {ObjectType} enum for clarity.
      * @param {Array} objectIds - The list of object ids to copy. For Things, this should be an array of Thing UIDs.
      *                            For Items, this should be an array of Item names.
+     *                            For Sitemaps, this should be an array of Sitemap names.
      *                            When `null`, all objects of the given type will be copied.
      */
     copyFileDefinitionToClipboard(objectType, objectIds = null) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -46,7 +46,7 @@ export default {
   },
   methods: {
     /**
-     * Copies the file definitions of the given list of thingUIDs or item names to the clipboard.
+     * Copies the file definitions of the given list of thingUIDs, item names, or sitemap names to the clipboard.
      *
      * @param {string} objectType - The type of the objects (`thing`, `item`, or `sitemap`). Use {ObjectType} enum for clarity.
      * @param {Array} objectIds - The list of object ids to copy. For Things, this should be an array of Thing UIDs.

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -105,7 +105,7 @@
         <f7-list v-if="pages.length > 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list v-show="pages.length > 0" class="col pages-list" ref="pagesList" :contacts-list="groupBy === 'alphabetical'" media-list>
+        <f7-list v-show="pages.length > 0" class="col pages-list" ref="pagesList" :contacts-list="showSitemaps || groupBy === 'alphabetical'" media-list>
           <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
             <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
             <f7-list-item
@@ -270,7 +270,7 @@ export default {
       return this.showSitemaps ? this.sitemapPages : this.uiPages
     },
     filteredPagesCount() {
-      if (!this.searchQuery) return this.pages.length
+      if (!this.searchQuery.length) return this.pages.length
       return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).length
     },
     indexedPages() {
@@ -307,12 +307,12 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      const visibleUids = this.searchQuery ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
+      const visibleUids = this.searchQuery.length ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
       return this.selectedItems.length >= visibleUids.length && visibleUids.length > 0
     },
     listTitle() {
       let title = this.filteredPagesCount
-      if (!!this.searchQuery) {
+      if (this.searchQuery.length) {
         title += ` of ${this.pages.length} `
         title += this.showSitemaps ? `sitemaps` : `pages`
         title += ' found'
@@ -448,14 +448,14 @@ export default {
       return terms.every((term) => pageSearchText.includes(term))
     },
     getVisiblePageUids() {
-      if (!this.searchQuery) return this.pages.map((p) => p.uid)
+      if (!this.searchQuery.length) return this.pages.map((p) => p.uid)
       return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).map((page) => page.uid)
     },
     selectDeselectAll() {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        const uidsToSelect = this.searchQuery ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
+        const uidsToSelect = this.searchQuery.length ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
         this.selectedItems = uidsToSelect
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -20,7 +20,7 @@
     </f7-navbar>
 
     <f7-toolbar v-if="showCheckboxes" class="contextual-toolbar" :class="{ navbar: theme.md }" bottom-ios bottom-aurora>
-      <div v-if="!theme.md && selection.length > 0" class="display-flex justify-content-center" style="width: 100%">
+      <div v-if="!theme.md && selectedItems.length > 0" class="display-flex justify-content-center" style="width: 100%">
         <f7-link
           v-if="!theme.md"
           v-show="selection.length"
@@ -85,7 +85,7 @@
       <f7-col v-show="ready">
         <f7-block-title class="no-margin-top">
           <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && pages.length">
+          <template v-if="showCheckboxes && selectablePageUids.length">
             -
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
@@ -314,8 +314,8 @@ export default {
     },
     allSelected() {
       return (
-        this.visiblePageUids.length > 0 &&
-        this.visiblePageUids.every((uid) => (!this.showSitemaps && uid === 'overview') || this.selection.includes(uid))
+        this.selectablePageUids.length > 0 &&
+        this.selectablePageUids.every((uid) => this.selectedItems.includes(uid))
       )
     },
     listTitle() {
@@ -332,13 +332,11 @@ export default {
       }
       return title
     },
-    visiblePageUids() {
-      return this.filteredPages.map((page) => page.uid)
+    selectablePageUids() {
+      return this.filteredPages.filter((page) => (this.showSitemaps || page.uid !== 'overview')).map((page) => page.uid)
     },
     selection() {
-      return this.pages
-        .filter((page) => (this.showSitemaps || page.uid !== 'overview') && this.selectedItems.includes(page.uid))
-        .map((page) => page.uid)
+      return this.selectablePageUids.filter((uid) => this.selectedItems.includes(uid))
     }
   },
   methods: {
@@ -448,7 +446,7 @@ export default {
       }
     },
     isChecked(item) {
-      return this.selection.indexOf(item) >= 0
+      return this.selectedItems.indexOf(item) >= 0
     },
     getNormalizedSearchTerms(query) {
       return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
@@ -473,7 +471,7 @@ export default {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        this.selectedItems = this.visiblePageUids
+        this.selectedItems = this.selectablePageUids
       }
     },
     copySelected() {
@@ -493,7 +491,7 @@ export default {
     },
     ctrlClick(event, item) {
       this.toggleItemCheck(event, item.uid, item)
-      if (!this.selection.length) this.showCheckboxes = false
+      if (!this.selectedItems.length) this.showCheckboxes = false
     },
     toggleItemCheck(event, itemName, item) {
       if (!this.showSitemaps && itemName === 'overview') return

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -120,7 +120,7 @@
               class="pagelist-item"
               :checkbox="showCheckboxes && (showSitemaps || page.uid !== 'overview')"
               :checked="isChecked(page.uid) ? true : null"
-              :disabled="showCheckboxes && page.uid === 'overview' ? true : null"
+              :disabled="showCheckboxes && !showSitemaps && page.uid === 'overview' ? true : null"
               prevent-router
               @click.ctrl="ctrlClick($event, page)"
               @click.meta="ctrlClick($event, page)"
@@ -153,7 +153,7 @@
               <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
               <template #media>
                 <oh-icon
-                  :color="page.config.sidebar || page.uid === 'overview' ? '' : 'gray'"
+                  :color="page.config.sidebar || (!showSitemaps && page.uid === 'overview') ? '' : 'gray'"
                   :icon="getPageIcon(page)"
                   :height="32"
                   :width="32" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -120,7 +120,7 @@
               @click.ctrl="ctrlClick($event, page)"
               @click.meta="ctrlClick($event, page)"
               @click.exact="click($event, page)"
-              :link="`${encodeURIComponent(getPageType(page).type)}/${encodeURIComponent(page.uid)}`"
+              :link="getPageLink(page)"
               :no-chevron="!page.editable"
               :title="page.config.label"
               :subtitle="!showSitemaps ? getPageType(page).label : ''"
@@ -245,7 +245,8 @@ export default {
       sitemaps: [],
       sitemapPages: [],
       selectedItems: [],
-      showCheckboxes: false
+      showCheckboxes: false,
+      searchQuery: ''
     }
   },
   computed: {
@@ -267,6 +268,10 @@ export default {
     },
     pages() {
       return this.showSitemaps ? this.sitemapPages : this.uiPages
+    },
+    filteredPagesCount() {
+      if (!this.searchQuery) return this.pages.length
+      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).length
     },
     indexedPages() {
       if (this.showSitemaps || this.groupBy === 'alphabetical') {
@@ -306,11 +311,8 @@ export default {
       return this.selectedItems.length >= visibleUids.length && visibleUids.length > 0
     },
     listTitle() {
-      const hasSearch = !!this.searchQuery
-      const visibleCount = hasSearch ? this.filteredPagesCount : this.pages.length
-
-      let title = visibleCount
-      if (hasSearch) {
+      let title = this.filteredPagesCount
+      if (!!this.searchQuery) {
         title += ` of ${this.pages.length} `
         title += this.showSitemaps ? `sitemaps` : `pages`
         title += ' found'
@@ -324,23 +326,11 @@ export default {
     }
   },
   methods: {
-    updateFilteredPagesCount() {
-      if (!this.searchQuery) {
-        this.filteredPagesCount = this.pages.length
-        return
-      }
-      this.$nextTick(() => {
-        const pageItems = this.$refs.pagesList?.$el?.querySelectorAll?.('.pagelist-item') || []
-        this.filteredPagesCount = Array.from(pageItems).filter((el) => el.offsetParent !== null).length
-      })
-    },
     searchbarSearch(event) {
       this.searchQuery = event?.query || ''
-      this.updateFilteredPagesCount()
     },
     searchbarClear() {
       this.searchQuery = ''
-      this.filteredPagesCount = this.pages.length
     },
     onPageAfterIn() {
       this.load()
@@ -355,48 +345,55 @@ export default {
       if (this.initSearchbar) this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
       this.initSearchbar = false
 
+      this.sitemaps = []
+      this.uiPages = []
       this.selectedItems = []
       this.showCheckboxes = false
       let promises = [this.$oh.api.get('/rest/sitemaps/*/definition'), this.$oh.api.get('/rest/ui/components/ui:page')]
-      Promise.all(promises).then((data) => {
-        this.sitemaps = data[0]
-        this.sitemapPages = this.sitemaps
-          .map((sitemap) => {
-            return {
-              uid: sitemap.name,
-              component: 'Sitemap',
-              editable: sitemap.editable,
-              config: {
-                label: sitemap.label || sitemap.name,
-                icon: sitemap.icon
+      Promise.all(promises)
+        .then((data) => {
+          this.sitemaps = data[0]
+          this.sitemapPages = this.sitemaps
+            .map((sitemap) => {
+              return {
+                uid: sitemap.name,
+                component: 'Sitemap',
+                editable: sitemap.editable,
+                config: {
+                  label: sitemap.label || sitemap.name,
+                  icon: sitemap.icon
+                }
               }
+            })
+            .sort((a, b) => {
+              return a.config.label.localeCompare(b.config.label)
+            })
+          this.uiPages = data[1]
+            .map((page) => {
+              page.editable = true
+              return page
+            })
+            .sort((a, b) => {
+              return a.config.label.localeCompare(b.config.label)
+            })
+          this.initSearchbar = true
+          this.ready = true
+
+          nextTick(() => {
+            if (this.$refs.listIndex) this.$refs.listIndex.update()
+            if (this.$device.desktop && this.$refs.searchbar) {
+              this.$refs.searchbar.$el.f7Searchbar.$inputEl[0].focus()
             }
+            this.$refs.searchbar?.$el.f7Searchbar.search(this.lastSearchQueryStore.lastPagesSearchQuery || '')
           })
-          .sort((a, b) => {
-            return a.config.label.localeCompare(b.config.label)
-          })
-        this.uiPages = data[1]
-          .map((page) => {
-            page.editable = true
-            return page
-          })
-          .sort((a, b) => {
-            return a.config.label.localeCompare(b.config.label)
-          })
-        this.initSearchbar = true
-
-        this.loading = false
-        this.ready = true
-
-        nextTick(() => {
-          if (this.$refs.listIndex) this.$refs.listIndex.update()
-          if (this.$device.desktop && this.$refs.searchbar) {
-            this.$refs.searchbar.$el.f7Searchbar.$inputEl[0].focus()
-          }
-          this.$refs.searchbar?.$el.f7Searchbar.search(this.lastSearchQueryStore.lastPagesSearchQuery || '')
-          this.updateFilteredPagesCount()
         })
-      })
+        .catch((err) => {
+          console.error(err)
+          showToast('An error occurred while loading pages: ' + err)
+        })
+        .finally(() => {
+          this.loading = false
+        })
     },
     switchShowSitemaps(showSitemaps) {
       if (this.showSitemaps === showSitemaps) return
@@ -407,7 +404,6 @@ export default {
         if (filterQuery) {
           searchbar.clear()
           searchbar.search(filterQuery)
-          this.updateFilteredPagesCount()
         }
         if (this.showSitemaps || this.groupBy === 'alphabetical') this.$refs.listIndex.update()
         this.selectedItems = []
@@ -422,7 +418,6 @@ export default {
         if (filterQuery) {
           searchbar.clear()
           searchbar.search(filterQuery)
-          this.updateFilteredPagesCount()
         }
         if (this.groupBy === 'alphabetical') this.$refs.listIndex.update()
       })
@@ -433,17 +428,35 @@ export default {
     isChecked(item) {
       return this.selectedItems.indexOf(item) >= 0
     },
-    getVisiblePageUids() {
-      // Extract UIDs from visible pagelist-item DOM elements
-      const pageListEl = this.$refs.pagesList?.$el
-      if (!pageListEl) return []
-      const visibleItems = Array.from(pageListEl.querySelectorAll('.pagelist-item')).filter((el) => el.offsetParent !== null)
-      return visibleItems
-        .map((el) => {
-          const footer = el.querySelector('.item-footer')
-          return footer?.textContent?.trim()
-        })
+    getNormalizedSearchTerms(query) {
+      return (query || '')
+        .toLowerCase()
+        .trim()
+        .split(/\s+/)
         .filter(Boolean)
+    },
+    getPageSearchText(page) {
+      const searchFields = [
+        page.config?.label,
+        page.uid,
+        this.showSitemaps ? null : this.getPageType(page)?.label,
+        ...(page.tags || []),
+        ...((page.config?.visibleTo || []).map((role) => role))
+      ]
+      return searchFields
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+    },
+    pageMatchesSearch(page, query) {
+      const terms = this.getNormalizedSearchTerms(query)
+      if (!terms.length) return true
+      const pageSearchText = this.getPageSearchText(page)
+      return terms.every((term) => pageSearchText.includes(term))
+    },
+    getVisiblePageUids() {
+      if (!this.searchQuery) return this.pages.map((p) => p.uid)
+      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).map((page) => page.uid)
     },
     selectDeselectAll() {
       if (this.allSelected) {
@@ -454,8 +467,11 @@ export default {
       }
     },
     copySelected() {
-      const selectedSitemaps = this.sitemapPages.filter((s) => this.selectedItems.includes(s.uid))
-      this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, selectedSitemaps)
+      if (this.selectedItems.length === 0) {
+        showToast('No sitemaps selected to copy')
+        return
+      }
+      this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, this.selectedItems)
     },
     click(event, item) {
       if (this.showCheckboxes) {
@@ -482,13 +498,13 @@ export default {
     getPageLink(page) {
       if (!page.editable) return null
       const type = this.getPageType(page)
-      return type ? `/settings/pages/${type.type}/${page.uid}` : null
+      return type ? `${encodeURIComponent(type.type)}/${encodeURIComponent(page.uid)}` : null
     },
     removeSelected() {
       const vm = this
 
       if (!this.showSitemaps && this.selectedItems.indexOf('overview') >= 0) {
-        f7.dialog.alert('The overview page cannot be deleted!')
+        showToast('The overview page cannot be deleted!')
         return
       }
 
@@ -501,7 +517,7 @@ export default {
       )
     },
     doRemoveSelected() {
-      if (this.selectedItems.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
+      if (this.showSitemaps && this.selectedItems.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
         f7.dialog.alert('Some of the selected sitemaps are not modifiable because they have been created by textual configuration')
         return
       }
@@ -527,7 +543,7 @@ export default {
           dialog.close()
           this.load()
           console.error(err)
-          f7.dialog.alert('An error occurred while deleting: ' + err)
+          showToast('An error occurred while deleting: ' + err)
           f7.emit('sidebarRefresh', null)
         })
     }
@@ -535,11 +551,6 @@ export default {
   asyncComputed: {
     iconUrl() {
       return (icon) => this.$oh.media.getIcon(icon)
-    }
-  },
-  watch: {
-    pages() {
-      this.updateFilteredPagesCount()
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -263,7 +263,7 @@ export default {
     },
     groupBy: {
       get() {
-        return this.runtimeStore.pagesGroupOrder || 'alphabetical'
+        return this.runtimeStore.pagesGroupOrder
       },
       set(value) {
         this.runtimeStore.pagesGroupOrder = value

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -429,11 +429,7 @@ export default {
       return this.selectedItems.indexOf(item) >= 0
     },
     getNormalizedSearchTerms(query) {
-      return (query || '')
-        .toLowerCase()
-        .trim()
-        .split(/\s+/)
-        .filter(Boolean)
+      return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
     },
     getPageSearchText(page) {
       const searchFields = [
@@ -441,12 +437,9 @@ export default {
         page.uid,
         this.showSitemaps ? null : this.getPageType(page)?.label,
         ...(page.tags || []),
-        ...((page.config?.visibleTo || []).map((role) => role))
+        ...(page.config?.visibleTo || []).map((role) => role)
       ]
-      return searchFields
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase()
+      return searchFields.filter(Boolean).join(' ').toLowerCase()
     },
     pageMatchesSearch(page, query) {
       const terms = this.getNormalizedSearchTerms(query)

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -54,7 +54,7 @@
 
     <f7-list-index
       v-if="ready"
-      v-show="groupBy === 'alphabetical' && !$device.desktop"
+      v-show="(showSitemaps || groupBy === 'alphabetical') && !$device.desktop"
       ref="listIndex"
       :key="'pages-index'"
       list-el=".pages-list"
@@ -312,7 +312,9 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      const visibleUids = this.searchQuery.length ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
+      const visibleUids = this.searchQuery.length
+        ? this.getVisiblePageUids()
+        : this.pages.map((p) => p.uid).filter((uid) => this.showSitemaps || uid !== 'overview')
       return this.selectedItems.length >= visibleUids.length && visibleUids.length > 0
     },
     listTitle() {
@@ -457,13 +459,18 @@ export default {
     },
     getVisiblePageUids() {
       if (!this.searchQuery.length) return this.pages.map((p) => p.uid)
-      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).map((page) => page.uid)
+      return this.pages
+        .filter((page) => this.pageMatchesSearch(page, this.searchQuery))
+        .map((page) => page.uid)
+        .filter((uid) => this.showSitemaps || uid !== 'overview')
     },
     selectDeselectAll() {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        const uidsToSelect = this.searchQuery.length ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
+        const uidsToSelect = this.searchQuery.length
+          ? this.getVisiblePageUids()
+          : this.pages.map((p) => p.uid).filter((uid) => this.showSitemaps || uid !== 'overview')
         this.selectedItems = uidsToSelect
       }
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -105,7 +105,12 @@
         <f7-list v-if="pages.length > 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list v-show="pages.length > 0" class="col pages-list" ref="pagesList" :contacts-list="showSitemaps || groupBy === 'alphabetical'" media-list>
+        <f7-list
+          v-show="pages.length > 0"
+          class="col pages-list"
+          ref="pagesList"
+          :contacts-list="showSitemaps || groupBy === 'alphabetical'"
+          media-list>
           <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
             <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
             <f7-list-item
@@ -424,6 +429,9 @@ export default {
     },
     toggleCheck() {
       this.showCheckboxes = !this.showCheckboxes
+      if (!this.showCheckboxes) {
+        this.selectedItems = []
+      }
     },
     isChecked(item) {
       return this.selectedItems.indexOf(item) >= 0
@@ -479,6 +487,7 @@ export default {
       if (!this.selectedItems.length) this.showCheckboxes = false
     },
     toggleItemCheck(event, itemName, item) {
+      if (itemName === 'overview') return
       if (!this.showCheckboxes) this.showCheckboxes = true
       if (this.isChecked(itemName)) {
         this.selectedItems.splice(this.selectedItems.indexOf(itemName), 1)

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -454,8 +454,7 @@ export default {
       }
     },
     copySelected() {
-      const selectedSitemaps = this.sitemapPages
-        .filter((s) => this.selectedItems.includes(s.uid))
+      const selectedSitemaps = this.sitemapPages.filter((s) => this.selectedItems.includes(s.uid))
       this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, selectedSitemaps)
     },
     click(event, item) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -22,10 +22,10 @@
     </f7-navbar>
 
     <f7-toolbar v-if="showCheckboxes" class="contextual-toolbar" :class="{ navbar: theme.md }" bottom-ios bottom-aurora>
-      <div v-if="!theme.md && selectedItems.length > 0" class="display-flex justify-content-center" style="width: 100%">
+      <div v-if="!theme.md && selection.length > 0" class="display-flex justify-content-center" style="width: 100%">
         <f7-link
           v-if="!theme.md"
-          v-show="selectedItems.length"
+          v-show="selection.length"
           color="red"
           class="delete display-flex flex-direction-row margin-right"
           icon-ios="f7:trash"
@@ -35,7 +35,7 @@
         </f7-link>
         <f7-link
           v-if="showSitemaps"
-          v-show="selectedItems.length"
+          v-show="selection.length"
           color="blue"
           class="copy display-flex flex-direction-row"
           icon-ios="f7:square_on_square"
@@ -44,9 +44,9 @@
           &nbsp;Copy
         </f7-link>
       </div>
-      <f7-link v-if="theme.md" icon-md="material:close" icon-color="white" @click="showCheckboxes = false" />
-      <div v-if="theme.md" class="title">{{ selectedItems.length }} selected</div>
-      <div v-if="theme.md && selectedItems.length" class="right">
+      <f7-link v-if="theme.md" icon-md="material:close" icon-color="white" @click="toggleCheck()" />
+      <div v-if="theme.md" class="title">{{ selection.length }} selected</div>
+      <div v-if="theme.md && selection.length" class="right">
         <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected" />
         <f7-link v-if="showSitemaps" icon-md="material:content_copy" icon-color="white" @click="copySelected" />
       </div>
@@ -118,7 +118,7 @@
               :key="page.uid"
               media-item
               class="pagelist-item"
-              :checkbox="showCheckboxes && (showSitemaps || (!showSitemaps && page.uid !== 'overview'))"
+              :checkbox="showCheckboxes && (showSitemaps || page.uid !== 'overview')"
               :checked="isChecked(page.uid) ? true : null"
               :disabled="showCheckboxes && page.uid === 'overview' ? true : null"
               prevent-router
@@ -312,10 +312,10 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      const visibleUids = this.searchQuery.length
-        ? this.getVisiblePageUids()
-        : this.pages.map((p) => p.uid).filter((uid) => this.showSitemaps || uid !== 'overview')
-      return this.selectedItems.length >= visibleUids.length && visibleUids.length > 0
+      return (
+        this.visiblePageUids.length > 0 &&
+        this.visiblePageUids.every((uid) => (this.showSitemaps || uid !== 'overview') && this.selection.includes(uid))
+      )
     },
     listTitle() {
       let title = this.filteredPagesCount
@@ -326,10 +326,19 @@ export default {
       } else {
         title += this.showSitemaps ? ' sitemaps' : ' pages'
       }
-      if (this.selectedItems.length > 0) {
-        title += `, ${this.selectedItems.length} selected`
+      if (this.selection.length > 0) {
+        title += `, ${this.selection.length} selected`
       }
       return title
+    },
+    visiblePageUids() {
+      if (!this.searchQuery.length) return this.pages.map((p) => p.uid)
+      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).map((page) => page.uid)
+    },
+    selection() {
+      return this.pages
+        .filter((page) => (this.showSitemaps || page.uid !== 'overview') && this.selectedItems.includes(page.uid))
+        .map((page) => page.uid)
     }
   },
   methods: {
@@ -413,7 +422,6 @@ export default {
           searchbar.search(filterQuery)
         }
         if (this.showSitemaps || this.groupBy === 'alphabetical') this.$refs.listIndex.update()
-        this.selectedItems = []
       })
     },
     switchGroupOrder(groupBy) {
@@ -436,7 +444,7 @@ export default {
       }
     },
     isChecked(item) {
-      return this.selectedItems.indexOf(item) >= 0
+      return this.selection.indexOf(item) >= 0
     },
     getNormalizedSearchTerms(query) {
       return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
@@ -457,29 +465,19 @@ export default {
       const pageSearchText = this.getPageSearchText(page)
       return terms.every((term) => pageSearchText.includes(term))
     },
-    getVisiblePageUids() {
-      if (!this.searchQuery.length) return this.pages.map((p) => p.uid)
-      return this.pages
-        .filter((page) => this.pageMatchesSearch(page, this.searchQuery))
-        .map((page) => page.uid)
-        .filter((uid) => this.showSitemaps || uid !== 'overview')
-    },
     selectDeselectAll() {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        const uidsToSelect = this.searchQuery.length
-          ? this.getVisiblePageUids()
-          : this.pages.map((p) => p.uid).filter((uid) => this.showSitemaps || uid !== 'overview')
-        this.selectedItems = uidsToSelect
+        this.selectedItems = this.visiblePageUids
       }
     },
     copySelected() {
-      if (this.selectedItems.length === 0) {
+      if (this.selection.length === 0) {
         showToast('No sitemaps selected to copy')
         return
       }
-      this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, this.selectedItems)
+      this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, this.selection)
     },
     click(event, item) {
       if (this.showCheckboxes) {
@@ -491,10 +489,10 @@ export default {
     },
     ctrlClick(event, item) {
       this.toggleItemCheck(event, item.uid, item)
-      if (!this.selectedItems.length) this.showCheckboxes = false
+      if (!this.selection.length) this.showCheckboxes = false
     },
     toggleItemCheck(event, itemName, item) {
-      if (itemName === 'overview') return
+      if (!this.showSitemaps && itemName === 'overview') return
       if (!this.showCheckboxes) this.showCheckboxes = true
       if (this.isChecked(itemName)) {
         this.selectedItems.splice(this.selectedItems.indexOf(itemName), 1)
@@ -512,13 +510,8 @@ export default {
     removeSelected() {
       const vm = this
 
-      if (!this.showSitemaps && this.selectedItems.indexOf('overview') >= 0) {
-        showToast('The overview page cannot be deleted!')
-        return
-      }
-
       f7.dialog.confirm(
-        `Remove ${this.selectedItems.length} selected ${this.showSitemaps ? 'sitemaps' : 'pages'}?`,
+        `Remove ${this.selection.length} selected ${this.showSitemaps ? 'sitemaps' : 'pages'}?`,
         `Remove ${this.showSitemaps ? 'Sitemaps' : 'Pages'}`,
         () => {
           vm.doRemoveSelected()
@@ -526,14 +519,14 @@ export default {
       )
     },
     doRemoveSelected() {
-      if (this.showSitemaps && this.selectedItems.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
+      if (this.showSitemaps && this.selection.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
         f7.dialog.alert('Some of the selected sitemaps are not modifiable because they have been created by textual configuration')
         return
       }
 
       let dialog = f7.dialog.progress(`Deleting ${this.showSitemaps ? 'Sitemaps' : 'Pages'}...`)
 
-      const promises = this.selectedItems.map((p) => {
+      const promises = this.selection.map((p) => {
         if (this.showSitemaps) {
           return this.$oh.api.delete('/rest/sitemaps/' + p)
         } else {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -314,7 +314,7 @@ export default {
     allSelected() {
       return (
         this.visiblePageUids.length > 0 &&
-        this.visiblePageUids.every((uid) => (this.showSitemaps || uid !== 'overview') && this.selection.includes(uid))
+        this.visiblePageUids.every((uid) => (!this.showSitemaps && uid === 'overview') || this.selection.includes(uid))
       )
     },
     listTitle() {
@@ -362,6 +362,7 @@ export default {
       this.initSearchbar = false
 
       this.sitemaps = []
+      this.sitemapPages = []
       this.uiPages = []
       this.selectedItems = []
       this.showCheckboxes = false
@@ -414,6 +415,9 @@ export default {
     switchShowSitemaps(showSitemaps) {
       if (this.showSitemaps === showSitemaps) return
       this.showSitemaps = showSitemaps
+      if (this.showCheckboxes) {
+        this.toggleCheck()
+      }
       const searchbar = this.$refs.searchbar.$el.f7Searchbar
       const filterQuery = searchbar.query
       nextTick(() => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -11,9 +11,7 @@
           v-if="initSearchbar"
           ref="searchbar"
           class="searchbar-pages"
-          search-container=".pages-list"
-          search-item=".pagelist-item"
-          search-in=".item-title, .item-subtitle, .item-header, .item-footer"
+          :custom-search="true"
           @searchbar:search="searchbarSearch"
           @searchbar:clear="searchbarClear"
           :placeholder="searchPlaceholder"
@@ -102,11 +100,11 @@
           </f7-segmented>
         </div>
 
-        <f7-list v-if="pages.length > 0" class="searchbar-not-found">
+        <f7-list v-if="pages.length > 0 && filteredPages.length === 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
         <f7-list
-          v-show="pages.length > 0"
+          v-show="filteredPages.length > 0"
           class="col pages-list"
           ref="pagesList"
           :contacts-list="showSitemaps || groupBy === 'alphabetical'"
@@ -274,13 +272,16 @@ export default {
     pages() {
       return this.showSitemaps ? this.sitemapPages : this.uiPages
     },
+    filteredPages() {
+      if (!this.searchQuery.length) return this.pages
+      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery))
+    },
     filteredPagesCount() {
-      if (!this.searchQuery.length) return this.pages.length
-      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).length
+      return this.filteredPages.length
     },
     indexedPages() {
       if (this.showSitemaps || this.groupBy === 'alphabetical') {
-        return this.pages.reduce((prev, page, i, pages) => {
+        return this.filteredPages.reduce((prev, page, i, pages) => {
           const label = page.config.label || page.uid
           const initial = label.substring(0, 1).toUpperCase()
           if (!prev[initial]) {
@@ -291,7 +292,7 @@ export default {
           return prev
         }, {})
       } else {
-        const typeGroups = this.pages.reduce((prev, page, i, things) => {
+        const typeGroups = this.filteredPages.reduce((prev, page, i, things) => {
           const type = getPageType(page).label
           if (!prev[type]) {
             prev[type] = []
@@ -332,8 +333,7 @@ export default {
       return title
     },
     visiblePageUids() {
-      if (!this.searchQuery.length) return this.pages.map((p) => p.uid)
-      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery)).map((page) => page.uid)
+      return this.filteredPages.map((page) => page.uid)
     },
     selection() {
       return this.pages
@@ -406,7 +406,7 @@ export default {
         })
         .catch((err) => {
           console.error(err)
-          showToast('An error occurred while loading pages: ' + err)
+          showToast('An error occurred while loading pages: ' + err.message)
         })
         .finally(() => {
           this.loading = false

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -164,7 +164,7 @@
         </f7-list>
 
         <!-- empty-state-placeholder only needed for sitemaps because the overview page cannot be deleted, so there is at least 1 page -->
-        <f7-block v-if="!pages.length" class="block-narrow">
+        <f7-block v-if="showSitemaps && !pages.length" class="block-narrow">
           <empty-state-placeholder icon="square_on_circle" title="sitemaps.title" text="sitemaps.text" />
           <f7-row v-if="$f7dim.width < 1280" class="display-flex justify-content-center">
             <f7-button
@@ -313,10 +313,7 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      return (
-        this.selectablePageUids.length > 0 &&
-        this.selectablePageUids.every((uid) => this.selectedItems.includes(uid))
-      )
+      return this.selectablePageUids.length > 0 && this.selectablePageUids.every((uid) => this.selectedItems.includes(uid))
     },
     listTitle() {
       let title = this.filteredPagesCount
@@ -333,7 +330,7 @@ export default {
       return title
     },
     selectablePageUids() {
-      return this.filteredPages.filter((page) => (this.showSitemaps || page.uid !== 'overview')).map((page) => page.uid)
+      return this.filteredPages.filter((page) => this.showSitemaps || page.uid !== 'overview').map((page) => page.uid)
     },
     selection() {
       return this.selectablePageUids.filter((uid) => this.selectedItems.includes(uid))
@@ -429,8 +426,8 @@ export default {
     switchGroupOrder(groupBy) {
       this.switchShowSitemaps(false)
       this.groupBy = groupBy
-      const searchbar = this.$refs.searchbar.$el.f7Searchbar
-      const filterQuery = searchbar.query
+      const searchbar = this.$refs.searchbar?.$el?.f7Searchbar
+      const filterQuery = searchbar?.query
       nextTick(() => {
         if (filterQuery) {
           searchbar.clear()
@@ -547,7 +544,8 @@ export default {
           dialog.close()
           this.load()
           console.error(err)
-          showToast('An error occurred while deleting: ' + err)
+          const errorMessage = err && err.message ? err.message : String(err)
+          showToast('An error occurred while deleting: ' + errorMessage)
           f7.emit('sidebarRefresh', null)
         })
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -401,7 +401,7 @@ export default {
         })
         .catch((err) => {
           console.error(err)
-          showToast('An error occurred while loading pages: ' + err.message)
+          showToast('An error occurred while loading pages: ' + (err?.message || String(err)))
         })
         .finally(() => {
           this.loading = false
@@ -544,8 +544,7 @@ export default {
           dialog.close()
           this.load()
           console.error(err)
-          const errorMessage = err && err.message ? err.message : String(err)
-          showToast('An error occurred while deleting: ' + errorMessage)
+          showToast('An error occurred while deleting: ' + (err?.message || String(err)))
           f7.emit('sidebarRefresh', null)
         })
     }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -363,7 +363,7 @@ export default {
         this.sitemapPages = this.sitemaps
           .map((sitemap) => {
             return {
-              uid: sitemap.name.startsWith('uicomponents_') ? sitemap.name.replace('uicomponents_', '') : sitemap.name,
+              uid: sitemap.name,
               component: 'Sitemap',
               editable: sitemap.editable,
               config: {
@@ -456,7 +456,6 @@ export default {
     copySelected() {
       const selectedSitemaps = this.sitemapPages
         .filter((s) => this.selectedItems.includes(s.uid))
-        .map((s) => (s.editable ? 'uicomponents_' + s.uid : s.uid))
       this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, selectedSitemaps)
     },
     click(event, item) {
@@ -512,7 +511,7 @@ export default {
 
       const promises = this.selectedItems.map((p) => {
         if (this.showSitemaps) {
-          return this.$oh.api.delete('/rest/sitemaps/uicomponents_' + p)
+          return this.$oh.api.delete('/rest/sitemaps/' + p)
         } else {
           return this.$oh.api.delete('/rest/ui/components/ui:page/' + p)
         }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -14,26 +14,41 @@
           search-container=".pages-list"
           search-item=".pagelist-item"
           search-in=".item-title, .item-subtitle, .item-header, .item-footer"
+          @searchbar:search="searchbarSearch"
+          @searchbar:clear="searchbarClear"
           :placeholder="searchPlaceholder"
           :disable-button="!theme.aurora" />
       </f7-subnavbar>
     </f7-navbar>
 
     <f7-toolbar v-if="showCheckboxes" class="contextual-toolbar" :class="{ navbar: theme.md }" bottom-ios bottom-aurora>
-      <f7-link
-        v-if="!theme.md"
-        v-show="selectedItems.length"
-        color="red"
-        class="delete"
-        icon-ios="f7:trash"
-        icon-aurora="f7:trash"
-        @click="removeSelected">
-        Remove {{ selectedItems.length }}
-      </f7-link>
+      <div v-if="!theme.md && selectedItems.length > 0" class="display-flex justify-content-center" style="width: 100%">
+        <f7-link
+          v-if="!theme.md"
+          v-show="selectedItems.length"
+          color="red"
+          class="delete display-flex flex-direction-row margin-right"
+          icon-ios="f7:trash"
+          icon-aurora="f7:trash"
+          @click="removeSelected">
+          Remove
+        </f7-link>
+        <f7-link
+          v-if="showSitemaps"
+          v-show="selectedItems.length"
+          color="blue"
+          class="copy display-flex flex-direction-row"
+          icon-ios="f7:square_on_square"
+          icon-aurora="f7:square_on_square"
+          @click="copySelected">
+          &nbsp;Copy
+        </f7-link>
+      </div>
       <f7-link v-if="theme.md" icon-md="material:close" icon-color="white" @click="showCheckboxes = false" />
       <div v-if="theme.md" class="title">{{ selectedItems.length }} selected</div>
-      <div v-if="theme.md" class="right">
-        <f7-link v-show="selectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected" />
+      <div v-if="theme.md && selectedItems.length" class="right">
+        <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected" />
+        <f7-link v-if="showSitemaps" icon-md="material:content_copy" icon-color="white" @click="copySelected" />
       </div>
     </f7-toolbar>
 
@@ -70,35 +85,45 @@
       </f7-col>
 
       <f7-col v-show="ready">
-        <f7-block-title class="searchbar-hide-on-search"> {{ pages.length }} pages </f7-block-title>
-        <div v-show="!ready || pages.length > 0" class="padding-left padding-right">
+        <f7-block-title class="no-margin-top">
+          <span>{{ listTitle }}</span>
+          <template v-if="showCheckboxes && pages.length">
+            -
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+        </f7-block-title>
+        <div v-show="ready && (uiPages.length > 0 || sitemapPages.length > 0)" class="padding-left padding-right">
           <f7-segmented strong tag="p">
-            <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')"> Alphabetical </f7-button>
-            <f7-button :active="groupBy === 'type'" @click="switchGroupOrder('type')"> By type </f7-button>
+            <f7-button :active="!showSitemaps && groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')">
+              Alphabetical
+            </f7-button>
+            <f7-button :active="!showSitemaps && groupBy === 'type'" @click="switchGroupOrder('type')"> By type </f7-button>
+            <f7-button :active="showSitemaps" @click="switchShowSitemaps(true)"> Sitemaps </f7-button>
           </f7-segmented>
         </div>
 
-        <f7-list class="searchbar-not-found">
+        <f7-list v-if="pages.length > 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
         <f7-list v-show="pages.length > 0" class="col pages-list" ref="pagesList" :contacts-list="groupBy === 'alphabetical'" media-list>
           <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
             <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
             <f7-list-item
-              v-for="(page, index) in pagesWithInitial"
-              :key="index"
+              v-for="page in pagesWithInitial"
+              :key="page.uid"
               media-item
               class="pagelist-item"
-              :checkbox="showCheckboxes && page.uid !== 'overview'"
-              :checked="isChecked((page.component === 'Sitemap' ? 'system:sitemap:' : 'ui:page:') + page.uid)"
+              :checkbox="showCheckboxes && (showSitemaps || (!showSitemaps && page.uid !== 'overview'))"
+              :checked="isChecked(page.uid) ? true : null"
               :disabled="showCheckboxes && page.uid === 'overview' ? true : null"
               prevent-router
               @click.ctrl="ctrlClick($event, page)"
               @click.meta="ctrlClick($event, page)"
               @click.exact="click($event, page)"
               :link="`${encodeURIComponent(getPageType(page).type)}/${encodeURIComponent(page.uid)}`"
+              :no-chevron="!page.editable"
               :title="page.config.label"
-              :subtitle="getPageType(page).label"
+              :subtitle="!showSitemaps ? getPageType(page).label : ''"
               :footer="page.uid"
               :badge="page.config.order">
               <template #subtitle>
@@ -128,22 +153,38 @@
                   :height="32"
                   :width="32" />
               </template>
+              <template #after-title>
+                <f7-icon v-if="!page.editable" f7="lock_fill" size="1rem" color="gray" />
+              </template>
             </f7-list-item>
           </f7-list-group>
         </f7-list>
+
+        <!-- empty-state-placeholder only needed for sitemaps because the overview page cannot be deleted, so there is at least 1 page -->
+        <f7-block v-if="!pages.length" class="block-narrow">
+          <empty-state-placeholder icon="square_on_circle" title="sitemaps.title" text="sitemaps.text" />
+          <f7-row v-if="$f7dim.width < 1280" class="display-flex justify-content-center">
+            <f7-button
+              large
+              fill
+              color="blue"
+              external
+              :href="`${runtimeStore.websiteUrl}/docs/ui/sitemaps`"
+              target="_blank"
+              :text="$t('home.overview.button.documentation')" />
+          </f7-row>
+        </f7-block>
       </f7-col>
     </f7-block>
 
-    <!-- empty-state-placeholder not needed because the overview page cannot be deleted, so there is at least 1 page -->
-
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue">
+      <f7-fab v-show="ready && !showCheckboxes && showSitemaps" position="right-bottom" color="blue" href="sitemap/add">
+        <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
+      </f7-fab>
+      <f7-fab v-show="ready && !showCheckboxes && !showSitemaps" position="right-bottom" color="blue">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
         <f7-fab-buttons position="top">
-          <f7-fab-button fab-close label="Create sitemap" href="sitemap/add">
-            <f7-icon f7="menu" />
-          </f7-fab-button>
           <f7-fab-button fab-close label="Create layout" href="layout/add">
             <f7-icon f7="rectangle_grid_2x2" />
           </f7-fab-button>
@@ -169,31 +210,66 @@
 import { nextTick } from 'vue'
 import { f7, theme } from 'framework7-vue'
 
+import FileDefinition from '@/pages/settings/file-definition-mixin'
+
 import { useLastSearchQueryStore } from '@/js/stores/useLastSearchQueryStore'
+import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
+import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
 import { showToast } from '@/js/dialog-promises'
 import { getPageType, getPageIcon } from '@/pages/page-type'
 
 export default {
+  mixins: [FileDefinition],
   props: {
     f7router: Object
   },
+  components: {
+    EmptyStatePlaceholder
+  },
   setup() {
-    return { theme }
+    const runtimeStore = useRuntimeStore()
+    const lastSearchQueryStore = useLastSearchQueryStore()
+
+    return {
+      theme,
+      runtimeStore,
+      lastSearchQueryStore
+    }
   },
   data() {
     return {
       ready: false,
       initSearchbar: false,
       loading: false,
-      pages: [],
+      uiPages: [],
+      sitemaps: [],
+      sitemapPages: [],
       selectedItems: [],
-      groupBy: 'alphabetical',
       showCheckboxes: false
     }
   },
   computed: {
+    showSitemaps: {
+      get() {
+        return !!this.runtimeStore.pagesShowSitemaps
+      },
+      set(value) {
+        this.runtimeStore.pagesShowSitemaps = value
+      }
+    },
+    groupBy: {
+      get() {
+        return this.runtimeStore.pagesGroupOrder || 'alphabetical'
+      },
+      set(value) {
+        this.runtimeStore.pagesGroupOrder = value
+      }
+    },
+    pages() {
+      return this.showSitemaps ? this.sitemapPages : this.uiPages
+    },
     indexedPages() {
-      if (this.groupBy === 'alphabetical') {
+      if (this.showSitemaps || this.groupBy === 'alphabetical') {
         return this.pages.reduce((prev, page, i, pages) => {
           const label = page.config.label || page.uid
           const initial = label.substring(0, 1).toUpperCase()
@@ -224,30 +300,89 @@ export default {
     },
     searchPlaceholder() {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
+    },
+    allSelected() {
+      const visibleUids = this.searchQuery ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
+      return this.selectedItems.length >= visibleUids.length && visibleUids.length > 0
+    },
+    listTitle() {
+      const hasSearch = !!this.searchQuery
+      const visibleCount = hasSearch ? this.filteredPagesCount : this.pages.length
+
+      let title = visibleCount
+      if (hasSearch) {
+        title += ` of ${this.pages.length} `
+        title += this.showSitemaps ? `sitemaps` : `pages`
+        title += ' found'
+      } else {
+        title += this.showSitemaps ? ' sitemaps' : ' pages'
+      }
+      if (this.selectedItems.length > 0) {
+        title += `, ${this.selectedItems.length} selected`
+      }
+      return title
     }
   },
   methods: {
+    updateFilteredPagesCount() {
+      if (!this.searchQuery) {
+        this.filteredPagesCount = this.pages.length
+        return
+      }
+      this.$nextTick(() => {
+        const pageItems = this.$refs.pagesList?.$el?.querySelectorAll?.('.pagelist-item') || []
+        this.filteredPagesCount = Array.from(pageItems).filter((el) => el.offsetParent !== null).length
+      })
+    },
+    searchbarSearch(event) {
+      this.searchQuery = event?.query || ''
+      this.updateFilteredPagesCount()
+    },
+    searchbarClear() {
+      this.searchQuery = ''
+      this.filteredPagesCount = this.pages.length
+    },
     onPageAfterIn() {
       this.load()
     },
     onPageBeforeOut() {
-      useLastSearchQueryStore().lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
+      this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
     },
     load() {
       if (this.loading) return
       this.loading = true
 
-      if (this.initSearchbar) useLastSearchQueryStore().lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
+      if (this.initSearchbar) this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
       this.initSearchbar = false
 
       this.selectedItems = []
       this.showCheckboxes = false
-      let promises = [this.$oh.api.get('/rest/ui/components/system:sitemap'), this.$oh.api.get('/rest/ui/components/ui:page')]
+      let promises = [this.$oh.api.get('/rest/sitemaps/*/definition'), this.$oh.api.get('/rest/ui/components/ui:page')]
       Promise.all(promises).then((data) => {
-        const pagesAndSitemaps = data[0].concat(data[1])
-        this.pages = pagesAndSitemaps.sort((a, b) => {
-          return a.config.label.localeCompare(b.config.label)
-        })
+        this.sitemaps = data[0]
+        this.sitemapPages = this.sitemaps
+          .map((sitemap) => {
+            return {
+              uid: sitemap.name.startsWith('uicomponents_') ? sitemap.name.replace('uicomponents_', '') : sitemap.name,
+              component: 'Sitemap',
+              editable: sitemap.editable,
+              config: {
+                label: sitemap.label || sitemap.name,
+                icon: sitemap.icon
+              }
+            }
+          })
+          .sort((a, b) => {
+            return a.config.label.localeCompare(b.config.label)
+          })
+        this.uiPages = data[1]
+          .map((page) => {
+            page.editable = true
+            return page
+          })
+          .sort((a, b) => {
+            return a.config.label.localeCompare(b.config.label)
+          })
         this.initSearchbar = true
 
         this.loading = false
@@ -258,11 +393,28 @@ export default {
           if (this.$device.desktop && this.$refs.searchbar) {
             this.$refs.searchbar.$el.f7Searchbar.$inputEl[0].focus()
           }
-          this.$refs.searchbar?.$el.f7Searchbar.search(useLastSearchQueryStore().lastPagesSearchQuery || '')
+          this.$refs.searchbar?.$el.f7Searchbar.search(this.lastSearchQueryStore.lastPagesSearchQuery || '')
+          this.updateFilteredPagesCount()
         })
       })
     },
+    switchShowSitemaps(showSitemaps) {
+      if (this.showSitemaps === showSitemaps) return
+      this.showSitemaps = showSitemaps
+      const searchbar = this.$refs.searchbar.$el.f7Searchbar
+      const filterQuery = searchbar.query
+      nextTick(() => {
+        if (filterQuery) {
+          searchbar.clear()
+          searchbar.search(filterQuery)
+          this.updateFilteredPagesCount()
+        }
+        if (this.showSitemaps || this.groupBy === 'alphabetical') this.$refs.listIndex.update()
+        this.selectedItems = []
+      })
+    },
     switchGroupOrder(groupBy) {
+      this.switchShowSitemaps(false)
       this.groupBy = groupBy
       const searchbar = this.$refs.searchbar.$el.f7Searchbar
       const filterQuery = searchbar.query
@@ -270,8 +422,9 @@ export default {
         if (filterQuery) {
           searchbar.clear()
           searchbar.search(filterQuery)
+          this.updateFilteredPagesCount()
         }
-        if (groupBy === 'alphabetical') this.$refs.listIndex.update()
+        if (this.groupBy === 'alphabetical') this.$refs.listIndex.update()
       })
     },
     toggleCheck() {
@@ -280,11 +433,38 @@ export default {
     isChecked(item) {
       return this.selectedItems.indexOf(item) >= 0
     },
+    getVisiblePageUids() {
+      // Extract UIDs from visible pagelist-item DOM elements
+      const pageListEl = this.$refs.pagesList?.$el
+      if (!pageListEl) return []
+      const visibleItems = Array.from(pageListEl.querySelectorAll('.pagelist-item')).filter((el) => el.offsetParent !== null)
+      return visibleItems
+        .map((el) => {
+          const footer = el.querySelector('.item-footer')
+          return footer?.textContent?.trim()
+        })
+        .filter(Boolean)
+    },
+    selectDeselectAll() {
+      if (this.allSelected) {
+        this.selectedItems = []
+      } else {
+        const uidsToSelect = this.searchQuery ? this.getVisiblePageUids() : this.pages.map((p) => p.uid)
+        this.selectedItems = uidsToSelect
+      }
+    },
+    copySelected() {
+      const selectedSitemaps = this.sitemapPages
+        .filter((s) => this.selectedItems.includes(s.uid))
+        .map((s) => (s.editable ? 'uicomponents_' + s.uid : s.uid))
+      this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, selectedSitemaps)
+    },
     click(event, item) {
       if (this.showCheckboxes) {
         this.toggleItemCheck(event, item.uid, item)
       } else {
-        this.f7router.navigate(getPageType(item).type + '/' + item.uid)
+        const pageLink = this.getPageLink(item)
+        if (pageLink) this.f7router.navigate(pageLink)
       }
     },
     ctrlClick(event, item) {
@@ -293,7 +473,6 @@ export default {
     },
     toggleItemCheck(event, itemName, item) {
       if (!this.showCheckboxes) this.showCheckboxes = true
-      itemName = item.component === 'Sitemap' ? 'system:sitemap:' + itemName : 'ui:page:' + itemName
       if (this.isChecked(itemName)) {
         this.selectedItems.splice(this.selectedItems.indexOf(itemName), 1)
       } else {
@@ -302,31 +481,45 @@ export default {
     },
     getPageType,
     getPageIcon,
+    getPageLink(page) {
+      if (!page.editable) return null
+      const type = this.getPageType(page)
+      return type ? `/settings/pages/${type.type}/${page.uid}` : null
+    },
     removeSelected() {
       const vm = this
 
-      if (this.selectedItems.indexOf('ui:page:overview') >= 0) {
+      if (!this.showSitemaps && this.selectedItems.indexOf('overview') >= 0) {
         f7.dialog.alert('The overview page cannot be deleted!')
         return
       }
 
-      f7.dialog.confirm(`Remove ${this.selectedItems.length} selected pages?`, 'Remove Pages', () => {
-        vm.doRemoveSelected()
-      })
+      f7.dialog.confirm(
+        `Remove ${this.selectedItems.length} selected ${this.showSitemaps ? 'sitemaps' : 'pages'}?`,
+        `Remove ${this.showSitemaps ? 'Sitemaps' : 'Pages'}`,
+        () => {
+          vm.doRemoveSelected()
+        }
+      )
     },
     doRemoveSelected() {
-      let dialog = f7.dialog.progress('Deleting Pages...')
+      if (this.selectedItems.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
+        f7.dialog.alert('Some of the selected sitemaps are not modifiable because they have been created by textual configuration')
+        return
+      }
+
+      let dialog = f7.dialog.progress(`Deleting ${this.showSitemaps ? 'Sitemaps' : 'Pages'}...`)
 
       const promises = this.selectedItems.map((p) => {
-        if (p.startsWith('system:sitemap')) {
-          return this.$oh.api.delete('/rest/ui/components/system:sitemap/' + p.replace('system:sitemap:', ''))
+        if (this.showSitemaps) {
+          return this.$oh.api.delete('/rest/sitemaps/uicomponents_' + p)
         } else {
-          return this.$oh.api.delete('/rest/ui/components/ui:page/' + p.replace('ui:page:', ''))
+          return this.$oh.api.delete('/rest/ui/components/ui:page/' + p)
         }
       })
       Promise.all(promises)
         .then((data) => {
-          showToast('Pages removed')
+          showToast(this.showSitemaps ? 'Sitemaps removed' : 'Pages removed')
           this.selectedItems = []
           dialog.close()
           this.load()
@@ -344,6 +537,11 @@ export default {
   asyncComputed: {
     iconUrl() {
       return (icon) => this.$oh.media.getIcon(icon)
+    }
+  },
+  watch: {
+    pages() {
+      this.updateFilteredPagesCount()
     }
   }
 }


### PR DESCRIPTION
See discussion https://github.com/openhab/openhab-core/issues/5007

This is the first step to have all sitemap definitions in the UI and use core converters to convert to/from file formats.

This PR simply introduces a list of sitemaps as a separate tab on the pages list with specific functionality.:
- it will also show the unmanaged sitemaps in the list (non-editable).
- It introduces a copy to file definition button on the sitemaps tab, using the new REST endpoint from https://github.com/openhab/openhab-core/pull/5459
I opted to put the sitemaps in a separate list (next to Alphabetic and By Type). The reason is they are something totally different and cannot be used in the mainUI, I required specific logic (copy button only for sitemaps) and I didn't want to create another entry in settings to separate them out as it is to define UIs after all. Also, keeping it on the same level took less space in the UI then introducing another tab one level up to distinguish between mainUI widgets and sitemaps. Of course, this can be debated.

Next steps will be in a separate PR, building on top of this:
- ability to show unmanged sitemaps in the sitemap editor (all fields read only).
- replacing all DSL parsing and generation in the UI code by calls to the sitemap REST API.
- refactoring and improvements in the sitemap editor UI, such as better editors for rules and mappings, separating the format string from the label and editor with validation for the format string, etc.
A large part of that code is done, but as this will be a larger refactoring, I want to keep this separate.

@lolodomo FYI
@jimtng You may also want to have a look at this, especially since you are working on the mainUI widgets side of this.