### PR TITLE
Fix app drawer when dev sidebar is open

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -347,7 +347,7 @@
     </f7-panel>
 
     <!-- Right Panel -->
-    <f7-panel v-if="ready" right reveal dark>
+    <f7-panel v-if="ready" right reveal dark resizable>
       <panel-right />
       <!-- <f7-view url="/panel-right/"></f7-view> -->
     </f7-panel>

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -55,7 +55,7 @@
           icon-md="material:exit_to_app"
           :tooltip="$t('home.otherApps')"
           panel-open="right"
-          @click="runtimeStore.showDeveloperDock ? f7.emit('toggleDeveloperDock') : ''" />
+          @click="appDrawerClick" />
       </f7-nav-right>
     </f7-navbar>
 
@@ -302,6 +302,11 @@ export default {
     },
     triggerDialog() {
       f7.emit('triggerDialog')
+    },
+    appDrawerClick() {
+      if (useRuntimeStore().showDeveloperDock) {
+        f7.emit('toggleDeveloperDock')
+      }
     }
   }
 }


### PR DESCRIPTION
Steps to reproduce:
- Go to home page / overview
- Open dev sidebar click on the icon or shift+alt+d
- Click on the app drawer icon 

When the devsidebar is open, clicking on the appdrawer icon (from the home page) creates an extra blank vertical column. The appdrawer didn't show up.

Also made the appdrawer panel resizable, since its size is otherwise only governed by the right panel size which is only resizable through the devsidebar.

We possibly need to backport this to 5.1 because this bug exists there too. I haven't checked 5.0.

This bug didn't exist in 4.x, so it was probably introduced in the vue2 -> vue3 upgrade.

<img width="685" height="561" alt="image" src="https://github.com/user-attachments/assets/1a9b837f-b669-459a-8b74-318f434df953" />

