### PR TITLE
Charts: Remove default for `barBorderRadius`

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.ts
@@ -195,11 +195,11 @@ const lineChartSymbolParameter = pb(
   return configuration.type === 'line'
 })
 
-const barChartBorderRadiusParameter = pn('barBorderRadius', 'Bar Border Radius', 'The radius of the border of the bar.')
-  .d('0')
-  .v((_value, configuration) => {
+const barChartBorderRadiusParameter = pn('barBorderRadius', 'Bar Border Radius', 'The radius of the border of the bar.').v(
+  (_value, configuration) => {
     return configuration.type === 'bar'
-  })
+  }
+)
 
 const seriesStyleParameters = [seriesLabelPositionParameter, seriesColorParameter, lineChartSymbolParameter, barChartBorderRadiusParameter]
 


### PR DESCRIPTION
Fixes an issue where the default value changed the appearance of existing charts that set a border radius array.