### PR TITLE
Log viewer: Fix details popup can shift when buffer is full & Limit log dock height to screen height

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -950,6 +950,17 @@ export default {
     toggleLogDockFullscreen() {
       if (!useRuntimeStore().showLogDock) this.setLogDockVisible(true)
       this.logDockFullscreen = !this.logDockFullscreen
+      if (!this.logDockFullscreen) {
+        this.$nextTick(() => this.avoidLogDockOverflow())
+      }
+    },
+    avoidLogDockOverflow() {
+      const maxHeight = window.innerHeight
+      const currentHeight =
+        this.logDockHeight || parseInt(getComputedStyle(document.documentElement).getPropertyValue('--log-dock-height')) || 300
+      if (currentHeight > maxHeight) {
+        this.logDockHeight = Math.round(maxHeight)
+      }
     },
     startDockResize(ev) {
       const startY = ev.clientY
@@ -1229,6 +1240,7 @@ export default {
 
       if (window) {
         window.addEventListener('keydown', this.keyDown)
+        window.addEventListener('resize', this.avoidLogDockOverflow)
       }
 
       this.startEventSource()
@@ -1238,6 +1250,7 @@ export default {
   beforeUnmount() {
     if (window) {
       window.removeEventListener('keydown', this.keyDown)
+      window.removeEventListener('resize', this.avoidLogDockOverflow)
       if (this._logDockResizeHandlers) {
         const { onMove, onUp, onCancel } = this._logDockResizeHandlers
         window.removeEventListener('pointermove', onMove)

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -358,7 +358,7 @@
 </style>
 
 <script setup lang="ts">
-import { ref, computed, nextTick, useTemplateRef, shallowRef, triggerRef } from 'vue'
+import { ref, computed, nextTick, useTemplateRef, shallowRef, triggerRef, watch } from 'vue'
 import { f7 } from 'framework7-vue'
 import { useDraggable } from '@vueuse/core'
 import { storeToRefs } from 'pinia'
@@ -485,6 +485,7 @@ const currentHighlightColorItemIndex = ref<number | null>(null)
 const currentHighlightColor = ref('#FF5252')
 const lastSequence = ref(0)
 const selectedId = ref<number>(0)
+const selectedLog = ref<EnrichedLogEntry | null>(null)
 
 // Computed
 const filteredTableData = computed(() => {
@@ -497,13 +498,15 @@ const countersBadgeColor = computed(() => {
   return 'green'
 })
 
-const selectedLog = computed<EnrichedLogEntry | null>(() => {
-  return tableData.value.find((entry) => entry.id === selectedId.value) || null
-})
-
 const periodRangeColor = computed(() => {
   if (!stateConnected.value) return 'red'
   return stateProcessing.value ? 'green' : 'orange'
+})
+
+// Watchers
+watch(selectedId, (newId) => {
+  const log = tableData.value[newId]
+  if (log) selectedLog.value = { ...log }
 })
 
 const periodRangeTooltip = computed(() => {
@@ -708,8 +711,12 @@ function renderEntry(entry: EnrichedLogEntry) {
 }
 
 function onRowClick(entityId: number) {
-  selectedId.value = entityId
-  f7.popup.open('#logdetails-popup')
+  const index = tableData.value.findIndex((e) => e.id === entityId)
+  if (index !== -1) {
+    selectedId.value = index
+    selectedLog.value = { ...tableData.value[index] }
+    f7.popup.open('#logdetails-popup')
+  }
 }
 
 function addLogEntry(logEntry: LogEntry) {
@@ -825,6 +832,10 @@ function clearLog() {
   filterCount.value = 0
   logStart.value = '--:--:--'
   logEnd.value = '--:--:--'
+  selectedId.value = 0
+  selectedLog.value = null
+  nextId = 0
+  batchLogs.length = 0
   const tableBody = getTableBody()
   if (tableBody) tableBody.innerHTML = ''
 }


### PR DESCRIPTION
- The log details popup can change/loose it's data when the buffer is full and logs are pushed through the buffer and old entries get removed.
- The log dock didn't resize to the screen height when reducing the window height, causing the control elements and content to flow over.