### PR TITLE
 Upgrade to Karaf 4.4.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <oh.java.version>21</oh.java.version>
     <maven.compiler.release>${oh.java.version}</maven.compiler.release>
 
-    <bnd.version>7.2.1</bnd.version>
+    <bnd.version>7.2.3</bnd.version>
     <eea.version>2.4.0</eea.version>
     <jackson.annotations.version>2.20</jackson.annotations.version>
     <karaf.version>4.4.11</karaf.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,8 +68,8 @@
     <bnd.version>7.2.1</bnd.version>
     <eea.version>2.4.0</eea.version>
     <jackson.annotations.version>2.20</jackson.annotations.version>
-    <karaf.version>4.4.10</karaf.version>
-    <karaf.maven.plugin.version>4.4.10</karaf.maven.plugin.version>
+    <karaf.version>4.4.11</karaf.version>
+    <karaf.maven.plugin.version>4.4.11</karaf.maven.plugin.version>
     <ohc.version>5.2.0-SNAPSHOT</ohc.version>
     <sat.version>0.18.0</sat.version>
     <spotless.version>2.44.3</spotless.version>


### PR DESCRIPTION
Upgrade Karaf from 4.4.10 to 4.4.11 and bndtools to from 7.2.1 to 7.2.3.

Depends on https://github.com/openhab/openhab-core/pull/5510 ~~(and final release of Karaf 4.4.11)~~.