### PR TITLE
Model page: Fix subnavbar icon color for filled theme

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -284,6 +284,8 @@
 .model-page
   .subnavbar
     background-color var(--f7-searchbar-bg-color, var(--f7-bars-bg-color))
+    .button, .link
+      color var(--f7-toolbar-link-color, var(--f7-bars-link-color, var(--f7-theme-color)))
   .expand-button
     height unset
     margin-right 8px


### PR DESCRIPTION
This only happens when the theme is set to orange

before:

<img width="506" height="89" alt="image" src="https://github.com/user-attachments/assets/c40f068a-f325-428d-b200-9dda4e9d85ad" />


After:

<img width="498" height="90" alt="image" src="https://github.com/user-attachments/assets/a0a173e9-90ee-4ce2-a320-d2f2af07ebb4" />

