### PR TITLE
Add-on store: Make back link return to Thing details / choose binding

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut" ref="addonstore" class="page-addon-store">
     <f7-navbar large class="store-nav">
-      <oh-nav-content :title="AddonTitles[currentTab] || 'Add-on Store'" :large="true" back-link-url="/" :f7router />
+      <oh-nav-content :title="AddonTitles[currentTab] || 'Add-on Store'" :large="true" :back-link-url="backLinkUrl" :f7router />
     </f7-navbar>
     <f7-toolbar v-show="$f7dim.width < 1024 || !leftPanelOpened" tabbar bottom>
       <f7-link
@@ -296,6 +296,10 @@ export default {
   mixins: [AddonStoreMixin],
   props: {
     searchFor: String,
+    backLinkUrl: {
+      type: String,
+      default: '/'
+    },
     f7router: Object
   },
   components: {

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -53,11 +53,11 @@
     <f7-block v-if="runtimeStore.apiEndpoint('addons')" class="block-narrow">
       <f7-col v-if="bindings.length">
         <f7-list>
-          <f7-list-button color="blue" title="Install More Bindings" href="/addons/binding/" />
+          <f7-list-button color="blue" title="Install More Bindings" @click="installBindings" />
         </f7-list>
       </f7-col>
       <f7-row v-else-if="ready" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" href="/addons/binding/"> Install Bindings </f7-button>
+        <f7-button large fill color="blue" @click="installBindings"> Install Bindings </f7-button>
       </f7-row>
     </f7-block>
   </f7-page>
@@ -112,6 +112,19 @@ export default {
       this.$oh.api.get('/rest/inbox?includeIgnored=false').then((data) => {
         this.inbox = data
       })
+    },
+    installBindings() {
+      console.log('current route', this.f7router.currentRoute)
+      this.f7router.navigate(
+        {
+          url: '/addons/binding/'
+        },
+        {
+          props: {
+            backLinkUrl: this.f7router.currentRoute.url
+          }
+        }
+      )
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -811,7 +811,8 @@ export default {
         },
         {
           props: {
-            searchFor: this.thing.UID.split(':')[0]
+            searchFor: this.thing.UID.split(':')[0],
+            backLinkUrl: this.f7router.currentRoute.url
           }
         }
       )


### PR DESCRIPTION
When the Thing Details or Choose Binding (Adding a Thing) offers to "Install Binding", the user is brought to the Addon store. From there, make the Back link return the user back to Thing Details / Choose Binding.

