### PR TITLE
Setup Wizard: Fix add-on search in description

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/addons/addons-setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-setup-wizard.vue
@@ -53,9 +53,6 @@
         <f7-searchbar
           v-model:value="addonSearchQuery"
           :placeholder="t('setupwizard.' + type + '.selectAddons.placeholder')"
-          search-container=".addon-selection-list"
-          search-item=".addon-selection-item"
-          search-in=".addon-selection-label"
           :disable-button-text="t('dialogs.cancel')" />
         <f7-list media-list class="addon-selection-list">
           <f7-list-item
@@ -174,7 +171,12 @@ export default {
         return available
       }
       const query = this.addonSearchQuery.toLowerCase()
-      return available.filter((a) => a.label.toLowerCase().includes(query) || a.uid.toLowerCase().includes(query))
+      return available.filter((a) => {
+        if (a.label.toLowerCase().includes(query) || a.uid.toLowerCase().includes(query)) return true
+        const descrHtml = this.addonDescription(a)
+        const descrText = descrHtml.replace(/<[^>]+>/g, ' ').toLowerCase()
+        return descrText.includes(query)
+      })
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/addons/addons-setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-setup-wizard.vue
@@ -173,6 +173,7 @@ export default {
       const query = this.addonSearchQuery.toLowerCase()
       return available.filter((a) => {
         if (a.label.toLowerCase().includes(query) || a.uid.toLowerCase().includes(query)) return true
+        if (a.keywords.toLowerCase().includes(query)) return true
         const descrHtml = this.addonDescription(a)
         const descrText = descrHtml.replace(/<[^>]+>/g, ' ').toLowerCase()
         return descrText.includes(query)

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -284,6 +284,8 @@
 .model-page
   .subnavbar
     background-color var(--f7-searchbar-bg-color, var(--f7-bars-bg-color))
+    .button, .link
+      color var(--f7-toolbar-link-color, var(--f7-bars-link-color, var(--f7-theme-color)))
   .expand-button
     height unset
     margin-right 8px


### PR DESCRIPTION
The "More binding" search filter didn't look in the description v-html. It does now:

<img width="724" height="487" alt="image" src="https://github.com/user-attachments/assets/451364e9-77c0-4e9d-8ee8-e12bc101b006" />
