### PR TITLE
Channel list: Scroll to the bottom after "Select All" is clicked

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -91,10 +91,10 @@
           </f7-col>
         </f7-row>
         <f7-list v-if="multipleLinksMode">
-          <f7-list-button style="padding-left: 0; text-align: left" color="blue" @click="toggleAllChecks(true)">
+          <f7-list-button style="padding-left: 0; text-align: left" color="blue" @click="toggleAllChecks(true, $event)">
             Select All
           </f7-list-button>
-          <f7-list-button color="blue" @click="toggleAllChecks(false)"> Unselect All </f7-list-button>
+          <f7-list-button color="blue" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
         </f7-list>
       </f7-block>
     </f7-col>
@@ -272,7 +272,7 @@ export default {
     stateDescription(channelType) {
       return channelType?.stateDescription?.pattern
     },
-    toggleAllChecks(checked) {
+    toggleAllChecks(checked, event) {
       this.thing.channels.forEach((c) => {
         if (this.multipleLinksMode && c.kind === 'TRIGGER') return
         const channelType = this.channelTypesMap.get(c.channelTypeUID)
@@ -288,6 +288,10 @@ export default {
         .forEach((i) => {
           this.$$(i).prop('checked', checked)
         })
+
+      nextTick(() => {
+        event.currentTarget?.scrollIntoView()
+      })
     },
     newItem(channel) {
       return this.newItems.find((i) => i.channel === channel)


### PR DESCRIPTION
This is a small QoL improvement, I think. In "Add equipment to model" -> Channel list when clicking Select All, the list of channels would expand to display more information. This results in the "Select All" and the "Add to Model" buttons to disappear off the screen because they get pushed down very far.

## Before clicking:
<img width="809" height="613" alt="image" src="https://github.com/user-attachments/assets/90cd0323-417b-48dc-ad78-b3ebdebda9aa" />

# After clicking

After clicking "Select All", the current position is about 20% towards the top of the screen - at the start of the channel list which has now all expanded much longer. The user would have to scroll way down before they can see the "Select All" button that they clicked and to find "Add To Model" (the natural next step). This "jump" is quite jarring from a UX perspective.

