### PR TITLE
Widget edit: Don't cache expressions in edit mode & throttle rerender on input

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -122,6 +122,8 @@ import { useViewArea } from '@/js/composables/useViewArea'
 import { transformParameterDefaults } from '@/components/widgets/helpers.ts'
 import { showToast } from '@/js/dialog-promises'
 
+import debounce from 'debounce'
+
 const toStringOptions = { toStringDefaults: { lineWidth: 0 } }
 
 export default {
@@ -178,7 +180,8 @@ export default {
         store: useStatesStore().trackedItems,
         props: this.props,
         vars: this.vars,
-        ctxVars: this.ctxVars
+        ctxVars: this.ctxVars,
+        editmode: true
       }
     },
     widget() {
@@ -191,6 +194,9 @@ export default {
     }
   },
   methods: {
+    updateWidgetDefinition: debounce(function (value) {
+      this.widgetDefinition = value
+    }, 200),
     onPageAfterIn() {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
@@ -205,7 +211,7 @@ export default {
       useStatesStore().stopTrackingStates()
     },
     onEditorInput(value) {
-      this.widgetDefinition = value
+      this.updateWidgetDefinition(value)
       if (!this.loading) {
         this.dirty = true
       }

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -121,8 +121,7 @@ import { useStatesStore } from '@/js/stores/useStatesStore'
 import { useViewArea } from '@/js/composables/useViewArea'
 import { transformParameterDefaults } from '@/components/widgets/helpers.ts'
 import { showToast } from '@/js/dialog-promises'
-
-import debounce from 'debounce'
+import { useThrottleFn } from '@vueuse/core'
 
 const toStringOptions = { toStringDefaults: { lineWidth: 0 } }
 
@@ -194,9 +193,6 @@ export default {
     }
   },
   methods: {
-    updateWidgetDefinition: debounce(function (value) {
-      this.widgetDefinition = value
-    }, 200),
     onPageAfterIn() {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
@@ -210,12 +206,12 @@ export default {
       }
       useStatesStore().stopTrackingStates()
     },
-    onEditorInput(value) {
-      this.updateWidgetDefinition(value)
+    onEditorInput: useThrottleFn(function (value) {
+      this.widgetDefinition = value
       if (!this.loading) {
         this.dirty = true
       }
-    },
+    }, 300),
     keyDown(ev) {
       if ((ev.ctrlKey || ev.metaKey) && !(ev.altKey || ev.shiftKey)) {
         switch (ev.keyCode) {


### PR DESCRIPTION
Fixes #4092

Widget-edit context needs to have editmode=true
also debounced editor input