### PR TITLE
Charts: Fix inconsistencies with `week`/`weekday` fixed to start on Sunday vs. depending on locale

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/chart/index.ts
@@ -243,9 +243,6 @@ export const OhCategoryAxisDefinition = new WidgetDefinition('oh-category-axis',
       .r()
       .d('default')
       .v((_, cfg) => cfg.categoryType === 'week'),
-    pb('startOnSunday', 'Start Week on Sunday', 'Check to start the week on Sundays instead of Mondays').v(
-      (_, cfg) => cfg.categoryType === 'week'
-    ),
     po('monthFormat', 'Month Format', 'Format of months labels', [
       { value: 'default', label: 'Long (default)' },
       { value: 'short', label: 'Short' }

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/chart.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/chart.ts
@@ -8,8 +8,8 @@ export default () => [
     [
       { value: '', label: 'Dynamic period' },
       { value: 'day', label: 'Day' },
-      { value: 'isoWeek', label: 'Week (starting on Monday)' },
-      { value: 'week', label: 'Week (starting on Sunday)' },
+      { value: 'isoWeek', label: 'Week (always starting on Monday)' },
+      { value: 'week', label: 'Week (starts according to locale)' },
       { value: 'month', label: 'Month' },
       { value: 'year', label: 'Year' },
       { value: 'twoYears', label: '2 Years' },

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.test.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import dayjs from 'dayjs'
+import { ChartType, OhCategoryAxis } from '@/types/components/widgets'
+import { getCategoryAxisData } from './oh-category-axis'
+
+describe('oh-category-axis', () => {
+  describe('getCategoryAxisData', () => {
+    const startTime = dayjs('2026-01-01T00:00:00')
+    const endTime = dayjs('2026-01-02T00:00:00')
+
+    it('should return minutes 0-59 for CategoryType.hour', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.hour
+      } as any
+      const result = getCategoryAxisData(config, startTime, endTime)
+      expect(result.data).toHaveLength(60)
+      expect(result.data[0]).toEqual('0')
+      expect(result.data[59]).toEqual('59')
+      expect(result.name).toEqual('min')
+    })
+
+    it('should return hours 0-24 for CategoryType.day', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.day
+      } as any
+      const result = getCategoryAxisData(config, startTime, endTime)
+      expect(result.data).toHaveLength(24)
+      expect(result.data[0]).toEqual('0')
+      expect(result.data[23]).toEqual('23')
+      expect(result.name).toEqual('h')
+    })
+
+    describe('should return days of week for CategoryType.week', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.week,
+        weekdayFormat: OhCategoryAxis.WeekdayFormat.default
+      } as any
+
+      it('should return days as [Sunday, ..., Saturday] in default (en) locale', () => {
+        const result = getCategoryAxisData(config, startTime, endTime)
+        expect(result.data).toHaveLength(7)
+        expect(result.data).toEqual(['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'])
+        expect(result.name).toEqual('day')
+      })
+
+      it('should return days as [Monday, ..., Sunday] in German (de) locale', async () => {
+        const originalLocale = dayjs.locale()
+        try {
+          await import('dayjs/locale/de')
+          dayjs.locale('de')
+          const result = getCategoryAxisData(config, startTime, endTime)
+          expect(result.data).toHaveLength(7)
+          expect(result.data).toEqual(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'])
+          expect(result.name).toEqual('day')
+        } finally {
+          dayjs.locale(originalLocale)
+        }
+      })
+
+      it('should return days of week as [Monday, ..., Sunday] if chartType is ChartType.isoWeek', () => {
+        const result = getCategoryAxisData(config, startTime, endTime, ChartType.isoWeek)
+        expect(result.data).toHaveLength(7)
+        expect(result.data).toEqual(['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'])
+        expect(result.name).toEqual('day')
+      })
+    })
+
+    it('should return days of month for CategoryType.month', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.month
+      } as any
+      // January 2026 has 31 days
+      const janStartTime = dayjs('2026-01-01T00:00:00')
+      const result = getCategoryAxisData(config, janStartTime, endTime)
+      expect(result.data).toHaveLength(31)
+      expect(result.data[0]).toEqual('1')
+      expect(result.data[30]).toEqual('31')
+      expect(result.name).toEqual('day')
+    })
+
+    it('should return months for CategoryType.year', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.year,
+        monthFormat: OhCategoryAxis.MonthFormat.default
+      } as any
+      const result = getCategoryAxisData(config, startTime, endTime, ChartType.year)
+      expect(result.data).toHaveLength(12)
+      expect(result.name).toEqual('month')
+    })
+
+    it('should return multi-year months for CategoryType.year when chart period is longer than a year', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.year,
+        monthFormat: OhCategoryAxis.MonthFormat.short
+      } as any
+      // Start of 2026
+      const startOf2026 = dayjs('2026-01-01T00:00:00')
+      const result = getCategoryAxisData(config, startOf2026, endTime, ChartType.twoYears)
+      // 12 months * 2 years = 24 entries
+      expect(result.data).toHaveLength(24)
+      // Check some entries (format depends on locale, but should contain the year)
+      expect(result.data[0]).toContain('2026')
+      expect(result.data[12]).toContain('2027')
+    })
+
+    it('should return years for CategoryType.years', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.years
+      } as any
+      const start = dayjs('2020-01-01')
+      const end = dayjs('2025-01-01')
+      const result = getCategoryAxisData(config, start, end)
+      expect(result.data).toEqual(['2020', '2021', '2022', '2023', '2024'])
+      expect(result.name).toBe('year')
+    })
+
+    it('should return empty data for CategoryType.values', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.values
+      } as any
+      const result = getCategoryAxisData(config, startTime, endTime)
+      expect(result.data).toEqual([])
+      expect(result.name).toBeUndefined()
+    })
+
+    it('should not override name if already provided in config', () => {
+      const config = {
+        categoryType: OhCategoryAxis.CategoryType.hour,
+        name: 'My Custom Axis'
+      } as any
+      const result = getCategoryAxisData(config, startTime, endTime)
+      expect(result.name).toBeUndefined()
+    })
+  })
+})

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
@@ -1,9 +1,9 @@
-import dayjs from 'dayjs'
+import dayjs, { type Dayjs } from 'dayjs'
 import LocalizedFormat from 'dayjs/plugin/localizedFormat'
 import LocaleData from 'dayjs/plugin/localeData'
 import ComponentId from '../../component-id'
 import type { AxisComponent, OhCategoryAxisOption } from '../types'
-import { OhCategoryAxis } from '@/types/components/widgets'
+import { ChartType, OhCategoryAxis } from '@/types/components/widgets'
 import { OhCategoryAxisDefinition } from '@/assets/definitions/widgets/chart'
 import { chartTypeLongerThanAYear, mapChartTypeToYears } from '@/components/widgets/chart/util/time.ts'
 
@@ -21,6 +21,79 @@ const weekdays = {
   default: [...dayjs.localeData().weekdays()]
 }
 
+/**
+ * Returns the axis data and optionally a default name for the axis based on the category type.
+ *
+ * @param config the component configuration
+ * @param startTime the start time of the chart
+ * @param endTime the end time of the chart
+ * @param chartType the chart type
+ * @returns axis name and axis data
+ */
+export function getCategoryAxisData(config: OhCategoryAxis.Config, startTime: Dayjs, endTime: Dayjs, chartType?: ChartType) {
+  const data: string[] = []
+  let name: string | undefined = undefined
+
+  switch (config.categoryType) {
+    case OhCategoryAxis.CategoryType.hour:
+      if (!config.name) name = 'min'
+      for (let i = 0; i < 60; i++) {
+        data.push(i.toString())
+      }
+      break
+    case OhCategoryAxis.CategoryType.day:
+      if (!config.name) name = 'h'
+      for (let i = 0; i < 24; i++) {
+        data.push(i.toString())
+      }
+      break
+    case OhCategoryAxis.CategoryType.week:
+      if (!config.name) name = 'day'
+      const axisWeekdays = weekdays[config.weekdayFormat] || weekdays.default
+      data.push(...axisWeekdays)
+      // Determine first day-of-week: Monday if chartType is isoWeek, locale dependent otherwise
+      let firstDay = dayjs.localeData().firstDayOfWeek()
+      if (chartType === ChartType.isoWeek) firstDay = 1
+      if (firstDay !== 0) {
+        for (let i = 0; i < firstDay; i++) data.push(data.shift()!)
+      }
+      break
+    case OhCategoryAxis.CategoryType.month:
+      if (!config.name) name = 'day'
+      const daysInMonth = dayjs(startTime).daysInMonth()
+      for (let i = 1; i <= daysInMonth; i++) {
+        data.push(i.toString())
+      }
+      break
+    case OhCategoryAxis.CategoryType.year:
+      if (!config.name) name = 'month'
+      const axisMonths = months[config.monthFormat] || months.default
+      if (chartType && chartTypeLongerThanAYear(chartType)) {
+        let year = startTime.year()
+        for (let i = 0; i < mapChartTypeToYears(chartType); i++) {
+          data.push(...axisMonths.map((m) => `${m} ${year}`))
+          year++
+        }
+      } else {
+        data.push(...axisMonths)
+      }
+      break
+    case OhCategoryAxis.CategoryType.years:
+      if (!config.name) name = 'year'
+      for (let year = startTime.year(); year < endTime.year(); year++) {
+        data.push(year.toString())
+      }
+      break
+    case OhCategoryAxis.CategoryType.values:
+      break
+    default:
+      const exhaustiveCheck: never = config.categoryType
+      console.warn('oh-category-axis: Unknown categoryType', exhaustiveCheck)
+  }
+
+  return { data, name }
+}
+
 const categoryAxis: AxisComponent = {
   get(context, component, startTime, endTime, inverse) {
     const config = component.config as any as OhCategoryAxis.Config
@@ -29,62 +102,9 @@ const categoryAxis: AxisComponent = {
     axis.type = 'category'
     const chartType = context.chart.config.chartType
 
-    axis.data = axis.data || []
-    switch (config.categoryType) {
-      case OhCategoryAxis.CategoryType.hour:
-        if (!config.name) axis.name = 'min'
-        for (let i = 0; i < 60; i++) {
-          axis.data.push(i)
-        }
-        break
-      case OhCategoryAxis.CategoryType.day:
-        if (!config.name) axis.name = 'h'
-        for (let i = 0; i < 24; i++) {
-          axis.data.push(i)
-        }
-        break
-      case OhCategoryAxis.CategoryType.week:
-        if (!config.name) axis.name = 'day'
-        const axisWeekdays = weekdays[config.weekdayFormat] || weekdays.default
-        axis.data = [...axisWeekdays]
-        // Determine first day-of-week: use startOnSunday config if set, otherwise use locale
-        const firstDay = config.startOnSunday === true ? 0 : config.startOnSunday === false ? 1 : dayjs.localeData().firstDayOfWeek()
-        if (firstDay !== 0) {
-          for (let i = 0; i < firstDay; i++) axis.data.push(axis.data.shift()!)
-        }
-        break
-      case OhCategoryAxis.CategoryType.month:
-        if (!config.name) axis.name = 'day'
-        const daysInMonth = dayjs(startTime).daysInMonth()
-        for (let i = 1; i <= daysInMonth; i++) {
-          axis.data.push(i)
-        }
-        break
-      case OhCategoryAxis.CategoryType.year:
-        if (!config.name) axis.name = 'month'
-        const axisMonths = months[config.monthFormat] || months.default
-        if (chartTypeLongerThanAYear(chartType)) {
-          let year = startTime.year()
-          for (let i = 0; i < mapChartTypeToYears(chartType); i++) {
-            axis.data.push(...axisMonths.map((m) => `${m} ${year}`))
-            year++
-          }
-        } else {
-          axis.data = [...axisMonths]
-        }
-        break
-      case OhCategoryAxis.CategoryType.years:
-        if (!config.name) axis.name = 'year'
-        for (let year = startTime.year(); year < endTime.year(); year++) {
-          axis.data.push(year)
-        }
-        break
-      case OhCategoryAxis.CategoryType.values:
-        break
-      default:
-        const exhaustiveCheck: never = config.categoryType
-        console.warn('oh-category-axis: Unknown categoryType', exhaustiveCheck, context.chart)
-    }
+    const { name, data } = getCategoryAxisData(config, startTime, endTime, chartType)
+    axis.name = name
+    axis.data = data
 
     if (inverse) axis.data = axis.data.reverse()
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
@@ -47,8 +47,10 @@ const categoryAxis: AxisComponent = {
         if (!config.name) axis.name = 'day'
         const axisWeekdays = weekdays[config.weekdayFormat] || weekdays.default
         axis.data = [...axisWeekdays]
-        if (!config.startOnSunday) {
-          axis.data.push(axis.data.shift()!)
+        // Determine first day-of-week: use startOnSunday config if set, otherwise use locale
+        const firstDay = config.startOnSunday === true ? 0 : config.startOnSunday === false ? 1 : dayjs.localeData().firstDayOfWeek()
+        if (firstDay !== 0) {
+          for (let i = 0; i < firstDay; i++) axis.data.push(axis.data.shift()!)
         }
         break
       case OhCategoryAxis.CategoryType.month:

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.test.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect } from 'vitest'
 import dayjs from 'dayjs'
 import IsoWeek from 'dayjs/plugin/isoWeek'
+import Weekday from 'dayjs/plugin/weekday'
 import { dimensionFromDate } from './oh-aggregate-series'
 import { ChartType, OhAggregateSeries } from '@/types/components/widgets'
 
 dayjs.extend(IsoWeek)
+dayjs.extend(Weekday)
 
 describe('dimensionFromDate', () => {
   const startTime = dayjs('2023-01-01')
@@ -28,19 +30,26 @@ describe('dimensionFromDate', () => {
     const endTime = dayjs('2025-10-26') // Sunday
     const chartType = ChartType.month
 
-    describe('Dimension.weekday (0=Sun, 6=Sat)', () => {
-      it.each([
-        { day: 'Sunday', date: '2025-10-19', invert: false, expected: 0 },
-        { day: 'Sunday', date: '2025-10-19', invert: true, expected: 6 }, // 6 - 0
-        { day: 'Saturday', date: '2025-10-25', invert: false, expected: 6 },
-        { day: 'Saturday', date: '2025-10-25', invert: true, expected: 0 } // 6 - 6
-      ])('should handle $day (invert: $invert)', ({ date, invert, expected }) => {
-        const d = dayjs(date)
-        expect(dimensionFromDate(chartType, startTime, endTime, d, OhAggregateSeries.Dimension.weekday, invert)).toBe(expected)
+    describe('Dimension.weekday (locale-aware)', () => {
+      it('should return 0 for Sunday in default (en) locale', () => {
+        const d = dayjs('2025-10-19')
+        expect(dimensionFromDate(chartType, startTime, endTime, d, OhAggregateSeries.Dimension.weekday)).toBe(0)
+      })
+
+      it('should return 6 for Sunday in German (de) locale', async () => {
+        const originalLocale = dayjs.locale()
+        try {
+          await import('dayjs/locale/de')
+          dayjs.locale('de')
+          const d = dayjs('2025-10-19') // Sunday
+          expect(dimensionFromDate(chartType, startTime, endTime, d, OhAggregateSeries.Dimension.weekday)).toBe(6)
+        } finally {
+          dayjs.locale(originalLocale)
+        }
       })
     })
 
-    describe('Dimension.isoWeekday (0=Mon, 6=Sun)', () => {
+    describe('Dimension.isoWeekday (always 0=Mon, 6=Sun)', () => {
       it.each([
         { day: 'Monday', date: '2025-10-20', invert: false, expected: 0 }, // iso (1) - 1
         { day: 'Monday', date: '2025-10-20', invert: true, expected: 6 }, // 7 - iso (1)

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.ts
@@ -1,5 +1,6 @@
 import dayjs, { type Dayjs } from 'dayjs'
 import IsoWeek from 'dayjs/plugin/isoWeek'
+import Weekday from 'dayjs/plugin/weekday'
 import ComponentId from '../../component-id'
 import aggregate from '../util/aggregators'
 import type { OhAggregateSeriesOption, SeriesComponent } from '../types.ts'
@@ -10,6 +11,7 @@ import { OhAggregateSeriesDefinition } from '@/assets/definitions/widgets/chart'
 import { chartTypeLongerThanAYear, mapChartTypeToYears } from '@/components/widgets/chart/util/time.ts'
 
 dayjs.extend(IsoWeek)
+dayjs.extend(Weekday)
 
 export function dimensionFromDate(
   chartType: ChartType,
@@ -18,15 +20,16 @@ export function dimensionFromDate(
   d: Dayjs,
   dimension?: OhAggregateSeries.Dimension,
   invert?: boolean
-) {
+): number | Date {
   if (!dimension) return d.toDate()
+  const dWithWeekday = d as Dayjs & { weekday(): number }
   switch (dimension) {
     case OhAggregateSeries.Dimension.minute:
       return invert ? 59 - d.minute() : d.minute()
     case OhAggregateSeries.Dimension.hour:
       return invert ? 23 - d.hour() : d.hour()
     case OhAggregateSeries.Dimension.weekday:
-      return invert ? 6 - d.day() : d.day()
+      return invert ? 6 - dWithWeekday.weekday() : dWithWeekday.weekday()
     case OhAggregateSeries.Dimension.isoWeekday:
       return invert ? 7 - d.isoWeekday() : d.isoWeekday() - 1
     case OhAggregateSeries.Dimension.date:
@@ -76,10 +79,41 @@ const aggregateSeries: SeriesComponent = {
       component.config,
       OhAggregateSeriesDefinition
     )
-    const dimension1 = series.dimension1 ?? (context.chart.config.chartType as unknown as OhAggregateSeries.Dimension)
+
+    const chartType = context.chart.config.chartType
+    let dimension1 = series.dimension1
+    // if no dimension set: apply reasonable defaults based on chartType
+    if (!dimension1 && chartType) {
+      switch (chartType) {
+        case ChartType.day:
+          dimension1 = OhAggregateSeries.Dimension.hour
+          break
+        case ChartType.week:
+          dimension1 = OhAggregateSeries.Dimension.weekday
+          break
+        case ChartType.isoWeek:
+          dimension1 = OhAggregateSeries.Dimension.isoWeekday
+          break
+        case ChartType.month:
+          dimension1 = OhAggregateSeries.Dimension.date
+          break
+        case ChartType.year:
+          dimension1 = OhAggregateSeries.Dimension.month
+          break
+        case ChartType.twoYears:
+        case ChartType.threeYears:
+        case ChartType.fiveYears:
+          dimension1 = OhAggregateSeries.Dimension.year
+          break
+      }
+    }
+    if (!dimension1) {
+      console.warn('oh-aggregate-series: no dimension1 set, falling back to chartType', chartType)
+      dimension1 = chartType as unknown as OhAggregateSeries.Dimension
+    }
+
     const dimension2 = series.dimension2
     const boundary = includeBoundaryAndItemStateFor(component.config)
-    const chartType = context.chart.config.chartType
 
     const itemPoints = points.find((p) => p.name === series.item)?.data ?? []
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/util/time.test.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/util/time.test.ts
@@ -13,12 +13,27 @@ describe('Time Utility Tests', () => {
       expect(result.format('YYYY-MM-DD HH:mm')).toBe('2026-02-09 00:00')
     })
 
-    it('should return Sunday 00:00 for ChartType.week', () => {
+    it('should return Sunday 00:00 for ChartType.week (default locale)', () => {
       // Saturday, Feb 14, 2026
       const date = dayjs('2026-02-14')
       const result = startOf(ChartType.week, date)
 
       expect(result.format('YYYY-MM-DD HH:mm')).toBe('2026-02-08 00:00')
+    })
+
+    it('should return Monday 00:00 for ChartType.week when locale is de', async () => {
+      const originalLocale = dayjs.locale()
+      try {
+        await import('dayjs/locale/de')
+        dayjs.locale('de')
+        // Saturday, Feb 14, 2026. German week starts on Monday, Feb 9.
+        const date = dayjs('2026-02-14')
+        const result = startOf(ChartType.week, date)
+
+        expect(result.format('YYYY-MM-DD HH:mm')).toBe('2026-02-09 00:00')
+      } finally {
+        dayjs.locale(originalLocale)
+      }
     })
 
     it('should avoid shifting back if date is already Sunday for ChartType.week', () => {

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/util/time.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/util/time.ts
@@ -68,10 +68,7 @@ export function mapChartTypeToYears(chartType: ChartType): number {
 export function startOf(chartType: ChartType, date?: string | number | dayjs.Dayjs | Date): Dayjs {
   const d = dayjs(date)
   if (chartType === ChartType.week) {
-    // Week starting on Sunday & passed-in date is on Sunday: jump to start of day
-    if (d.day() === 0) return d.startOf('day')
-    // Week starting on Sunday
-    return d.startOf('isoWeek').subtract(1, 'day')
+    return d.startOf('week')
   } else if (chartTypeLongerThanAYear(chartType)) {
     return d.startOf('year').subtract(mapChartTypeToYears(chartType) - 1, 'year')
   }

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/chart-aggregate.ts
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/chart-aggregate.ts
@@ -143,7 +143,6 @@ const aggregateCoordSystem: CoordSystem = {
         config: {
           gridIndex: 0,
           categoryType: categoryType,
-          startOnSunday: aggregateCoordSettings.chartType === ChartType.week,
           monthFormat: OhCategoryAxis.MonthFormat.short,
           weekdayFormat: OhCategoryAxis.WeekdayFormat.short
         } satisfies OhCategoryAxis.Config

--- a/bundles/org.openhab.ui/web/src/types/components/widgets/chart/oh-category-axis.gen.ts
+++ b/bundles/org.openhab.ui/web/src/types/components/widgets/chart/oh-category-axis.gen.ts
@@ -35,7 +35,6 @@ export interface Config {
   gridIndex?: number
   categoryType: CategoryType
   weekdayFormat: WeekdayFormat
-  startOnSunday?: boolean
   monthFormat: MonthFormat
   data?: string[]
 }


### PR DESCRIPTION
Previously, in some places `week` start of a period was forced to Sunday in some places and `weekday` indexing was dynamic based on the locale.
This caused issues with `oh-aggregate-series` `week` charts, where the axis and the data did not match.
This PR fixes this by having `week` start of period always depend on the locale to align with the indexing of `weekday`.

Additionally, it removes the `startOnSunday` config parameter from `oh-aggregate-series` as it now starts the week based on the locale default for `ChartType.week` or starts with Monday with `ChartType.isoWeek`.

If you want a chart based on Monday = start of week: `isoWeek` always starts on Monday, `isoWeekday` uses other indexing and `weekday`.