### PR TITLE
useStatesStore: Reactivity fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { nextTick, ref } from 'vue'
+import { nextTick, ref, reactive } from 'vue'
 
 import sse from '@/js/openhab/sse'
 import * as api from '@/api'
@@ -47,14 +47,9 @@ export const useStatesStore = defineStore('states', () => {
   function ensureItemTracking(itemName: string): ItemState {
     if (itemName === 'undefined') return UndefinedItemState
 
-    let itemState = itemStates.value.get(itemName)
+    const itemState = itemStates.value.get(itemName)
     if (!isItemTracked(itemName)) {
       pendingNewItems.add(itemName)
-
-      if (!itemState) {
-        itemState = UndefinedItemState
-        setItemState(itemName, itemState)
-      }
 
       // Start processing interval if not already running
       if (processingIntervalId === null) {
@@ -64,7 +59,7 @@ export const useStatesStore = defineStore('states', () => {
       }
     }
 
-    return itemState!
+    return itemState ?? UndefinedItemState
   }
 
   /* global ProxyHandler:readonly */
@@ -89,7 +84,7 @@ export const useStatesStore = defineStore('states', () => {
     }
   }
 
-  const trackedItems = ref<TrackedItems>(new Proxy({}, handler))
+  const trackedItems = reactive<TrackedItems>(new Proxy({}, handler))
   const trackingList = ref<Array<string>>([])
   let trackerConnectionId: string | null = null
   let trackerEventSource: EventSource | null = null


### PR DESCRIPTION
* Removed Side-Effects from Proxy Getter: Previously, when an Item state was first requested, the Proxy's get handler would immediately add a placeholder state to the itemStates Map. In Vue 3, mutating reactive state (the Map) during the evaluation of a computed property can cause the dependency tracker to ignore that access. Modifies ensureItemTracking to return a placeholder without mutating the Map if the item is not yet tracked. Ensures Vue correctly records the dependency on that item.
* Reactive Proxy: Changes `trackedItems` from a ref of a Proxy to a reactive Proxy. Improves integration with Vue's reactivity system, making it more reliable for dependency tracking when accessed in expressions.

This fixes an issue where expressions in widget configuration were incorrectly evaluated due to missing Item states.