### PR TITLE
Thing details: Add a link to the bridge when the bridge is offline

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -43,6 +43,10 @@
             <f7-chip class="margin-left" :text="thing?.statusInfo?.status" :color="thingStatusBadgeColor(thing.statusInfo)" />
             <div>
               <strong>{{ thing?.statusInfo?.statusDetail !== 'NONE' ? thing.statusInfo.statusDetail : '&nbsp;' }}</strong>
+              <template v-if="bridgeHasProblem">
+                -
+                <f7-link :href="'/settings/things/' + thing.bridgeUID"> View Bridge </f7-link>
+              </template>
               <br />
               <div v-if="thingStatusDescription(thing.statusInfo)" v-html="thingStatusDescription(thing.statusInfo)" />
             </div>
@@ -556,6 +560,9 @@ export default {
     },
     firmwareUpdating() {
       return this.thing.statusInfo.status === 'OFFLINE' && this.thing.statusInfo.statusDetail === 'FIRMWARE_UPDATING'
+    },
+    bridgeHasProblem() {
+      return this.thing && this.thing.bridgeUID && ['BRIDGE_OFFLINE', 'BRIDGE_UNINITIALIZED'].includes(this.thing.statusInfo?.statusDetail)
     },
     ...mapState(useThingEditStore, [
       'configDirty',


### PR DESCRIPTION
This lets the user quickly jump to the bridge details to see and possibly resolve the problem (e.g. needing authorization, config adjustments, etc.)

<img width="459" height="102" alt="image" src="https://github.com/user-attachments/assets/9419d2f0-6219-4b8b-ad4e-2dc3e41a17b2" />


