### PR TITLE
Split Sitemaps and Pages into two different entries in the settings menu

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -117,19 +117,6 @@
                 </template>
               </f7-list-item>
               <f7-list-item
-                v-if="runtimeStore.apiEndpoint('sitemaps')"
-                link="/settings/sitemaps/"
-                title="Sitemaps"
-                view=".view-main"
-                panel-close
-                :animate="false"
-                no-chevron
-                :class="{ currentsection: currentPath.settings?.sitemaps }">
-                <template #media>
-                  <f7-icon f7="menu" color="gray" />
-                </template>
-              </f7-list-item>
-              <f7-list-item
                 v-if="runtimeStore.apiEndpoint('rules')"
                 link="/settings/rules/"
                 title="Rules"

--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -925,10 +925,13 @@ export default {
         }
 
         let currentSection = this.$$('.currentsection .item-title')?.[0]?.textContent
+        // Add special cases where the page doesn't have a special entry in the left sidebar menu
         if (this.currentPath.settings?.transformations) {
           currentSection = 'Transformations'
         } else if (this.currentPath.settings?.persistence) {
           currentSection = 'Persistence'
+        } else if (this.currentPath.settings?.sitemaps) {
+          currentSection = 'Sitemaps'
         }
         title.unshift(currentSection)
       }

--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -55,7 +55,8 @@
                 currentPath.settings?.services ||
                 currentPath.settings?.addons ||
                 currentPath.settings?.persistence ||
-                currentPath.settings?.transformations
+                currentPath.settings?.transformations ||
+                currentPath.settings?.sitemaps
             }">
             <template #media>
               <f7-icon ios="f7:gear_alt_fill" aurora="f7:gear_alt_fill" md="material:settings" color="gray" />

--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -117,6 +117,19 @@
                 </template>
               </f7-list-item>
               <f7-list-item
+                v-if="runtimeStore.apiEndpoint('sitemaps')"
+                link="/settings/sitemaps/"
+                title="Sitemaps"
+                view=".view-main"
+                panel-close
+                :animate="false"
+                no-chevron
+                :class="{ currentsection: currentPath.settings?.sitemaps }">
+                <template #media>
+                  <f7-icon f7="menu" color="gray" />
+                </template>
+              </f7-list-item>
+              <f7-list-item
                 v-if="runtimeStore.apiEndpoint('rules')"
                 link="/settings/rules/"
                 title="Rules"

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -560,7 +560,7 @@
             <f7-list-button href="/settings/pages/map/add" color="blue" :animate="false"> Create map view </f7-list-button>
             <f7-list-button href="/settings/pages/plan/add" color="blue" :animate="false"> Create floor plan </f7-list-button>
             <f7-list-button href="/settings/pages/chart/add" color="blue" :animate="false"> Create chart </f7-list-button>
-            <f7-list-button href="/settings/pages/sitemap/add" color="blue" :animate="false"> Create sitemap </f7-list-button>
+            <f7-list-button href="/settings/sitemaps/add" color="blue" :animate="false"> Create sitemap </f7-list-button>
             <f7-list-item divider title="Automation" />
             <f7-list-button href="/settings/rules/add" color="blue" :animate="false"> Create rule </f7-list-button>
             <f7-list-button href="/settings/scripts/add" color="blue" :animate="false"> Create script </f7-list-button>

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -53,8 +53,7 @@ const PageEditors = {
   tabs: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/tabs/tabs-edit.vue'),
   map: () => import(/* webpackChunkName: "admin-pages-leaflet" */ '@/pages/settings/pages/map/map-edit.vue'),
   plan: () => import(/* webpackChunkName: "admin-pages-leaflet" */ '@/pages/settings/pages/plan/plan-edit.vue'),
-  chart: () => import(/* webpackChunkName: "admin-pages-echarts" */ '@/pages/settings/pages/chart/chart-edit.vue'),
-  sitemap: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemap/sitemap-edit.vue')
+  chart: () => import(/* webpackChunkName: "admin-pages-echarts" */ '@/pages/settings/pages/chart/chart-edit.vue')
 }
 
 const SitemapsListPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemaps-list.vue')

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -47,7 +47,6 @@ const PersistenceEditPage = () => import(/* webpackChunkName: "admin-config" */ 
 const SemanticModelPage = () => import(/* webpackChunkName: "admin-config" */ '@/pages/settings/model/model.vue')
 
 const PagesListPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/pages-list.vue')
-const SitemapsListPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemaps-list.vue')
 const PageEditors = {
   home: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/home/home-edit.vue'),
   layout: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/layout/layout-edit.vue'),
@@ -57,6 +56,9 @@ const PageEditors = {
   chart: () => import(/* webpackChunkName: "admin-pages-echarts" */ '@/pages/settings/pages/chart/chart-edit.vue'),
   sitemap: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemap/sitemap-edit.vue')
 }
+
+const SitemapsListPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemaps-list.vue')
+const SitemapEditPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemap/sitemap-edit.vue')
 
 const RulesListPage = () => import(/* webpackChunkName: "admin-rules" */ '@/pages/settings/rules/rules-list.vue')
 const RuleEditPage = () => import(/* webpackChunkName: "admin-rules" */ '@/pages/settings/rules/rule-edit.vue')
@@ -301,19 +303,19 @@ export default [
             path: 'add',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
-            async: loadAsync(PageEditors.sitemap, { createMode: true })
+            async: loadAsync(SitemapEditPage, { createMode: true })
           },
           {
             path: 'duplicate',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
-            async: loadAsync(PageEditors.sitemap, { createMode: true })
+            async: loadAsync(SitemapEditPage, { createMode: true })
           },
           {
             path: ':uid',
             beforeEnter: [enforceAdminForRoute],
             beforeLeave: [checkDirtyBeforeLeave],
-            async: loadAsync(PageEditors.sitemap)
+            async: loadAsync(SitemapEditPage)
           }
         ]
       },

--- a/bundles/org.openhab.ui/web/src/js/routes.js
+++ b/bundles/org.openhab.ui/web/src/js/routes.js
@@ -47,6 +47,7 @@ const PersistenceEditPage = () => import(/* webpackChunkName: "admin-config" */ 
 const SemanticModelPage = () => import(/* webpackChunkName: "admin-config" */ '@/pages/settings/model/model.vue')
 
 const PagesListPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/pages-list.vue')
+const SitemapsListPage = () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/sitemaps-list.vue')
 const PageEditors = {
   home: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/home/home-edit.vue'),
   layout: () => import(/* webpackChunkName: "admin-pages" */ '@/pages/settings/pages/layout/layout-edit.vue'),
@@ -290,6 +291,31 @@ export default [
         async: loadAsync(PagesListPage),
         beforeEnter: [enforceAdminForRoute],
         routes: PageRoutes
+      },
+      {
+        path: 'sitemaps/',
+        beforeEnter: [enforceAdminForRoute],
+        async: loadAsync(SitemapsListPage),
+        routes: [
+          {
+            path: 'add',
+            beforeEnter: [enforceAdminForRoute],
+            beforeLeave: [checkDirtyBeforeLeave],
+            async: loadAsync(PageEditors.sitemap, { createMode: true })
+          },
+          {
+            path: 'duplicate',
+            beforeEnter: [enforceAdminForRoute],
+            beforeLeave: [checkDirtyBeforeLeave],
+            async: loadAsync(PageEditors.sitemap, { createMode: true })
+          },
+          {
+            path: ':uid',
+            beforeEnter: [enforceAdminForRoute],
+            beforeLeave: [checkDirtyBeforeLeave],
+            async: loadAsync(PageEditors.sitemap)
+          }
+        ]
       },
       {
         path: 'transformations/',

--- a/bundles/org.openhab.ui/web/src/js/stores/useLastSearchQueryStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useLastSearchQueryStore.ts
@@ -16,6 +16,7 @@ export const useLastSearchQueryStore = defineStore('lastSearchQuery', () => {
     lastItemSearchQuery,
     lastThingsSearchQuery,
     lastPagesSearchQuery,
+    lastSitemapsSearchQuery,
     lastScheduleSearchQuery,
     lastModelSearchQuery,
     lastRulesSearchQuery,

--- a/bundles/org.openhab.ui/web/src/js/stores/useLastSearchQueryStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useLastSearchQueryStore.ts
@@ -6,6 +6,7 @@ export const useLastSearchQueryStore = defineStore('lastSearchQuery', () => {
   const lastItemSearchQuery = ref<string>('')
   const lastThingsSearchQuery = ref<string>('')
   const lastPagesSearchQuery = ref<string>('')
+  const lastSitemapsSearchQuery = ref<string>('')
   const lastScheduleSearchQuery = ref<string>('')
   const lastModelSearchQuery = ref<string>('')
   const lastRulesSearchQuery = ref<object>({})

--- a/bundles/org.openhab.ui/web/src/pages/page-type.ts
+++ b/bundles/org.openhab.ui/web/src/pages/page-type.ts
@@ -8,7 +8,6 @@ type PageType = {
 }
 
 const pageTypes: Record<string, PageType> = {
-  Sitemap: { type: 'sitemap', label: 'Sitemap', icon: 'f7:menu' },
   'oh-layout-page': { type: 'layout', label: 'Layout', icon: 'f7:rectangle_grid_2x2' },
   'oh-home-page': { type: 'home', label: 'Home', icon: 'f7:house' },
   'oh-tabs-page': { type: 'tabs', label: 'Tabbed', icon: 'f7:squares_below_rectangle' },

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -424,9 +424,9 @@ export default {
             console.error('Error loading items:', error.message)
           })
 
-      if (useRuntimeStore().apiEndpoint('ui'))
+      if (useRuntimeStore().apiEndpoint('sitemaps'))
         api
-          .getRegisteredUiComponentsInNamespace({ namespace: 'system:sitemap' })
+          .getSitemaps()
           .then((data) => {
             this.sitemapsCount = data.length
           })

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -62,17 +62,6 @@
                 <f7-icon f7="square_on_circle" color="gray" />
               </template>
             </f7-list-item>
-            <f7-list-item
-              v-if="runtimeStore.apiEndpoint('ui')"
-              link="pages/"
-              title="Pages"
-              :after="componentsStore.pages().length + sitemapsCount"
-              badge-color="blue"
-              :footer="objectsSubtitles.pages">
-              <template #media>
-                <f7-icon f7="tv" color="gray" />
-              </template>
-            </f7-list-item>
           </f7-list>
           <f7-list media-list class="search-list">
             <f7-list-item
@@ -90,6 +79,32 @@
             <f7-list-item media-item link="persistence/" title="Persistence" badge-color="blue" :footer="objectsSubtitles.persistence">
               <template #media>
                 <f7-icon f7="download_circle" color="gray" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+          <f7-block-title v-if="runtimeStore.apiEndpoint('ui') || runtimeStore.apiEndpoint('sitemaps')"> User Interface </f7-block-title>
+          <f7-list media-list class="search-list">
+            <f7-list-item
+              v-if="runtimeStore.apiEndpoint('ui')"
+              link="pages/"
+              title="Pages"
+              :after="componentsStore.pages().length"
+              badge-color="blue"
+              :footer="objectsSubtitles.pages">
+              <template #media>
+                <f7-icon f7="tv" color="gray" />
+              </template>
+            </f7-list-item>
+            <f7-list-item
+              v-if="runtimeStore.apiEndpoint('sitemaps')"
+              media-item
+              link="sitemaps/"
+              title="Sitemaps"
+              :after="sitemapsCount"
+              badge-color="blue"
+              :footer="objectsSubtitles.sitemaps">
+              <template #media>
+                <f7-icon f7="menu" color="gray" />
               </template>
             </f7-list-item>
           </f7-list>
@@ -208,7 +223,7 @@
 </style>
 
 <script>
-import { theme } from 'framework7-vue'
+import { f7, theme } from 'framework7-vue'
 import { mapStores, mapWritableState } from 'pinia'
 
 import AddonSection from './addon-section.vue'
@@ -241,9 +256,10 @@ export default {
         things: 'Manage the physical layer',
         model: 'The semantic model of your home',
         items: 'Manage the functional layer',
-        pages: 'Design displays for user interaction',
         transform: 'Make raw data human-readable',
         persistence: 'How to keep data for future use',
+        pages: 'Design displays for user interaction',
+        sitemaps: 'Design classic sitemaps for user interaction',
         rules: 'Automate with triggers and actions',
         scenes: 'Store a set of desired states to recall',
         scripts: 'Rules dedicated to running code',

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -223,7 +223,7 @@
 </style>
 
 <script>
-import { f7, theme } from 'framework7-vue'
+import { theme } from 'framework7-vue'
 import { mapStores, mapWritableState } from 'pinia'
 
 import AddonSection from './addon-section.vue'

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -141,9 +141,6 @@
                   :height="32"
                   :width="32" />
               </template>
-              <template #after-title>
-                <f7-icon v-if="!page.editable" f7="lock_fill" size="1rem" color="gray" />
-              </template>
             </f7-list-item>
           </f7-list-group>
         </f7-list>
@@ -304,10 +301,6 @@ export default {
         .get('/rest/ui/components/ui:page')
         .then((data) => {
           this.pages = data
-            .map((page) => {
-              page.editable = true
-              return page
-            })
             .sort((a, b) => {
               return a.config.label.localeCompare(b.config.label)
             })
@@ -405,7 +398,6 @@ export default {
     getPageType,
     getPageIcon,
     getPageLink(page) {
-      if (!page.editable) return null
       const type = this.getPageType(page)
       return type ? `${encodeURIComponent(type.type)}/${encodeURIComponent(page.uid)}` : null
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -79,7 +79,7 @@
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
         </f7-block-title>
-        <div v-show="ready && uiPages.length > 0" class="padding-left padding-right">
+        <div v-show="ready && pages.length > 0" class="padding-left padding-right">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')"> Alphabetical </f7-button>
             <f7-button :active="groupBy === 'type'" @click="switchGroupOrder('type')"> By type </f7-button>
@@ -204,7 +204,7 @@ export default {
       ready: false,
       initSearchbar: false,
       loading: false,
-      uiPages: [],
+      pages: [],
       selectedItems: [],
       showCheckboxes: false,
       searchQuery: ''
@@ -218,9 +218,6 @@ export default {
       set(value) {
         this.runtimeStore.pagesGroupOrder = value
       }
-    },
-    pages() {
-      return this.uiPages
     },
     filteredPages() {
       if (!this.searchQuery.length) return this.pages
@@ -259,7 +256,7 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      return this.selectablePageUids.length > 0 && this.selectablePageUids.every((uid) => this.selectedItems.includes(uid))
+      return this.selectablePageUids.length > 0 && this.selectedItems.length >= this.selectablePageUids.length
     },
     listTitle() {
       let title = this.filteredPagesCount
@@ -300,13 +297,13 @@ export default {
       if (this.initSearchbar) this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
       this.initSearchbar = false
 
-      this.uiPages = []
+      this.pages = []
       this.selectedItems = []
       this.showCheckboxes = false
       this.$oh.api
         .get('/rest/ui/components/ui:page')
         .then((data) => {
-          this.uiPages = data
+          this.pages = data
             .map((page) => {
               page.editable = true
               return page
@@ -377,7 +374,8 @@ export default {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        this.selectedItems = this.selectablePageUids
+        // assign a copy so mutations to `selectedItems` don't modify the computed `selectablePageUids` array
+        this.selectedItems = Array.from(this.selectablePageUids)
       }
     },
     click(event, item) {
@@ -400,6 +398,9 @@ export default {
       } else {
         this.selectedItems.push(itemName)
       }
+      // f7-list-item renders a <label> wrapping the checkbox <input>; without this,
+      // the browser's native label click would toggle el.checked independently of Vue's binding.
+      event.preventDefault()
     },
     getPageType,
     getPageIcon,

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -300,10 +300,9 @@ export default {
       this.$oh.api
         .get('/rest/ui/components/ui:page')
         .then((data) => {
-          this.pages = data
-            .sort((a, b) => {
-              return a.config.label.localeCompare(b.config.label)
-            })
+          this.pages = data.sort((a, b) => {
+            return a.config.label.localeCompare(b.config.label)
+          })
           this.initSearchbar = true
           this.ready = true
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -110,7 +110,6 @@
               @click.meta="ctrlClick($event, page)"
               @click.exact="click($event, page)"
               :link="getPageLink(page)"
-              :no-chevron="!page.editable"
               :title="page.config.label"
               :subtitle="getPageType(page).label"
               :footer="page.uid"
@@ -148,10 +147,6 @@
             </f7-list-item>
           </f7-list-group>
         </f7-list>
-
-        <f7-block v-if="!pages.length" class="block-narrow">
-          <empty-state-placeholder icon="square_on_circle" title="pages.title" text="pages.text" />
-        </f7-block>
       </f7-col>
     </f7-block>
 
@@ -187,16 +182,12 @@ import { f7, theme } from 'framework7-vue'
 
 import { useLastSearchQueryStore } from '@/js/stores/useLastSearchQueryStore'
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
-import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
 import { showToast } from '@/js/dialog-promises'
 import { getPageType, getPageIcon } from '@/pages/page-type'
 
 export default {
   props: {
     f7router: Object
-  },
-  components: {
-    EmptyStatePlaceholder
   },
   setup() {
     const runtimeStore = useRuntimeStore()

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -110,10 +110,10 @@
               @click.meta="ctrlClick($event, page)"
               @click.exact="click($event, page)"
               :link="getPageLink(page)"
-              :title="page.config.label"
+              :title="page.config?.label || page.uid"
               :subtitle="getPageType(page).label"
               :footer="page.uid"
-              :badge="page.config.order">
+              :badge="page.config?.order">
               <template #subtitle>
                 <div>
                   <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
@@ -122,7 +122,7 @@
                     </template>
                   </f7-chip>
                   <f7-chip
-                    v-for="userrole in page.config.visibleTo || []"
+                    v-for="userrole in page.config?.visibleTo || []"
                     :key="userrole"
                     :text="userrole"
                     media-bg-color="green"
@@ -136,7 +136,7 @@
               <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
               <template #media>
                 <oh-icon
-                  :color="page.config.sidebar || page.uid === 'overview' ? '' : 'gray'"
+                  :color="page.config?.sidebar || page.uid === 'overview' ? '' : 'gray'"
                   :icon="getPageIcon(page)"
                   :height="32"
                   :width="32" />
@@ -226,7 +226,7 @@ export default {
     indexedPages() {
       if (this.groupBy === 'alphabetical') {
         return this.filteredPages.reduce((prev, page) => {
-          const label = page.config.label || page.uid
+          const label = page.config?.label || page.uid
           const initial = label.substring(0, 1).toUpperCase()
           if (!prev[initial]) prev[initial] = []
           prev[initial].push(page)
@@ -301,7 +301,9 @@ export default {
         .get('/rest/ui/components/ui:page')
         .then((data) => {
           this.pages = data.sort((a, b) => {
-            return a.config.label.localeCompare(b.config.label)
+            const aLabel = a.config?.label || a.uid
+            const bLabel = b.config?.label || b.uid
+            return aLabel.localeCompare(bLabel)
           })
           this.initSearchbar = true
           this.ready = true

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -253,7 +253,7 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      return this.selectablePageUids.length > 0 && this.selectedItems.length >= this.selectablePageUids.length
+      return this.selectablePageUids.length > 0 && this.selectablePageUids.every((uid) => this.selectedItems.includes(uid))
     },
     listTitle() {
       let title = this.filteredPagesCount

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -390,9 +390,6 @@ export default {
       } else {
         this.selectedItems.push(itemName)
       }
-      // f7-list-item renders a <label> wrapping the checkbox <input>; without this,
-      // the browser's native label click would toggle el.checked independently of Vue's binding.
-      event.preventDefault()
     },
     getPageType,
     getPageIcon,

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -297,8 +297,7 @@ export default {
       if (this.showCheckboxes) {
         this.toggleItemCheck(event, item.name, item)
       } else {
-        const pageLink = this.getPageLink(item)
-        if (pageLink) this.f7router.navigate(pageLink)
+        this.f7router.navigate(item.name)
       }
     },
     ctrlClick(event, item) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -284,7 +284,12 @@ export default {
       return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
     },
     getSitemapSearchText(sitemap) {
-      const searchFields = [sitemap.config?.label, sitemap.uid, ...(sitemap.tags || []), ...(sitemap.config?.visibleTo || []).map((role) => role)]
+      const searchFields = [
+        sitemap.config?.label,
+        sitemap.uid,
+        ...(sitemap.tags || []),
+        ...(sitemap.config?.visibleTo || []).map((role) => role)
+      ]
       return searchFields.filter(Boolean).join(' ').toLowerCase()
     },
     sitemapMatchesSearch(sitemap, query) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -89,13 +89,13 @@
               @click.ctrl="ctrlClick($event, sitemap)"
               @click.meta="ctrlClick($event, sitemap)"
               @click.exact="click($event, sitemap)"
-              :link="getPageLink(sitemap)"
+              :link="getSitemapLink(sitemap)"
               :no-chevron="!sitemap.editable"
               :title="sitemap.config.label"
               :footer="sitemap.uid"
               :badge="sitemap.config.order">
               <template #media>
-                <oh-icon :color="sitemap.config.sidebar ? '' : 'gray'" :icon="getPageIcon(sitemap)" :height="32" :width="32" />
+                <oh-icon :color="sitemap.config.sidebar ? '' : 'gray'" :icon="getSitemapIcon(sitemap)" :height="32" :width="32" />
               </template>
               <template #after-title>
                 <f7-icon v-if="!sitemap.editable" f7="lock_fill" size="1rem" color="gray" />
@@ -336,14 +336,15 @@ export default {
       // which would cause it to go out of sync with Vue's state.
       // This is because f7-list-item renders a <label> that wraps the checkbox <input>.
       // without this, the browser's native label click would toggle el.checked independently of Vue's binding.
+      // This issue only occurs when the list item has no link (i.e. is not editable)
       event.preventDefault()
     },
-    getPageIcon(page) {
-      return page.config.icon || 'f7:menu'
+    getSitemapIcon(sitemap) {
+      return sitemap.config.icon || 'f7:menu'
     },
-    getPageLink(page) {
-      if (!page.editable) return null
-      return encodeURIComponent(page.uid)
+    getSitemapLink(sitemap) {
+      if (!sitemap.editable) return null
+      return encodeURIComponent(sitemap.uid)
     },
     removeSelected() {
       const vm = this

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -1,7 +1,7 @@
 <template>
   <f7-page @page:afterin="onPageAfterIn" @page:beforeout="onPageBeforeOut">
     <f7-navbar>
-      <oh-nav-content title="Pages" back-link="Settings" back-link-url="/settings/" :f7router>
+      <oh-nav-content title="Sitemaps" back-link="Settings" back-link-url="/settings/" :f7router>
         <template #right>
           <f7-link icon-md="material:done_all" @click="toggleCheck()" :text="!theme.md ? (showCheckboxes ? 'Done' : 'Select') : ''" />
         </template>
@@ -31,46 +31,34 @@
           @click="removeSelected">
           Remove
         </f7-link>
+        <f7-link
+          v-show="selection.length"
+          color="blue"
+          class="copy display-flex flex-direction-row"
+          icon-ios="f7:square_on_square"
+          icon-aurora="f7:square_on_square"
+          @click="copySelected">
+          &nbsp;Copy
+        </f7-link>
       </div>
       <f7-link v-if="theme.md" icon-md="material:close" icon-color="white" @click="toggleCheck()" />
       <div v-if="theme.md" class="title">{{ selection.length }} selected</div>
       <div v-if="theme.md && selection.length" class="right">
         <f7-link icon-md="material:delete" icon-color="white" @click="removeSelected" />
+        <f7-link icon-md="material:content_copy" icon-color="white" @click="copySelected" />
       </div>
     </f7-toolbar>
 
     <f7-list-index
       v-if="ready"
-      v-show="groupBy === 'alphabetical' && !$device.desktop"
+      v-show="!$device.desktop"
       ref="listIndex"
-      :key="'pages-index'"
-      list-el=".pages-list"
+      :key="'sitemaps-index'"
+      list-el=".sitemaps-list"
       :scroll-list="true"
       :label="true" />
 
     <f7-block class="block-narrow">
-      <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
-        <f7-block-title>&nbsp;Loading...</f7-block-title>
-        <f7-list v-if="!ready" contacts-list class="col wide pages-list">
-          <f7-list-group>
-            <f7-list-item
-              v-for="n in 20"
-              media-item
-              :key="n"
-              :class="`skeleton-text skeleton-effect-blink`"
-              title="Title of the page"
-              subtitle="Page type"
-              after="The item state"
-              footer="Page ID">
-              <template #media>
-                <f7-skeleton-block style="width: 32px; height: 32px; border-radius: 50%" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
-      </f7-col>
-
       <f7-col v-show="ready">
         <f7-block-title class="no-margin-top">
           <span>{{ listTitle }}</span>
@@ -79,22 +67,12 @@
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
         </f7-block-title>
-        <div v-show="ready && uiPages.length > 0" class="padding-left padding-right">
-          <f7-segmented strong tag="p">
-            <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')"> Alphabetical </f7-button>
-            <f7-button :active="groupBy === 'type'" @click="switchGroupOrder('type')"> By type </f7-button>
-          </f7-segmented>
-        </div>
 
         <f7-list v-if="pages.length > 0 && filteredPages.length === 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list
-          v-show="filteredPages.length > 0"
-          class="col pages-list"
-          ref="pagesList"
-          :contacts-list="groupBy === 'alphabetical'"
-          media-list>
+
+        <f7-list v-show="filteredPages.length > 0" class="col sitemaps-list" ref="pagesList" :contacts-list="true" media-list>
           <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
             <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
             <f7-list-item
@@ -102,9 +80,8 @@
               :key="page.uid"
               media-item
               class="pagelist-item"
-              :checkbox="showCheckboxes && page.uid !== 'overview'"
+              :checkbox="showCheckboxes"
               :checked="isChecked(page.uid) ? true : null"
-              :disabled="showCheckboxes && page.uid === 'overview' ? true : null"
               prevent-router
               @click.ctrl="ctrlClick($event, page)"
               @click.meta="ctrlClick($event, page)"
@@ -115,32 +92,8 @@
               :subtitle="getPageType(page).label"
               :footer="page.uid"
               :badge="page.config.order">
-              <template #subtitle>
-                <div>
-                  <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                  <f7-chip
-                    v-for="userrole in page.config.visibleTo || []"
-                    :key="userrole"
-                    :text="userrole"
-                    media-bg-color="green"
-                    style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon f7="person_crop_circle_fill_badge_checkmark" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-              <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
               <template #media>
-                <oh-icon
-                  :color="page.config.sidebar || page.uid === 'overview' ? '' : 'gray'"
-                  :icon="getPageIcon(page)"
-                  :height="32"
-                  :width="32" />
+                <oh-icon :color="page.config.sidebar ? '' : 'gray'" :icon="getPageIcon(page)" :height="32" :width="32" />
               </template>
               <template #after-title>
                 <f7-icon v-if="!page.editable" f7="lock_fill" size="1rem" color="gray" />
@@ -150,32 +103,24 @@
         </f7-list>
 
         <f7-block v-if="!pages.length" class="block-narrow">
-          <empty-state-placeholder icon="square_on_circle" title="pages.title" text="pages.text" />
+          <empty-state-placeholder icon="square_on_circle" title="sitemaps.title" text="sitemaps.text" />
+          <f7-row v-if="$f7dim.width < 1280" class="display-flex justify-content-center">
+            <f7-button
+              large
+              fill
+              color="blue"
+              external
+              :href="`${runtimeStore.websiteUrl}/docs/ui/sitemaps`"
+              target="_blank"
+              :text="$t('home.overview.button.documentation')" />
+          </f7-row>
         </f7-block>
       </f7-col>
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
-        <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
-        <f7-fab-buttons position="top">
-          <f7-fab-button fab-close label="Create layout" href="layout/add">
-            <f7-icon f7="rectangle_grid_2x2" />
-          </f7-fab-button>
-          <f7-fab-button fab-close label="Create tabbed page" href="tabs/add">
-            <f7-icon f7="squares_below_rectangle" />
-          </f7-fab-button>
-          <f7-fab-button fab-close label="Create map view" href="map/add">
-            <f7-icon f7="map" />
-          </f7-fab-button>
-          <f7-fab-button fab-close label="Create floor plan" href="plan/add">
-            <f7-icon f7="square_stack_3d_up" />
-          </f7-fab-button>
-          <f7-fab-button fab-close label="Create chart" href="chart/add">
-            <f7-icon f7="graph_square" />
-          </f7-fab-button>
-        </f7-fab-buttons>
       </f7-fab>
     </template>
   </f7-page>
@@ -185,6 +130,8 @@
 import { nextTick } from 'vue'
 import { f7, theme } from 'framework7-vue'
 
+import FileDefinition from '@/pages/settings/file-definition-mixin'
+
 import { useLastSearchQueryStore } from '@/js/stores/useLastSearchQueryStore'
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
 import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
@@ -192,6 +139,7 @@ import { showToast } from '@/js/dialog-promises'
 import { getPageType, getPageIcon } from '@/pages/page-type'
 
 export default {
+  mixins: [FileDefinition],
   props: {
     f7router: Object
   },
@@ -213,23 +161,16 @@ export default {
       ready: false,
       initSearchbar: false,
       loading: false,
-      uiPages: [],
+      sitemaps: [],
+      sitemapPages: [],
       selectedItems: [],
       showCheckboxes: false,
       searchQuery: ''
     }
   },
   computed: {
-    groupBy: {
-      get() {
-        return this.runtimeStore.pagesGroupOrder
-      },
-      set(value) {
-        this.runtimeStore.pagesGroupOrder = value
-      }
-    },
     pages() {
-      return this.uiPages
+      return this.sitemapPages
     },
     filteredPages() {
       if (!this.searchQuery.length) return this.pages
@@ -239,30 +180,13 @@ export default {
       return this.filteredPages.length
     },
     indexedPages() {
-      if (this.groupBy === 'alphabetical') {
-        return this.filteredPages.reduce((prev, page) => {
-          const label = page.config.label || page.uid
-          const initial = label.substring(0, 1).toUpperCase()
-          if (!prev[initial]) prev[initial] = []
-          prev[initial].push(page)
-
-          return prev
-        }, {})
-      } else {
-        const typeGroups = this.filteredPages.reduce((prev, page) => {
-          const type = getPageType(page).label
-          if (!prev[type]) prev[type] = []
-          prev[type].push(page)
-
-          return prev
-        }, {})
-        return Object.keys(typeGroups)
-          .sort((a, b) => a.localeCompare(b))
-          .reduce((objEntries, key) => {
-            objEntries[key] = typeGroups[key]
-            return objEntries
-          }, {})
-      }
+      return this.filteredPages.reduce((prev, page) => {
+        const label = page.config.label || page.uid
+        const initial = label.substring(0, 1).toUpperCase()
+        if (!prev[initial]) prev[initial] = []
+        prev[initial].push(page)
+        return prev
+      }, {})
     },
     searchPlaceholder() {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
@@ -273,9 +197,9 @@ export default {
     listTitle() {
       let title = this.filteredPagesCount
       if (this.searchQuery.length) {
-        title += ` of ${this.pages.length} pages found`
+        title += ` of ${this.pages.length} sitemaps found`
       } else {
-        title += ' pages'
+        title += ' sitemaps'
       }
       if (this.selection.length > 0) {
         title += `, ${this.selection.length} selected`
@@ -283,7 +207,7 @@ export default {
       return title
     },
     selectablePageUids() {
-      return this.filteredPages.filter((page) => page.uid !== 'overview').map((page) => page.uid)
+      return this.filteredPages.map((page) => page.uid)
     },
     selection() {
       return this.selectablePageUids.filter((uid) => this.selectedItems.includes(uid))
@@ -309,20 +233,30 @@ export default {
       if (this.initSearchbar) this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
       this.initSearchbar = false
 
-      this.uiPages = []
+      this.sitemaps = []
+      this.sitemapPages = []
       this.selectedItems = []
       this.showCheckboxes = false
+
       this.$oh.api
-        .get('/rest/ui/components/ui:page')
+        .get('/rest/sitemaps/*/definition')
         .then((data) => {
-          this.uiPages = data
-            .map((page) => {
-              page.editable = true
-              return page
+          this.sitemaps = data
+          this.sitemapPages = this.sitemaps
+            .map((sitemap) => {
+              return {
+                uid: sitemap.name,
+                component: 'Sitemap',
+                editable: sitemap.editable,
+                config: {
+                  label: sitemap.label || sitemap.name,
+                  icon: sitemap.icon,
+                  sidebar: sitemap.sidebar
+                }
+              }
             })
-            .sort((a, b) => {
-              return a.config.label.localeCompare(b.config.label)
-            })
+            .sort((a, b) => a.config.label.localeCompare(b.config.label))
+
           this.initSearchbar = true
           this.ready = true
 
@@ -336,23 +270,11 @@ export default {
         })
         .catch((err) => {
           console.error(err)
-          showToast('An error occurred while loading pages: ' + (err?.message || String(err)))
+          showToast('An error occurred while loading sitemaps: ' + (err?.message || String(err)))
         })
         .finally(() => {
           this.loading = false
         })
-    },
-    switchGroupOrder(groupBy) {
-      this.groupBy = groupBy
-      const searchbar = this.$refs.searchbar?.$el?.f7Searchbar
-      const filterQuery = searchbar?.query
-      nextTick(() => {
-        if (filterQuery) {
-          searchbar.clear()
-          searchbar.search(filterQuery)
-        }
-        if (this.groupBy === 'alphabetical') this.$refs.listIndex.update()
-      })
     },
     toggleCheck() {
       this.showCheckboxes = !this.showCheckboxes
@@ -367,13 +289,7 @@ export default {
       return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
     },
     getPageSearchText(page) {
-      const searchFields = [
-        page.config?.label,
-        page.uid,
-        this.getPageType(page)?.label,
-        ...(page.tags || []),
-        ...(page.config?.visibleTo || []).map((role) => role)
-      ]
+      const searchFields = [page.config?.label, page.uid, ...(page.tags || []), ...(page.config?.visibleTo || []).map((role) => role)]
       return searchFields.filter(Boolean).join(' ').toLowerCase()
     },
     pageMatchesSearch(page, query) {
@@ -389,6 +305,13 @@ export default {
         this.selectedItems = this.selectablePageUids
       }
     },
+    copySelected() {
+      if (this.selection.length === 0) {
+        showToast('No sitemaps selected to copy')
+        return
+      }
+      this.copyFileDefinitionToClipboard(this.ObjectType.SITEMAP, this.selection)
+    },
     click(event, item) {
       if (this.showCheckboxes) {
         this.toggleItemCheck(event, item.uid, item)
@@ -402,7 +325,6 @@ export default {
       if (!this.selectedItems.length) this.showCheckboxes = false
     },
     toggleItemCheck(event, itemName, item) {
-      if (itemName === 'overview') return
       if (!this.showCheckboxes) this.showCheckboxes = true
       if (this.isChecked(itemName)) {
         this.selectedItems.splice(this.selectedItems.indexOf(itemName), 1)
@@ -414,25 +336,29 @@ export default {
     getPageIcon,
     getPageLink(page) {
       if (!page.editable) return null
-      const type = this.getPageType(page)
-      return type ? `${encodeURIComponent(type.type)}/${encodeURIComponent(page.uid)}` : null
+      return encodeURIComponent(page.uid)
     },
     removeSelected() {
       const vm = this
 
-      f7.dialog.confirm(`Remove ${this.selection.length} selected pages?`, `Remove Pages`, () => {
+      f7.dialog.confirm(`Remove ${this.selection.length} selected sitemaps?`, `Remove Sitemaps`, () => {
         vm.doRemoveSelected()
       })
     },
     doRemoveSelected() {
-      let dialog = f7.dialog.progress(`Deleting Pages...`)
+      if (this.selection.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
+        f7.dialog.alert('Some of the selected sitemaps are not modifiable because they have been created by textual configuration')
+        return
+      }
+
+      let dialog = f7.dialog.progress(`Deleting Sitemaps...`)
 
       const promises = this.selection.map((p) => {
-        return this.$oh.api.delete('/rest/ui/components/ui:page/' + p)
+        return this.$oh.api.delete('/rest/sitemaps/' + p)
       })
       Promise.all(promises)
         .then((data) => {
-          showToast('Pages removed')
+          showToast('Sitemaps removed')
           this.selectedItems = []
           dialog.close()
           this.load()

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -62,7 +62,7 @@
       <f7-col v-show="ready">
         <f7-block-title class="no-margin-top">
           <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && selectableSitemapUids.length">
+          <template v-if="showCheckboxes && selectableSitemapNames.length">
             -
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
@@ -138,6 +138,8 @@ import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
 import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
 import { showToast } from '@/js/dialog-promises'
 
+import * as api from '@/api'
+
 export default {
   mixins: [FileDefinition],
   props: {
@@ -188,7 +190,7 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      return this.selectedItems.length > 0 && this.selectedItems.length >= this.selectableSitemapUids.length
+      return this.selectableSitemapNames.length > 0 && this.selectableSitemapNames.every((name) => this.selectedItems.includes(name))
     },
     listTitle() {
       let title = this.filteredSitemapsCount
@@ -202,11 +204,11 @@ export default {
       }
       return title
     },
-    selectableSitemapUids() {
-      return this.filteredSitemaps.map((sitemap) => sitemap.uid)
+    selectableSitemapNames() {
+      return this.filteredSitemaps.map((sitemap) => sitemap.name)
     },
     selection() {
-      return this.selectableSitemapUids.filter((uid) => this.selectedItems.includes(uid))
+      return this.selectableSitemapNames.filter((name) => this.selectedItems.includes(name))
     }
   },
   methods: {
@@ -233,8 +235,8 @@ export default {
       this.selectedItems = []
       this.showCheckboxes = false
 
-      this.$oh.api
-        .get('/rest/sitemaps/*/definition')
+      api
+        .getSitemapDefinitions()
         .then((data) => {
           this.sitemaps = data.sort((a, b) => a.label.localeCompare(b.label))
           this.initSearchbar = true
@@ -282,8 +284,8 @@ export default {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        // assign a copy so mutations to `selectedItems` don't modify the computed `selectableSitemapUids` array
-        this.selectedItems = Array.from(this.selectableSitemapUids)
+        // assign a copy so mutations to `selectedItems` don't modify the computed `selectableSitemapNames` array
+        this.selectedItems = Array.from(this.selectableSitemapNames)
       }
     },
     copySelected() {
@@ -334,7 +336,7 @@ export default {
       let dialog = f7.dialog.progress(`Deleting Sitemaps...`)
 
       const promises = this.selection.map((p) => {
-        return this.$oh.api.delete('/rest/sitemaps/' + p)
+        return api.removeSitemapFromRegistry({ sitemapname: p })
       })
       Promise.all(promises)
         .then((data) => {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -75,9 +75,6 @@
         <f7-list v-show="filteredSitemaps.length > 0" class="col sitemaps-list" ref="sitemapsList" :contacts-list="true" media-list>
           <f7-list-group v-for="(sitemapsWithInitial, initial) in indexedSitemaps" :key="initial">
             <f7-list-item v-if="sitemapsWithInitial.length" :title="initial" group-title />
-            <!-- We have to use :key with a dynamic value to ensure proper reactivity to selection changes
-              A root cause of selection reactivity issues was unclear.
-            -->
             <f7-list-item
               v-for="sitemap in sitemapsWithInitial"
               :key="sitemap.name"
@@ -91,7 +88,7 @@
               @click.exact="click($event, sitemap)"
               :link="sitemap.editable ? encodeURIComponent(sitemap.name) : null"
               :no-chevron="!sitemap.editable"
-              :title="sitemap.label"
+              :title="sitemap.label || sitemap.name"
               :footer="sitemap.name">
               <template #media>
                 <oh-icon :icon="sitemap.icon || 'f7:menu'" :height="32" :width="32" />
@@ -242,7 +239,7 @@ export default {
       api
         .getSitemapDefinitions()
         .then((data) => {
-          this.sitemaps = data.sort((a, b) => a.label.localeCompare(b.label))
+          this.sitemaps = data.sort((a, b) => (a.label || a.name).localeCompare(b.label || b.name))
           this.initSearchbar = true
           this.ready = true
 
@@ -357,11 +354,6 @@ export default {
           showToast('An error occurred while deleting: ' + (err?.message || String(err)))
           f7.emit('sidebarRefresh', null)
         })
-    }
-  },
-  asyncComputed: {
-    iconUrl() {
-      return (icon) => this.$oh.media.getIcon(icon)
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -96,6 +96,10 @@
               <template #media>
                 <oh-icon :icon="sitemap.icon || 'f7:menu'" :height="32" :width="32" />
               </template>
+              <template #after>
+                <!-- push the lock icon so it appears immediately after the title,
+                 consistent with other list items (Things, Items, etc) -->
+              </template>
               <template #after-title>
                 <f7-icon v-if="!sitemap.editable" f7="lock_fill" size="1rem" color="gray" />
               </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -80,22 +80,21 @@
             -->
             <f7-list-item
               v-for="sitemap in sitemapsWithInitial"
-              :key="sitemap.uid"
+              :key="sitemap.name"
               media-item
               class="sitemapslist-item"
               :checkbox="showCheckboxes"
-              :checked="isChecked(sitemap.uid) ? true : null"
+              :checked="isChecked(sitemap.name) ? true : null"
               prevent-router
               @click.ctrl="ctrlClick($event, sitemap)"
               @click.meta="ctrlClick($event, sitemap)"
               @click.exact="click($event, sitemap)"
-              :link="getSitemapLink(sitemap)"
+              :link="sitemap.editable ? encodeURIComponent(sitemap.name) : null"
               :no-chevron="!sitemap.editable"
-              :title="sitemap.config.label"
-              :footer="sitemap.uid"
-              :badge="sitemap.config.order">
+              :title="sitemap.label"
+              :footer="sitemap.name">
               <template #media>
-                <oh-icon :color="sitemap.config.sidebar ? '' : 'gray'" :icon="getSitemapIcon(sitemap)" :height="32" :width="32" />
+                <oh-icon :icon="sitemap.icon || 'f7:menu'" :height="32" :width="32" />
               </template>
               <template #after-title>
                 <f7-icon v-if="!sitemap.editable" f7="lock_fill" size="1rem" color="gray" />
@@ -178,7 +177,7 @@ export default {
     },
     indexedSitemaps() {
       return this.filteredSitemaps.reduce((prev, sitemap) => {
-        const label = sitemap.config.label || sitemap.uid
+        const label = sitemap.label || sitemap.name
         const initial = label.substring(0, 1).toUpperCase()
         if (!prev[initial]) prev[initial] = []
         prev[initial].push(sitemap)
@@ -237,21 +236,7 @@ export default {
       this.$oh.api
         .get('/rest/sitemaps/*/definition')
         .then((data) => {
-          this.sitemaps = data
-            .map((sitemap) => {
-              return {
-                uid: sitemap.name,
-                component: 'Sitemap',
-                editable: sitemap.editable,
-                config: {
-                  label: sitemap.label || sitemap.name,
-                  icon: sitemap.icon,
-                  sidebar: sitemap.sidebar
-                }
-              }
-            })
-            .sort((a, b) => a.config.label.localeCompare(b.config.label))
-
+          this.sitemaps = data.sort((a, b) => a.label.localeCompare(b.label))
           this.initSearchbar = true
           this.ready = true
 
@@ -284,13 +269,8 @@ export default {
       return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
     },
     getSitemapSearchText(sitemap) {
-      const searchFields = [
-        sitemap.config?.label,
-        sitemap.uid,
-        ...(sitemap.tags || []),
-        ...(sitemap.config?.visibleTo || []).map((role) => role)
-      ]
-      return searchFields.filter(Boolean).join(' ').toLowerCase()
+      const searchText = sitemap.label + ' ' + sitemap.name
+      return searchText.toLowerCase()
     },
     sitemapMatchesSearch(sitemap, query) {
       const terms = this.getNormalizedSearchTerms(query)
@@ -315,14 +295,14 @@ export default {
     },
     click(event, item) {
       if (this.showCheckboxes) {
-        this.toggleItemCheck(event, item.uid, item)
+        this.toggleItemCheck(event, item.name, item)
       } else {
         const pageLink = this.getPageLink(item)
         if (pageLink) this.f7router.navigate(pageLink)
       }
     },
     ctrlClick(event, item) {
-      this.toggleItemCheck(event, item.uid, item)
+      this.toggleItemCheck(event, item.name, item)
       if (!this.selectedItems.length) this.showCheckboxes = false
     },
     toggleItemCheck(event, itemName, item) {
@@ -339,13 +319,6 @@ export default {
       // This issue only occurs when the list item has no link (i.e. is not editable)
       event.preventDefault()
     },
-    getSitemapIcon(sitemap) {
-      return sitemap.config.icon || 'f7:menu'
-    },
-    getSitemapLink(sitemap) {
-      if (!sitemap.editable) return null
-      return encodeURIComponent(sitemap.uid)
-    },
     removeSelected() {
       const vm = this
 
@@ -354,7 +327,7 @@ export default {
       })
     },
     doRemoveSelected() {
-      if (this.selection.some((i) => !this.sitemaps.find((s) => s.uid === i)?.editable)) {
+      if (this.selection.some((i) => !this.sitemaps.find((s) => s.name === i)?.editable)) {
         f7.dialog.alert('Some of the selected sitemaps are not modifiable because they have been created by textual configuration')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -10,7 +10,7 @@
         <f7-searchbar
           v-if="initSearchbar"
           ref="searchbar"
-          class="searchbar-pages"
+          class="searchbar-sitemaps"
           :custom-search="true"
           @searchbar:search="searchbarSearch"
           @searchbar:clear="searchbarClear"
@@ -62,46 +62,49 @@
       <f7-col v-show="ready">
         <f7-block-title class="no-margin-top">
           <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && selectablePageUids.length">
+          <template v-if="showCheckboxes && selectableSitemapUids.length">
             -
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
         </f7-block-title>
 
-        <f7-list v-if="pages.length > 0 && filteredPages.length === 0" class="searchbar-not-found">
+        <f7-list v-if="sitemaps.length > 0 && filteredSitemaps.length === 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
 
-        <f7-list v-show="filteredPages.length > 0" class="col sitemaps-list" ref="pagesList" :contacts-list="true" media-list>
-          <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
-            <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
+        <f7-list v-show="filteredSitemaps.length > 0" class="col sitemaps-list" ref="sitemapsList" :contacts-list="true" media-list>
+          <f7-list-group v-for="(sitemapsWithInitial, initial) in indexedSitemaps" :key="initial">
+            <f7-list-item v-if="sitemapsWithInitial.length" :title="initial" group-title />
+            <!-- We have to use :key with a dynamic value to ensure proper reactivity to selection changes
+              A root cause of selection reactivity issues was unclear.
+            -->
             <f7-list-item
-              v-for="page in pagesWithInitial"
-              :key="page.uid"
+              v-for="sitemap in sitemapsWithInitial"
+              :key="sitemap.uid"
               media-item
-              class="pagelist-item"
+              class="sitemapslist-item"
               :checkbox="showCheckboxes"
-              :checked="isChecked(page.uid) ? true : null"
+              :checked="isChecked(sitemap.uid) ? true : null"
               prevent-router
-              @click.ctrl="ctrlClick($event, page)"
-              @click.meta="ctrlClick($event, page)"
-              @click.exact="click($event, page)"
-              :link="getPageLink(page)"
-              :no-chevron="!page.editable"
-              :title="page.config.label"
-              :footer="page.uid"
-              :badge="page.config.order">
+              @click.ctrl="ctrlClick($event, sitemap)"
+              @click.meta="ctrlClick($event, sitemap)"
+              @click.exact="click($event, sitemap)"
+              :link="getPageLink(sitemap)"
+              :no-chevron="!sitemap.editable"
+              :title="sitemap.config.label"
+              :footer="sitemap.uid"
+              :badge="sitemap.config.order">
               <template #media>
-                <oh-icon :color="page.config.sidebar ? '' : 'gray'" :icon="getPageIcon(page)" :height="32" :width="32" />
+                <oh-icon :color="sitemap.config.sidebar ? '' : 'gray'" :icon="getPageIcon(sitemap)" :height="32" :width="32" />
               </template>
               <template #after-title>
-                <f7-icon v-if="!page.editable" f7="lock_fill" size="1rem" color="gray" />
+                <f7-icon v-if="!sitemap.editable" f7="lock_fill" size="1rem" color="gray" />
               </template>
             </f7-list-item>
           </f7-list-group>
         </f7-list>
 
-        <f7-block v-if="!pages.length" class="block-narrow">
+        <f7-block v-if="!sitemaps.length" class="block-narrow">
           <empty-state-placeholder icon="square_on_circle" title="sitemaps.title" text="sitemaps.text" />
           <f7-row v-if="$f7dim.width < 1280" class="display-flex justify-content-center">
             <f7-button
@@ -160,29 +163,25 @@ export default {
       initSearchbar: false,
       loading: false,
       sitemaps: [],
-      sitemapPages: [],
       selectedItems: [],
       showCheckboxes: false,
       searchQuery: ''
     }
   },
   computed: {
-    pages() {
-      return this.sitemapPages
+    filteredSitemaps() {
+      if (!this.searchQuery.length) return this.sitemaps
+      return this.sitemaps.filter((sitemap) => this.sitemapMatchesSearch(sitemap, this.searchQuery))
     },
-    filteredPages() {
-      if (!this.searchQuery.length) return this.pages
-      return this.pages.filter((page) => this.pageMatchesSearch(page, this.searchQuery))
+    filteredSitemapsCount() {
+      return this.filteredSitemaps.length
     },
-    filteredPagesCount() {
-      return this.filteredPages.length
-    },
-    indexedPages() {
-      return this.filteredPages.reduce((prev, page) => {
-        const label = page.config.label || page.uid
+    indexedSitemaps() {
+      return this.filteredSitemaps.reduce((prev, sitemap) => {
+        const label = sitemap.config.label || sitemap.uid
         const initial = label.substring(0, 1).toUpperCase()
         if (!prev[initial]) prev[initial] = []
-        prev[initial].push(page)
+        prev[initial].push(sitemap)
         return prev
       }, {})
     },
@@ -190,12 +189,12 @@ export default {
       return window.innerWidth >= 1280 ? 'Search (for advanced search, use the developer sidebar (Shift+Alt+D))' : 'Search'
     },
     allSelected() {
-      return this.selectablePageUids.length > 0 && this.selectablePageUids.every((uid) => this.selectedItems.includes(uid))
+      return this.selectedItems.length > 0 && this.selectedItems.length >= this.selectableSitemapUids.length
     },
     listTitle() {
-      let title = this.filteredPagesCount
+      let title = this.filteredSitemapsCount
       if (this.searchQuery.length) {
-        title += ` of ${this.pages.length} sitemaps found`
+        title += ` of ${this.sitemaps.length} sitemaps found`
       } else {
         title += ' sitemaps'
       }
@@ -204,11 +203,11 @@ export default {
       }
       return title
     },
-    selectablePageUids() {
-      return this.filteredPages.map((page) => page.uid)
+    selectableSitemapUids() {
+      return this.filteredSitemaps.map((sitemap) => sitemap.uid)
     },
     selection() {
-      return this.selectablePageUids.filter((uid) => this.selectedItems.includes(uid))
+      return this.selectableSitemapUids.filter((uid) => this.selectedItems.includes(uid))
     }
   },
   methods: {
@@ -232,7 +231,6 @@ export default {
       this.initSearchbar = false
 
       this.sitemaps = []
-      this.sitemapPages = []
       this.selectedItems = []
       this.showCheckboxes = false
 
@@ -240,7 +238,6 @@ export default {
         .get('/rest/sitemaps/*/definition')
         .then((data) => {
           this.sitemaps = data
-          this.sitemapPages = this.sitemaps
             .map((sitemap) => {
               return {
                 uid: sitemap.name,
@@ -286,21 +283,22 @@ export default {
     getNormalizedSearchTerms(query) {
       return (query || '').toLowerCase().trim().split(/\s+/).filter(Boolean)
     },
-    getPageSearchText(page) {
-      const searchFields = [page.config?.label, page.uid, ...(page.tags || []), ...(page.config?.visibleTo || []).map((role) => role)]
+    getSitemapSearchText(sitemap) {
+      const searchFields = [sitemap.config?.label, sitemap.uid, ...(sitemap.tags || []), ...(sitemap.config?.visibleTo || []).map((role) => role)]
       return searchFields.filter(Boolean).join(' ').toLowerCase()
     },
-    pageMatchesSearch(page, query) {
+    sitemapMatchesSearch(sitemap, query) {
       const terms = this.getNormalizedSearchTerms(query)
       if (!terms.length) return true
-      const pageSearchText = this.getPageSearchText(page)
-      return terms.every((term) => pageSearchText.includes(term))
+      const sitemapSearchText = this.getSitemapSearchText(sitemap)
+      return terms.every((term) => sitemapSearchText.includes(term))
     },
     selectDeselectAll() {
       if (this.allSelected) {
         this.selectedItems = []
       } else {
-        this.selectedItems = this.selectablePageUids
+        // assign a copy so mutations to `selectedItems` don't modify the computed `selectableSitemapUids` array
+        this.selectedItems = Array.from(this.selectableSitemapUids)
       }
     },
     copySelected() {
@@ -329,6 +327,11 @@ export default {
       } else {
         this.selectedItems.push(itemName)
       }
+      // Calling preventDefault() is necessary to prevent the default label-click behavior of toggling the checkbox,
+      // which would cause it to go out of sync with Vue's state.
+      // This is because f7-list-item renders a <label> that wraps the checkbox <input>.
+      // without this, the browser's native label click would toggle el.checked independently of Vue's binding.
+      event.preventDefault()
     },
     getPageIcon(page) {
       return page.config.icon || 'f7:menu'
@@ -345,7 +348,7 @@ export default {
       })
     },
     doRemoveSelected() {
-      if (this.selection.some((i) => !this.sitemapPages.find((s) => s.uid === i)?.editable)) {
+      if (this.selection.some((i) => !this.sitemaps.find((s) => s.uid === i)?.editable)) {
         f7.dialog.alert('Some of the selected sitemaps are not modifiable because they have been created by textual configuration')
         return
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -297,7 +297,7 @@ export default {
       if (this.showCheckboxes) {
         this.toggleItemCheck(event, item.name, item)
       } else {
-        this.f7router.navigate(item.name)
+        this.f7router.navigate(encodeURIComponent(item.name))
       }
     },
     ctrlClick(event, item) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -89,7 +89,6 @@
               :link="getPageLink(page)"
               :no-chevron="!page.editable"
               :title="page.config.label"
-              :subtitle="getPageType(page).label"
               :footer="page.uid"
               :badge="page.config.order">
               <template #media>
@@ -136,7 +135,6 @@ import { useLastSearchQueryStore } from '@/js/stores/useLastSearchQueryStore'
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
 import EmptyStatePlaceholder from '@/components/empty-state-placeholder.vue'
 import { showToast } from '@/js/dialog-promises'
-import { getPageType, getPageIcon } from '@/pages/page-type'
 
 export default {
   mixins: [FileDefinition],
@@ -224,13 +222,13 @@ export default {
       this.load()
     },
     onPageBeforeOut() {
-      this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
+      this.lastSearchQueryStore.lastSitemapsSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
     },
     load() {
       if (this.loading) return
       this.loading = true
 
-      if (this.initSearchbar) this.lastSearchQueryStore.lastPagesSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
+      if (this.initSearchbar) this.lastSearchQueryStore.lastSitemapsSearchQuery = this.$refs.searchbar?.$el.f7Searchbar.query
       this.initSearchbar = false
 
       this.sitemaps = []
@@ -265,7 +263,7 @@ export default {
             if (this.$device.desktop && this.$refs.searchbar) {
               this.$refs.searchbar.$el.f7Searchbar.$inputEl[0].focus()
             }
-            this.$refs.searchbar?.$el.f7Searchbar.search(this.lastSearchQueryStore.lastPagesSearchQuery || '')
+            this.$refs.searchbar?.$el.f7Searchbar.search(this.lastSearchQueryStore.lastSitemapsSearchQuery || '')
           })
         })
         .catch((err) => {
@@ -332,8 +330,9 @@ export default {
         this.selectedItems.push(itemName)
       }
     },
-    getPageType,
-    getPageIcon,
+    getPageIcon(page) {
+      return page.config.icon || 'f7:menu'
+    },
     getPageLink(page) {
       if (!page.editable) return null
       return encodeURIComponent(page.uid)

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -298,7 +298,7 @@ export default {
     click(event, item) {
       if (this.showCheckboxes) {
         this.toggleItemCheck(event, item.name, item)
-      } else {
+      } else if (item.editable) {
         this.f7router.navigate(encodeURIComponent(item.name))
       }
     },


### PR DESCRIPTION
See https://github.com/openhab/openhab-webui/pull/4103#issuecomment-4350329532
Resolves #4168

Reasons:
- The two are conceptually different. Splitting them up clears any confusion between the two.
- They now use different rest endpoints
- Sitemaps have file-based YAML and DSL whereas Pages will only have file-based YAML. This simplifies the "Copy definition"
- We emphasize the "User Interface" part of openHAB by listing them separately

<img width="502" height="616" alt="image" src="https://github.com/user-attachments/assets/91404952-4e82-4800-beb8-a7c39a25db17" />



