### PR TITLE
Disable UPPERCASE capitalization of f7-button text

### DIFF
--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -95,6 +95,10 @@ html
 .oh-cell.card-opened
   z-index 5000 !important
 
+/* General adjustments */
+:root
+  --f7-button-large-text-transform none
+
 /* Adjustments for iOS & Material Design themes */
 .ios
 .md


### PR DESCRIPTION
This reverts the appearance to Framework7 v5 look. Normal `<f7-button>` text casing is way more readable than ALL UPPERCASE.