### PR TITLE
Fix rule module reordering bug

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -828,7 +828,7 @@ export default {
     reorderModule(ev, section) {
       const newSection = [...this.rule[section]]
       newSection.splice(ev.to, 0, newSection.splice(ev.from, 1)[0])
-      this.rule.section = newSection
+      this.rule[section] = newSection
     },
     saveModule(updatedModule) {
       if (!updatedModule.type) return


### PR DESCRIPTION
Reordering rule modules doesn't work because the reordered modules aren't stored in the correct location. This fixes that.

Fixes #4132 

It stems from #3350, perhaps other reordering refactorings should be checked for the same issue.