### PR TITLE
Editor: Support adding additional floating icons through a slot

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -8,7 +8,11 @@
       :read-only="readOnly"
       :read-only-msg="readOnlyMsg"
       @input="onEditorInput"
-      @save="$emit('save')" />
+      @save="$emit('save')">
+      <template v-if="$slots['floating-icons']" #floating-icons>
+        <slot name="floating-icons" />
+      </template>
+    </editor>
   </div>
 
   <f7-toolbar bottom class="code-editor-toolbar">

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="code-editor-fit">
-    <f7-icon v-if="readOnly" f7="lock" size="50" class="code-readonly-icon" :tooltip="readOnlyMsg || 'Not editable'" />
+    <div v-if="$slots['floating-icons'] || readOnly" class="code-editor-icons">
+      <slot name="floating-icons" />
+      <f7-icon v-if="readOnly" f7="lock" size="50" class="lock-icon" :tooltip="resolvedReadOnlyMsg" />
+    </div>
     <codemirror ref="cm" :model-value="value" :extensions="extensions" @ready="onCmReady" @change="onCmCodeChange" />
   </div>
 </template>
@@ -17,15 +20,19 @@
   height 100%
   display flex !important
 
-  .code-readonly-icon
+  .code-editor-icons
     position absolute
     top 0
     right 0
+    display flex
+    gap 6px
     margin var(--f7-typography-margin) !important
-    color var(--f7-color-gray)
-    opacity 0.5
     z-index 4000
     user-select none
+
+    .lock-icon
+      color var(--f7-color-gray)
+      opacity 0.5
 
   .v-codemirror
     flex 1
@@ -173,6 +180,8 @@ const dynamicExtensions = computed((): Extension[] => {
 
   return extensions
 })
+
+const resolvedReadOnlyMsg = computed(() => props.readOnlyMsg || 'Not editable')
 
 const extensions = [
   keymap.of([...defaultKeymap, ...historyKeymap, ...KEYMAP]),


### PR DESCRIPTION
To add additional floating icons to the editor:

```vue
<code-editor blah blah>
  <template #floating-icons>
    <f7-icon size="50" blah blah>
  </template>
</code-editor>
```

This will display the additional icons to the left of the lock icon side by side, but you can control the styling / behaviour of your own icons independently of the lock icon.
