### PR TITLE
Fix token auth on SSE reconnection

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.ts
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.ts
@@ -29,24 +29,27 @@ function newSSEConnection (
 ): KeepaliveEventSource {
   let eventSource: KeepaliveEventSource
   let reconnectSeconds = 1
-  const headers: Record<string, string> = {}
-
-  // Setup headers for authentication
-  const accessToken = getAccessToken()
-  if (accessToken && getRequireToken()) {
-    if (getTokenInCustomHeader()) {
-      headers['X-OPENHAB-TOKEN'] = accessToken
-    } else {
-      headers['Authorization'] = 'Bearer ' + accessToken
-    }
-  }
-  const basicCreds = getBasicCredentials()
-  if (basicCreds) {
-    headers['Authorization'] = 'Basic ' + btoa(basicCreds.id + ':' + basicCreds.password)
-  }
 
   // Core initialization logic
   function initEventSource (): KeepaliveEventSource {
+    const headers: Record<string, string> = {}
+    // Setup headers for authentication.
+    // We make sure to always use the latest token here, otherwise it may
+    // have already expired when initEventSource() is called again after
+    // a connection failure.
+    const accessToken = getAccessToken()
+    if (accessToken && getRequireToken()) {
+      if (getTokenInCustomHeader()) {
+        headers['X-OPENHAB-TOKEN'] = accessToken
+      } else {
+        headers['Authorization'] = 'Bearer ' + accessToken
+      }
+    }
+    const basicCreds = getBasicCredentials()
+    if (basicCreds) {
+      headers['Authorization'] = 'Basic ' + btoa(basicCreds.id + ':' + basicCreds.password)
+    }
+
     let newEventSource: EventSource
 
     if (Object.keys(headers).length > 0) {


### PR DESCRIPTION
The headers containing the token for the SSE endpoint were initialized only once with some initial token. On future reconnections, for example if the connection breaks this old token was still used even though it was possibly expired.
In that case, the UI will show an error message and only update states again after manually pressing the reload button.

This became visible for me when having the iOS app in the background for over an hour, which does not kill the app, but close the SSE connection after a while. On re-entereing the app I always saw the "Communication failed" toast of the main ui.

The issue can be reproduced by opening the web ui on an instance with the implicit user role disabled in API security settings, waiting for the initially aquired token to expire and then breaking the /states SSE connection somehow (e.g. disconnecting network for a few seconds).
When the main ui tries to reconnect, it will retry indefinitely with the expired token:

<img width="2172" height="1090" alt="Bildschirmfoto 2026-05-03 um 20 50 57" src="https://github.com/user-attachments/assets/080f13bd-a185-451c-92e9-aea952b1d18f" />

To not have to wait an entire hour, one can use this patch on rg.openhab.core.io.rest.auth:

```diff
diff --git a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
index d3e78dca7..c34b3d43f 100644
--- a/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
+++ b/bundles/org.openhab.core.io.rest.auth/src/main/java/org/openhab/core/io/rest/auth/internal/TokenResource.java
@@ -98,7 +98,7 @@ public class TokenResource implements RESTResource {
             + "=%s; Domain=%s; Path=/; Max-Age=2147483647; HttpOnly; SameSite=Strict";

     /** The default lifetime of tokens in minutes before they expire */
-    public static final int TOKEN_LIFETIME = 60;
+    public static final int TOKEN_LIFETIME = 1;

     private final UserRegistry userRegistry;
     private final JwtHelper jwtHelper;
```

This patch is for 5.1.x. I tried to reproduce this with the latest development state on main as well, but there the SSE connection did not even work on the first connection for me, so it will need some further investigation there.