### PR TITLE
useThrottleFn: Configure useThrottleFn to guarantee function is executed

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -206,12 +206,16 @@ export default {
       }
       useStatesStore().stopTrackingStates()
     },
-    onEditorInput: useThrottleFn(function (value) {
-      this.widgetDefinition = value
-      if (!this.loading) {
-        this.dirty = true
-      }
-    }, 300),
+    onEditorInput: useThrottleFn(
+      function (value) {
+        this.widgetDefinition = value
+        if (!this.loading) {
+          this.dirty = true
+        }
+      },
+      300,
+      true
+    ),
     keyDown(ev) {
       if ((ev.ctrlKey || ev.metaKey) && !(ev.altKey || ev.shiftKey)) {
         switch (ev.keyCode) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
@@ -207,9 +207,13 @@ const mediaType = computed(() => SupportedMediaTypes.items[codeEditorType.value]
 // watchers
 watch(
   code,
-  useThrottleFn(() => {
-    parseItems()
-  }, 300)
+  useThrottleFn(
+    () => {
+      parseItems()
+    },
+    300,
+    true
+  )
 )
 
 watch(codeEditorType, () => {


### PR DESCRIPTION
By default, useThrottle will only trigger on the leading edge and will then "miss" any additional keystrokes in the last window. To prevent that, we need to enable the "last" parameter to use the trailing edge.