### PR TITLE
docs: Remove EditPageLink from oh-button.md

### DIFF
--- a/bundles/org.openhab.ui/doc/components/oh-button.md
+++ b/bundles/org.openhab.ui/doc/components/oh-button.md
@@ -1239,5 +1239,3 @@ TBA
 ![Big Ol' Grid O' Buttons](./images/oh-button/bogob.png)
 
 [BoGoB: Big Ol' Grid O' Buttons](https://community.openhab.org/t/bogob-big-ol-grid-o-buttons-is-this-even-possible-yes-yes-it-is/115343/7) - using the `oh-button` and `oh-repeater` objects together with YAML arrays to create large grids of buttons (emulating remote control operation).
-
-<EditPageLink/>


### PR DESCRIPTION
Removed the EditPageLink component from the oh-button documentation.

It gets added during the website processing stage. By having it here, we have duplicate links.

<img width="1124" height="309" alt="image" src="https://github.com/user-attachments/assets/e84731a8-6b00-4736-b63f-7cf87475ba51" />


<img width="662" height="196" alt="image" src="https://github.com/user-attachments/assets/4c606447-c7cf-481a-9858-9fe0ad0fd2a8" />

---

Or more prominently visible when the screen is narrower

<img width="590" height="263" alt="image" src="https://github.com/user-attachments/assets/b0f813d1-ea06-4db4-ab4a-73d532cdb84c" />
