### PR TITLE
Log Viewer: Make table columns resizable

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -1,46 +1,15 @@
 <template>
   <div class="table-block">
     <f7-card class="log-viewer-card">
-      <div
-        class="table-container"
-        :class="{ 'resize-hovering': !textMode && (hoveredResizeHandle >= 0 || activeResizeHandle >= 0) }"
-        ref="tableContainer"
+      <resizable-table
+        ref="resizableTable"
+        :columns="TABLE_COLUMN_DEFS"
+        :text-mode="textMode"
+        :wrap-messages="wrapMessages"
+        :storage-key="COLUMN_WIDTHS_KEY"
+        :default-column-widths="DEFAULT_COLUMN_WIDTHS"
         @scroll="handleScroll"
-        @mousemove="handleTableMouseMove"
-        @mouseleave="handleTableMouseLeave"
-        @mousedown="handleTableMouseDown"
-        @dblclick="handleTableDoubleClick"
-        @touchstart="handleTableTouchStart">
-        <div
-          v-if="!textMode"
-          class="column-header-overlay"
-          :class="{ 'column-header-overlay-visible': showColumnHeaders }"
-          :style="{ width: totalTableWidth + 'px' }">
-          <div
-            v-for="(col, i) in TABLE_COLUMN_DEFS"
-            :key="i"
-            class="column-header-cell"
-            :class="{ 'column-header-cell-sticky': i === 0 }"
-            :style="{ width: columnWidths[i] + 'px' }">
-            <span>{{ col.label }}</span>
-          </div>
-        </div>
-        <table
-          ref="dataTable"
-          :class="{ 'wrap-messages': wrapMessages && !textMode }"
-          :style="!textMode ? { tableLayout: 'fixed', width: totalTableWidth + 'px' } : { width: '100%' }">
-          <colgroup v-if="!textMode">
-            <col v-for="(width, i) in columnWidths" :key="i" :style="{ width: width + 'px' }" />
-          </colgroup>
-          <tbody />
-        </table>
-        <div
-          v-if="!textMode && resizeGuideLeft !== null"
-          class="resize-guide"
-          :class="{ 'resize-guide-active': activeResizeHandle >= 0 }"
-          :style="{ left: resizeGuideLeft + 'px', top: tableScrollTop + 'px', height: tableViewportHeight + 'px' }"
-          aria-hidden="true" />
-      </div>
+        @auto-size-column="autoSizeColumn" />
     </f7-card>
     <button v-show="!autoScroll" class="button button-fill dock-scroll-button color-blue" @click="showLatestLogs()">
       <f7-icon f7="arrow_down_to_line" />
@@ -483,6 +452,7 @@ import { f7 } from 'framework7-vue'
 import { useDraggable } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
 import { useUIOptionsStore } from '@/js/stores/useUIOptionsStore'
+import ResizableTable from './resizable-table.vue'
 
 // TODO: Remove once we have refactored clipboard to TypeScript
 // @ts-expect-error-next-line
@@ -520,13 +490,24 @@ enum LEVEL_ICONS {
 
 const maxEntries = 2000
 const lineHeight = 31
-const resizeHoverDistance = 6
 
-const dataTableRef = useTemplateRef('dataTable')
-const dataTableContainerRef = useTemplateRef('tableContainer')
+type ResizableTableExposed = {
+  getTableBody: () => HTMLTableSectionElement | null
+  getTableElement: () => HTMLTableElement | null
+  getContainerElement: () => HTMLDivElement | null
+  resetColumnWidths: () => void
+  setColumnWidth: (colIndex: number, width: number) => void
+  clearResizeHoverState: () => void
+}
+
+const resizableTableRef = useTemplateRef('resizableTable')
 const logDetailsPopupRef = useTemplateRef('logDetailsPopup')
 const logDetailsNavbarRef = useTemplateRef('logDetailsNavbar')
 let tableClickHandler: ((e: Event) => void) | null = null
+
+function getResizableTable(): ResizableTableExposed | null {
+  return (resizableTableRef.value as unknown as ResizableTableExposed | null) ?? null
+}
 
 // Composables
 useDraggable(() => logDetailsNavbarRef.value?.$el, {
@@ -615,31 +596,6 @@ const selectedId = ref<number>(0)
 const COLUMN_WIDTHS_KEY = 'openhab.ui:logviewer.columnWidths'
 const DEFAULT_COLUMN_WIDTHS = [110, 60, 280, 2000]
 const TABLE_COLUMN_DEFS = [{ label: 'Time' }, { label: 'Level' }, { label: 'Logger' }, { label: 'Message' }]
-
-function loadColumnWidths(): number[] {
-  try {
-    const stored = localStorage.getItem(COLUMN_WIDTHS_KEY)
-    if (stored) {
-      const parsed = JSON.parse(stored) as unknown
-      if (Array.isArray(parsed) && parsed.length === DEFAULT_COLUMN_WIDTHS.length && parsed.every((n) => typeof n === 'number' && n > 0)) {
-        return parsed as number[]
-      }
-    }
-  } catch {}
-  return [...DEFAULT_COLUMN_WIDTHS]
-}
-
-const columnWidths = ref<number[]>(loadColumnWidths())
-
-// Column resize state
-let resizingIndex = -1
-let resizeStartX = 0
-let resizeStartWidth = 0
-const activeResizeHandle = ref(-1)
-const hoveredResizeHandle = ref(-1)
-const isHoveringTableTop = ref(false)
-const tableScrollTop = ref(0)
-const tableViewportHeight = ref(0)
 let measureCanvasCtx: CanvasRenderingContext2D | null = null
 
 function getMeasureCtx(): CanvasRenderingContext2D | null {
@@ -656,159 +612,6 @@ function measureTextWidth(text: string, font: string): number {
   return ctx.measureText(text).width
 }
 
-function syncTableViewportMetrics() {
-  const tableContainer = dataTableContainerRef.value
-  if (!tableContainer) return
-  tableScrollTop.value = tableContainer.scrollTop
-  tableViewportHeight.value = tableContainer.clientHeight
-}
-
-function beginResize(clientX: number, colIndex: number) {
-  resizingIndex = colIndex
-  resizeStartX = clientX
-  resizeStartWidth = columnWidths.value[colIndex]
-  activeResizeHandle.value = colIndex
-}
-
-function startResize(event: MouseEvent, colIndex: number) {
-  beginResize(event.clientX, colIndex)
-  document.body.classList.add('col-resizing')
-  document.body.style.cursor = 'col-resize'
-  document.addEventListener('mousemove', handleResize)
-  document.addEventListener('mouseup', stopResize)
-}
-
-function handleResize(event: MouseEvent) {
-  if (resizingIndex < 0) return
-  columnWidths.value[resizingIndex] = Math.max(40, resizeStartWidth + (event.clientX - resizeStartX))
-}
-
-function stopResize() {
-  if (resizingIndex < 0) return
-  resizingIndex = -1
-  activeResizeHandle.value = -1
-  document.body.classList.remove('col-resizing')
-  document.body.style.cursor = ''
-  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths.value))
-  document.removeEventListener('mousemove', handleResize)
-  document.removeEventListener('mouseup', stopResize)
-}
-
-function resetColumnWidths() {
-  columnWidths.value = [...DEFAULT_COLUMN_WIDTHS]
-  localStorage.removeItem(COLUMN_WIDTHS_KEY)
-}
-
-function startResizeTouch(event: TouchEvent, colIndex: number) {
-  if (event.touches.length !== 1) return
-  const touch = event.touches[0]
-  beginResize(touch.clientX, colIndex)
-  document.addEventListener('touchmove', handleResizeTouch, { passive: false })
-  document.addEventListener('touchend', stopResizeTouch)
-  document.addEventListener('touchcancel', stopResizeTouch)
-}
-
-function handleResizeTouch(event: TouchEvent) {
-  if (resizingIndex < 0 || event.touches.length !== 1) return
-  event.preventDefault()
-  const touch = event.touches[0]
-  columnWidths.value[resizingIndex] = Math.max(40, resizeStartWidth + (touch.clientX - resizeStartX))
-}
-
-function stopResizeTouch() {
-  if (resizingIndex < 0) return
-  resizingIndex = -1
-  activeResizeHandle.value = -1
-  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths.value))
-  document.removeEventListener('touchmove', handleResizeTouch)
-  document.removeEventListener('touchend', stopResizeTouch)
-  document.removeEventListener('touchcancel', stopResizeTouch)
-}
-
-function clearResizeHoverState() {
-  if (resizingIndex >= 0) {
-    stopResize()
-    stopResizeTouch()
-  }
-  hoveredResizeHandle.value = -1
-  activeResizeHandle.value = -1
-  isHoveringTableTop.value = false
-}
-
-function updateTableHoverState(clientX: number, clientY: number) {
-  if (textMode.value) {
-    clearResizeHoverState()
-    return
-  }
-
-  const tableContainer = dataTableContainerRef.value
-  if (!tableContainer) return
-  syncTableViewportMetrics()
-
-  const rect = tableContainer.getBoundingClientRect()
-  const withinContainer = clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
-
-  if (!withinContainer) {
-    if (resizingIndex < 0) {
-      hoveredResizeHandle.value = -1
-    }
-    isHoveringTableTop.value = false
-    return
-  }
-
-  isHoveringTableTop.value = clientY - rect.top <= lineHeight
-
-  if (resizingIndex >= 0) return
-
-  const cursorX = clientX - rect.left + tableContainer.scrollLeft
-  let closestCol = -1
-  let closestDist = Infinity
-
-  for (const border of columnBorders.value) {
-    const dist = Math.abs(cursorX - border.left)
-    if (dist < closestDist) {
-      closestDist = dist
-      closestCol = border.index
-    }
-  }
-
-  hoveredResizeHandle.value = closestDist <= resizeHoverDistance ? closestCol : -1
-}
-
-function handleTableMouseMove(event: MouseEvent) {
-  updateTableHoverState(event.clientX, event.clientY)
-}
-
-function handleTableMouseLeave() {
-  if (textMode.value) return
-  if (resizingIndex >= 0) return
-  hoveredResizeHandle.value = -1
-  isHoveringTableTop.value = false
-}
-
-function handleTableMouseDown(event: MouseEvent) {
-  if (textMode.value) return
-  if (event.button !== 0 || hoveredResizeHandle.value < 0) return
-  event.preventDefault()
-  startResize(event, hoveredResizeHandle.value)
-}
-
-function handleTableDoubleClick(event: MouseEvent) {
-  if (textMode.value) return
-  if (hoveredResizeHandle.value < 0) return
-  event.preventDefault()
-  autoSizeColumn(hoveredResizeHandle.value)
-}
-
-function handleTableTouchStart(event: TouchEvent) {
-  if (textMode.value) return
-  if (event.touches.length !== 1) return
-  const touch = event.touches[0]
-  updateTableHoverState(touch.clientX, touch.clientY)
-  if (hoveredResizeHandle.value < 0) return
-  startResizeTouch(event, hoveredResizeHandle.value)
-}
-
 function autoSizeColumn(colIndex: number) {
   const tbody = getTableBody()
   const firstTd = tbody?.querySelector('td')
@@ -823,35 +626,17 @@ function autoSizeColumn(colIndex: number) {
   }
   // add cell padding; col 0 also needs room for the icon (~26px)
   const padding = colIndex === 0 ? 52 : 16
-  columnWidths.value[colIndex] = Math.min(Math.ceil(maxWidth) + padding, 6000)
-  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths.value))
+  getResizableTable()?.setColumnWidth(colIndex, Math.min(Math.ceil(maxWidth) + padding, 6000))
+}
+
+function resetColumnWidths() {
+  getResizableTable()?.resetColumnWidths()
 }
 
 // Computed
 const filteredTableData = computed(() => {
   return tableData.value.filter((item) => item.visible)
 })
-
-const totalTableWidth = computed(() => columnWidths.value.reduce((sum, w) => sum + w, 0))
-
-const columnBorders = computed(() => {
-  let offset = 0
-  return columnWidths.value.map((width, index) => {
-    offset += width
-    return {
-      index,
-      left: offset
-    }
-  })
-})
-
-const resizeGuideLeft = computed(() => {
-  const guideIndex = activeResizeHandle.value >= 0 ? activeResizeHandle.value : hoveredResizeHandle.value
-  if (guideIndex < 0) return null
-  return columnBorders.value[guideIndex]?.left ?? null
-})
-
-const showColumnHeaders = computed(() => isHoveringTableTop.value || hoveredResizeHandle.value >= 0 || activeResizeHandle.value >= 0)
 
 const countersBadgeColor = computed(() => {
   if (tableData.value.length >= maxEntries) return 'red'
@@ -941,18 +726,10 @@ function cleanup() {
     }
     tableClickHandler = null
   }
-  // Clean up any active column resize listeners
-  document.body.classList.remove('col-resizing')
-  document.body.style.cursor = ''
-  document.removeEventListener('mousemove', handleResize)
-  document.removeEventListener('mouseup', stopResize)
-  document.removeEventListener('touchmove', handleResizeTouch)
-  document.removeEventListener('touchend', stopResizeTouch)
-  document.removeEventListener('touchcancel', stopResizeTouch)
 }
 
 function getTableBody(): HTMLTableSectionElement | null {
-  return dataTableRef.value?.tBodies?.[0] ?? null
+  return getResizableTable()?.getTableBody() ?? null
 }
 
 function updateLogLevel(logger: api.LoggerInfo, value: string) {
@@ -1207,7 +984,7 @@ function showLatestLogs() {
 
 function scrollToBottom() {
   // Scroll to the bottom of the table
-  const tableContainer = dataTableContainerRef.value
+  const tableContainer = getResizableTable()?.getContainerElement()
   if (tableContainer) {
     tableContainer.scrollTop = tableContainer.scrollHeight
     // Delay manual scroll detection to avoid autoscrolling being defeated when new logs arrive
@@ -1217,9 +994,8 @@ function scrollToBottom() {
 }
 
 function handleScroll() {
-  const tableContainer = dataTableContainerRef.value
+  const tableContainer = getResizableTable()?.getContainerElement()
   if (!tableContainer) return
-  syncTableViewportMetrics()
 
   if (Date.now() < scrollTime) return
 
@@ -1231,7 +1007,7 @@ function handleScroll() {
 }
 
 function redrawPartOfTable() {
-  const tableContainer = dataTableContainerRef.value
+  const tableContainer = getResizableTable()?.getContainerElement()
   if (!tableContainer) return
 
   const tableBody = getTableBody()
@@ -1406,7 +1182,7 @@ function copyTableToClipboard() {
     return
   }
 
-  const table = dataTableRef.value
+  const table = getResizableTable()?.getTableElement()
   if (!table) {
     return
   }
@@ -1438,7 +1214,7 @@ function copyTableToClipboard() {
 function setTextMode(textModeEnabled: boolean) {
   textMode.value = textModeEnabled
   if (textModeEnabled) {
-    clearResizeHoverState()
+    getResizableTable()?.clearResizeHoverState()
   }
   updateFilter()
 }

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -532,7 +532,10 @@ let tableClickHandler: ((e: Event) => void) | null = null
 useDraggable(() => logDetailsNavbarRef.value?.$el, {
   preventDefault: true,
   stopPropagation: true,
-  onStart: () => {
+  onStart: (_, event) => {
+    const target = event.target as HTMLElement | null
+    if (target?.closest('.popup-close, .link, a, button, input, select, textarea')) return false
+
     const popupEl = logDetailsPopupRef.value?.$el
     if (!popupEl || !popupEl.parentElement) return false
 

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -206,77 +206,11 @@
     display block
     position relative
 
-  .table-container.resize-hovering
-    cursor col-resize
-
   table
     overflow-x auto
     position relative
     border-collapse collapse
     table-layout auto
-
-  .column-header-overlay
-    position sticky
-    top 0
-    z-index 4
-    display flex
-    align-items stretch
-    height 31px
-    margin-bottom -31px
-    opacity 0
-    transform translateY(-100%)
-    transition opacity 0.12s ease, transform 0.12s ease
-    pointer-events none
-
-  .column-header-overlay-visible
-    opacity 1
-    transform translateY(0)
-
-  .column-header-cell
-    background var(--f7-bars-bg-color)
-    color var(--f7-bars-text-color)
-    box-sizing border-box
-    padding 5px
-    padding-right 14px
-    text-align left
-    font-weight bold
-    // box-shadow avoids border-collapse clipping on sticky cells
-    box-shadow 0 1px 0 rgba(128, 128, 128, 0.3)
-    user-select none
-    white-space nowrap
-    overflow hidden
-    flex 0 0 auto
-
-  .column-header-cell-sticky
-    position sticky
-    left 0
-    z-index 1
-
-  .resize-guide
-    position absolute
-    width 2px
-    transform translateX(-1px)
-    background rgba(90, 90, 90, 0.95)
-    box-shadow 0 0 0 1px rgba(255, 255, 255, 0.55)
-    border-radius 1px
-    opacity 0.9
-    z-index 6
-    pointer-events none
-    transition opacity 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease
-
-  .resize-guide-active
-    background var(--f7-theme-color)
-    box-shadow 0 0 0 1px rgba(255, 255, 255, 0.7)
-    opacity 1
-
-  body.col-resizing &
-    *
-      user-select none
-      cursor col-resize !important
-
-  @media (pointer coarse)
-    .resize-guide
-      opacity 0.8
 
   table.content-wrapped
     tr.table-rows

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -1,7 +1,30 @@
 <template>
   <div class="table-block">
     <f7-card class="log-viewer-card">
-      <div class="table-container" ref="tableContainer" @scroll="handleScroll">
+      <div
+        class="table-container"
+        :class="{ 'resize-hovering': !textMode && (hoveredResizeHandle >= 0 || activeResizeHandle >= 0) }"
+        ref="tableContainer"
+        @scroll="handleScroll"
+        @mousemove="handleTableMouseMove"
+        @mouseleave="handleTableMouseLeave"
+        @mousedown="handleTableMouseDown"
+        @dblclick="handleTableDoubleClick"
+        @touchstart="handleTableTouchStart">
+        <div
+          v-if="!textMode"
+          class="column-header-overlay"
+          :class="{ 'column-header-overlay-visible': showColumnHeaders }"
+          :style="{ width: totalTableWidth + 'px' }">
+          <div
+            v-for="(col, i) in TABLE_COLUMN_DEFS"
+            :key="i"
+            class="column-header-cell"
+            :class="{ 'column-header-cell-sticky': i === 0 }"
+            :style="{ width: columnWidths[i] + 'px' }">
+            <span>{{ col.label }}</span>
+          </div>
+        </div>
         <table
           ref="dataTable"
           :class="{ 'wrap-messages': wrapMessages && !textMode }"
@@ -9,21 +32,14 @@
           <colgroup v-if="!textMode">
             <col v-for="(width, i) in columnWidths" :key="i" :style="{ width: width + 'px' }" />
           </colgroup>
-          <thead v-if="!textMode">
-            <tr @mousemove="handleHeaderMouseMove" @mouseleave="handleHeaderMouseLeave">
-              <th v-for="(col, i) in TABLE_COLUMN_DEFS" :key="i" :class="{ 'th-sticky': i === 0 }">
-                <span>{{ col.label }}</span>
-                <div
-                  class="resize-handle"
-                  :class="{ 'resize-handle-active': activeResizeHandle === i }"
-                  @mousedown.prevent="startResize($event, i)"
-                  @touchstart="startResizeTouch($event, i)"
-                  @dblclick.prevent="autoSizeColumn(i)" />
-              </th>
-            </tr>
-          </thead>
           <tbody />
         </table>
+        <div
+          v-if="!textMode && resizeGuideLeft !== null"
+          class="resize-guide"
+          :class="{ 'resize-guide-active': activeResizeHandle >= 0 }"
+          :style="{ left: resizeGuideLeft + 'px', top: tableScrollTop + 'px', height: tableViewportHeight + 'px' }"
+          aria-hidden="true" />
       </div>
     </f7-card>
     <button v-show="!autoScroll" class="button button-fill dock-scroll-button color-blue" @click="showLatestLogs()">
@@ -219,6 +235,10 @@
     overflow-y auto
     overflow-x auto
     display block
+    position relative
+
+  .table-container.resize-hovering
+    cursor col-resize
 
   table
     overflow-x auto
@@ -226,12 +246,27 @@
     border-collapse collapse
     table-layout auto
 
-  thead th
+  .column-header-overlay
     position sticky
     top 0
+    z-index 4
+    display flex
+    align-items stretch
+    height 31px
+    margin-bottom -31px
+    opacity 0
+    transform translateY(-100%)
+    transition opacity 0.12s ease, transform 0.12s ease
+    pointer-events none
+
+  .column-header-overlay-visible
+    opacity 1
+    transform translateY(0)
+
+  .column-header-cell
     background var(--f7-bars-bg-color)
     color var(--f7-bars-text-color)
-    z-index 2
+    box-sizing border-box
     padding 5px
     padding-right 14px
     text-align left
@@ -241,34 +276,29 @@
     user-select none
     white-space nowrap
     overflow hidden
+    flex 0 0 auto
 
-  thead th.th-sticky
+  .column-header-cell-sticky
+    position sticky
     left 0
-    z-index 3
+    z-index 1
 
-  .resize-handle
+  .resize-guide
     position absolute
-    right 0
-    top 0
-    bottom 0
-    width 8px
-    cursor col-resize
-    touch-action none
-    background transparent
-    &::after
-      content ''
-      position absolute
-      top 15%
-      bottom 15%
-      right 2px
-      width 2px
-      border-radius 1px
-      background currentColor
-      opacity 0.2
-      transition opacity 0.15s ease
+    width 2px
+    transform translateX(-1px)
+    background rgba(90, 90, 90, 0.95)
+    box-shadow 0 0 0 1px rgba(255, 255, 255, 0.55)
+    border-radius 1px
+    opacity 0.9
+    z-index 6
+    pointer-events none
+    transition opacity 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease
 
-  .resize-handle.resize-handle-active::after
-    opacity 0.75
+  .resize-guide-active
+    background var(--f7-theme-color)
+    box-shadow 0 0 0 1px rgba(255, 255, 255, 0.7)
+    opacity 1
 
   body.col-resizing &
     *
@@ -276,8 +306,8 @@
       cursor col-resize !important
 
   @media (pointer coarse)
-    .resize-handle::after
-      opacity 0.45
+    .resize-guide
+      opacity 0.8
 
   table.wrap-messages
     tr.table-rows
@@ -301,11 +331,17 @@
     position sticky
     left 0
     width 105px
-    color var(--f7-bars-text-color)
-    background var(--f7-bars-bg-color)
+    color #000
+    background-color #fff
     z-index 1
     white-space nowrap
     overflow hidden
+
+  td.details-trigger
+    cursor pointer
+
+  td.details-trigger *
+    cursor pointer
 
   td.level
     width 50px
@@ -355,6 +391,7 @@
       margin-right 5px
     .time
       margin-left -3.2em
+      cursor pointer
     .level
       width 3em
       display inline-block
@@ -483,6 +520,7 @@ enum LEVEL_ICONS {
 
 const maxEntries = 2000
 const lineHeight = 31
+const resizeHoverDistance = 6
 
 const dataTableRef = useTemplateRef('dataTable')
 const dataTableContainerRef = useTemplateRef('tableContainer')
@@ -599,6 +637,10 @@ let resizingIndex = -1
 let resizeStartX = 0
 let resizeStartWidth = 0
 const activeResizeHandle = ref(-1)
+const hoveredResizeHandle = ref(-1)
+const isHoveringTableTop = ref(false)
+const tableScrollTop = ref(0)
+const tableViewportHeight = ref(0)
 let measureCanvasCtx: CanvasRenderingContext2D | null = null
 
 function getMeasureCtx(): CanvasRenderingContext2D | null {
@@ -615,11 +657,22 @@ function measureTextWidth(text: string, font: string): number {
   return ctx.measureText(text).width
 }
 
-function startResize(event: MouseEvent, colIndex: number) {
+function syncTableViewportMetrics() {
+  const tableContainer = dataTableContainerRef.value
+  if (!tableContainer) return
+  tableScrollTop.value = tableContainer.scrollTop
+  tableViewportHeight.value = tableContainer.clientHeight
+}
+
+function beginResize(clientX: number, colIndex: number) {
   resizingIndex = colIndex
-  resizeStartX = event.clientX
+  resizeStartX = clientX
   resizeStartWidth = columnWidths.value[colIndex]
   activeResizeHandle.value = colIndex
+}
+
+function startResize(event: MouseEvent, colIndex: number) {
+  beginResize(event.clientX, colIndex)
   document.body.classList.add('col-resizing')
   document.body.style.cursor = 'col-resize'
   document.addEventListener('mousemove', handleResize)
@@ -650,10 +703,7 @@ function resetColumnWidths() {
 function startResizeTouch(event: TouchEvent, colIndex: number) {
   if (event.touches.length !== 1) return
   const touch = event.touches[0]
-  resizingIndex = colIndex
-  resizeStartX = touch.clientX
-  resizeStartWidth = columnWidths.value[colIndex]
-  activeResizeHandle.value = colIndex
+  beginResize(touch.clientX, colIndex)
   document.addEventListener('touchmove', handleResizeTouch, { passive: false })
   document.addEventListener('touchend', stopResizeTouch)
   document.addEventListener('touchcancel', stopResizeTouch)
@@ -676,26 +726,88 @@ function stopResizeTouch() {
   document.removeEventListener('touchcancel', stopResizeTouch)
 }
 
-function handleHeaderMouseMove(event: MouseEvent) {
-  if (resizingIndex >= 0) return // don't override during active drag
-  const tr = event.currentTarget as HTMLElement
-  const ths = Array.from(tr.children) as HTMLElement[]
-  const cursorX = event.clientX
-  let closestCol = -1
-  let closestDist = Infinity
-  for (let i = 0; i < ths.length; i++) {
-    const dist = Math.abs(cursorX - ths[i].getBoundingClientRect().right)
-    if (dist < closestDist) {
-      closestDist = dist
-      closestCol = i
-    }
+function clearResizeHoverState() {
+  if (resizingIndex >= 0) {
+    stopResize()
+    stopResizeTouch()
   }
-  activeResizeHandle.value = closestCol
+  hoveredResizeHandle.value = -1
+  activeResizeHandle.value = -1
+  isHoveringTableTop.value = false
 }
 
-function handleHeaderMouseLeave() {
-  if (resizingIndex >= 0) return // don't clear during active drag
-  activeResizeHandle.value = -1
+function updateTableHoverState(clientX: number, clientY: number) {
+  if (textMode.value) {
+    clearResizeHoverState()
+    return
+  }
+
+  const tableContainer = dataTableContainerRef.value
+  if (!tableContainer) return
+  syncTableViewportMetrics()
+
+  const rect = tableContainer.getBoundingClientRect()
+  const withinContainer = clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+
+  if (!withinContainer) {
+    if (resizingIndex < 0) {
+      hoveredResizeHandle.value = -1
+    }
+    isHoveringTableTop.value = false
+    return
+  }
+
+  isHoveringTableTop.value = clientY - rect.top <= lineHeight
+
+  if (resizingIndex >= 0) return
+
+  const cursorX = clientX - rect.left + tableContainer.scrollLeft
+  let closestCol = -1
+  let closestDist = Infinity
+
+  for (const border of columnBorders.value) {
+    const dist = Math.abs(cursorX - border.left)
+    if (dist < closestDist) {
+      closestDist = dist
+      closestCol = border.index
+    }
+  }
+
+  hoveredResizeHandle.value = closestDist <= resizeHoverDistance ? closestCol : -1
+}
+
+function handleTableMouseMove(event: MouseEvent) {
+  updateTableHoverState(event.clientX, event.clientY)
+}
+
+function handleTableMouseLeave() {
+  if (textMode.value) return
+  if (resizingIndex >= 0) return
+  hoveredResizeHandle.value = -1
+  isHoveringTableTop.value = false
+}
+
+function handleTableMouseDown(event: MouseEvent) {
+  if (textMode.value) return
+  if (event.button !== 0 || hoveredResizeHandle.value < 0) return
+  event.preventDefault()
+  startResize(event, hoveredResizeHandle.value)
+}
+
+function handleTableDoubleClick(event: MouseEvent) {
+  if (textMode.value) return
+  if (hoveredResizeHandle.value < 0) return
+  event.preventDefault()
+  autoSizeColumn(hoveredResizeHandle.value)
+}
+
+function handleTableTouchStart(event: TouchEvent) {
+  if (textMode.value) return
+  if (event.touches.length !== 1) return
+  const touch = event.touches[0]
+  updateTableHoverState(touch.clientX, touch.clientY)
+  if (hoveredResizeHandle.value < 0) return
+  startResizeTouch(event, hoveredResizeHandle.value)
 }
 
 function autoSizeColumn(colIndex: number) {
@@ -722,6 +834,25 @@ const filteredTableData = computed(() => {
 })
 
 const totalTableWidth = computed(() => columnWidths.value.reduce((sum, w) => sum + w, 0))
+
+const columnBorders = computed(() => {
+  let offset = 0
+  return columnWidths.value.map((width, index) => {
+    offset += width
+    return {
+      index,
+      left: offset
+    }
+  })
+})
+
+const resizeGuideLeft = computed(() => {
+  const guideIndex = activeResizeHandle.value >= 0 ? activeResizeHandle.value : hoveredResizeHandle.value
+  if (guideIndex < 0) return null
+  return columnBorders.value[guideIndex]?.left ?? null
+})
+
+const showColumnHeaders = computed(() => isHoveringTableTop.value || hoveredResizeHandle.value >= 0 || activeResizeHandle.value >= 0)
 
 const countersBadgeColor = computed(() => {
   if (tableData.value.length >= maxEntries) return 'red'
@@ -786,7 +917,9 @@ async function load() {
 
     tableClickHandler = (e: Event) => {
       const target = e.target as HTMLElement
-      const tr = target.closest('tr') as HTMLTableRowElement | null
+      const detailTrigger = target.closest('.details-trigger') as HTMLElement | null
+      if (!detailTrigger) return
+      const tr = detailTrigger.closest('tr') as HTMLTableRowElement | null
       if (!tr) return
       if (tr.classList.contains('padder')) return
       const idAttr = tr.dataset.id
@@ -927,14 +1060,14 @@ function renderEntry(entry: EnrichedLogEntry) {
   const levelLowerCased = entry.level.toLowerCase()
   if (textMode.value) {
     tr.innerHTML =
-      `<td class="text"><span class="time">${entry.time}${entry.milliseconds}</span>` +
+      `<td class="text"><span class="time details-trigger">${entry.time}${entry.milliseconds}</span>` +
       `[<span class="level ${levelLowerCased}">${entry.level}</span>] ` +
       `[<span class="logger" title="${entry.loggerName}">${entry.loggerName}</span>] - ` +
       `<span class="msg ${levelLowerCased}">${highlightText(escapeHtml(entry.message))}</span></td>`
   } else {
     tr.className = 'table-rows ' + levelLowerCased
     tr.innerHTML =
-      '<td class="sticky"><i class="icon f7-icons" style="font-size: 18px;">' +
+      '<td class="sticky details-trigger"><i class="icon f7-icons" style="font-size: 18px;">' +
       icon +
       `</i> ${entry.time}<span class="milliseconds">${entry.milliseconds}</span></td>` +
       `<td class="level">${entry.level}</td>` +
@@ -943,7 +1076,6 @@ function renderEntry(entry: EnrichedLogEntry) {
   }
   // mark row for delegated click handling
   tr.dataset.id = String(entry.id)
-  tr.style.cursor = 'pointer'
   return tr
 }
 
@@ -1088,6 +1220,7 @@ function scrollToBottom() {
 function handleScroll() {
   const tableContainer = dataTableContainerRef.value
   if (!tableContainer) return
+  syncTableViewportMetrics()
 
   if (Date.now() < scrollTime) return
 
@@ -1305,6 +1438,9 @@ function copyTableToClipboard() {
 
 function setTextMode(textModeEnabled: boolean) {
   textMode.value = textModeEnabled
+  if (textModeEnabled) {
+    clearResizeHoverState()
+  }
   updateFilter()
 }
 

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -2,7 +2,24 @@
   <div class="table-block">
     <f7-card class="log-viewer-card">
       <div class="table-container" ref="tableContainer" @scroll="handleScroll">
-        <table ref="dataTable">
+        <table
+          ref="dataTable"
+          :style="!textMode ? { tableLayout: 'fixed', width: totalTableWidth + 'px' } : { width: '100%' }">
+          <colgroup v-if="!textMode">
+            <col v-for="(width, i) in columnWidths" :key="i" :style="{ width: width + 'px' }" />
+          </colgroup>
+          <thead v-if="!textMode">
+            <tr @mousemove="handleHeaderMouseMove" @mouseleave="handleHeaderMouseLeave">
+              <th v-for="(col, i) in TABLE_COLUMN_DEFS" :key="i" :class="{ 'th-sticky': i === 0 }">
+                <span>{{ col.label }}</span>
+                <div
+                  class="resize-handle"
+                  :class="{ 'resize-handle-active': activeResizeHandle === i }"
+                  @mousedown.prevent="startResize($event, i)"
+                  @dblclick.prevent="autoSizeColumn(i)" />
+              </th>
+            </tr>
+          </thead>
           <tbody />
         </table>
       </div>
@@ -202,11 +219,57 @@
     display block
 
   table
-    width 100%
     overflow-x auto
     position relative
     border-collapse collapse
     table-layout auto
+
+  thead th
+    position sticky
+    top 0
+    background var(--f7-bars-bg-color)
+    color var(--f7-bars-text-color)
+    z-index 2
+    padding 5px
+    padding-right 14px
+    text-align left
+    font-weight bold
+    border-bottom 2px solid var(--f7-bars-border-color)
+    user-select none
+    white-space nowrap
+    overflow hidden
+
+  thead th.th-sticky
+    left 0
+    z-index 3
+
+  .resize-handle
+    position absolute
+    right 0
+    top 0
+    bottom 0
+    width 8px
+    cursor col-resize
+    background transparent
+    &::after
+      content ''
+      position absolute
+      top 15%
+      bottom 15%
+      right 2px
+      width 2px
+      border-radius 1px
+      background currentColor
+      opacity 0
+      transition opacity 0.15s ease
+
+  .resize-handle.resize-handle-active::after
+    opacity 0.55
+
+  body.col-resizing &
+    *
+      user-select none
+      cursor col-resize !important
 
   td.nowrap
     padding 5px
@@ -220,20 +283,22 @@
     position sticky
     left 0
     width 105px
-    color black
-    background #f1f1f1
+    color var(--f7-bars-text-color)
+    background var(--f7-bars-bg-color)
     z-index 1
     white-space nowrap
     overflow hidden
 
   td.level
     width 50px
+    overflow hidden
 
   td.logger
     width 280px
+    overflow hidden
 
   span.logger
-    width 280px
+    width 100%
     display block
     direction rtl
     text-align left
@@ -486,10 +551,129 @@ const currentHighlightColor = ref('#FF5252')
 const lastSequence = ref(0)
 const selectedId = ref<number>(0)
 
+// Column definitions (table mode only)
+const COLUMN_WIDTHS_KEY = 'openhab.ui:logviewer.columnWidths'
+const DEFAULT_COLUMN_WIDTHS = [110, 60, 280, 2000]
+const TABLE_COLUMN_DEFS = [{ label: 'Time' }, { label: 'Level' }, { label: 'Logger' }, { label: 'Message' }]
+
+function loadColumnWidths(): number[] {
+  try {
+    const stored = localStorage.getItem(COLUMN_WIDTHS_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as unknown
+      if (
+        Array.isArray(parsed) &&
+        parsed.length === DEFAULT_COLUMN_WIDTHS.length &&
+        parsed.every((n) => typeof n === 'number' && n > 0)
+      ) {
+        return parsed as number[]
+      }
+    }
+  } catch {}
+  return [...DEFAULT_COLUMN_WIDTHS]
+}
+
+const columnWidths = ref<number[]>(loadColumnWidths())
+
+// Column resize state
+let resizingIndex = -1
+let resizeStartX = 0
+let resizeStartWidth = 0
+const activeResizeHandle = ref(-1)
+let measureCanvasCtx: CanvasRenderingContext2D | null = null
+
+function getMeasureCtx(): CanvasRenderingContext2D | null {
+  if (!measureCanvasCtx) {
+    measureCanvasCtx = document.createElement('canvas').getContext('2d')
+  }
+  return measureCanvasCtx
+}
+
+function measureTextWidth(text: string, font: string): number {
+  const ctx = getMeasureCtx()
+  if (!ctx) return 0
+  ctx.font = font
+  return ctx.measureText(text).width
+}
+
+function startResize(event: MouseEvent, colIndex: number) {
+  resizingIndex = colIndex
+  resizeStartX = event.clientX
+  resizeStartWidth = columnWidths.value[colIndex]
+  activeResizeHandle.value = colIndex
+  document.body.classList.add('col-resizing')
+  document.body.style.cursor = 'col-resize'
+  document.addEventListener('mousemove', handleResize)
+  document.addEventListener('mouseup', stopResize)
+}
+
+function handleResize(event: MouseEvent) {
+  if (resizingIndex < 0) return
+  columnWidths.value[resizingIndex] = Math.max(40, resizeStartWidth + (event.clientX - resizeStartX))
+}
+
+function stopResize() {
+  if (resizingIndex < 0) return
+  resizingIndex = -1
+  activeResizeHandle.value = -1
+  document.body.classList.remove('col-resizing')
+  document.body.style.cursor = ''
+  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths.value))
+  document.removeEventListener('mousemove', handleResize)
+  document.removeEventListener('mouseup', stopResize)
+}
+
+function resetColumnWidths() {
+  columnWidths.value = [...DEFAULT_COLUMN_WIDTHS]
+  localStorage.removeItem(COLUMN_WIDTHS_KEY)
+}
+
+function handleHeaderMouseMove(event: MouseEvent) {
+  if (resizingIndex >= 0) return // don't override during active drag
+  const tr = event.currentTarget as HTMLElement
+  const ths = Array.from(tr.children) as HTMLElement[]
+  const cursorX = event.clientX
+  let closestCol = -1
+  let closestDist = Infinity
+  for (let i = 0; i < ths.length; i++) {
+    const dist = Math.abs(cursorX - ths[i].getBoundingClientRect().right)
+    if (dist < closestDist) {
+      closestDist = dist
+      closestCol = i
+    }
+  }
+  activeResizeHandle.value = closestCol
+}
+
+function handleHeaderMouseLeave() {
+  if (resizingIndex >= 0) return // don't clear during active drag
+  activeResizeHandle.value = -1
+}
+
+function autoSizeColumn(colIndex: number) {
+  const tbody = getTableBody()
+  const firstTd = tbody?.querySelector('td')
+  const font = firstTd ? getComputedStyle(firstTd).font : '13px sans-serif'
+  const fields: (keyof EnrichedLogEntry)[] = ['time', 'level', 'loggerName', 'message']
+  const field = fields[colIndex]
+  let maxWidth = measureTextWidth(TABLE_COLUMN_DEFS[colIndex].label, font)
+  for (const entry of filteredTableData.value) {
+    const text = colIndex === 0 ? entry.time + entry.milliseconds : String(entry[field])
+    const w = measureTextWidth(text, font)
+    if (w > maxWidth) maxWidth = w
+  }
+  // add cell padding; col 0 also needs room for the icon (~26px)
+  const padding = colIndex === 0 ? 52 : 16
+  columnWidths.value[colIndex] = Math.min(Math.ceil(maxWidth) + padding, 6000)
+  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths.value))
+}
+
 // Computed
 const filteredTableData = computed(() => {
   return tableData.value.filter((item) => item.visible)
 })
+
+const totalTableWidth = computed(() => columnWidths.value.reduce((sum, w) => sum + w, 0))
 
 const countersBadgeColor = computed(() => {
   if (tableData.value.length >= maxEntries) return 'red'
@@ -577,6 +761,11 @@ function cleanup() {
     }
     tableClickHandler = null
   }
+  // Clean up any active column resize listeners
+  document.body.classList.remove('col-resizing')
+  document.body.style.cursor = ''
+  document.removeEventListener('mousemove', handleResize)
+  document.removeEventListener('mouseup', stopResize)
 }
 
 function getTableBody(): HTMLTableSectionElement | null {
@@ -1121,6 +1310,7 @@ defineExpose({
   downloadCSV,
   copyTableToClipboard,
   clearLog,
-  setTextMode
+  setTextMode,
+  resetColumnWidths
 })
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -4,8 +4,8 @@
       <resizable-table
         ref="resizableTable"
         :columns="TABLE_COLUMN_DEFS"
-        :text-mode="textMode"
-        :wrap-messages="wrapMessages"
+        :column-resize-enabled="!textMode"
+        :content-wrap-enabled="wrapMessages && !textMode"
         :storage-key="COLUMN_WIDTHS_KEY"
         :default-column-widths="DEFAULT_COLUMN_WIDTHS"
         @scroll="handleScroll"
@@ -278,7 +278,7 @@
     .resize-guide
       opacity 0.8
 
-  table.wrap-messages
+  table.content-wrapped
     tr.table-rows
       height auto
       min-height 31px

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -4,6 +4,7 @@
       <div class="table-container" ref="tableContainer" @scroll="handleScroll">
         <table
           ref="dataTable"
+          :class="{ 'wrap-messages': wrapMessages && !textMode }"
           :style="!textMode ? { tableLayout: 'fixed', width: totalTableWidth + 'px' } : { width: '100%' }">
           <colgroup v-if="!textMode">
             <col v-for="(width, i) in columnWidths" :key="i" :style="{ width: width + 'px' }" />
@@ -16,6 +17,7 @@
                   class="resize-handle"
                   :class="{ 'resize-handle-active': activeResizeHandle === i }"
                   @mousedown.prevent="startResize($event, i)"
+                  @touchstart="startResizeTouch($event, i)"
                   @dblclick.prevent="autoSizeColumn(i)" />
               </th>
             </tr>
@@ -234,7 +236,8 @@
     padding-right 14px
     text-align left
     font-weight bold
-    border-bottom 2px solid var(--f7-bars-border-color)
+    // box-shadow avoids border-collapse clipping on sticky cells
+    box-shadow 0 1px 0 rgba(128, 128, 128, 0.3)
     user-select none
     white-space nowrap
     overflow hidden
@@ -250,6 +253,7 @@
     bottom 0
     width 8px
     cursor col-resize
+    touch-action none
     background transparent
     &::after
       content ''
@@ -260,16 +264,30 @@
       width 2px
       border-radius 1px
       background currentColor
-      opacity 0
+      opacity 0.2
       transition opacity 0.15s ease
 
   .resize-handle.resize-handle-active::after
-    opacity 0.55
+    opacity 0.75
 
   body.col-resizing &
     *
       user-select none
       cursor col-resize !important
+
+  @media (pointer coarse)
+    .resize-handle::after
+      opacity 0.45
+
+  table.wrap-messages
+    tr.table-rows
+      height auto
+      min-height 31px
+    td.nowrap
+      white-space normal
+      overflow visible
+      text-overflow unset
+      word-break break-word
 
   td.nowrap
     padding 5px
@@ -543,6 +561,7 @@ const stateConnecting = ref(false)
 const loadingLoggers = ref(true)
 const autoScroll = ref(true)
 const filterCount = ref(0)
+const wrapMessages = ref(localStorage.getItem('openhab.ui:logviewer.wrapMessages') === 'true')
 const tableData = shallowRef<EnrichedLogEntry[]>([])
 const logStart = ref('--:--:--')
 const logEnd = ref('--:--:--')
@@ -626,6 +645,35 @@ function stopResize() {
 function resetColumnWidths() {
   columnWidths.value = [...DEFAULT_COLUMN_WIDTHS]
   localStorage.removeItem(COLUMN_WIDTHS_KEY)
+}
+
+function startResizeTouch(event: TouchEvent, colIndex: number) {
+  if (event.touches.length !== 1) return
+  const touch = event.touches[0]
+  resizingIndex = colIndex
+  resizeStartX = touch.clientX
+  resizeStartWidth = columnWidths.value[colIndex]
+  activeResizeHandle.value = colIndex
+  document.addEventListener('touchmove', handleResizeTouch, { passive: false })
+  document.addEventListener('touchend', stopResizeTouch)
+  document.addEventListener('touchcancel', stopResizeTouch)
+}
+
+function handleResizeTouch(event: TouchEvent) {
+  if (resizingIndex < 0 || event.touches.length !== 1) return
+  event.preventDefault()
+  const touch = event.touches[0]
+  columnWidths.value[resizingIndex] = Math.max(40, resizeStartWidth + (touch.clientX - resizeStartX))
+}
+
+function stopResizeTouch() {
+  if (resizingIndex < 0) return
+  resizingIndex = -1
+  activeResizeHandle.value = -1
+  localStorage.setItem(COLUMN_WIDTHS_KEY, JSON.stringify(columnWidths.value))
+  document.removeEventListener('touchmove', handleResizeTouch)
+  document.removeEventListener('touchend', stopResizeTouch)
+  document.removeEventListener('touchcancel', stopResizeTouch)
 }
 
 function handleHeaderMouseMove(event: MouseEvent) {
@@ -766,6 +814,9 @@ function cleanup() {
   document.body.style.cursor = ''
   document.removeEventListener('mousemove', handleResize)
   document.removeEventListener('mouseup', stopResize)
+  document.removeEventListener('touchmove', handleResizeTouch)
+  document.removeEventListener('touchend', stopResizeTouch)
+  document.removeEventListener('touchcancel', stopResizeTouch)
 }
 
 function getTableBody(): HTMLTableSectionElement | null {
@@ -1052,7 +1103,19 @@ function redrawPartOfTable() {
   if (!tableContainer) return
 
   const tableBody = getTableBody()
+  if (!tableBody) return
+
   const filteredItemsCount = filteredTableData.value.length
+
+  // When messages wrap, row heights vary — skip fixed-height virtual windowing
+  if (!textMode.value && wrapMessages.value) {
+    tableBody.innerHTML = ''
+    for (let i = 0; i < filteredItemsCount; i++) {
+      tableBody.appendChild(renderEntry(filteredTableData.value[i]))
+    }
+    return
+  }
+
   const currentIndexAtTop = Math.floor(tableContainer.scrollTop / lineHeight)
   const nbVisibleLines = Math.floor(tableContainer.offsetHeight / lineHeight)
 
@@ -1060,8 +1123,6 @@ function redrawPartOfTable() {
   const firstIndexToRedraw = Math.max(0, currentIndexAtTop - 50)
   const lastIndexToRedraw = Math.min(currentIndexAtTop + nbVisibleLines + 50, filteredItemsCount - 1)
   // console.debug(`Should redraw ${firstIndexToRedraw}/${lastIndexToRedraw}`)
-
-  if (!tableBody) return
 
   tableBody.innerHTML = ''
   if (firstIndexToRedraw > 0) {
@@ -1281,6 +1342,12 @@ function toggleErrorDisplay() {
   updateFilter()
 }
 
+function toggleWrapMessages() {
+  wrapMessages.value = !wrapMessages.value
+  localStorage.setItem('openhab.ui:logviewer.wrapMessages', wrapMessages.value.toString())
+  updateFilter()
+}
+
 defineExpose({
   logStart,
   logEnd,
@@ -1311,6 +1378,8 @@ defineExpose({
   copyTableToClipboard,
   clearLog,
   setTextMode,
-  resetColumnWidths
+  resetColumnWidths,
+  wrapMessages,
+  toggleWrapMessages
 })
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -331,8 +331,8 @@
     position sticky
     left 0
     width 105px
-    color #000
-    background-color #fff
+    color black
+    background-color #f1f1f1
     z-index 1
     white-space nowrap
     overflow hidden

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -621,11 +621,7 @@ function loadColumnWidths(): number[] {
     const stored = localStorage.getItem(COLUMN_WIDTHS_KEY)
     if (stored) {
       const parsed = JSON.parse(stored) as unknown
-      if (
-        Array.isArray(parsed) &&
-        parsed.length === DEFAULT_COLUMN_WIDTHS.length &&
-        parsed.every((n) => typeof n === 'number' && n > 0)
-      ) {
+      if (Array.isArray(parsed) && parsed.length === DEFAULT_COLUMN_WIDTHS.length && parsed.every((n) => typeof n === 'number' && n > 0)) {
         return parsed as number[]
       }
     }

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -284,7 +284,7 @@
       height auto
       min-height 31px
     td.nowrap
-      white-space normal
+      white-space pre-wrap
       overflow visible
       text-overflow unset
       word-break break-word

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -381,7 +381,7 @@
 </style>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, useTemplateRef, shallowRef, triggerRef } from 'vue'
+import { ref, computed, nextTick, useTemplateRef, shallowRef, triggerRef, watch } from 'vue'
 import { f7 } from 'framework7-vue'
 import { useDraggable } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
@@ -411,6 +411,7 @@ interface EnrichedLogEntry extends LogEntry {
   milliseconds: string
   visible: boolean
   time: string
+  el?: HTMLTableRowElement
 }
 
 enum LEVEL_ICONS {
@@ -518,6 +519,7 @@ const currentHighlightColorItemIndex = ref<number | null>(null)
 const currentHighlightColor = ref('#FF5252')
 const lastSequence = ref(0)
 const selectedId = ref<number>(0)
+let lastFirstIndex = -1
 
 // Column definitions (table mode only)
 const COLUMN_WIDTHS_KEY = 'openhab.ui:logviewer.columnWidths'
@@ -590,6 +592,15 @@ const isConnecting = computed(() => stateConnecting.value)
 
 const filterTextLowerCase = computed(() => filterText.value.toLowerCase())
 const activeHighlightFilters = computed(() => highlightFilters.value.filter((filter) => filter.active && filter.text.trim() !== ''))
+
+function clearCache() {
+  tableData.value.forEach((entry) => delete entry.el)
+}
+
+watch(activeHighlightFilters, () => {
+  clearCache()
+  updateFilter()
+}, { deep: true })
 
 // Methods
 async function load() {
@@ -758,6 +769,7 @@ function socketClose() {
 }
 
 function renderEntry(entry: EnrichedLogEntry) {
+  if (entry.el) return entry.el
   let tr = document.createElement('tr')
   let icon = LEVEL_ICONS[entry.level as keyof typeof LEVEL_ICONS] || LEVEL_ICONS.DEFAULT
   const levelLowerCased = entry.level.toLowerCase()
@@ -779,6 +791,7 @@ function renderEntry(entry: EnrichedLogEntry) {
   }
   // mark row for delegated click handling
   tr.dataset.id = String(entry.id)
+  entry.el = tr
   return tr
 }
 
@@ -840,6 +853,7 @@ function addLogEntry(logEntry: LogEntry) {
         }
 
         if (tableData.value.length > maxEntries) {
+          lastFirstIndex = -1 // Force redraw as indices shifted
           const removedElement = tableData.value.shift()
           if (removedElement) {
             logStart.value = removedElement.time
@@ -917,7 +931,9 @@ function scrollToBottom() {
     // Delay manual scroll detection to avoid autoscrolling being defeated when new logs arrive
     scrollTime = Date.now() + 250
   }
-  redrawPartOfTable()
+  if (textMode.value || !wrapMessages.value) {
+    redrawPartOfTable()
+  }
 }
 
 function handleScroll() {
@@ -930,7 +946,9 @@ function handleScroll() {
   const isAtBottom = tableContainer.scrollHeight - tableContainer.scrollTop < tableContainer.clientHeight + 20
   autoScroll.value = isAtBottom
 
-  redrawPartOfTable()
+  if (textMode.value || !wrapMessages.value) {
+    redrawPartOfTable()
+  }
 }
 
 function redrawPartOfTable() {
@@ -958,6 +976,15 @@ function redrawPartOfTable() {
   const firstIndexToRedraw = Math.max(0, currentIndexAtTop - 50)
   const lastIndexToRedraw = Math.min(currentIndexAtTop + nbVisibleLines + 50, filteredItemsCount - 1)
   // console.debug(`Should redraw ${firstIndexToRedraw}/${lastIndexToRedraw}`)
+
+  if (firstIndexToRedraw === lastFirstIndex) {
+    // Check if the last visible element is already in the table (happens when new logs arrive)
+    const lastRow = tableBody.lastElementChild as HTMLElement | null
+    if (!lastRow || lastRow.classList.contains('padder') || Number(lastRow.dataset.id) === filteredTableData.value[lastIndexToRedraw]?.id) {
+      return
+    }
+  }
+  lastFirstIndex = firstIndexToRedraw
 
   tableBody.innerHTML = ''
   if (firstIndexToRedraw > 0) {
@@ -1022,6 +1049,7 @@ function updateFilter() {
     }
   }
   filterCount.value = cnt
+  lastFirstIndex = -1
   redrawPartOfTable()
 }
 
@@ -1143,10 +1171,13 @@ function setTextMode(textModeEnabled: boolean) {
   if (textModeEnabled) {
     getResizableTable()?.clearResizeHoverState()
   }
+  clearCache()
+  lastFirstIndex = -1
   updateFilter()
 }
 
 function saveHighlighters() {
+  clearCache()
   updateFilter()
 }
 
@@ -1183,6 +1214,7 @@ function toggleErrorDisplay() {
 function toggleWrapMessages() {
   wrapMessages.value = !wrapMessages.value
   localStorage.setItem('openhab.ui:logviewer.wrapMessages', wrapMessages.value.toString())
+  lastFirstIndex = -1
   updateFilter()
 }
 

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -597,10 +597,14 @@ function clearCache() {
   tableData.value.forEach((entry) => delete entry.el)
 }
 
-watch(activeHighlightFilters, () => {
-  clearCache()
-  updateFilter()
-}, { deep: true })
+watch(
+  activeHighlightFilters,
+  () => {
+    clearCache()
+    updateFilter()
+  },
+  { deep: true }
+)
 
 // Methods
 async function load() {

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -425,14 +425,7 @@ enum LEVEL_ICONS {
 const maxEntries = 2000
 const lineHeight = 31
 
-type ResizableTableExposed = {
-  getTableBody: () => HTMLTableSectionElement | null
-  getTableElement: () => HTMLTableElement | null
-  getContainerElement: () => HTMLDivElement | null
-  resetColumnWidths: () => void
-  setColumnWidth: (colIndex: number, width: number) => void
-  clearResizeHoverState: () => void
-}
+type ResizableTableExposed = InstanceType<typeof ResizableTable>
 
 const resizableTableRef = useTemplateRef('resizableTable')
 const logDetailsPopupRef = useTemplateRef('logDetailsPopup')

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
@@ -69,7 +69,20 @@
 
     <log-viewer-core ref="logViewerCore" />
 
-    <div v-if="!collapsed" class="dock-toolbar">
+    <div
+      v-if="!collapsed"
+      class="dock-toolbar"
+      :class="{ 'has-scroll-left': showToolbarScrollLeft, 'has-scroll-right': showToolbarScrollRight, 'toolbar-scrollable-mobile': !device.desktop }"
+      ref="toolbarRef">
+      <button
+        v-if="showToolbarScrollLeft && !device.desktop"
+        type="button"
+        class="toolbar-scroll-indicator toolbar-scroll-indicator-left"
+        aria-label="Scroll toolbar left"
+        @pointerdown.stop.prevent
+        @click.stop.prevent="scrollToolbar('left')">
+        <i class="icon f7-icons">chevron_left</i>
+      </button>
       <f7-link
         icon-f7="cloud_download"
         tooltip="Download filtered log as CSV"
@@ -122,6 +135,15 @@
         tooltip="Toggle message wrapping"
         @click="logViewerCore?.toggleWrapMessages()" />
       <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
+      <button
+        v-if="showToolbarScrollRight && !device.desktop"
+        type="button"
+        class="toolbar-scroll-indicator toolbar-scroll-indicator-right"
+        aria-label="Scroll toolbar right"
+        @pointerdown.stop.prevent
+        @click.stop.prevent="scrollToolbar('right')">
+        <i class="icon f7-icons">chevron_right</i>
+      </button>
     </div>
   </div>
 </template>
@@ -220,10 +242,53 @@
       height 100%
     .table-container
       height 100%
+
+  @media (max-width 767px)
+    .dock-toolbar.toolbar-scrollable-mobile
+      position relative
+      justify-content flex-start
+      gap 4px
+      overflow-x auto
+      overflow-y hidden
+      scrollbar-width none
+      -ms-overflow-style none
+
+      .toolbar-scroll-indicator
+        position sticky
+        z-index 2
+        flex 0 0 18px
+        display flex
+        align-items center
+        justify-content center
+        color var(--f7-text-color)
+        font-size 18px
+        line-height 1
+        background var(--f7-bars-bg-color)
+        border 0
+        margin 0
+        padding 0
+        cursor pointer
+
+        .icon
+          pointer-events none
+
+      .toolbar-scroll-indicator-left
+        left 0
+        box-shadow -10px 0 12px 10px var(--f7-bars-bg-color)
+
+      .toolbar-scroll-indicator-right
+        right 0
+        box-shadow 10px 0 12px 10px var(--f7-bars-bg-color)
+
+      &::-webkit-scrollbar
+        display none
+
+      > *
+        flex 0 0 auto
 </style>
 
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, useTemplateRef, nextTick } from 'vue'
+import { onBeforeUnmount, onMounted, useTemplateRef, nextTick, ref, watch } from 'vue'
 import { getDevice } from 'framework7'
 import { theme } from 'framework7-vue'
 import { storeToRefs } from 'pinia'
@@ -248,6 +313,64 @@ const uiOptionsStore = useUIOptionsStore()
 const { logViewerEmbeddedCollapsed: collapsed } = storeToRefs(uiOptionsStore)
 const logViewerCore = useTemplateRef('logViewerCore')
 const searchbar = useTemplateRef('searchbar')
+const toolbarRef = useTemplateRef('toolbarRef')
+const showToolbarScrollLeft = ref(false)
+const showToolbarScrollRight = ref(false)
+let toolbarResizeObserver: ResizeObserver | null = null
+let toolbarMutationObserver: MutationObserver | null = null
+
+function updateToolbarScrollIndicators() {
+  const toolbarEl = toolbarRef.value
+  if (!toolbarEl) {
+    showToolbarScrollLeft.value = false
+    showToolbarScrollRight.value = false
+    return
+  }
+
+  const maxScrollLeft = Math.max(0, toolbarEl.scrollWidth - toolbarEl.clientWidth)
+  showToolbarScrollLeft.value = toolbarEl.scrollLeft > 4
+  showToolbarScrollRight.value = maxScrollLeft - toolbarEl.scrollLeft > 4
+}
+
+function handleToolbarScroll() {
+  updateToolbarScrollIndicators()
+}
+
+function scrollToolbar(direction: 'left' | 'right') {
+  const toolbarEl = toolbarRef.value
+  if (!toolbarEl) return
+
+  const distance = Math.max(toolbarEl.clientWidth * 0.75, 120)
+  toolbarEl.scrollBy({
+    left: direction === 'left' ? -distance : distance,
+    behavior: 'smooth'
+  })
+}
+
+function setupToolbarScrollIndicators() {
+  nextTick(() => {
+    const toolbarEl = toolbarRef.value
+    if (!toolbarEl) return
+
+    toolbarEl.addEventListener('scroll', handleToolbarScroll, { passive: true })
+
+    toolbarResizeObserver = new ResizeObserver(() => updateToolbarScrollIndicators())
+    toolbarResizeObserver.observe(toolbarEl)
+
+    toolbarMutationObserver = new MutationObserver(() => nextTick(updateToolbarScrollIndicators))
+    toolbarMutationObserver.observe(toolbarEl, { childList: true, subtree: true, attributes: true })
+
+    updateToolbarScrollIndicators()
+  })
+}
+
+function cleanupToolbarScrollIndicators() {
+  toolbarRef.value?.removeEventListener('scroll', handleToolbarScroll)
+  toolbarResizeObserver?.disconnect()
+  toolbarResizeObserver = null
+  toolbarMutationObserver?.disconnect()
+  toolbarMutationObserver = null
+}
 
 function toggleCollapsed() {
   collapsed.value = !collapsed.value
@@ -256,6 +379,7 @@ function toggleCollapsed() {
 // Lifecycle Hooks
 onMounted(() => {
   logViewerCore.value?.load()
+  setupToolbarScrollIndicators()
   // Ensure the F7 searchbar shows the persisted query (Framework7 may not
   // update its internal query from the prop binding in some cases).
   nextTick(() => {
@@ -267,6 +391,11 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
+  cleanupToolbarScrollIndicators()
   logViewerCore.value?.cleanup()
+})
+
+watch(collapsed, () => {
+  nextTick(updateToolbarScrollIndicators)
 })
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
@@ -110,6 +110,11 @@
           @click="logViewerCore?.setTextMode(true)"
           tooltip="Show logs as plain text" />
       </f7-segmented>
+      <f7-link
+        v-if="!logViewerCore?.textMode"
+        icon-f7="arrow_counterclockwise"
+        tooltip="Reset column widths to default"
+        @click="logViewerCore?.resetColumnWidths()" />
       <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
     </div>
   </div>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
@@ -69,85 +69,8 @@
 
     <log-viewer-core ref="logViewerCore" />
 
-    <div
-      v-if="!collapsed"
-      class="dock-toolbar"
-      :class="{
-        'has-scroll-left': showToolbarScrollLeft,
-        'has-scroll-right': showToolbarScrollRight,
-        'toolbar-scrollable-mobile': !device.desktop
-      }"
-      ref="toolbarRef">
-      <button
-        v-if="showToolbarScrollLeft && !device.desktop"
-        type="button"
-        class="toolbar-scroll-indicator toolbar-scroll-indicator-left"
-        aria-label="Scroll toolbar left"
-        @pointerdown.stop.prevent
-        @click.stop.prevent="scrollToolbar('left')">
-        <i class="icon f7-icons">chevron_left</i>
-      </button>
-      <f7-link
-        icon-f7="cloud_download"
-        tooltip="Download filtered log as CSV"
-        :class="{ 'disabled-link': logViewerCore?.filterCount == 0 }"
-        @click="logViewerCore?.downloadCSV()" />
-      <f7-link
-        icon-f7="rectangle_on_rectangle"
-        tooltip="Copy filtered log to clipboard"
-        :class="{ 'disabled-link': logViewerCore?.filterCount == 0 }"
-        @click="logViewerCore?.copyTableToClipboard()" />
-      <f7-link
-        icon-f7="trash"
-        tooltip="Clear the log buffer"
-        :class="{ 'disabled-link': (logViewerCore?.tableData?.length ?? 0) == 0 }"
-        @click="logViewerCore?.clearLog()" />
-      <f7-link @click="logViewerCore?.toggleErrorDisplay()" tooltip="Always show error level logs">
-        <f7-icon v-if="logViewerCore?.showErrors" f7="exclamationmark_triangle_fill" />
-        <f7-icon v-else f7="exclamationmark_triangle" />
-      </f7-link>
-      <f7-link icon-f7="pencil" tooltip="Configure highlights" data-popup=".log-highlights-popup" class="popup-open" />
-      <f7-segmented>
-        <f7-button
-          outline
-          small
-          :active="!logViewerCore?.textMode"
-          icon-f7="table"
-          :icon-size="theme.aurora ? 20 : 22"
-          class="no-ripple"
-          @click="logViewerCore?.setTextMode(false)"
-          tooltip="Show logs in a table" />
-        <f7-button
-          outline
-          small
-          :active="logViewerCore?.textMode"
-          icon-f7="text_justifyleft"
-          :icon-size="theme.aurora ? 20 : 22"
-          class="no-ripple"
-          @click="logViewerCore?.setTextMode(true)"
-          tooltip="Show logs as plain text" />
-      </f7-segmented>
-      <f7-link
-        v-if="!logViewerCore?.textMode"
-        icon-f7="arrow_counterclockwise"
-        tooltip="Reset column widths to default"
-        @click="logViewerCore?.resetColumnWidths()" />
-      <f7-link
-        v-if="!logViewerCore?.textMode"
-        icon-f7="arrow_turn_down_left"
-        :icon-color="logViewerCore?.wrapMessages ? '' : 'gray'"
-        tooltip="Toggle message wrapping"
-        @click="logViewerCore?.toggleWrapMessages()" />
-      <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
-      <button
-        v-if="showToolbarScrollRight && !device.desktop"
-        type="button"
-        class="toolbar-scroll-indicator toolbar-scroll-indicator-right"
-        aria-label="Scroll toolbar right"
-        @pointerdown.stop.prevent
-        @click.stop.prevent="scrollToolbar('right')">
-        <i class="icon f7-icons">chevron_right</i>
-      </button>
+    <div v-if="!collapsed" class="dock-toolbar">
+      <log-viewer-toolbar :log-viewer-core="logViewerCore" />
     </div>
   </div>
 </template>
@@ -246,58 +169,15 @@
       height 100%
     .table-container
       height 100%
-
-  @media (max-width 767px)
-    .dock-toolbar.toolbar-scrollable-mobile
-      position relative
-      justify-content flex-start
-      gap 4px
-      overflow-x auto
-      overflow-y hidden
-      scrollbar-width none
-      -ms-overflow-style none
-
-      .toolbar-scroll-indicator
-        position sticky
-        z-index 2
-        flex 0 0 18px
-        display flex
-        align-items center
-        justify-content center
-        color var(--f7-text-color)
-        font-size 18px
-        line-height 1
-        background var(--f7-bars-bg-color)
-        border 0
-        margin 0
-        padding 0
-        cursor pointer
-
-        .icon
-          pointer-events none
-
-      .toolbar-scroll-indicator-left
-        left 0
-        box-shadow -10px 0 12px 10px var(--f7-bars-bg-color)
-
-      .toolbar-scroll-indicator-right
-        right 0
-        box-shadow 10px 0 12px 10px var(--f7-bars-bg-color)
-
-      &::-webkit-scrollbar
-        display none
-
-      > *
-        flex 0 0 auto
 </style>
 
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, useTemplateRef, nextTick, ref, watch } from 'vue'
 import { getDevice } from 'framework7'
-import { theme } from 'framework7-vue'
 import { storeToRefs } from 'pinia'
 import { useUIOptionsStore } from '@/js/stores/useUIOptionsStore'
 import LogViewerCore from './log-viewer-core.vue'
+import LogViewerToolbar from './log-viewer-toolbar.vue'
 
 // Constants
 const device = getDevice()
@@ -317,64 +197,6 @@ const uiOptionsStore = useUIOptionsStore()
 const { logViewerEmbeddedCollapsed: collapsed } = storeToRefs(uiOptionsStore)
 const logViewerCore = useTemplateRef('logViewerCore')
 const searchbar = useTemplateRef('searchbar')
-const toolbarRef = useTemplateRef('toolbarRef')
-const showToolbarScrollLeft = ref(false)
-const showToolbarScrollRight = ref(false)
-let toolbarResizeObserver: ResizeObserver | null = null
-let toolbarMutationObserver: MutationObserver | null = null
-
-function updateToolbarScrollIndicators() {
-  const toolbarEl = toolbarRef.value
-  if (!toolbarEl) {
-    showToolbarScrollLeft.value = false
-    showToolbarScrollRight.value = false
-    return
-  }
-
-  const maxScrollLeft = Math.max(0, toolbarEl.scrollWidth - toolbarEl.clientWidth)
-  showToolbarScrollLeft.value = toolbarEl.scrollLeft > 4
-  showToolbarScrollRight.value = maxScrollLeft - toolbarEl.scrollLeft > 4
-}
-
-function handleToolbarScroll() {
-  updateToolbarScrollIndicators()
-}
-
-function scrollToolbar(direction: 'left' | 'right') {
-  const toolbarEl = toolbarRef.value
-  if (!toolbarEl) return
-
-  const distance = Math.max(toolbarEl.clientWidth * 0.75, 120)
-  toolbarEl.scrollBy({
-    left: direction === 'left' ? -distance : distance,
-    behavior: 'smooth'
-  })
-}
-
-function setupToolbarScrollIndicators() {
-  nextTick(() => {
-    const toolbarEl = toolbarRef.value
-    if (!toolbarEl) return
-
-    toolbarEl.addEventListener('scroll', handleToolbarScroll, { passive: true })
-
-    toolbarResizeObserver = new ResizeObserver(() => updateToolbarScrollIndicators())
-    toolbarResizeObserver.observe(toolbarEl)
-
-    toolbarMutationObserver = new MutationObserver(() => nextTick(updateToolbarScrollIndicators))
-    toolbarMutationObserver.observe(toolbarEl, { childList: true, subtree: true, attributes: true })
-
-    updateToolbarScrollIndicators()
-  })
-}
-
-function cleanupToolbarScrollIndicators() {
-  toolbarRef.value?.removeEventListener('scroll', handleToolbarScroll)
-  toolbarResizeObserver?.disconnect()
-  toolbarResizeObserver = null
-  toolbarMutationObserver?.disconnect()
-  toolbarMutationObserver = null
-}
 
 function toggleCollapsed() {
   collapsed.value = !collapsed.value
@@ -383,7 +205,6 @@ function toggleCollapsed() {
 // Lifecycle Hooks
 onMounted(() => {
   logViewerCore.value?.load()
-  setupToolbarScrollIndicators()
   // Ensure the F7 searchbar shows the persisted query (Framework7 may not
   // update its internal query from the prop binding in some cases).
   nextTick(() => {
@@ -395,11 +216,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  cleanupToolbarScrollIndicators()
   logViewerCore.value?.cleanup()
-})
-
-watch(collapsed, () => {
-  nextTick(updateToolbarScrollIndicators)
 })
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
@@ -115,6 +115,12 @@
         icon-f7="arrow_counterclockwise"
         tooltip="Reset column widths to default"
         @click="logViewerCore?.resetColumnWidths()" />
+      <f7-link
+        v-if="!logViewerCore?.textMode"
+        icon-f7="arrow_turn_down_left"
+        :icon-color="logViewerCore?.wrapMessages ? '' : 'gray'"
+        tooltip="Toggle message wrapping"
+        @click="logViewerCore?.toggleWrapMessages()" />
       <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
     </div>
   </div>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-embedded.vue
@@ -72,7 +72,11 @@
     <div
       v-if="!collapsed"
       class="dock-toolbar"
-      :class="{ 'has-scroll-left': showToolbarScrollLeft, 'has-scroll-right': showToolbarScrollRight, 'toolbar-scrollable-mobile': !device.desktop }"
+      :class="{
+        'has-scroll-left': showToolbarScrollLeft,
+        'has-scroll-right': showToolbarScrollRight,
+        'toolbar-scrollable-mobile': !device.desktop
+      }"
       ref="toolbarRef">
       <button
         v-if="showToolbarScrollLeft && !device.desktop"

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
@@ -103,6 +103,12 @@
         icon-f7="arrow_counterclockwise"
         tooltip="Reset column widths to default"
         @click="logViewerCore?.resetColumnWidths()" />
+      <f7-link
+        v-if="!logViewerCore?.textMode"
+        icon-f7="arrow_turn_down_left"
+        :icon-color="logViewerCore?.wrapMessages ? '' : 'gray'"
+        tooltip="Toggle message wrapping"
+        @click="logViewerCore?.toggleWrapMessages()" />
       <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
     </f7-toolbar>
 

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
@@ -57,85 +57,8 @@
       </f7-subnavbar>
     </f7-navbar>
 
-    <f7-toolbar
-      bottom
-      class="log-viewer-toolbar"
-      :class="{
-        'has-scroll-left': showToolbarScrollLeft,
-        'has-scroll-right': showToolbarScrollRight,
-        'toolbar-scrollable-mobile': !device.desktop
-      }"
-      ref="toolbarRef">
-      <button
-        v-if="showToolbarScrollLeft && !device.desktop"
-        type="button"
-        class="toolbar-scroll-indicator toolbar-scroll-indicator-left"
-        aria-label="Scroll toolbar left"
-        @pointerdown.stop.prevent
-        @click.stop.prevent="scrollToolbar('left')">
-        <i class="icon f7-icons">chevron_left</i>
-      </button>
-      <f7-link
-        icon-f7="cloud_download"
-        tooltip="Download filtered log as CSV"
-        :class="{ 'disabled-link': logViewerCore?.filterCount == 0 }"
-        @click="logViewerCore?.downloadCSV" />
-      <f7-link
-        icon-f7="rectangle_on_rectangle"
-        tooltip="Copy filtered log to clipboard"
-        :class="{ 'disabled-link': logViewerCore?.filterCount == 0 }"
-        @click="logViewerCore?.copyTableToClipboard" />
-      <f7-link
-        icon-f7="trash"
-        tooltip="Clear the log buffer"
-        :class="{ 'disabled-link': logViewerCore?.tableData.length == 0 }"
-        @click="logViewerCore?.clearLog" />
-      <f7-link @click="logViewerCore?.toggleErrorDisplay" tooltip="Always show error level logs">
-        <f7-icon v-if="logViewerCore?.showErrors" f7="exclamationmark_triangle_fill" />
-        <f7-icon v-else f7="exclamationmark_triangle" />
-      </f7-link>
-      <f7-link icon-f7="pencil" tooltip="Configure highlights" data-popup=".log-highlights-popup" class="popup-open" />
-      <f7-segmented>
-        <f7-button
-          outline
-          small
-          :active="!logViewerCore?.textMode"
-          icon-f7="table"
-          :icon-size="theme.aurora ? 20 : 22"
-          class="no-ripple"
-          @click="logViewerCore?.setTextMode(false)"
-          tooltip="Show logs in a table" />
-        <f7-button
-          outline
-          small
-          :active="logViewerCore?.textMode"
-          icon-f7="text_justifyleft"
-          :icon-size="theme.aurora ? 20 : 22"
-          class="no-ripple"
-          @click="logViewerCore?.setTextMode(true)"
-          tooltip="Show logs as plain text" />
-      </f7-segmented>
-      <f7-link
-        v-if="!logViewerCore?.textMode"
-        icon-f7="arrow_counterclockwise"
-        tooltip="Reset column widths to default"
-        @click="logViewerCore?.resetColumnWidths()" />
-      <f7-link
-        v-if="!logViewerCore?.textMode"
-        icon-f7="arrow_turn_down_left"
-        :icon-color="logViewerCore?.wrapMessages ? '' : 'gray'"
-        tooltip="Toggle message wrapping"
-        @click="logViewerCore?.toggleWrapMessages()" />
-      <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
-      <button
-        v-if="showToolbarScrollRight && !device.desktop"
-        type="button"
-        class="toolbar-scroll-indicator toolbar-scroll-indicator-right"
-        aria-label="Scroll toolbar right"
-        @pointerdown.stop.prevent
-        @click.stop.prevent="scrollToolbar('right')">
-        <i class="icon f7-icons">chevron_right</i>
-      </button>
+    <f7-toolbar bottom class="log-viewer-toolbar">
+      <log-viewer-toolbar :log-viewer-core="logViewerCore" />
     </f7-toolbar>
 
     <log-viewer-core ref="logViewerCore" />
@@ -164,58 +87,13 @@
 
   .dock-scroll-button
     bottom: calc(var(--f7-toolbar-height) + 16px)
-
-  @media (max-width 767px)
-    .log-viewer-toolbar.toolbar-scrollable-mobile
-      .toolbar-scroll-indicator
-        position sticky
-        z-index 2
-        flex 0 0 18px
-        display flex
-        align-items center
-        justify-content center
-        color var(--f7-text-color)
-        font-size 18px
-        line-height 1
-        background var(--f7-bars-bg-color)
-        border 0
-        margin 0
-        padding 0
-        cursor pointer
-
-        .icon
-          pointer-events none
-
-      .toolbar-scroll-indicator-left
-        left 0
-        box-shadow -10px 0 12px 10px var(--f7-bars-bg-color)
-
-      .toolbar-scroll-indicator-right
-        right 0
-        box-shadow 10px 0 12px 10px var(--f7-bars-bg-color)
-
-      .toolbar-inner
-        justify-content flex-start
-        gap 4px
-        overflow-x auto
-        overflow-y hidden
-        padding-left calc(8px + var(--f7-safe-area-left))
-        padding-right calc(8px + var(--f7-safe-area-right))
-        scrollbar-width none
-        -ms-overflow-style none
-        &::-webkit-scrollbar
-          display none
-
-      .link,
-      .segmented
-        flex 0 0 auto
 </style>
 
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount, useTemplateRef, ref, nextTick } from 'vue'
+import { useTemplateRef } from 'vue'
 import { type Router, getDevice } from 'framework7'
-import { theme } from 'framework7-vue'
 import LogViewerCore from './log-viewer-core.vue'
+import LogViewerToolbar from './log-viewer-toolbar.vue'
 
 // Constants
 const device = getDevice()
@@ -227,88 +105,13 @@ defineProps<{
 
 // State/Data
 const logViewerCore = useTemplateRef('logViewerCore')
-const toolbarRef = useTemplateRef('toolbarRef')
-const showToolbarScrollLeft = ref(false)
-const showToolbarScrollRight = ref(false)
-let toolbarScrollEl: HTMLElement | null = null
-let toolbarResizeObserver: ResizeObserver | null = null
-let toolbarMutationObserver: MutationObserver | null = null
-
-function getToolbarScrollElement(): HTMLElement | null {
-  return (toolbarRef.value?.$el as HTMLElement | undefined)?.querySelector('.toolbar-inner') ?? null
-}
-
-function updateToolbarScrollIndicators() {
-  const scrollEl = toolbarScrollEl ?? getToolbarScrollElement()
-  if (!scrollEl) {
-    showToolbarScrollLeft.value = false
-    showToolbarScrollRight.value = false
-    return
-  }
-
-  toolbarScrollEl = scrollEl
-  const maxScrollLeft = Math.max(0, scrollEl.scrollWidth - scrollEl.clientWidth)
-  showToolbarScrollLeft.value = scrollEl.scrollLeft > 4
-  showToolbarScrollRight.value = maxScrollLeft - scrollEl.scrollLeft > 4
-}
-
-function handleToolbarScroll() {
-  updateToolbarScrollIndicators()
-}
-
-function scrollToolbar(direction: 'left' | 'right') {
-  const scrollEl = toolbarScrollEl ?? getToolbarScrollElement()
-  if (!scrollEl) return
-
-  const distance = Math.max(scrollEl.clientWidth * 0.75, 120)
-  scrollEl.scrollBy({
-    left: direction === 'left' ? -distance : distance,
-    behavior: 'smooth'
-  })
-}
-
-function setupToolbarScrollIndicators() {
-  nextTick(() => {
-    const scrollEl = getToolbarScrollElement()
-    if (!scrollEl) return
-
-    toolbarScrollEl = scrollEl
-    scrollEl.addEventListener('scroll', handleToolbarScroll, { passive: true })
-
-    toolbarResizeObserver = new ResizeObserver(() => updateToolbarScrollIndicators())
-    toolbarResizeObserver.observe(scrollEl)
-
-    toolbarMutationObserver = new MutationObserver(() => nextTick(updateToolbarScrollIndicators))
-    toolbarMutationObserver.observe(scrollEl, { childList: true, subtree: true, attributes: true })
-
-    updateToolbarScrollIndicators()
-  })
-}
-
-function cleanupToolbarScrollIndicators() {
-  toolbarScrollEl?.removeEventListener('scroll', handleToolbarScroll)
-  toolbarScrollEl = null
-  toolbarResizeObserver?.disconnect()
-  toolbarResizeObserver = null
-  toolbarMutationObserver?.disconnect()
-  toolbarMutationObserver = null
-}
 
 // Lifecycle Hooks
 function onPageAfterIn() {
   logViewerCore.value?.load()
-  nextTick(updateToolbarScrollIndicators)
 }
 
 function onPageBeforeOut() {
   logViewerCore.value?.cleanup()
 }
-
-onMounted(() => {
-  setupToolbarScrollIndicators()
-})
-
-onBeforeUnmount(() => {
-  cleanupToolbarScrollIndicators()
-})
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
@@ -98,6 +98,11 @@
           @click="logViewerCore?.setTextMode(true)"
           tooltip="Show logs as plain text" />
       </f7-segmented>
+      <f7-link
+        v-if="!logViewerCore?.textMode"
+        icon-f7="arrow_counterclockwise"
+        tooltip="Reset column widths to default"
+        @click="logViewerCore?.resetColumnWidths()" />
       <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
     </f7-toolbar>
 

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
@@ -57,7 +57,20 @@
       </f7-subnavbar>
     </f7-navbar>
 
-    <f7-toolbar bottom>
+    <f7-toolbar
+      bottom
+      class="log-viewer-toolbar"
+      :class="{ 'has-scroll-left': showToolbarScrollLeft, 'has-scroll-right': showToolbarScrollRight, 'toolbar-scrollable-mobile': !device.desktop }"
+      ref="toolbarRef">
+      <button
+        v-if="showToolbarScrollLeft && !device.desktop"
+        type="button"
+        class="toolbar-scroll-indicator toolbar-scroll-indicator-left"
+        aria-label="Scroll toolbar left"
+        @pointerdown.stop.prevent
+        @click.stop.prevent="scrollToolbar('left')">
+        <i class="icon f7-icons">chevron_left</i>
+      </button>
       <f7-link
         icon-f7="cloud_download"
         tooltip="Download filtered log as CSV"
@@ -110,6 +123,15 @@
         tooltip="Toggle message wrapping"
         @click="logViewerCore?.toggleWrapMessages()" />
       <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
+      <button
+        v-if="showToolbarScrollRight && !device.desktop"
+        type="button"
+        class="toolbar-scroll-indicator toolbar-scroll-indicator-right"
+        aria-label="Scroll toolbar right"
+        @pointerdown.stop.prevent
+        @click.stop.prevent="scrollToolbar('right')">
+        <i class="icon f7-icons">chevron_right</i>
+      </button>
     </f7-toolbar>
 
     <log-viewer-core ref="logViewerCore" />
@@ -138,10 +160,55 @@
 
   .dock-scroll-button
     bottom: calc(var(--f7-toolbar-height) + 16px)
+
+  @media (max-width 767px)
+    .log-viewer-toolbar.toolbar-scrollable-mobile
+      .toolbar-scroll-indicator
+        position sticky
+        z-index 2
+        flex 0 0 18px
+        display flex
+        align-items center
+        justify-content center
+        color var(--f7-text-color)
+        font-size 18px
+        line-height 1
+        background var(--f7-bars-bg-color)
+        border 0
+        margin 0
+        padding 0
+        cursor pointer
+
+        .icon
+          pointer-events none
+
+      .toolbar-scroll-indicator-left
+        left 0
+        box-shadow -10px 0 12px 10px var(--f7-bars-bg-color)
+
+      .toolbar-scroll-indicator-right
+        right 0
+        box-shadow 10px 0 12px 10px var(--f7-bars-bg-color)
+
+      .toolbar-inner
+        justify-content flex-start
+        gap 4px
+        overflow-x auto
+        overflow-y hidden
+        padding-left calc(8px + var(--f7-safe-area-left))
+        padding-right calc(8px + var(--f7-safe-area-right))
+        scrollbar-width none
+        -ms-overflow-style none
+        &::-webkit-scrollbar
+          display none
+
+      .link,
+      .segmented
+        flex 0 0 auto
 </style>
 
 <script setup lang="ts">
-import { useTemplateRef } from 'vue'
+import { onMounted, onBeforeUnmount, useTemplateRef, ref, nextTick } from 'vue'
 import { type Router, getDevice } from 'framework7'
 import { theme } from 'framework7-vue'
 import LogViewerCore from './log-viewer-core.vue'
@@ -156,13 +223,88 @@ defineProps<{
 
 // State/Data
 const logViewerCore = useTemplateRef('logViewerCore')
+const toolbarRef = useTemplateRef('toolbarRef')
+const showToolbarScrollLeft = ref(false)
+const showToolbarScrollRight = ref(false)
+let toolbarScrollEl: HTMLElement | null = null
+let toolbarResizeObserver: ResizeObserver | null = null
+let toolbarMutationObserver: MutationObserver | null = null
+
+function getToolbarScrollElement(): HTMLElement | null {
+  return (toolbarRef.value?.$el as HTMLElement | undefined)?.querySelector('.toolbar-inner') ?? null
+}
+
+function updateToolbarScrollIndicators() {
+  const scrollEl = toolbarScrollEl ?? getToolbarScrollElement()
+  if (!scrollEl) {
+    showToolbarScrollLeft.value = false
+    showToolbarScrollRight.value = false
+    return
+  }
+
+  toolbarScrollEl = scrollEl
+  const maxScrollLeft = Math.max(0, scrollEl.scrollWidth - scrollEl.clientWidth)
+  showToolbarScrollLeft.value = scrollEl.scrollLeft > 4
+  showToolbarScrollRight.value = maxScrollLeft - scrollEl.scrollLeft > 4
+}
+
+function handleToolbarScroll() {
+  updateToolbarScrollIndicators()
+}
+
+function scrollToolbar(direction: 'left' | 'right') {
+  const scrollEl = toolbarScrollEl ?? getToolbarScrollElement()
+  if (!scrollEl) return
+
+  const distance = Math.max(scrollEl.clientWidth * 0.75, 120)
+  scrollEl.scrollBy({
+    left: direction === 'left' ? -distance : distance,
+    behavior: 'smooth'
+  })
+}
+
+function setupToolbarScrollIndicators() {
+  nextTick(() => {
+    const scrollEl = getToolbarScrollElement()
+    if (!scrollEl) return
+
+    toolbarScrollEl = scrollEl
+    scrollEl.addEventListener('scroll', handleToolbarScroll, { passive: true })
+
+    toolbarResizeObserver = new ResizeObserver(() => updateToolbarScrollIndicators())
+    toolbarResizeObserver.observe(scrollEl)
+
+    toolbarMutationObserver = new MutationObserver(() => nextTick(updateToolbarScrollIndicators))
+    toolbarMutationObserver.observe(scrollEl, { childList: true, subtree: true, attributes: true })
+
+    updateToolbarScrollIndicators()
+  })
+}
+
+function cleanupToolbarScrollIndicators() {
+  toolbarScrollEl?.removeEventListener('scroll', handleToolbarScroll)
+  toolbarScrollEl = null
+  toolbarResizeObserver?.disconnect()
+  toolbarResizeObserver = null
+  toolbarMutationObserver?.disconnect()
+  toolbarMutationObserver = null
+}
 
 // Lifecycle Hooks
 function onPageAfterIn() {
   logViewerCore.value?.load()
+  nextTick(updateToolbarScrollIndicators)
 }
 
 function onPageBeforeOut() {
   logViewerCore.value?.cleanup()
 }
+
+onMounted(() => {
+  setupToolbarScrollIndicators()
+})
+
+onBeforeUnmount(() => {
+  cleanupToolbarScrollIndicators()
+})
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-page.vue
@@ -60,7 +60,11 @@
     <f7-toolbar
       bottom
       class="log-viewer-toolbar"
-      :class="{ 'has-scroll-left': showToolbarScrollLeft, 'has-scroll-right': showToolbarScrollRight, 'toolbar-scrollable-mobile': !device.desktop }"
+      :class="{
+        'has-scroll-left': showToolbarScrollLeft,
+        'has-scroll-right': showToolbarScrollRight,
+        'toolbar-scrollable-mobile': !device.desktop
+      }"
       ref="toolbarRef">
       <button
         v-if="showToolbarScrollLeft && !device.desktop"

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-toolbar.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-toolbar.vue
@@ -1,0 +1,225 @@
+<template>
+  <div
+    ref="toolbarRef"
+    class="log-viewer-toolbar-actions"
+    :class="{
+      'has-scroll-left': showToolbarScrollLeft,
+      'has-scroll-right': showToolbarScrollRight,
+      'toolbar-scrollable-mobile': !device.desktop
+    }">
+    <button
+      v-if="showToolbarScrollLeft && !device.desktop"
+      type="button"
+      class="toolbar-scroll-indicator toolbar-scroll-indicator-left"
+      aria-label="Scroll toolbar left"
+      @pointerdown.stop.prevent
+      @click.stop.prevent="scrollToolbar('left')">
+      <i class="icon f7-icons">chevron_left</i>
+    </button>
+    <f7-link
+      icon-f7="cloud_download"
+      tooltip="Download filtered log as CSV"
+      :class="{ 'disabled-link': logViewerCore?.filterCount === 0 }"
+      @click="logViewerCore?.downloadCSV()" />
+    <f7-link
+      icon-f7="rectangle_on_rectangle"
+      tooltip="Copy filtered log to clipboard"
+      :class="{ 'disabled-link': logViewerCore?.filterCount === 0 }"
+      @click="logViewerCore?.copyTableToClipboard()" />
+    <f7-link
+      icon-f7="trash"
+      tooltip="Clear the log buffer"
+      :class="{ 'disabled-link': (logViewerCore?.tableData?.length ?? 0) === 0 }"
+      @click="logViewerCore?.clearLog()" />
+    <f7-link @click="logViewerCore?.toggleErrorDisplay()" tooltip="Always show error level logs">
+      <f7-icon v-if="logViewerCore?.showErrors" f7="exclamationmark_triangle_fill" />
+      <f7-icon v-else f7="exclamationmark_triangle" />
+    </f7-link>
+    <f7-link icon-f7="pencil" tooltip="Configure highlights" data-popup=".log-highlights-popup" class="popup-open" />
+    <f7-segmented>
+      <f7-button
+        outline
+        small
+        :active="!logViewerCore?.textMode"
+        icon-f7="table"
+        :icon-size="theme.aurora ? 20 : 22"
+        class="no-ripple"
+        @click="logViewerCore?.setTextMode(false)"
+        tooltip="Show logs in a table" />
+      <f7-button
+        outline
+        small
+        :active="logViewerCore?.textMode"
+        icon-f7="text_justifyleft"
+        :icon-size="theme.aurora ? 20 : 22"
+        class="no-ripple"
+        @click="logViewerCore?.setTextMode(true)"
+        tooltip="Show logs as plain text" />
+    </f7-segmented>
+    <f7-link
+      v-if="!logViewerCore?.textMode"
+      icon-f7="arrow_counterclockwise"
+      tooltip="Reset column widths to default"
+      @click="logViewerCore?.resetColumnWidths()" />
+    <f7-link
+      v-if="!logViewerCore?.textMode"
+      icon-f7="arrow_turn_down_left"
+      :icon-color="logViewerCore?.wrapMessages ? '' : 'gray'"
+      tooltip="Toggle message wrapping"
+      @click="logViewerCore?.toggleWrapMessages()" />
+    <f7-link icon-f7="gear" tooltip="Configure logging" data-popup=".log-settings-popup" class="popup-open" />
+    <button
+      v-if="showToolbarScrollRight && !device.desktop"
+      type="button"
+      class="toolbar-scroll-indicator toolbar-scroll-indicator-right"
+      aria-label="Scroll toolbar right"
+      @pointerdown.stop.prevent
+      @click.stop.prevent="scrollToolbar('right')">
+      <i class="icon f7-icons">chevron_right</i>
+    </button>
+  </div>
+</template>
+
+<style lang="stylus">
+.log-viewer-toolbar-actions
+  width 100%
+  display flex
+  align-items center
+  justify-content space-between
+
+  @media (max-width 767px)
+    &.toolbar-scrollable-mobile
+      justify-content flex-start
+      gap 4px
+      overflow-x auto
+      overflow-y hidden
+      scrollbar-width none
+      -ms-overflow-style none
+
+      &::-webkit-scrollbar
+        display none
+
+      > .link,
+      > .segmented
+        flex 0 0 auto
+
+      .toolbar-scroll-indicator
+        position sticky
+        z-index 2
+        flex 0 0 18px
+        display flex
+        align-items center
+        justify-content center
+        color var(--f7-text-color)
+        font-size 18px
+        line-height 1
+        background var(--f7-bars-bg-color)
+        border 0
+        margin 0
+        padding 0
+        cursor pointer
+
+        .icon
+          pointer-events none
+
+      .toolbar-scroll-indicator-left
+        left 0
+        box-shadow -10px 0 12px 10px var(--f7-bars-bg-color)
+
+      .toolbar-scroll-indicator-right
+        right 0
+        box-shadow 10px 0 12px 10px var(--f7-bars-bg-color)
+</style>
+
+<script setup lang="ts">
+import { nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
+import { getDevice } from 'framework7'
+import { theme } from 'framework7-vue'
+
+interface LogViewerToolbarTarget {
+  filterCount: number
+  tableData: unknown[]
+  textMode: boolean
+  showErrors: boolean
+  wrapMessages: boolean
+  downloadCSV: () => void
+  copyTableToClipboard: () => void
+  clearLog: () => void
+  toggleErrorDisplay: () => void
+  setTextMode: (enabled: boolean) => void
+  resetColumnWidths: () => void
+  toggleWrapMessages: () => void
+}
+
+defineProps<{
+  logViewerCore: LogViewerToolbarTarget | null
+}>()
+
+const device = getDevice()
+const toolbarRef = useTemplateRef('toolbarRef')
+const showToolbarScrollLeft = ref(false)
+const showToolbarScrollRight = ref(false)
+let toolbarResizeObserver: ResizeObserver | null = null
+let toolbarMutationObserver: MutationObserver | null = null
+
+function updateToolbarScrollIndicators() {
+  const toolbarEl = toolbarRef.value
+  if (!toolbarEl) {
+    showToolbarScrollLeft.value = false
+    showToolbarScrollRight.value = false
+    return
+  }
+
+  const maxScrollLeft = Math.max(0, toolbarEl.scrollWidth - toolbarEl.clientWidth)
+  showToolbarScrollLeft.value = toolbarEl.scrollLeft > 4
+  showToolbarScrollRight.value = maxScrollLeft - toolbarEl.scrollLeft > 4
+}
+
+function handleToolbarScroll() {
+  updateToolbarScrollIndicators()
+}
+
+function scrollToolbar(direction: 'left' | 'right') {
+  const toolbarEl = toolbarRef.value
+  if (!toolbarEl) return
+
+  const distance = Math.max(toolbarEl.clientWidth * 0.75, 120)
+  toolbarEl.scrollBy({
+    left: direction === 'left' ? -distance : distance,
+    behavior: 'smooth'
+  })
+}
+
+function setupToolbarScrollIndicators() {
+  nextTick(() => {
+    const toolbarEl = toolbarRef.value
+    if (!toolbarEl) return
+
+    toolbarEl.addEventListener('scroll', handleToolbarScroll, { passive: true })
+
+    toolbarResizeObserver = new ResizeObserver(() => updateToolbarScrollIndicators())
+    toolbarResizeObserver.observe(toolbarEl)
+
+    toolbarMutationObserver = new MutationObserver(() => nextTick(updateToolbarScrollIndicators))
+    toolbarMutationObserver.observe(toolbarEl, { childList: true, subtree: true, attributes: true })
+
+    updateToolbarScrollIndicators()
+  })
+}
+
+function cleanupToolbarScrollIndicators() {
+  toolbarRef.value?.removeEventListener('scroll', handleToolbarScroll)
+  toolbarResizeObserver?.disconnect()
+  toolbarResizeObserver = null
+  toolbarMutationObserver?.disconnect()
+  toolbarMutationObserver = null
+}
+
+onMounted(() => {
+  setupToolbarScrollIndicators()
+})
+
+onBeforeUnmount(() => {
+  cleanupToolbarScrollIndicators()
+})
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-toolbar.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-toolbar.vue
@@ -135,24 +135,10 @@
 import { nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef } from 'vue'
 import { getDevice } from 'framework7'
 import { theme } from 'framework7-vue'
-
-interface LogViewerToolbarTarget {
-  filterCount: number
-  tableData: unknown[]
-  textMode: boolean
-  showErrors: boolean
-  wrapMessages: boolean
-  downloadCSV: () => void
-  copyTableToClipboard: () => void
-  clearLog: () => void
-  toggleErrorDisplay: () => void
-  setTextMode: (enabled: boolean) => void
-  resetColumnWidths: () => void
-  toggleWrapMessages: () => void
-}
+import type LogViewerCore from '@/pages/developer/log-viewer/log-viewer-core.vue'
 
 defineProps<{
-  logViewerCore: LogViewerToolbarTarget | null
+  logViewerCore: InstanceType<typeof LogViewerCore> | null
 }>()
 
 const device = getDevice()

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/resizable-table.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/resizable-table.vue
@@ -1,0 +1,410 @@
+<template>
+  <div
+    ref="tableContainer"
+    class="table-container resizable-table-container"
+    :class="{ 'resize-hovering': !textMode && (hoveredResizeHandle >= 0 || activeResizeHandle >= 0) }"
+    @scroll="handleScroll"
+    @mousemove="handleTableMouseMove"
+    @mouseleave="handleTableMouseLeave"
+    @mousedown="handleTableMouseDown"
+    @dblclick="handleTableDoubleClick"
+    @touchstart="handleTableTouchStart">
+    <div
+      v-if="!textMode"
+      class="resizable-table-header-overlay"
+      :class="{ 'resizable-table-header-overlay-visible': showColumnHeaders }"
+      :style="{ width: totalTableWidth + 'px' }">
+      <div
+        v-for="(col, i) in columns"
+        :key="i"
+        class="resizable-table-header-cell"
+        :class="{ 'resizable-table-header-cell-sticky': i === 0 }"
+        :style="{ width: columnWidths[i] + 'px' }">
+        <span>{{ col.label }}</span>
+      </div>
+    </div>
+    <table
+      ref="dataTable"
+      class="resizable-table"
+      :class="{ 'wrap-messages': wrapMessages && !textMode }"
+      :style="!textMode ? { tableLayout: 'fixed', width: totalTableWidth + 'px' } : { width: '100%' }">
+      <colgroup v-if="!textMode">
+        <col v-for="(width, i) in columnWidths" :key="i" :style="{ width: width + 'px' }" />
+      </colgroup>
+      <tbody />
+    </table>
+    <div
+      v-if="!textMode && resizeGuideLeft !== null"
+      class="resizable-table-guide"
+      :class="{ 'resizable-table-guide-active': activeResizeHandle >= 0 }"
+      :style="{ left: resizeGuideLeft + 'px', top: tableScrollTop + 'px', height: tableViewportHeight + 'px' }"
+      aria-hidden="true" />
+  </div>
+</template>
+
+<style lang="stylus">
+.resizable-table-container
+  overflow-y auto
+  overflow-x auto
+  display block
+  position relative
+
+.resizable-table-container.resize-hovering
+  cursor col-resize
+
+.resizable-table
+  overflow-x auto
+  position relative
+  border-collapse collapse
+  table-layout auto
+
+.resizable-table-header-overlay
+  position sticky
+  top 0
+  z-index 4
+  display flex
+  align-items stretch
+  height 31px
+  margin-bottom -31px
+  opacity 0
+  transform translateY(-100%)
+  transition opacity 0.12s ease, transform 0.12s ease
+  pointer-events none
+
+.resizable-table-header-overlay-visible
+  opacity 1
+  transform translateY(0)
+
+.resizable-table-header-cell
+  background var(--f7-bars-bg-color)
+  color var(--f7-bars-text-color)
+  box-sizing border-box
+  padding 5px
+  padding-right 14px
+  text-align left
+  font-weight bold
+  box-shadow 0 1px 0 rgba(128, 128, 128, 0.3)
+  user-select none
+  white-space nowrap
+  overflow hidden
+  flex 0 0 auto
+
+.resizable-table-header-cell-sticky
+  position sticky
+  left 0
+  z-index 1
+
+.resizable-table-guide
+  position absolute
+  width 2px
+  transform translateX(-1px)
+  background rgba(90, 90, 90, 0.95)
+  box-shadow 0 0 0 1px rgba(255, 255, 255, 0.55)
+  border-radius 1px
+  opacity 0.9
+  z-index 6
+  pointer-events none
+  transition opacity 0.15s ease, background-color 0.15s ease, box-shadow 0.15s ease
+
+.resizable-table-guide-active
+  background var(--f7-theme-color)
+  box-shadow 0 0 0 1px rgba(255, 255, 255, 0.7)
+  opacity 1
+
+body.col-resizing .resizable-table-container
+  *
+    user-select none
+    cursor col-resize !important
+
+@media (pointer coarse)
+  .resizable-table-guide
+    opacity 0.8
+</style>
+
+<script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
+
+type TableColumnDef = {
+  label: string
+}
+
+const props = withDefaults(
+  defineProps<{
+    columns: TableColumnDef[]
+    textMode: boolean
+    wrapMessages: boolean
+    storageKey: string
+    defaultColumnWidths: number[]
+    minColumnWidth?: number
+  }>(),
+  {
+    minColumnWidth: 40
+  }
+)
+
+const emit = defineEmits<{
+  scroll: []
+  'auto-size-column': [colIndex: number]
+}>()
+
+const resizeHoverDistance = 6
+const lineHeight = 31
+
+const dataTableRef = useTemplateRef('dataTable')
+const dataTableContainerRef = useTemplateRef('tableContainer')
+
+function loadColumnWidths(): number[] {
+  try {
+    const stored = localStorage.getItem(props.storageKey)
+    if (stored) {
+      const parsed = JSON.parse(stored) as unknown
+      if (
+        Array.isArray(parsed) &&
+        parsed.length === props.defaultColumnWidths.length &&
+        parsed.every((n) => typeof n === 'number' && n > 0)
+      ) {
+        return parsed as number[]
+      }
+    }
+  } catch {}
+
+  return [...props.defaultColumnWidths]
+}
+
+const columnWidths = ref<number[]>(loadColumnWidths())
+let resizingIndex = -1
+let resizeStartX = 0
+let resizeStartWidth = 0
+const activeResizeHandle = ref(-1)
+const hoveredResizeHandle = ref(-1)
+const isHoveringTableTop = ref(false)
+const tableScrollTop = ref(0)
+const tableViewportHeight = ref(0)
+
+function persistColumnWidths() {
+  localStorage.setItem(props.storageKey, JSON.stringify(columnWidths.value))
+}
+
+function syncTableViewportMetrics() {
+  const tableContainer = dataTableContainerRef.value
+  if (!tableContainer) return
+  tableScrollTop.value = tableContainer.scrollTop
+  tableViewportHeight.value = tableContainer.clientHeight
+}
+
+function beginResize(clientX: number, colIndex: number) {
+  resizingIndex = colIndex
+  resizeStartX = clientX
+  resizeStartWidth = columnWidths.value[colIndex]
+  activeResizeHandle.value = colIndex
+}
+
+function startResize(event: MouseEvent, colIndex: number) {
+  beginResize(event.clientX, colIndex)
+  document.body.classList.add('col-resizing')
+  document.body.style.cursor = 'col-resize'
+  document.addEventListener('mousemove', handleResize)
+  document.addEventListener('mouseup', stopResize)
+}
+
+function handleResize(event: MouseEvent) {
+  if (resizingIndex < 0) return
+  columnWidths.value[resizingIndex] = Math.max(props.minColumnWidth, resizeStartWidth + (event.clientX - resizeStartX))
+}
+
+function stopResize() {
+  if (resizingIndex < 0) return
+  resizingIndex = -1
+  activeResizeHandle.value = -1
+  document.body.classList.remove('col-resizing')
+  document.body.style.cursor = ''
+  persistColumnWidths()
+  document.removeEventListener('mousemove', handleResize)
+  document.removeEventListener('mouseup', stopResize)
+}
+
+function startResizeTouch(event: TouchEvent, colIndex: number) {
+  if (event.touches.length !== 1) return
+  const touch = event.touches[0]
+  beginResize(touch.clientX, colIndex)
+  document.addEventListener('touchmove', handleResizeTouch, { passive: false })
+  document.addEventListener('touchend', stopResizeTouch)
+  document.addEventListener('touchcancel', stopResizeTouch)
+}
+
+function handleResizeTouch(event: TouchEvent) {
+  if (resizingIndex < 0 || event.touches.length !== 1) return
+  event.preventDefault()
+  const touch = event.touches[0]
+  columnWidths.value[resizingIndex] = Math.max(props.minColumnWidth, resizeStartWidth + (touch.clientX - resizeStartX))
+}
+
+function stopResizeTouch() {
+  if (resizingIndex < 0) return
+  resizingIndex = -1
+  activeResizeHandle.value = -1
+  persistColumnWidths()
+  document.removeEventListener('touchmove', handleResizeTouch)
+  document.removeEventListener('touchend', stopResizeTouch)
+  document.removeEventListener('touchcancel', stopResizeTouch)
+}
+
+function clearResizeHoverState() {
+  if (resizingIndex >= 0) {
+    stopResize()
+    stopResizeTouch()
+  }
+  hoveredResizeHandle.value = -1
+  activeResizeHandle.value = -1
+  isHoveringTableTop.value = false
+}
+
+function updateTableHoverState(clientX: number, clientY: number) {
+  if (props.textMode) {
+    clearResizeHoverState()
+    return
+  }
+
+  const tableContainer = dataTableContainerRef.value
+  if (!tableContainer) return
+  syncTableViewportMetrics()
+
+  const rect = tableContainer.getBoundingClientRect()
+  const withinContainer = clientX >= rect.left && clientX <= rect.right && clientY >= rect.top && clientY <= rect.bottom
+
+  if (!withinContainer) {
+    if (resizingIndex < 0) {
+      hoveredResizeHandle.value = -1
+    }
+    isHoveringTableTop.value = false
+    return
+  }
+
+  isHoveringTableTop.value = clientY - rect.top <= lineHeight
+
+  if (resizingIndex >= 0) return
+
+  const cursorX = clientX - rect.left + tableContainer.scrollLeft
+  let closestCol = -1
+  let closestDist = Infinity
+
+  for (const border of columnBorders.value) {
+    const dist = Math.abs(cursorX - border.left)
+    if (dist < closestDist) {
+      closestDist = dist
+      closestCol = border.index
+    }
+  }
+
+  hoveredResizeHandle.value = closestDist <= resizeHoverDistance ? closestCol : -1
+}
+
+function handleTableMouseMove(event: MouseEvent) {
+  updateTableHoverState(event.clientX, event.clientY)
+}
+
+function handleTableMouseLeave() {
+  if (props.textMode) return
+  if (resizingIndex >= 0) return
+  hoveredResizeHandle.value = -1
+  isHoveringTableTop.value = false
+}
+
+function handleTableMouseDown(event: MouseEvent) {
+  if (props.textMode) return
+  if (event.button !== 0 || hoveredResizeHandle.value < 0) return
+  event.preventDefault()
+  startResize(event, hoveredResizeHandle.value)
+}
+
+function handleTableDoubleClick(event: MouseEvent) {
+  if (props.textMode) return
+  if (hoveredResizeHandle.value < 0) return
+  event.preventDefault()
+  emit('auto-size-column', hoveredResizeHandle.value)
+}
+
+function handleTableTouchStart(event: TouchEvent) {
+  if (props.textMode) return
+  if (event.touches.length !== 1) return
+  const touch = event.touches[0]
+  updateTableHoverState(touch.clientX, touch.clientY)
+  if (hoveredResizeHandle.value < 0) return
+  startResizeTouch(event, hoveredResizeHandle.value)
+}
+
+function handleScroll() {
+  syncTableViewportMetrics()
+  emit('scroll')
+}
+
+function resetColumnWidths() {
+  columnWidths.value = [...props.defaultColumnWidths]
+  localStorage.removeItem(props.storageKey)
+}
+
+function setColumnWidth(colIndex: number, width: number) {
+  if (colIndex < 0 || colIndex >= columnWidths.value.length) return
+  columnWidths.value[colIndex] = Math.max(props.minColumnWidth, width)
+  persistColumnWidths()
+}
+
+function getTableBody(): HTMLTableSectionElement | null {
+  return dataTableRef.value?.tBodies?.[0] ?? null
+}
+
+function getTableElement(): HTMLTableElement | null {
+  return dataTableRef.value ?? null
+}
+
+function getContainerElement(): HTMLDivElement | null {
+  return dataTableContainerRef.value ?? null
+}
+
+const totalTableWidth = computed(() => columnWidths.value.reduce((sum, width) => sum + width, 0))
+
+const columnBorders = computed(() => {
+  let offset = 0
+  return columnWidths.value.map((width, index) => {
+    offset += width
+    return {
+      index,
+      left: offset
+    }
+  })
+})
+
+const resizeGuideLeft = computed(() => {
+  const guideIndex = activeResizeHandle.value >= 0 ? activeResizeHandle.value : hoveredResizeHandle.value
+  if (guideIndex < 0) return null
+  return columnBorders.value[guideIndex]?.left ?? null
+})
+
+const showColumnHeaders = computed(() => isHoveringTableTop.value || hoveredResizeHandle.value >= 0 || activeResizeHandle.value >= 0)
+
+watch(
+  () => props.textMode,
+  (textModeEnabled) => {
+    if (textModeEnabled) {
+      clearResizeHoverState()
+    }
+  }
+)
+
+onMounted(() => {
+  nextTick(syncTableViewportMetrics)
+})
+
+onBeforeUnmount(() => {
+  clearResizeHoverState()
+})
+
+defineExpose({
+  getTableBody,
+  getTableElement,
+  getContainerElement,
+  resetColumnWidths,
+  setColumnWidth,
+  clearResizeHoverState
+})
+</script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/resizable-table.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/resizable-table.vue
@@ -2,7 +2,7 @@
   <div
     ref="tableContainer"
     class="table-container resizable-table-container"
-    :class="{ 'resize-hovering': !textMode && (hoveredResizeHandle >= 0 || activeResizeHandle >= 0) }"
+    :class="{ 'resize-hovering': columnResizeEnabled && (hoveredResizeHandle >= 0 || activeResizeHandle >= 0) }"
     @scroll="handleScroll"
     @mousemove="handleTableMouseMove"
     @mouseleave="handleTableMouseLeave"
@@ -10,7 +10,7 @@
     @dblclick="handleTableDoubleClick"
     @touchstart="handleTableTouchStart">
     <div
-      v-if="!textMode"
+      v-if="columnResizeEnabled"
       class="resizable-table-header-overlay"
       :class="{ 'resizable-table-header-overlay-visible': showColumnHeaders }"
       :style="{ width: totalTableWidth + 'px' }">
@@ -26,15 +26,15 @@
     <table
       ref="dataTable"
       class="resizable-table"
-      :class="{ 'wrap-messages': wrapMessages && !textMode }"
-      :style="!textMode ? { tableLayout: 'fixed', width: totalTableWidth + 'px' } : { width: '100%' }">
-      <colgroup v-if="!textMode">
+      :class="{ 'content-wrapped': contentWrapEnabled }"
+      :style="columnResizeEnabled ? { tableLayout: 'fixed', width: totalTableWidth + 'px' } : { width: '100%' }">
+      <colgroup v-if="columnResizeEnabled">
         <col v-for="(width, i) in columnWidths" :key="i" :style="{ width: width + 'px' }" />
       </colgroup>
       <tbody />
     </table>
     <div
-      v-if="!textMode && resizeGuideLeft !== null"
+      v-if="columnResizeEnabled && resizeGuideLeft !== null"
       class="resizable-table-guide"
       :class="{ 'resizable-table-guide-active': activeResizeHandle >= 0 }"
       :style="{ left: resizeGuideLeft + 'px', top: tableScrollTop + 'px', height: tableViewportHeight + 'px' }"
@@ -124,15 +124,35 @@ body.col-resizing .resizable-table-container
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue'
 
+/**
+ * Reusable table shell with persisted resizable columns.
+ *
+ * Usage expectations:
+ * - The parent owns row rendering and writes rows directly into the exposed tbody.
+ * - The parent listens for `scroll` to keep any virtualized or lazy rendering in sync.
+ * - The parent listens for `auto-size-column` when column width depends on row data.
+ * - Width persistence is keyed by `storageKey`, so callers should pass a stable, feature-specific key.
+ *
+ * This component intentionally does not know anything about the row model. It only owns
+ * column widths, hover/drag/touch resize behavior, the temporary header overlay, and the
+ * DOM handles needed by parents that manage table body content themselves.
+ */
 type TableColumnDef = {
   label: string
 }
 
+/**
+ * Public configuration surface for the table shell.
+ *
+ * `columnResizeEnabled` controls whether the component uses explicit column widths and
+ * shows the resize affordance.
+ * `contentWrapEnabled` only affects the opt-in wrap class on the rendered table element.
+ */
 const props = withDefaults(
   defineProps<{
     columns: TableColumnDef[]
-    textMode: boolean
-    wrapMessages: boolean
+    columnResizeEnabled: boolean
+    contentWrapEnabled: boolean
     storageKey: string
     defaultColumnWidths: number[]
     minColumnWidth?: number
@@ -142,6 +162,10 @@ const props = withDefaults(
   }
 )
 
+/**
+ * `scroll` lets the parent react to viewport changes.
+ * `auto-size-column` lets the parent compute width from its own data model.
+ */
 const emit = defineEmits<{
   scroll: []
   'auto-size-column': [colIndex: number]
@@ -260,7 +284,7 @@ function clearResizeHoverState() {
 }
 
 function updateTableHoverState(clientX: number, clientY: number) {
-  if (props.textMode) {
+  if (!props.columnResizeEnabled) {
     clearResizeHoverState()
     return
   }
@@ -304,28 +328,28 @@ function handleTableMouseMove(event: MouseEvent) {
 }
 
 function handleTableMouseLeave() {
-  if (props.textMode) return
+  if (!props.columnResizeEnabled) return
   if (resizingIndex >= 0) return
   hoveredResizeHandle.value = -1
   isHoveringTableTop.value = false
 }
 
 function handleTableMouseDown(event: MouseEvent) {
-  if (props.textMode) return
+  if (!props.columnResizeEnabled) return
   if (event.button !== 0 || hoveredResizeHandle.value < 0) return
   event.preventDefault()
   startResize(event, hoveredResizeHandle.value)
 }
 
 function handleTableDoubleClick(event: MouseEvent) {
-  if (props.textMode) return
+  if (!props.columnResizeEnabled) return
   if (hoveredResizeHandle.value < 0) return
   event.preventDefault()
   emit('auto-size-column', hoveredResizeHandle.value)
 }
 
 function handleTableTouchStart(event: TouchEvent) {
-  if (props.textMode) return
+  if (!props.columnResizeEnabled) return
   if (event.touches.length !== 1) return
   const touch = event.touches[0]
   updateTableHoverState(touch.clientX, touch.clientY)
@@ -338,6 +362,12 @@ function handleScroll() {
   emit('scroll')
 }
 
+/**
+ * Imperative helpers exposed for parents that manage tbody content themselves.
+ *
+ * This keeps the resizable shell reusable while still supporting existing code paths that
+ * append/remove rows manually or need direct access to the scroll container and table node.
+ */
 function resetColumnWidths() {
   columnWidths.value = [...props.defaultColumnWidths]
   localStorage.removeItem(props.storageKey)
@@ -383,9 +413,9 @@ const resizeGuideLeft = computed(() => {
 const showColumnHeaders = computed(() => isHoveringTableTop.value || hoveredResizeHandle.value >= 0 || activeResizeHandle.value >= 0)
 
 watch(
-  () => props.textMode,
-  (textModeEnabled) => {
-    if (textModeEnabled) {
+  () => props.columnResizeEnabled,
+  (columnResizeEnabled) => {
+    if (!columnResizeEnabled) {
       clearResizeHoverState()
     }
   }


### PR DESCRIPTION
Resolves #2960 

New Features:
- Add a generic resizable table component
- Allow log columns to be resized. When hovering near the column borders, a resize handle will appear. This handle can be dragged left/right to resize the column.
- Add table column headers, visible only during column resizing, or when the cursor is near the top of the table.
- Double click the resize handle to set column width to the width of the longest content
- Add button to reset column widths
- Add button to toggle message column line wrapping (off by default)
- On mobile displays with narrow screen, show a left/right chevrons for scrolling the log toolbar.

Other changes:
- Make only the Time column clickable to show the detail popup. This frees up the other columns from being accidentally clicked when the user just wants to select text.
- DRY the log viewer toolbar into a separate component since they are the same in page and embedded.

Bug Fix:
- Fix regression in #4011 where clicking "close" on the detail popup didn't close it. Instead it moved lower right. A second click on the Close was required.

Note: This is mostly done by copilot (GPT 5.4)

<img width="848" height="409" alt="resizable-log-columns" src="https://github.com/user-attachments/assets/495ca8ae-2cca-4b54-b57e-c104d56514d3" />

