### PR TITLE
item-form: Allow copying of fields in list-input in model-detail-pane when disabled

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -172,6 +172,8 @@
     display inherit !important
   .item-title
     font-weight inherit !important
+  .disabled
+    pointer-events unset !important
 </style>
 
 <script>


### PR DESCRIPTION
Fix #4142

When an f7-list-input is disabled, pointer-events is set to none, this prevents the copying of the field content. This PR unsets the 'none' pointer-events to allow for copying of value.
