### PR TITLE
[ui] Stabilize oh-video WebRTC microphone activation flow

### DIFF
--- a/bundles/org.openhab.ui/AGENTS.md
+++ b/bundles/org.openhab.ui/AGENTS.md
@@ -91,6 +91,18 @@ All web development happens in the `web/` directory.
 - Avoid obvious comments (e.g., `// variable declaration`)
 - Use JSDoc for API/class/method documentation
 - Generate oh-* component documentation by running `node generate.js` in `doc/components/src` after modifying widget definitions
+  - If the script fails (TypeScript import issues), manually update the corresponding `.md` file in `doc/components/`
+  - Widget parameters are defined in `web/src/assets/definitions/widgets/` (TypeScript)
+  - Documentation follows the PropBlock structure with type, name, label, and description
+
+### Widget Development Workflow
+When modifying or creating oh-* widgets:
+1. Edit the Vue component in `web/src/components/widgets/` (e.g., `oh-video.vue`, `oh-video-webrtc.vue`)
+2. Update the widget definition in `web/src/assets/definitions/widgets/` (e.g., `video.ts`)
+3. Run `npm run generate-widget-component-ts` to regenerate TypeScript types
+4. Update documentation in `doc/components/oh-<widget>.md` (manually or via `node generate.js`)
+5. Test changes locally with `npm run dev`
+6. Format and lint: `npm run format && npm run lint`
 
 ### Formatting
 - Use `npm run format:check` to check for formatting issues

--- a/bundles/org.openhab.ui/doc/components/oh-video.md
+++ b/bundles/org.openhab.ui/doc/components/oh-video.md
@@ -97,6 +97,11 @@ Displays a video player from a URL or an item
     Control microphone activation externally (e.g. via an expression); hides the built-in mic button when set (requires WebRTC player type with sendAudio)
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="muteActive" label="External Mute Control">
+  <PropDescription>
+    Control stream mute state externally (e.g. via an expression); keeps audio output muted when true (requires WebRTC player type)
+  </PropDescription>
+</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/doc/components/oh-video.md
+++ b/bundles/org.openhab.ui/doc/components/oh-video.md
@@ -92,6 +92,11 @@ Displays a video player from a URL or an item
     Send audio to the WebRTC connection if supported (requires WebRTC player type)
   </PropDescription>
 </PropBlock>
+<PropBlock type="BOOLEAN" name="micActive" label="External Mic Control">
+  <PropDescription>
+    Control microphone activation externally (e.g. via an expression); hides the built-in mic button when set (requires WebRTC player type with sendAudio)
+  </PropDescription>
+</PropBlock>
 </PropGroup>
 </div>
 

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.ts
@@ -25,5 +25,6 @@ export default () => [
     'ICE candidates timeout',
     "WebRTC ICE candidates discovery timeout length in milliseconds (optional), defaults to '2000', '0' to disable"
   ).a(),
-  pb('sendAudio', 'Two Way Audio', 'Send audio to the WebRTC connection if supported (requires WebRTC player type)').a()
+  pb('sendAudio', 'Two Way Audio', 'Send audio to the WebRTC connection if supported (requires WebRTC player type)').a(),
+  pb('micActive', 'External Mic Control', 'Control microphone activation externally (e.g. via an expression); hides the built-in mic button when set (requires WebRTC player type with sendAudio)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/video.ts
@@ -26,5 +26,6 @@ export default () => [
     "WebRTC ICE candidates discovery timeout length in milliseconds (optional), defaults to '2000', '0' to disable"
   ).a(),
   pb('sendAudio', 'Two Way Audio', 'Send audio to the WebRTC connection if supported (requires WebRTC player type)').a(),
-  pb('micActive', 'External Mic Control', 'Control microphone activation externally (e.g. via an expression); hides the built-in mic button when set (requires WebRTC player type with sendAudio)').a()
+  pb('micActive', 'External Mic Control', 'Control microphone activation externally (e.g. via an expression); hides the built-in mic button when set (requires WebRTC player type with sendAudio)').a(),
+  pb('muteActive', 'External Mute Control', 'Control stream mute state externally (e.g. via an expression); keeps audio output muted when true (requires WebRTC player type)').a()
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -4,7 +4,7 @@
       ref="videoPlayer"
       :autoplay="this.startManually ? false : true"
       :controls="this.hideControls ? false : true"
-      :muted="startMuted ? true : false"
+      :muted="isMuted"
       :poster="computedPosterUrl"
       playsinline
       style="max-width: 100%">
@@ -38,14 +38,16 @@ export default {
     hideControls: { type: Boolean },
     posterURL: { type: String },
     sendAudio: { type: Boolean },
-    micActive: { type: Boolean, default: undefined }
+    micActive: { type: Boolean, default: undefined },
+    muteActive: { type: Boolean, default: undefined }
   },
   data() {
     return {
       webrtc: null,
       localAudioStream: null,
       audioTransceiver: null,
-      isMicOn: false
+      isMicOn: false,
+      isMuted: false
     }
   },
   watch: {
@@ -66,6 +68,13 @@ export default {
         this.isMicOn = false
         this.disableMicrophone()
       }
+    },
+    muteActive(value) {
+      if (value === true) {
+        this.isMuted = true
+      } else if (value === false) {
+        this.isMuted = false
+      }
     }
   },
   computed: {
@@ -80,6 +89,9 @@ export default {
           : `${this.posterURL}&_ts=${ts}`
         : this.posterURL
     }
+  },
+  mounted() {
+    this.isMuted = this.startMuted || false
   },
   methods: {
     stopStream() {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -11,7 +11,7 @@
       Sorry, your browser doesn't support embedded videos.
     </video>
     <button
-      v-if="sendAudio"
+      v-if="sendAudio && micActive === undefined"
       class="oh-video-mic"
       :class="{ active: isMicOn }"
       @click="toggleMic"
@@ -37,7 +37,8 @@ export default {
     startMuted: { type: Boolean },
     hideControls: { type: Boolean },
     posterURL: { type: String },
-    sendAudio: { type: Boolean }
+    sendAudio: { type: Boolean },
+    micActive: { type: Boolean, default: undefined }
   },
   data() {
     return {
@@ -53,6 +54,15 @@ export default {
     },
     sendAudio(value) {
       if (value === false && this.isMicOn) {
+        this.isMicOn = false
+        this.disableMicrophone()
+      }
+    },
+    micActive(value) {
+      if (value === true && !this.isMicOn) {
+        this.isMicOn = true
+        this.enableMicrophone(this.webrtc, this.audioTransceiver)
+      } else if (value === false && this.isMicOn) {
         this.isMicOn = false
         this.disableMicrophone()
       }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -71,7 +71,11 @@ export default {
     micActive(value) {
       if (value === true && !this.isMicOn) {
         this.isMicOn = true
-        this.enableMicrophone(this.webrtc, this.audioTransceiver)
+        if (this.webrtc) {
+          this.enableMicrophone(this.webrtc, this.audioTransceiver)
+        } else if (this.inForeground && this.src) {
+          this.startStream()
+        }
       } else if (value === false && this.isMicOn) {
         this.isMicOn = false
         this.disableMicrophone()
@@ -344,7 +348,8 @@ export default {
           return
         }
         // If already enabled, do nothing
-        if (this.localAudioStream && this.localAudioStream.getAudioTracks().some((t) => t.enabled)) {
+        if (this.localAudioStream && this.localAudioStream.getAudioTracks().some((t) => t.enabled)
+            && audioTransceiver && audioTransceiver.sender && audioTransceiver.sender.track) {
           return
         }
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true })

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -46,12 +46,20 @@ export default {
       webrtc: null,
       localAudioStream: null,
       audioTransceiver: null,
+      offerAbortController: null,
+      webrtcSendChannel: null,
+      popupElement: null,
+      isStopping: false,
       isMicOn: false,
       isMuted: false
     }
   },
   watch: {
     src(value) {
+      if (!value) {
+        this.stopStream()
+        return
+      }
       this.startStream()
     },
     sendAudio(value) {
@@ -92,19 +100,116 @@ export default {
   },
   mounted() {
     this.isMuted = this.startMuted || false
+    this.attachPopupLifecycleListeners()
+  },
+  beforeUnmount() {
+    this.detachPopupLifecycleListeners()
+    this.stopStream()
   },
   methods: {
+    attachPopupLifecycleListeners() {
+      const wrapper = this.$el
+      if (!wrapper || typeof wrapper.closest !== 'function') {
+        return
+      }
+      const popup = wrapper.closest('.popup')
+      if (!popup) {
+        return
+      }
+      this.popupElement = popup
+      popup.addEventListener('popup:close', this.onPopupClose)
+      popup.addEventListener('popup:opened', this.onPopupOpened)
+    },
+    detachPopupLifecycleListeners() {
+      const popup = this.popupElement
+      if (!popup) {
+        return
+      }
+      popup.removeEventListener('popup:close', this.onPopupClose)
+      popup.removeEventListener('popup:opened', this.onPopupOpened)
+      this.popupElement = null
+    },
+    onPopupClose() {
+      this.stopStream()
+    },
+    onPopupOpened() {
+      if (this.inForeground && this.src && !this.webrtc) {
+        this.startStream()
+      }
+    },
+    resetVideoElement() {
+      const videoPlayer = this.$refs.videoPlayer
+      if (!videoPlayer) {
+        return
+      }
+      try {
+        const stream = videoPlayer.srcObject
+        if (stream && typeof stream.getTracks === 'function') {
+          stream.getTracks().forEach((track) => {
+            try {
+              track.stop()
+            } catch (e) {}
+          })
+        }
+      } catch (e) {}
+
+      try {
+        videoPlayer.pause()
+      } catch (e) {}
+      videoPlayer.srcObject = null
+      try {
+        videoPlayer.removeAttribute('src')
+        videoPlayer.load()
+      } catch (e) {}
+    },
     stopStream() {
+      if (this.isStopping) {
+        return
+      }
+      const hasActiveStream = !!(
+        this.offerAbortController ||
+        this.webrtc ||
+        this.webrtcSendChannel ||
+        (this.$refs.videoPlayer && this.$refs.videoPlayer.srcObject)
+      )
+      if (!hasActiveStream) {
+        return
+      }
+      this.isStopping = true
       console.debug('WebRTC Closing Connection')
-      if (this.webrtc) {
-        this.webrtc.isClosed = true
-        try {
-          this.disableMicrophone()
-        } catch (e) {}
-        this.webrtc.close()
-        // see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close
-        this.audioTransceiver = null
-        this.webrtc = null
+      try {
+        if (this.offerAbortController) {
+          try {
+            this.offerAbortController.abort()
+          } catch (e) {}
+          this.offerAbortController = null
+        }
+        if (this.webrtcSendChannel) {
+          try {
+            this.webrtcSendChannel.onclose = null
+          } catch (e) {}
+          try {
+            this.webrtcSendChannel.close()
+          } catch (e) {}
+          this.webrtcSendChannel = null
+        }
+        if (this.webrtc) {
+          this.webrtc.isClosed = true
+          try {
+            this.disableMicrophone()
+          } catch (e) {}
+          try {
+            this.webrtc.ontrack = null
+            this.webrtc.onnegotiationneeded = null
+          } catch (e) {}
+          this.webrtc.close()
+          // see https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/close
+          this.audioTransceiver = null
+          this.webrtc = null
+        }
+        this.resetVideoElement()
+      } finally {
+        this.isStopping = false
       }
     },
     startStream() {
@@ -136,14 +241,25 @@ export default {
         this.enableMicrophone(webrtc, this.audioTransceiver)
       }
       webrtc.onnegotiationneeded = function handleNegotiationNeeded() {
+        self.offerAbortController = new AbortController()
         // WebRTC lifecycle to create a live stream
         webrtc
           .createOffer()
           .then((offer) => webrtc.setLocalDescription(offer))
           .then(() => waitForCandidates(self.candidatesTimeout))
           .then(() => sendOffer())
-          .then((answer) => webrtc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp: answer })))
+          .then((answer) => {
+            if (webrtc.isClosed || self.webrtc !== webrtc) {
+              return
+            }
+            return webrtc.setRemoteDescription(new RTCSessionDescription({ type: 'answer', sdp: answer }))
+          })
           .catch((e) => console.warn(e))
+          .finally(() => {
+            if (self.offerAbortController) {
+              self.offerAbortController = null
+            }
+          })
 
         // waits x amount of time for ICE candidates before resolving
         function waitForCandidates(timeout = 2000) {
@@ -172,12 +288,17 @@ export default {
           return new Promise((resolve, reject) => {
             fetch(self.src, {
               method: 'POST',
+              signal: self.offerAbortController ? self.offerAbortController.signal : undefined,
               body: new URLSearchParams({
                 data: btoa(webrtc.localDescription.sdp)
               })
             })
               .then((response) => response.text())
               .then((data) => {
+                if (webrtc.isClosed || self.webrtc !== webrtc) {
+                  reject(new Error('WebRTC connection already closed'))
+                  return
+                }
                 const answer = atob(data)
                 console.debug('Answer: ', answer)
                 resolve(answer)
@@ -188,10 +309,11 @@ export default {
       }
       // creates a channel needed by nest(?) cameras, we also use this to restart streams if closed
       const webrtcSendChannel = webrtc.createDataChannel('dataSendChannel')
+      this.webrtcSendChannel = webrtcSendChannel
       webrtcSendChannel.onclose = (_event) => {
         console.debug(`${webrtcSendChannel.label} has closed`)
         // if we did not close this, restart the stream
-        if (!webrtc.isClosed) {
+        if (!webrtc.isClosed && this.webrtc === webrtc && !this.isStopping) {
           console.warn(`${webrtcSendChannel.label} closed prematurely, restarting`)
           self.startStream()
         }

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video-webrtc.vue
@@ -69,6 +69,13 @@ export default {
       }
     },
     micActive(value) {
+      if (this.sendAudio !== true) {
+        if (this.isMicOn) {
+          this.isMicOn = false
+          this.disableMicrophone()
+        }
+        return
+      }
       if (value === true && !this.isMicOn) {
         this.isMicOn = true
         if (this.webrtc) {
@@ -103,7 +110,13 @@ export default {
     }
   },
   mounted() {
-    this.isMuted = this.startMuted || false
+    this.isMuted = this.muteActive !== undefined ? this.muteActive : (this.startMuted || false)
+    if (this.sendAudio === true && this.micActive === true) {
+      this.isMicOn = true
+      if (this.inForeground && this.src && !this.webrtc) {
+        this.startStream()
+      }
+    }
     this.attachPopupLifecycleListeners()
   },
   beforeUnmount() {
@@ -245,13 +258,14 @@ export default {
         this.enableMicrophone(webrtc, this.audioTransceiver)
       }
       webrtc.onnegotiationneeded = function handleNegotiationNeeded() {
-        self.offerAbortController = new AbortController()
+        const offerAbortController = new AbortController()
+        self.offerAbortController = offerAbortController
         // WebRTC lifecycle to create a live stream
         webrtc
           .createOffer()
           .then((offer) => webrtc.setLocalDescription(offer))
           .then(() => waitForCandidates(self.candidatesTimeout))
-          .then(() => sendOffer())
+          .then(() => sendOffer(offerAbortController))
           .then((answer) => {
             if (webrtc.isClosed || self.webrtc !== webrtc) {
               return
@@ -260,7 +274,7 @@ export default {
           })
           .catch((e) => console.warn(e))
           .finally(() => {
-            if (self.offerAbortController) {
+            if (self.offerAbortController === offerAbortController) {
               self.offerAbortController = null
             }
           })
@@ -287,12 +301,12 @@ export default {
           })
         }
         // Sends our SDP offer to the remote server, expects a SDP answer back
-        function sendOffer() {
+        function sendOffer(offerAbortController) {
           console.debug('Offer: ', webrtc.localDescription.sdp)
           return new Promise((resolve, reject) => {
             fetch(self.src, {
               method: 'POST',
-              signal: self.offerAbortController ? self.offerAbortController.signal : undefined,
+              signal: offerAbortController ? offerAbortController.signal : undefined,
               body: new URLSearchParams({
                 data: btoa(webrtc.localDescription.sdp)
               })

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -9,7 +9,8 @@
       :startMuted="config.startMuted"
       :hideControls="config.hideControls"
       :posterURL="posterSrc"
-      :sendAudio="config.sendAudio" />
+      :sendAudio="config.sendAudio"
+      :micActive="config.micActive" />
     <oh-video-videojs
       v-else
       :src="src"
@@ -40,7 +41,8 @@ export default {
   },
   props: {
     context: Object,
-    sendAudio: { type: Boolean }
+    sendAudio: { type: Boolean },
+    micActive: { type: Boolean }
   },
   setup(props) {
     const { config } = useWidgetContext(computed(() => props.context))

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-video.vue
@@ -10,7 +10,8 @@
       :hideControls="config.hideControls"
       :posterURL="posterSrc"
       :sendAudio="config.sendAudio"
-      :micActive="config.micActive" />
+      :micActive="config.micActive"
+      :muteActive="config.muteActive" />
     <oh-video-videojs
       v-else
       :src="src"
@@ -41,8 +42,7 @@ export default {
   },
   props: {
     context: Object,
-    sendAudio: { type: Boolean },
-    micActive: { type: Boolean }
+    sendAudio: { type: Boolean }
   },
   setup(props) {
     const { config } = useWidgetContext(computed(() => props.context))


### PR DESCRIPTION
## Description
This PR updates `oh-video-webrtc` in two areas:

- Feature: allow external button/state control to mute/unmute the playback stream via `muteActive`.
- Stability: improve microphone activation flow without restarting the peer connection.

Changes included:
- Add `muteActive` handling so external controls can toggle stream mute state.
- Ensure mic activation can bootstrap stream startup when external `micActive` is enabled and no peer exists yet.
- Tighten the microphone early-return guard to only skip when a sender track is actually attached.
- Keep hot-swap behavior based on `replaceTrack` without reconnect/re-offer side effects.

## Testing
- Ran `mvn spotless:apply -pl :org.openhab.ui`.
- Ran `mvn clean install -DskipTests -pl :org.openhab.ui` (BUILD SUCCESS).
- Manual validation in MainUI:
  - External button/state toggles mute/unmute via `muteActive`.
  - Mic toggle on/off during active Dahua call keeps stream stable.
  
  
needed by Dahua Door Intercom PR: https://github.com/openhab/openhab-addons/pull/20570