### PR TITLE
Update MainUI styling, add searchbar to config sheet, add advanced parameter indicators

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-parameter.vue
@@ -2,7 +2,7 @@
   <f7-list
     v-show="configDescription.visible ? configDescription.visible(value, configuration, configDescription, parameters) : true"
     ref="parameter"
-    class="config-parameter"
+    :class="['config-parameter', { 'advanced-param': configDescription.advanced }]"
     :no-hairlines-md="
       configDescription.type !== 'BOOLEAN' &&
       (!configDescription.options || !configDescription.options.length) &&
@@ -39,8 +39,6 @@
 </template>
 
 <script>
-import { f7 } from 'framework7-vue'
-
 // import ScriptEditorPopup from './config/script-editor-popup.vue'
 import ParameterThing from './controls/parameter-thing.vue'
 import ParameterBoolean from './controls/parameter-boolean.vue'
@@ -164,6 +162,7 @@ export default {
     padding-left 0
 .param-description
   padding-left 16px !important
+  padding-right 10px !important
   &.block-footer
     margin-top 2px
     margin-bottom 1rem
@@ -187,4 +186,6 @@ export default {
       white-space nowrap
       margin-top 0
       margin-bottom 0
+  &.advanced-param
+    border-left 2px solid var(--f7-color-blue)
 </style>

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -1,51 +1,64 @@
 <template>
   <f7-block v-if="parameters" class="config-sheet no-margin" ref="sheet">
-    <div v-if="hasAdvanced" style="text-align: right" class="padding-right padding-bottom">
-      <label class="advanced-label">
-        <f7-checkbox v-model:checked="showAdvanced" />
-        Show advanced
-        <f7-badge
-          v-if="advancedNonDefaultCount"
-          style="margin-left: 2px"
-          color="blue"
-          class="count-badge"
-          tooltip="Non-default advanced parameter">
-          {{ advancedNonDefaultCount }}
-        </f7-badge>
-      </label>
+    <div v-if="showFilterControls" class="config-sheet-filters">
+      <f7-searchbar
+        v-if="showSearchbar"
+        ref="searchbar"
+        custom-search
+        :backdrop="false"
+        placeholder="Search configuration"
+        :disable-button-text="null"
+        @searchbar:search="onSearch"
+        @searchbar:clear="clearSearch" />
+      <f7-chip
+        v-if="hasAdvanced"
+        media-bg-color="blue"
+        :color="showAdvanced ? 'blue' : ''"
+        class="advanced-chip not-selectable"
+        text="Advanced"
+        @click="showAdvanced = !showAdvanced">
+        <template #media>
+          <f7-icon v-if="showAdvanced" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
+        </template>
+      </f7-chip>
+      <f7-badge v-if="advancedNonDefaultCount" color="blue" class="count-badge" tooltip="Non-default advanced parameter">
+        {{ advancedNonDefaultCount }}
+      </f7-badge>
     </div>
-    <f7-col>
+
+    <group-box v-if="searchQuery && !filteredDisplayedParameters.length" class="text-color-gray">
+      <f7-list>
+        <f7-list-item title="No configuration parameters match the current filter." />
+      </f7-list>
+    </group-box>
+
+    <f7-col v-if="ungroupedParametersExists">
       <f7-block width="100" class="parameter-group no-margin no-padding">
-        <f7-row v-if="displayedParameters.some((p) => !p.groupName)">
-          <f7-col>
-            <config-parameter
-              v-for="parameter in displayedParameters.filter((p) => !p.groupName)"
-              :key="parameter.name"
-              :config-description="parameter"
-              :value="configurationWithDefaults[parameter.name]"
-              :parameters="parameters"
-              :configuration="configurationWithDefaults"
-              :read-only="readOnly"
-              :status="parameterStatus(parameter)"
-              :f7router="f7router"
-              @update="(value) => updateParameter(parameter, value)" />
-          </f7-col>
-        </f7-row>
+        <group-box :title :accordion="accordion">
+          <f7-list v-if="!ungroupedDisplayedParameters.length" class="text-color-gray">
+            <f7-list-item v-if="!ungroupedAdvancedParametersExists" title="There are no general configuration parameters for this item." />
+            <f7-list-item v-else title="There are no basic general configuration parameters." />
+          </f7-list>
+          <config-parameter
+            v-for="parameter in ungroupedDisplayedParameters"
+            :key="parameter.name"
+            :config-description="parameter"
+            :value="configurationWithDefaults[parameter.name]"
+            :parameters="parameters"
+            :configuration="configurationWithDefaults"
+            :read-only="readOnly"
+            :status="parameterStatus(parameter)"
+            :f7router="f7router"
+            @update="(value) => updateParameter(parameter, value)" />
+        </group-box>
       </f7-block>
     </f7-col>
-    <f7-col v-if="displayedParameterGroups.length">
-      <f7-block v-for="group in displayedParameterGroups" width="100" class="parameter-group" :key="group.name">
-        <f7-row v-if="displayedParameters.some((p) => p.groupName === group.name)">
-          <f7-col>
-            <f7-block-title class="parameter-group-title">
-              {{ group.label }}
-            </f7-block-title>
-            <f7-block-footer v-if="group.description" class="param-description">
-              <div v-html="group.description" />
-            </f7-block-footer>
-
+    <f7-col v-if="filteredDisplayedParameterGroups.length">
+      <f7-block v-for="group in filteredDisplayedParameterGroups" width="100" class="parameter-group" :key="group.name">
+        <f7-row>
+          <group-box :title="group.label" :description="group.description">
             <config-parameter
-              v-for="parameter in displayedParameters.filter((p) => p.groupName === group.name)"
+              v-for="parameter in filteredDisplayedParameters.filter((p) => p.groupName === group.name)"
               :key="parameter.name"
               :config-description="parameter"
               :value="configurationWithDefaults[parameter.name]"
@@ -55,7 +68,7 @@
               :status="parameterStatus(parameter)"
               :f7router="f7router"
               @update="(value) => updateParameter(parameter, value)" />
-          </f7-col>
+          </group-box>
         </f7-row>
       </f7-block>
     </f7-col>
@@ -67,6 +80,40 @@
   margin-left calc(-1*var(--f7-block-padding-horizontal))
   padding-left 0 !important
   padding-right 0 !important
+
+.config-sheet-filters
+  display flex
+  align-items center
+  gap 8px
+  padding 8px var(--f7-block-padding-horizontal)
+
+  .searchbar
+    flex 1 1 auto
+    min-width 0
+    margin 0
+    padding 0
+    background transparent
+    box-shadow none
+
+    &:before, &:after
+      display none !important
+
+  .searchbar-inner
+    padding 0
+
+  .searchbar-input-wrap
+    margin 0
+
+  .advanced-chip
+    margin-left auto
+    cursor pointer
+
+  .not-selectable
+    -webkit-user-select none
+    -moz-user-select none
+    -ms-user-select none
+    user-select none
+
 .parameter-group
   padding-right 0 !important
   padding-left 0 !important
@@ -75,12 +122,6 @@
   .item-content .item-inner
     overflow-x auto
     overflow-y hidden
-
-.param-description.block-footer h1
-  font-size 1em
-
-.advanced-label
-  cursor pointer
 
 .item-input-info
     white-space normal
@@ -93,6 +134,14 @@ import { f7 } from 'framework7-vue'
 
 export default {
   props: {
+    title: {
+      type: String,
+      default: 'Configuration'
+    },
+    accordion: {
+      type: Boolean,
+      default: false
+    },
     parameterGroups: Array,
     parameters: Array,
     configuration: Object,
@@ -108,7 +157,8 @@ export default {
   },
   data() {
     return {
-      showAdvanced: false
+      showAdvanced: false,
+      searchQuery: ''
     }
   },
   computed: {
@@ -129,6 +179,12 @@ export default {
     },
     hasAdvanced() {
       return this.parameters.length > 0 && this.parameters.some((p) => p.advanced)
+    },
+    showSearchbar() {
+      return this.allParameters.length > 1
+    },
+    showFilterControls() {
+      return this.hasAdvanced || this.showSearchbar
     },
     displayedParameterGroups() {
       if (!this.parameterGroups || !this.parameterGroups.length) return []
@@ -160,9 +216,51 @@ export default {
     displayedParameters() {
       if (this.showAdvanced) return this.allParameters // show all parameters
       return this.baseParameters
+    },
+    filteredDisplayedParameters() {
+      const query = this.searchQuery.trim().toLowerCase()
+      if (!query) return this.displayedParameters
+      return this.displayedParameters.filter((parameter) => this.parameterMatchesSearch(parameter, query))
+    },
+    filteredDisplayedParameterGroups() {
+      const groupNames = new Set(this.filteredDisplayedParameters.map((p) => p.groupName).filter(Boolean))
+      return this.displayedParameterGroups.filter((g) => groupNames.has(g.name))
+    },
+    ungroupedDisplayedParameters() {
+      return this.filteredDisplayedParameters.filter((p) => !p.groupName)
+    },
+    ungroupedParametersExists() {
+      return this.allParameters.some((p) => !p.groupName)
+    },
+    ungroupedAdvancedParametersExists() {
+      return this.advancedParameters.some((p) => !p.groupName)
     }
   },
   methods: {
+    onSearch(searchbar, query) {
+      this.searchQuery = (query || '').trim()
+    },
+    clearSearch() {
+      this.searchQuery = ''
+    },
+    parameterMatchesSearch(parameter, query) {
+      const label = parameter.label || parameter.name || ''
+      const description = parameter.description || ''
+      const value = this.serializeSearchValue(this.configurationWithDefaults[parameter.name])
+      return `${label} ${description} ${value}`.toLowerCase().includes(query)
+    },
+    serializeSearchValue(value) {
+      if (value == null) return ''
+      if (Array.isArray(value)) return value.join(' ')
+      if (typeof value === 'object') {
+        try {
+          return JSON.stringify(value)
+        } catch (e) {
+          return String(value)
+        }
+      }
+      return String(value)
+    },
     isValid() {
       return f7.input.validateInputs(this.$refs.sheet.$el)
     },
@@ -193,14 +291,12 @@ export default {
       return this.status.find((ps) => ps.parameterName === parameter.name)
     },
     isNonDefault(parameter) {
-      function notNullNotUndefined(value) {
-        return value !== null && value !== undefined
-      }
-      return (
-        notNullNotUndefined(parameter.default) &&
-        notNullNotUndefined(this.configuration[parameter.name]) &&
-        this.configuration[parameter.name].toString() !== parameter.default
-      )
+      const configValue = this.configuration[parameter.name]
+      const defaultValue = parameter.default
+
+      // Using != null (instead of !==) to concisely check that neither
+      // value is null or undefined in a single expression.
+      return defaultValue != null && configValue != null && configValue.toString() !== defaultValue
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -21,7 +21,7 @@
           <f7-icon v-if="showAdvanced" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
         </template>
       </f7-chip>
-      <f7-badge v-if="advancedNonDefaultCount" color="blue" class="count-badge" tooltip="Non-default advanced parameter">
+      <f7-badge v-if="advancedNonDefaultCount" color="theme-alt" class="count-badge" tooltip="Non-default advanced parameter">
         {{ advancedNonDefaultCount }}
       </f7-badge>
     </div>

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -1,51 +1,64 @@
 <template>
   <f7-block v-if="parameters" class="config-sheet no-margin" ref="sheet">
-    <div v-if="hasAdvanced" style="text-align: right" class="padding-right padding-bottom">
-      <label class="advanced-label">
-        <f7-checkbox v-model:checked="showAdvanced" />
-        Show advanced
-        <f7-badge
-          v-if="advancedNonDefaultCount"
-          style="margin-left: 2px"
-          color="theme-alt"
-          class="count-badge"
-          tooltip="Non-default advanced parameter">
-          {{ advancedNonDefaultCount }}
-        </f7-badge>
-      </label>
+    <div v-if="showFilterControls" class="config-sheet-filters">
+      <f7-searchbar
+        v-if="showSearchbar"
+        ref="searchbar"
+        custom-search
+        :backdrop="false"
+        placeholder="Search configuration"
+        :disable-button-text="null"
+        @searchbar:search="onSearch"
+        @searchbar:clear="clearSearch" />
+      <f7-chip
+        v-if="hasAdvanced"
+        media-bg-color="theme-alt"
+        :color="showAdvanced ? 'theme-alt' : ''"
+        class="advanced-chip not-selectable"
+        text="Advanced"
+        @click="showAdvanced = !showAdvanced">
+        <template #media>
+          <f7-icon v-if="showAdvanced" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
+        </template>
+      </f7-chip>
+      <f7-badge v-if="advancedNonDefaultCount" color="blue" class="count-badge" tooltip="Non-default advanced parameter">
+        {{ advancedNonDefaultCount }}
+      </f7-badge>
     </div>
-    <f7-col>
+
+    <group-box v-if="searchQuery && !filteredDisplayedParameters.length" class="text-color-gray">
+      <f7-list>
+        <f7-list-item title="No configuration parameters match the current filter." />
+      </f7-list>
+    </group-box>
+
+    <f7-col v-if="ungroupedParametersExists">
       <f7-block width="100" class="parameter-group no-margin no-padding">
-        <f7-row v-if="displayedParameters.some((p) => !p.groupName)">
-          <f7-col>
-            <config-parameter
-              v-for="parameter in displayedParameters.filter((p) => !p.groupName)"
-              :key="parameter.name"
-              :config-description="parameter"
-              :value="configurationWithDefaults[parameter.name]"
-              :parameters="parameters"
-              :configuration="configurationWithDefaults"
-              :read-only="readOnly"
-              :status="parameterStatus(parameter)"
-              :f7router="f7router"
-              @update="(value) => updateParameter(parameter, value)" />
-          </f7-col>
-        </f7-row>
+        <group-box :title :accordion="accordion">
+          <f7-list v-if="!ungroupedDisplayedParameters.length" class="text-color-gray">
+            <f7-list-item v-if="!ungroupedAdvancedParametersExists" title="There are no general configuration parameters for this item." />
+            <f7-list-item v-else title="There are no basic general configuration parameters." />
+          </f7-list>
+          <config-parameter
+            v-for="parameter in ungroupedDisplayedParameters"
+            :key="parameter.name"
+            :config-description="parameter"
+            :value="configurationWithDefaults[parameter.name]"
+            :parameters="parameters"
+            :configuration="configurationWithDefaults"
+            :read-only="readOnly"
+            :status="parameterStatus(parameter)"
+            :f7router="f7router"
+            @update="(value) => updateParameter(parameter, value)" />
+        </group-box>
       </f7-block>
     </f7-col>
-    <f7-col v-if="displayedParameterGroups.length">
-      <f7-block v-for="group in displayedParameterGroups" width="100" class="parameter-group" :key="group.name">
-        <f7-row v-if="displayedParameters.some((p) => p.groupName === group.name)">
-          <f7-col>
-            <f7-block-title class="parameter-group-title">
-              {{ group.label }}
-            </f7-block-title>
-            <f7-block-footer v-if="group.description" class="param-description">
-              <div v-html="group.description" />
-            </f7-block-footer>
-
+    <f7-col v-if="filteredDisplayedParameterGroups.length">
+      <f7-block v-for="group in filteredDisplayedParameterGroups" width="100" class="parameter-group" :key="group.name">
+        <f7-row>
+          <group-box :title="group.label" :description="group.description">
             <config-parameter
-              v-for="parameter in displayedParameters.filter((p) => p.groupName === group.name)"
+              v-for="parameter in filteredDisplayedParameters.filter((p) => p.groupName === group.name)"
               :key="parameter.name"
               :config-description="parameter"
               :value="configurationWithDefaults[parameter.name]"
@@ -55,7 +68,7 @@
               :status="parameterStatus(parameter)"
               :f7router="f7router"
               @update="(value) => updateParameter(parameter, value)" />
-          </f7-col>
+          </group-box>
         </f7-row>
       </f7-block>
     </f7-col>
@@ -67,6 +80,40 @@
   margin-left calc(-1*var(--f7-block-padding-horizontal))
   padding-left 0 !important
   padding-right 0 !important
+
+.config-sheet-filters
+  display flex
+  align-items center
+  gap 8px
+  padding 8px var(--f7-block-padding-horizontal)
+
+  .searchbar
+    flex 1 1 auto
+    min-width 0
+    margin 0
+    padding 0
+    background transparent
+    box-shadow none
+
+    &:before, &:after
+      display none !important
+
+  .searchbar-inner
+    padding 0
+
+  .searchbar-input-wrap
+    margin 0
+
+  .advanced-chip
+    margin-left auto
+    cursor pointer
+
+  .not-selectable
+    -webkit-user-select none
+    -moz-user-select none
+    -ms-user-select none
+    user-select none
+
 .parameter-group
   padding-right 0 !important
   padding-left 0 !important
@@ -75,12 +122,6 @@
   .item-content .item-inner
     overflow-x auto
     overflow-y hidden
-
-.param-description.block-footer h1
-  font-size 1em
-
-.advanced-label
-  cursor pointer
 
 .item-input-info
     white-space normal
@@ -93,6 +134,14 @@ import { f7 } from 'framework7-vue'
 
 export default {
   props: {
+    title: {
+      type: String,
+      default: 'Configuration'
+    },
+    accordion: {
+      type: Boolean,
+      default: false
+    },
     parameterGroups: Array,
     parameters: Array,
     configuration: Object,
@@ -108,7 +157,8 @@ export default {
   },
   data() {
     return {
-      showAdvanced: false
+      showAdvanced: false,
+      searchQuery: ''
     }
   },
   computed: {
@@ -129,6 +179,12 @@ export default {
     },
     hasAdvanced() {
       return this.parameters.length > 0 && this.parameters.some((p) => p.advanced)
+    },
+    showSearchbar() {
+      return this.allParameters.length > 1
+    },
+    showFilterControls() {
+      return this.hasAdvanced || this.showSearchbar
     },
     displayedParameterGroups() {
       if (!this.parameterGroups || !this.parameterGroups.length) return []
@@ -160,9 +216,51 @@ export default {
     displayedParameters() {
       if (this.showAdvanced) return this.allParameters // show all parameters
       return this.baseParameters
+    },
+    filteredDisplayedParameters() {
+      const query = this.searchQuery.trim().toLowerCase()
+      if (!query) return this.displayedParameters
+      return this.displayedParameters.filter((parameter) => this.parameterMatchesSearch(parameter, query))
+    },
+    filteredDisplayedParameterGroups() {
+      const groupNames = new Set(this.filteredDisplayedParameters.map((p) => p.groupName).filter(Boolean))
+      return this.displayedParameterGroups.filter((g) => groupNames.has(g.name))
+    },
+    ungroupedDisplayedParameters() {
+      return this.filteredDisplayedParameters.filter((p) => !p.groupName)
+    },
+    ungroupedParametersExists() {
+      return this.allParameters.some((p) => !p.groupName)
+    },
+    ungroupedAdvancedParametersExists() {
+      return this.advancedParameters.some((p) => !p.groupName)
     }
   },
   methods: {
+    onSearch(searchbar, query) {
+      this.searchQuery = (query || '').trim()
+    },
+    clearSearch() {
+      this.searchQuery = ''
+    },
+    parameterMatchesSearch(parameter, query) {
+      const label = parameter.label || parameter.name || ''
+      const description = parameter.description || ''
+      const value = this.serializeSearchValue(this.configurationWithDefaults[parameter.name])
+      return `${label} ${description} ${value}`.toLowerCase().includes(query)
+    },
+    serializeSearchValue(value) {
+      if (value == null) return ''
+      if (Array.isArray(value)) return value.join(' ')
+      if (typeof value === 'object') {
+        try {
+          return JSON.stringify(value)
+        } catch (e) {
+          return String(value)
+        }
+      }
+      return String(value)
+    },
     isValid() {
       return f7.input.validateInputs(this.$refs.sheet.$el)
     },
@@ -193,14 +291,12 @@ export default {
       return this.status.find((ps) => ps.parameterName === parameter.name)
     },
     isNonDefault(parameter) {
-      function notNullNotUndefined(value) {
-        return value !== null && value !== undefined
-      }
-      return (
-        notNullNotUndefined(parameter.default) &&
-        notNullNotUndefined(this.configuration[parameter.name]) &&
-        this.configuration[parameter.name].toString() !== parameter.default
-      )
+      const configValue = this.configuration[parameter.name]
+      const defaultValue = parameter.default
+
+      // Using != null (instead of !==) to concisely check that neither
+      // value is null or undefined in a single expression.
+      return defaultValue != null && configValue != null && configValue.toString() !== defaultValue
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -85,11 +85,16 @@
     outline 2px solid var(--f7-theme-color)
     outline-offset -2px
     border-radius var(--f7-list-inset-border-radius)
+  .item-title
+    flex-shrink 0
+    margin-right 16px
   .item-after
-    width 50%
     display flex
+    flex 1 1 0
+    min-width 0
     justify-content flex-end
     span
+      max-width 100%
       text-overflow ellipsis
       white-space nowrap
       overflow hidden

--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -2,7 +2,7 @@
   <div class="item-picker-container">
     <f7-list-item
       :title="showTitle ? label || 'Item' : undefined"
-      :after="$oh.utils.truncateString(displayValue, 60)"
+      :after="displayValue"
       link
       :disabled="disabled ? true : null"
       :textColor="textColor"
@@ -85,6 +85,14 @@
     outline 2px solid var(--f7-theme-color)
     outline-offset -2px
     border-radius var(--f7-list-inset-border-radius)
+  .item-after
+    width 50%
+    display flex
+    justify-content flex-end
+    span
+      text-overflow ellipsis
+      white-space nowrap
+      overflow hidden
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/item-picker.vue
@@ -2,7 +2,7 @@
   <div class="item-picker-container">
     <f7-list-item
       :title="showTitle ? label || 'Item' : undefined"
-      :after="displayValue"
+      :after="$oh.utils.truncateString(displayValue, 60)"
       link
       :disabled="disabled ? true : null"
       :textColor="textColor"

--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-location.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-location.vue
@@ -12,7 +12,7 @@
       @input="(ev) => updateValue(ev.target.value)"
       type="text">
       <template #content-end>
-        <div class="padding-left">
+        <div class="padding-right margin-top">
           <f7-button @click="openMapPicker"> <f7-icon f7="placemark" /> Map </f7-button>
         </div>
       </template>

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -1,35 +1,33 @@
 <template>
-  <f7-card>
-    <f7-card-content>
-      <f7-list>
-        <ul v-if="!editMembers">
-          <item
-            v-for="member in sortedGroupMembers"
-            :key="member.name"
-            :item="member"
-            :link="'/settings/items/' + member.name"
-            :context="context" />
-          <!-- <f7-list-button @click="enableEditMode" color="theme-alt" title="Add or Remove Members" /> -->
-        </ul>
-        <f7-list-group v-if="editMembers">
-          <item-picker
-            :multiple="true"
-            name="groupMembers"
-            :value="pickedMemberNames"
-            label="Members"
-            :editableOnly="true"
-            :filterType="compatibleItemTypes"
-            :showFilterToggle="true"
-            @input="(members) => (pickedMemberNames = members)" />
-        </f7-list-group>
-      </f7-list>
-    </f7-card-content>
+  <group-box title="Members">
+    <f7-list>
+      <ul v-if="!editMembers">
+        <item
+          v-for="member in sortedGroupMembers"
+          :key="member.name"
+          :item="member"
+          :link="'/settings/items/' + member.name"
+          :context="context" />
+        <!-- <f7-list-button @click="enableEditMode" color="theme-alt" title="Add or Remove Members" /> -->
+      </ul>
+      <f7-list-group v-if="editMembers">
+        <item-picker
+          :multiple="true"
+          name="groupMembers"
+          :value="pickedMemberNames"
+          label="Members"
+          :editableOnly="true"
+          :filterType="compatibleItemTypes"
+          :showFilterToggle="true"
+          @input="(members) => (pickedMemberNames = members)" />
+      </f7-list-group>
+    </f7-list>
     <f7-card-footer>
       <f7-button v-if="!editMembers" color="theme-alt" @click="enableEditMode"> Change </f7-button>
       <f7-button v-if="editMembers" color="theme-alt" fill raised @click="updateMembers"> Apply </f7-button>
       <f7-button v-if="editMembers" color="theme-alt" @click="cancelEditMode"> Cancel </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -1,35 +1,33 @@
 <template>
-  <f7-card>
-    <f7-card-content>
-      <f7-list>
-        <ul v-if="!editMembers">
-          <item
-            v-for="member in sortedGroupMembers"
-            :key="member.name"
-            :item="member"
-            :link="'/settings/items/' + member.name"
-            :context="context" />
-          <!-- <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" /> -->
-        </ul>
-        <f7-list-group v-if="editMembers">
-          <item-picker
-            :multiple="true"
-            name="groupMembers"
-            :value="pickedMemberNames"
-            label="Members"
-            :editableOnly="true"
-            :filterType="compatibleItemTypes"
-            :showFilterToggle="true"
-            @input="(members) => (pickedMemberNames = members)" />
-        </f7-list-group>
-      </f7-list>
-    </f7-card-content>
+  <group-box title="Members">
+    <f7-list>
+      <ul v-if="!editMembers">
+        <item
+          v-for="member in sortedGroupMembers"
+          :key="member.name"
+          :item="member"
+          :link="'/settings/items/' + member.name"
+          :context="context" />
+        <!-- <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" /> -->
+      </ul>
+      <f7-list-group v-if="editMembers">
+        <item-picker
+          :multiple="true"
+          name="groupMembers"
+          :value="pickedMemberNames"
+          label="Members"
+          :editableOnly="true"
+          :filterType="compatibleItemTypes"
+          :showFilterToggle="true"
+          @input="(members) => (pickedMemberNames = members)" />
+      </f7-list-group>
+    </f7-list>
     <f7-card-footer>
       <f7-button v-if="!editMembers" color="blue" @click="enableEditMode"> Change </f7-button>
       <f7-button v-if="editMembers" color="blue" fill raised @click="updateMembers"> Apply </f7-button>
       <f7-button v-if="editMembers" color="blue" @click="cancelEditMode"> Cancel </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="item" class="quick-link-form no-padding">
+  <group-box v-if="item" class="quick-link-form no-padding" title="Item Details">
     <f7-list inline-labels no-hairlines-md>
       <f7-list-group>
         <f7-list-input
@@ -123,14 +123,22 @@
         </f7-list-input>
       </f7-list-group>
     </f7-list>
+  </group-box>
+
+  <group-box title="Item Semantic">
     <semantics-picker v-if="!hideSemantics" :item="item" :createMode="createMode" :hide-none="forceSemantics" />
-    <f7-list inline-labels no-hairline-md>
-      <div>
-        <tag-input title="Non-Semantic Tags" :disabled="!editable ? true : null" :item="item" />
-      </div>
-    </f7-list>
-    <f7-list inline-labels no-hairline-md>
-      <f7-list-item title="Parent Groups" :badge="numberOfGroups" />
+  </group-box>
+  <!-- <semantics-picker v-if="!hideSemantics" :item="item" :createMode="createMode" :hide-none="forceSemantics" /> -->
+  <!-- <f7-list inline-labels> -->
+  <!-- <div> -->
+  <tag-input title="Non-Semantic Tags" :disabled="!editable ? true : null" :item="item" />
+  <!-- </div> -->
+  <!-- </f7-list> -->
+  <group-box title="Parent Groups">
+    <template #after-title>
+      <f7-badge>{{ numberOfGroups }}</f7-badge>
+    </template>
+    <f7-list inline-labels>
       <!-- make it cosmetically similar to the non-semantic tags above -->
       <f7-list-item v-if="numberOfGroups > 0">
         <template #inner>
@@ -163,7 +171,7 @@
           :set-value-text="false" />
       </f7-list-group>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -1,56 +1,59 @@
 <template>
   <div v-if="ready">
-    <div v-if="itemType !== 'Group' && editable" style="text-align: right" class="padding-right">
-      <label @click="toggleMultiple" style="cursor: pointer">Multiple</label>
-      <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
-    </div>
-    <f7-list>
-      <f7-list-item
-        :key="classSelectKey"
-        :title="'Alexa Device Type' + (itemType !== 'Group' ? (!multiple ? '/Attribute' : '/Attributes') : '')"
-        :disabled="!editable ? true : null"
-        smart-select
-        :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple, scrollToSelectedItem: true }"
-        ref="classes">
-        <select v-if="itemType === 'Group'" name="classes" @change="updateClasses">
-          <option value="" />
-          <option v-for="cl in orderedClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
-            {{ cl }}
-          </option>
-        </select>
-        <select v-else name="classes" @change="updateClasses" :multiple="multiple">
-          <option v-if="!multiple" value="" />
-          <optgroup v-if="!multiple" label="Default Attributes">
-            <option v-for="cl in defaultClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
+    <group-box title="Alexa Metadata">
+      <template v-if="itemType !== 'Group' && editable" #after-title>
+        <label>
+          <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
+          Multiple
+        </label>
+      </template>
+      <f7-list>
+        <f7-list-item
+          :key="classSelectKey"
+          :title="'Alexa Device Type' + (itemType !== 'Group' ? (!multiple ? '/Attribute' : '/Attributes') : '')"
+          :disabled="!editable ? true : null"
+          smart-select
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple, scrollToSelectedItem: true }"
+          ref="classes">
+          <select v-if="itemType === 'Group'" name="classes" @change="updateClasses">
+            <option value="" />
+            <option v-for="cl in orderedClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
               {{ cl }}
             </option>
-          </optgroup>
-          <optgroup label="Specific Attributes">
-            <option
-              v-for="cl in specificClasses"
-              :value="cl"
-              :key="cl"
-              :selected="isSelected(cl) ? true : null"
-              :disabled="isDefined(cl) ? true : null">
-              {{ cl }}
-            </option>
-          </optgroup>
-          <optgroup label="Generic Attributes">
-            <option v-for="cl in genericClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
-              {{ cl }}
-            </option>
-          </optgroup>
-        </select>
-      </f7-list-item>
-      <f7-block-footer v-if="isPartOfGroupEndpoint" class="padding-left no-padding no-margin">
-        <small v-html="`Part of group endpoint${item.groups.length > 1 ? 's' : ''}: ${groupLinks}`" />
-      </f7-block-footer>
-    </f7-list>
+          </select>
+          <select v-else name="classes" @change="updateClasses" :multiple="multiple">
+            <option v-if="!multiple" value="" />
+            <optgroup v-if="!multiple" label="Default Attributes">
+              <option v-for="cl in defaultClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
+                {{ cl }}
+              </option>
+            </optgroup>
+            <optgroup label="Specific Attributes">
+              <option
+                v-for="cl in specificClasses"
+                :value="cl"
+                :key="cl"
+                :selected="isSelected(cl) ? true : null"
+                :disabled="isDefined(cl) ? true : null">
+                {{ cl }}
+              </option>
+            </optgroup>
+            <optgroup label="Generic Attributes">
+              <option v-for="cl in genericClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
+                {{ cl }}
+              </option>
+            </optgroup>
+          </select>
+        </f7-list-item>
+        <f7-block-footer v-if="isPartOfGroupEndpoint">
+          <small v-html="`Part of group endpoint${item.groups.length > 1 ? 's' : ''}: ${groupLinks}`" />
+        </f7-block-footer>
+      </f7-list>
+    </group-box>
     <div>
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
-    <f7-block v-if="itemType === 'Group' && classes.length" class="padding-top no-padding no-margin">
-      <f7-block-title class="padding-left"> Group Endpoint Capabilities </f7-block-title>
+    <group-box v-if="itemType === 'Group' && classes.length" title="Group Endpoint Capabilities">
       <f7-list>
         <f7-list-item
           v-for="cap in groupCapabilities"
@@ -60,10 +63,10 @@
           :disabled="cap.isIgnored || !editable ? true : null"
           :link="`/settings/items/${cap.item}/metadata/alexa`" />
       </f7-list>
-      <f7-block-footer v-if="!groupCapabilities.length" class="padding-left">
+      <f7-card-footer v-if="!groupCapabilities.length" class="padding-left">
         No direct group members of {{ item.name }} configured for Alexa
-      </f7-block-footer>
-    </f7-block>
+      </f7-card-footer>
+    </group-box>
     <p class="padding">
       <f7-link color="blue" external target="_blank" :href="docLink"> Alexa Integration Documentation </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -1,56 +1,59 @@
 <template>
   <div v-if="ready">
-    <div v-if="itemType !== 'Group' && editable" style="text-align: right" class="padding-right">
-      <label @click="toggleMultiple" style="cursor: pointer">Multiple</label>
-      <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
-    </div>
-    <f7-list>
-      <f7-list-item
-        :key="classSelectKey"
-        :title="'Alexa Device Type' + (itemType !== 'Group' ? (!multiple ? '/Attribute' : '/Attributes') : '')"
-        :disabled="!editable ? true : null"
-        smart-select
-        :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple, scrollToSelectedItem: true }"
-        ref="classes">
-        <select v-if="itemType === 'Group'" name="classes" @change="updateClasses">
-          <option value="" />
-          <option v-for="cl in orderedClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
-            {{ cl }}
-          </option>
-        </select>
-        <select v-else name="classes" @change="updateClasses" :multiple="multiple">
-          <option v-if="!multiple" value="" />
-          <optgroup v-if="!multiple" label="Default Attributes">
-            <option v-for="cl in defaultClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
+    <group-box title="Alexa Metadata">
+      <template v-if="itemType !== 'Group' && editable" #after-title>
+        <label>
+          <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
+          Multiple
+        </label>
+      </template>
+      <f7-list>
+        <f7-list-item
+          :key="classSelectKey"
+          :title="'Alexa Device Type' + (itemType !== 'Group' ? (!multiple ? '/Attribute' : '/Attributes') : '')"
+          :disabled="!editable ? true : null"
+          smart-select
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple, scrollToSelectedItem: true }"
+          ref="classes">
+          <select v-if="itemType === 'Group'" name="classes" @change="updateClasses">
+            <option value="" />
+            <option v-for="cl in orderedClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
               {{ cl }}
             </option>
-          </optgroup>
-          <optgroup label="Specific Attributes">
-            <option
-              v-for="cl in specificClasses"
-              :value="cl"
-              :key="cl"
-              :selected="isSelected(cl) ? true : null"
-              :disabled="isDefined(cl) ? true : null">
-              {{ cl }}
-            </option>
-          </optgroup>
-          <optgroup label="Generic Attributes">
-            <option v-for="cl in genericClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
-              {{ cl }}
-            </option>
-          </optgroup>
-        </select>
-      </f7-list-item>
-      <f7-block-footer v-if="isPartOfGroupEndpoint" class="padding-left no-padding no-margin">
-        <small v-html="`Part of group endpoint${item.groups.length > 1 ? 's' : ''}: ${groupLinks}`" />
-      </f7-block-footer>
-    </f7-list>
+          </select>
+          <select v-else name="classes" @change="updateClasses" :multiple="multiple">
+            <option v-if="!multiple" value="" />
+            <optgroup v-if="!multiple" label="Default Attributes">
+              <option v-for="cl in defaultClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
+                {{ cl }}
+              </option>
+            </optgroup>
+            <optgroup label="Specific Attributes">
+              <option
+                v-for="cl in specificClasses"
+                :value="cl"
+                :key="cl"
+                :selected="isSelected(cl) ? true : null"
+                :disabled="isDefined(cl) ? true : null">
+                {{ cl }}
+              </option>
+            </optgroup>
+            <optgroup label="Generic Attributes">
+              <option v-for="cl in genericClasses" :value="cl" :key="cl" :selected="isSelected(cl) ? true : null">
+                {{ cl }}
+              </option>
+            </optgroup>
+          </select>
+        </f7-list-item>
+        <f7-block-footer v-if="isPartOfGroupEndpoint">
+          <small v-html="`Part of group endpoint${item.groups.length > 1 ? 's' : ''}: ${groupLinks}`" />
+        </f7-block-footer>
+      </f7-list>
+    </group-box>
     <div>
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
-    <f7-block v-if="itemType === 'Group' && classes.length" class="padding-top no-padding no-margin">
-      <f7-block-title class="padding-left"> Group Endpoint Capabilities </f7-block-title>
+    <group-box v-if="itemType === 'Group' && classes.length" title="Group Endpoint Capabilities">
       <f7-list>
         <f7-list-item
           v-for="cap in groupCapabilities"
@@ -60,10 +63,10 @@
           :disabled="cap.isIgnored || !editable ? true : null"
           :link="`/settings/items/${cap.item}/metadata/alexa`" />
       </f7-list>
-      <f7-block-footer v-if="!groupCapabilities.length" class="padding-left">
+      <f7-card-footer v-if="!groupCapabilities.length" class="padding-left">
         No direct group members of {{ item.name }} configured for Alexa
-      </f7-block-footer>
-    </f7-block>
+      </f7-card-footer>
+    </group-box>
     <p class="padding">
       <f7-link color="theme-alt" external target="_blank" :href="docLink"> Alexa Integration Documentation </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-autoupdate.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <group-box title="Auto Update">
     <f7-list>
       <f7-list-item
         title="Force auto-update"
@@ -12,7 +12,7 @@
     <f7-block-footer class="param-description">
       <small>Force the state to auto-update on command.</small>
     </f7-block-footer>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-expire.vue
@@ -1,38 +1,74 @@
 <template>
   <div>
-    <f7-block-title medium> Do </f7-block-title>
-    <f7-list v-if="editable">
-      <f7-list-item
-        radio
-        :checked="parsedAction.action === 'state' ? true : null"
-        name="action"
-        title="update state"
-        @click="updateAction('state')" />
-      <f7-list-item
-        radio
-        :checked="parsedAction.action === 'command'"
-        name="action"
-        title="send command"
-        @click="updateAction('command')" />
-      <f7-list-input
-        ref="value"
-        :label="parsedAction.action === 'command' ? 'Command' : 'State'"
-        name="value"
-        type="text"
-        placeholder="UNDEF if unset"
-        :value="parsedAction.value"
-        @blur="(evt) => updateActionValue(evt.target.value)" />
-      <f7-list-item
-        title="ignore state updates"
-        checkbox
-        :checked="ignoreStateUpdates ? true : null"
-        @change="(ev) => (metadata.config['ignoreStateUpdates'] = new Boolean(ev.target.checked).toString())" />
-      <f7-list-item
-        title="ignore commands"
-        checkbox
-        :checked="ignoreCommands ? true : null"
-        @change="(ev) => (metadata.config['ignoreCommands'] = new Boolean(ev.target.checked).toString())" />
-    </f7-list>
+    <group-box title="After" description="Duration to wait after a command or state update is received">
+      <f7-list>
+        <f7-list-input
+          :floating-label="theme.md"
+          label="Expiration Delay"
+          name="timer"
+          ref="duration"
+          type="text"
+          class="no-border"
+          :value="sanitizedDuration"
+          :disabled="!editable ? true : null"
+          @blur="(evt) => updateDuration(evt.target.value)"
+          pattern="(\d+h)*(\d+m)*(\d+s)*"
+          validate
+          validate-on-blur />
+        <f7-list-item v-if="editable" class="display-flex justify-content-center">
+          <div ref="picker" />
+        </f7-list-item>
+      </f7-list>
+      <f7-block-footer class="param-description padding-left padding-bottom">
+        <small>Delay to wait before the timer expires and the action specified above is performed.</small>
+      </f7-block-footer>
+    </group-box>
+
+    <template v-if="editable">
+      <group-box title="Perform Action" description="Choose the action to perform when the timer expires.">
+        <f7-list>
+          <f7-list-item
+            radio
+            :checked="parsedAction.action === 'state' ? true : null"
+            name="action"
+            title="Update state"
+            @click="updateAction('state')" />
+          <f7-list-item
+            radio
+            :checked="parsedAction.action === 'command'"
+            name="action"
+            title="Send a command"
+            @click="updateAction('command')" />
+          <f7-list-input
+            ref="value"
+            :label="parsedAction.action === 'command' ? 'Command' : 'State'"
+            name="value"
+            type="text"
+            placeholder="UNDEF if unset"
+            clear-button
+            :value="parsedAction.value"
+            @blur="(evt) => updateActionValue(evt.target.value)" />
+        </f7-list>
+      </group-box>
+
+      <group-box
+        title="Options"
+        description="By default, any new command or state update resets the countdown timer. Use the settings below to change this behavior"
+        full-width>
+        <f7-list>
+          <f7-list-item
+            title="Ignore state updates"
+            checkbox
+            :checked="ignoreStateUpdates ? true : null"
+            @change="(ev) => (metadata.config['ignoreStateUpdates'] = new Boolean(ev.target.checked).toString())" />
+          <f7-list-item
+            title="Ignore commands"
+            checkbox
+            :checked="ignoreCommands ? true : null"
+            @change="(ev) => (metadata.config['ignoreCommands'] = new Boolean(ev.target.checked).toString())" />
+        </f7-list>
+      </group-box>
+    </template>
     <f7-block v-else>
       {{ parsedAction.action === 'state' ? 'Update state to' : 'Send command' }}
       <strong>{{ parsedAction.value || 'UNDEF' }}</strong
@@ -41,35 +77,6 @@
         `${ignoreStateUpdates ? 'Ignore state updates' : ''}${ignoreCommands && ignoreCommands ? ', ' : ''}${ignoreCommands ? 'Ignore commands' : ''}`
       }}
     </f7-block>
-    <f7-block-footer class="param-description padding-left">
-      <small
-        >After a different command or state update is received, perform the chosen action when the duration specified below has passed. The
-        timer is reset if another state update or command is received before it expires. If the ignore state updates checkbox is set, only
-        state changes and commands will reset the timer. If the ignore commands checkbox is set, only state updates and state changes will
-        reset the timer.</small
-      >
-    </f7-block-footer>
-    <f7-block-title medium> After </f7-block-title>
-    <f7-list>
-      <f7-list-input
-        :floating-label="theme.md"
-        label="Expiration Delay"
-        name="timer"
-        ref="duration"
-        type="text"
-        :value="sanitizedDuration"
-        :disabled="!editable ? true : null"
-        @blur="(evt) => updateDuration(evt.target.value)"
-        pattern="(\d+h)*(\d+m)*(\d+s)*"
-        validate
-        validate-on-blur />
-      <f7-list-item v-if="editable" class="display-flex justify-content-center">
-        <div ref="picker" />
-      </f7-list-item>
-    </f7-list>
-    <f7-block-footer class="param-description padding-left">
-      <small>Delay to wait before the timer expires and the action specified above is performed.</small>
-    </f7-block-footer>
   </div>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -1,41 +1,43 @@
 <template>
   <div>
-    <f7-list>
-      <f7-list-item
-        :key="classSelectKey"
-        title="Google Assistant Class"
-        :disabled="!editable ? true : null"
-        smart-select
-        :smart-select-params="{
-          openIn: 'popup',
-          searchbar: true,
-          closeOnSelect: true,
-          scrollToSelectedItem: true
-        }"
-        ref="classes">
-        <select name="classes" @change="updateClass">
-          <option value="" />
-          <optgroup label="Types">
-            <option
-              v-for="cl in orderedClasses.filter((c) => c.indexOf('type:') === 0)"
-              :value="cl.replace('type:', '')"
-              :key="cl"
-              :selected="isSelected(cl.replace('type:', '')) ? true : null">
-              {{ cl.replace('type:', '') }}
-            </option>
-          </optgroup>
-          <optgroup label="Attributes">
-            <option
-              v-for="cl in orderedClasses.filter((c) => c.indexOf('attribute:') === 0)"
-              :value="cl.replace('attribute:', '')"
-              :key="cl"
-              :selected="isSelected(cl.replace('attribute:', '')) ? true : null">
-              {{ cl.replace('attribute:', '') }}
-            </option>
-          </optgroup>
-        </select>
-      </f7-list-item>
-    </f7-list>
+    <group-box title="Google Assistant Metadata">
+      <f7-list>
+        <f7-list-item
+          :key="classSelectKey"
+          title="Google Assistant Class"
+          :disabled="!editable ? true : null"
+          smart-select
+          :smart-select-params="{
+            openIn: 'popup',
+            searchbar: true,
+            closeOnSelect: true,
+            scrollToSelectedItem: true
+          }"
+          ref="classes">
+          <select name="classes" @change="updateClass">
+            <option value="" />
+            <optgroup label="Types">
+              <option
+                v-for="cl in orderedClasses.filter((c) => c.indexOf('type:') === 0)"
+                :value="cl.replace('type:', '')"
+                :key="cl"
+                :selected="isSelected(cl.replace('type:', '')) ? true : null">
+                {{ cl.replace('type:', '') }}
+              </option>
+            </optgroup>
+            <optgroup label="Attributes">
+              <option
+                v-for="cl in orderedClasses.filter((c) => c.indexOf('attribute:') === 0)"
+                :value="cl.replace('attribute:', '')"
+                :key="cl"
+                :selected="isSelected(cl.replace('attribute:', '')) ? true : null">
+                {{ cl.replace('attribute:', '') }}
+              </option>
+            </optgroup>
+          </select>
+        </f7-list-item>
+      </f7-list>
+    </group-box>
     <div>
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -1,73 +1,74 @@
 <template>
   <div>
-    <div v-if="editable" style="text-align: right" class="padding-right">
-      <label @click="toggleMultiple" style="cursor: pointer">Multiple</label>
-      <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
-    </div>
-    <f7-list>
-      <f7-list-item
-        :key="classSelectKey"
-        :title="multiple ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'"
-        :disabled="!editable ? true : null"
-        smart-select
-        :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }"
-        ref="classes">
-        <select v-if="itemType == 'Group'" name="parameters" @change="updateClasses" :multiple="multiple">
-          <option v-if="!multiple" value="" />
-          <option
-            v-for="cl in classesDefs.filter((c) => c.indexOf('.') === -1).filter((c) => c.indexOf('label:') !== 0)"
-            :value="cl"
-            :key="cl"
-            :selected="isSelected(cl) ? true : null">
-            {{ cl }}
-          </option>
-        </select>
-        <select v-else name="parameters" @change="updateClasses" :multiple="multiple">
-          <option v-if="!multiple" value="" />
-          <option
-            v-for="cl in classesDefs.filter((c) => c.indexOf('label:') !== 0)"
-            :value="cl"
-            :key="cl"
-            :selected="isSelected(cl) ? true : null">
-            {{ cl }}
-          </option>
-        </select>
-      </f7-list-item>
-    </f7-list>
+    <group-box title="HomeKit Metadata">
+      <template v-if="editable" #after-title>
+        <label style="cursor: pointer">
+          <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
+          Multiple
+        </label>
+      </template>
+      <f7-list>
+        <f7-list-item
+          :key="classSelectKey"
+          :title="multiple ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'"
+          :disabled="!editable ? true : null"
+          smart-select
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }"
+          ref="classes">
+          <select v-if="itemType == 'Group'" name="parameters" @change="updateClasses" :multiple="multiple">
+            <option v-if="!multiple" value="" />
+            <option
+              v-for="cl in classesDefs.filter((c) => c.indexOf('.') === -1).filter((c) => c.indexOf('label:') !== 0)"
+              :value="cl"
+              :key="cl"
+              :selected="isSelected(cl) ? true : null">
+              {{ cl }}
+            </option>
+          </select>
+          <select v-else name="parameters" @change="updateClasses" :multiple="multiple">
+            <option v-if="!multiple" value="" />
+            <option
+              v-for="cl in classesDefs.filter((c) => c.indexOf('label:') !== 0)"
+              :value="cl"
+              :key="cl"
+              :selected="isSelected(cl) ? true : null">
+              {{ cl }}
+            </option>
+          </select>
+        </f7-list-item>
+      </f7-list>
+    </group-box>
+
     <div>
       <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
-    <f7-block v-if="itemType === 'Group' && classes.length" class="padding-top no-padding no-margin">
-      <f7-block-title class="padding-left"> Group HomeKit Characteristics Mapping </f7-block-title>
-      <f7-block v-for="cl in classesAsArray" :key="cl">
-        <f7-block-title class="padding-left">
-          {{ cl }}
-        </f7-block-title>
-        <f7-list>
-          <f7-list-item
-            v-for="accessory in accessories[cl]"
-            :key="accessory.label"
-            :disabled="!editable ? true : null"
-            smart-select
-            :title="accessory.mandatory ? accessory.label + '*' : accessory.label"
-            :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
-            <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
-              <option value="" />
-              <option
-                v-for="mbr in item.members"
-                :value="mbr.name"
-                :key="mbr.id"
-                :selected="isLinked(cl, accessory.label, mbr) ? true : null">
-                {{ mbr.label }} ({{ mbr.name }})
-              </option>
-            </select>
-          </f7-list-item>
-        </f7-list>
-      </f7-block>
-      <f7-block-footer v-if="editable">
+    <group-box v-if="itemType === 'Group' && classes.length" title="Group HomeKit Characteristics Mapping">
+      <f7-list v-for="cl in classesAsArray" :key="cl">
+        <f7-list-item group-title :title="cl" />
+
+        <f7-list-item
+          v-for="accessory in accessories[cl]"
+          :key="accessory.label"
+          :disabled="!editable ? true : null"
+          smart-select
+          :title="accessory.mandatory ? accessory.label + '*' : accessory.label"
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
+          <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
+            <option value="" />
+            <option
+              v-for="mbr in item.members"
+              :value="mbr.name"
+              :key="mbr.id"
+              :selected="isLinked(cl, accessory.label, mbr) ? true : null">
+              {{ mbr.label }} ({{ mbr.name }})
+            </option>
+          </select>
+        </f7-list-item>
+      </f7-list>
+      <f7-card-footer v-if="editable">
         <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
-      </f7-block-footer>
-    </f7-block>
+      </f7-card-footer>
+    </group-box>
     <p class="padding">
       <f7-link color="theme-alt" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/homekit`">
         HomeKit integration documentation

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -1,73 +1,74 @@
 <template>
   <div>
-    <div v-if="editable" style="text-align: right" class="padding-right">
-      <label @click="toggleMultiple" style="cursor: pointer">Multiple</label>
-      <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
-    </div>
-    <f7-list>
-      <f7-list-item
-        :key="classSelectKey"
-        :title="multiple ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'"
-        :disabled="!editable ? true : null"
-        smart-select
-        :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }"
-        ref="classes">
-        <select v-if="itemType == 'Group'" name="parameters" @change="updateClasses" :multiple="multiple">
-          <option v-if="!multiple" value="" />
-          <option
-            v-for="cl in classesDefs.filter((c) => c.indexOf('.') === -1).filter((c) => c.indexOf('label:') !== 0)"
-            :value="cl"
-            :key="cl"
-            :selected="isSelected(cl) ? true : null">
-            {{ cl }}
-          </option>
-        </select>
-        <select v-else name="parameters" @change="updateClasses" :multiple="multiple">
-          <option v-if="!multiple" value="" />
-          <option
-            v-for="cl in classesDefs.filter((c) => c.indexOf('label:') !== 0)"
-            :value="cl"
-            :key="cl"
-            :selected="isSelected(cl) ? true : null">
-            {{ cl }}
-          </option>
-        </select>
-      </f7-list-item>
-    </f7-list>
+    <group-box title="HomeKit Metadata">
+      <template v-if="editable" #after-title>
+        <label style="cursor: pointer">
+          <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
+          Multiple
+        </label>
+      </template>
+      <f7-list>
+        <f7-list-item
+          :key="classSelectKey"
+          :title="multiple ? 'HomeKit Accessory/Characteristics' : 'HomeKit Accessory/Characteristic'"
+          :disabled="!editable ? true : null"
+          smart-select
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }"
+          ref="classes">
+          <select v-if="itemType == 'Group'" name="parameters" @change="updateClasses" :multiple="multiple">
+            <option v-if="!multiple" value="" />
+            <option
+              v-for="cl in classesDefs.filter((c) => c.indexOf('.') === -1).filter((c) => c.indexOf('label:') !== 0)"
+              :value="cl"
+              :key="cl"
+              :selected="isSelected(cl) ? true : null">
+              {{ cl }}
+            </option>
+          </select>
+          <select v-else name="parameters" @change="updateClasses" :multiple="multiple">
+            <option v-if="!multiple" value="" />
+            <option
+              v-for="cl in classesDefs.filter((c) => c.indexOf('label:') !== 0)"
+              :value="cl"
+              :key="cl"
+              :selected="isSelected(cl) ? true : null">
+              {{ cl }}
+            </option>
+          </select>
+        </f7-list-item>
+      </f7-list>
+    </group-box>
+
     <div>
       <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
-    <f7-block v-if="itemType === 'Group' && classes.length" class="padding-top no-padding no-margin">
-      <f7-block-title class="padding-left"> Group HomeKit Characteristics Mapping </f7-block-title>
-      <f7-block v-for="cl in classesAsArray" :key="cl">
-        <f7-block-title class="padding-left">
-          {{ cl }}
-        </f7-block-title>
-        <f7-list>
-          <f7-list-item
-            v-for="accessory in accessories[cl]"
-            :key="accessory.label"
-            :disabled="!editable ? true : null"
-            smart-select
-            :title="accessory.mandatory ? accessory.label + '*' : accessory.label"
-            :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
-            <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
-              <option value="" />
-              <option
-                v-for="mbr in item.members"
-                :value="mbr.name"
-                :key="mbr.id"
-                :selected="isLinked(cl, accessory.label, mbr) ? true : null">
-                {{ mbr.label }} ({{ mbr.name }})
-              </option>
-            </select>
-          </f7-list-item>
-        </f7-list>
-      </f7-block>
-      <f7-block-footer v-if="editable">
+    <group-box v-if="itemType === 'Group' && classes.length" title="Group HomeKit Characteristics Mapping">
+      <f7-list v-for="cl in classesAsArray" :key="cl">
+        <f7-list-item group-title :title="cl" />
+
+        <f7-list-item
+          v-for="accessory in accessories[cl]"
+          :key="accessory.label"
+          :disabled="!editable ? true : null"
+          smart-select
+          :title="accessory.mandatory ? accessory.label + '*' : accessory.label"
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: !multiple }">
+          <select @change="updateLinkedItem(cl, accessory.label, $event.target.value)">
+            <option value="" />
+            <option
+              v-for="mbr in item.members"
+              :value="mbr.name"
+              :key="mbr.id"
+              :selected="isLinked(cl, accessory.label, mbr) ? true : null">
+              {{ mbr.label }} ({{ mbr.name }})
+            </option>
+          </select>
+        </f7-list-item>
+      </f7-list>
+      <f7-card-footer v-if="editable">
         <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
-      </f7-block-footer>
-    </f7-block>
+      </f7-card-footer>
+    </group-box>
     <p class="padding">
       <f7-link color="blue" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/homekit`">
         HomeKit integration documentation

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -2,27 +2,30 @@
   <div v-if="ready">
     <config-sheet
       v-if="namespace === 'stateDescription'"
+      title="State Description Configuration"
       :parameterGroups="[]"
       :parameters="stateDescriptionParameters"
       :configuration="metadata.config"
       :read-only="!editable" />
-    <f7-list>
-      <f7-list-input
-        ref="input"
-        type="textarea"
-        :floating-label="theme.md"
-        :label="'Options'"
-        name="options"
-        :disabled="!editable ? true : null"
-        :value="options"
-        @input="updateOptions" />
-      <f7-block-footer class="param-description" alot="after-list">
-        <small
-          >Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the
-          option.</small
-        >
-      </f7-block-footer>
-    </f7-list>
+    <group-box title="Options">
+      <f7-list>
+        <f7-list-input
+          ref="input"
+          type="textarea"
+          :floating-label="theme.md"
+          name="options"
+          class="options-textarea"
+          :disabled="!editable ? true : null"
+          :value="options"
+          @input="updateOptions" />
+        <f7-block-footer class="param-description">
+          <small
+            >Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the
+            option.</small
+          >
+        </f7-block-footer>
+      </f7-list>
+    </group-box>
     <p class="padding">
       <f7-link v-if="namespace === 'stateDescription'" color="blue" external target="_blank" :href="docLink">
         State Description Documentation

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -2,27 +2,30 @@
   <div v-if="ready">
     <config-sheet
       v-if="namespace === 'stateDescription'"
+      title="State Description Configuration"
       :parameterGroups="[]"
       :parameters="stateDescriptionParameters"
       :configuration="metadata.config"
       :read-only="!editable" />
-    <f7-list>
-      <f7-list-input
-        ref="input"
-        type="textarea"
-        :floating-label="theme.md"
-        :label="'Options'"
-        name="options"
-        :disabled="!editable ? true : null"
-        :value="options"
-        @input="updateOptions" />
-      <f7-block-footer class="param-description" alot="after-list">
-        <small
-          >Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the
-          option.</small
-        >
-      </f7-block-footer>
-    </f7-list>
+    <group-box title="Options">
+      <f7-list>
+        <f7-list-input
+          ref="input"
+          type="textarea"
+          :floating-label="theme.md"
+          name="options"
+          class="options-textarea"
+          :disabled="!editable ? true : null"
+          :value="options"
+          @input="updateOptions" />
+        <f7-block-footer class="param-description">
+          <small
+            >Enter each option on a separate line.<br />Use <code>value=label</code> format to provide a label different than the
+            option.</small
+          >
+        </f7-block-footer>
+      </f7-list>
+    </group-box>
     <p class="padding">
       <f7-link v-if="namespace === 'stateDescription'" color="theme-alt" external target="_blank" :href="docLink">
         State Description Documentation

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -1,27 +1,18 @@
 <template>
-  <div>
+  <group-box title="Android App: Device Controls">
     <f7-list>
-      <f7-list-input
-        label="Android App: Device Controls"
-        name="value"
-        ref="value"
-        type="text"
-        :value="metadata.value"
-        :disabled="editable ? true : null"
-        @input="updateValue" />
-      <template #after-list>
-        <f7-block-footer class="param-description">
-          <small>
-            Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or
-            <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press a tile in Android Device Control.
-            <f7-link external color="blue" target="_blank" :href="runtimeStore.websiteUrl + '/docs/apps/android.html#device-controls'"
-              >Read the docs.</f7-link
-            >
-          </small>
-        </f7-block-footer>
-      </template>
+      <f7-list-input name="value" ref="value" type="text" :value="metadata.value" :disabled="editable ? true : null" @input="updateValue" />
+      <f7-block-footer class="param-description">
+        <small>
+          Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or
+          <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press a tile in Android Device Control.
+          <f7-link external color="blue" target="_blank" :href="runtimeStore.websiteUrl + '/docs/apps/android.html#device-controls'"
+            >Read the docs.</f7-link
+          >
+        </small>
+      </f7-block-footer>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -1,27 +1,18 @@
 <template>
-  <div>
+  <group-box title="Android App: Device Controls">
     <f7-list>
-      <f7-list-input
-        label="Android App: Device Controls"
-        name="value"
-        ref="value"
-        type="text"
-        :value="metadata.value"
-        :disabled="editable ? true : null"
-        @input="updateValue" />
-      <template #after-list>
-        <f7-block-footer class="param-description">
-          <small>
-            Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or
-            <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press a tile in Android Device Control.
-            <f7-link external color="theme-alt" target="_blank" :href="runtimeStore.websiteUrl + '/docs/apps/android.html#device-controls'"
-              >Read the docs.</f7-link
-            >
-          </small>
-        </f7-block-footer>
-      </template>
+      <f7-list-input name="value" ref="value" type="text" :value="metadata.value" :disabled="editable ? true : null" @input="updateValue" />
+      <f7-block-footer class="param-description">
+        <small>
+          Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or
+          <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press a tile in Android Device Control.
+          <f7-link external color="theme-alt" target="_blank" :href="runtimeStore.websiteUrl + '/docs/apps/android.html#device-controls'"
+            >Read the docs.</f7-link
+          >
+        </small>
+      </f7-block-footer>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -1,10 +1,12 @@
 <template>
   <div v-if="ready">
-    <div>
-      <div v-if="editable" style="text-align: right" class="padding-right">
-        <label @click="toggleMultiple" style="cursor: pointer">Multiple</label>
-        <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
-      </div>
+    <group-box title="Matter Device Types">
+      <template v-if="editable || true" #after-title>
+        <label>
+          <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
+          Multiple
+        </label>
+      </template>
       <f7-list v-if="deviceTypes">
         <f7-list-item
           :key="classSelectKey"
@@ -25,76 +27,72 @@
           </select>
         </f7-list-item>
       </f7-list>
-      <div v-if="parameters && parameters.length">
-        <config-sheet
-          :parameterGroups="parametersGroups"
-          :parameters="parameters"
-          :configuration="metadata.config"
-          :read-only="!editable" />
-      </div>
-      <f7-block v-if="shouldShowAttributeMapping" class="padding-top no-padding no-margin">
-        <f7-block-title class="padding-horizontal" medium> Matter Attributes Mapping </f7-block-title>
-        <f7-block-footer v-if="dirtyItem.size">
-          <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
-        </f7-block-footer>
-        <f7-block v-for="deviceType in classesAsArray" :key="deviceType" class="no-padding">
-          <f7-block-title class="padding-left">
-            {{ deviceType }}
-          </f7-block-title>
-          <f7-list>
-            <f7-list-item
-              v-for="attribute in deviceTypes[deviceType]?.attributes"
-              :key="attribute.name"
-              :disabled="!editable ? true : null"
-              smart-select
-              :title="attribute.mandatory ? attribute.label + '*' : attribute.label"
-              :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }">
-              <select @change="updateLinkedItem(deviceType, attribute.name, $event.target.value)">
-                <option value="" />
-                <option
-                  v-for="mbr in item.members"
-                  :value="mbr.name"
-                  :key="mbr.id"
-                  :selected="isLinked(deviceType, attribute.name, mbr) ? true : null">
-                  {{ mbr.label }} ({{ mbr.name }})
-                </option>
-              </select>
-            </f7-list-item>
-          </f7-list>
-          <!-- Option mapping UI: separate from item mapping list -->
-          <div v-for="attribute in deviceTypes[deviceType]?.attributes" :key="attribute.name + '-mapping'">
-            <template v-if="getMappedChild(attribute.name) && getAttributeOptions(attribute.name, deviceType).length">
-              <div class="option-mapping-fields padding-left padding-bottom">
-                <div class="padding-bottom padding-top">
-                  <b>Mapping options for {{ attribute.label }}</b>
-                </div>
-                <f7-list no-hairlines-md>
-                  <f7-list-input
-                    v-for="option in getAttributeOptions(attribute.name, deviceType)"
-                    :key="option.label"
-                    type="text"
-                    :label="option.label"
-                    :value="getChildMapping(attribute.name, option.label, option.value)"
-                    :disabled="!editable ? true : null"
-                    @input="setChildMapping(attribute.name, option.label, $event.target.value)" />
-                </f7-list>
-              </div>
-            </template>
-          </div>
-        </f7-block>
-        <f7-block-footer>
-          <small class="text-color-gray">* indicates mandatory mapping</small>
-        </f7-block-footer>
-        <f7-block-footer v-if="dirtyItem.size">
-          <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
-        </f7-block-footer>
-      </f7-block>
-      <p class="padding">
-        <f7-link color="blue" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/matter`">
-          Matter integration documentation
-        </f7-link>
-      </p>
+    </group-box>
+    <div v-if="parameters && parameters.length">
+      <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
+    <f7-block v-if="shouldShowAttributeMapping" class="padding-top no-padding no-margin">
+      <f7-block-title class="padding-horizontal" medium> Matter Attributes Mapping </f7-block-title>
+      <f7-block-footer v-if="dirtyItem.size">
+        <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
+      </f7-block-footer>
+      <f7-block v-for="deviceType in classesAsArray" :key="deviceType" class="no-padding">
+        <f7-block-title class="padding-left">
+          {{ deviceType }}
+        </f7-block-title>
+        <f7-list>
+          <f7-list-item
+            v-for="attribute in deviceTypes[deviceType]?.attributes"
+            :key="attribute.name"
+            :disabled="!editable ? true : null"
+            smart-select
+            :title="attribute.mandatory ? attribute.label + '*' : attribute.label"
+            :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }">
+            <select @change="updateLinkedItem(deviceType, attribute.name, $event.target.value)">
+              <option value="" />
+              <option
+                v-for="mbr in item.members"
+                :value="mbr.name"
+                :key="mbr.id"
+                :selected="isLinked(deviceType, attribute.name, mbr) ? true : null">
+                {{ mbr.label }} ({{ mbr.name }})
+              </option>
+            </select>
+          </f7-list-item>
+        </f7-list>
+        <!-- Option mapping UI: separate from item mapping list -->
+        <div v-for="attribute in deviceTypes[deviceType]?.attributes" :key="attribute.name + '-mapping'">
+          <template v-if="getMappedChild(attribute.name) && getAttributeOptions(attribute.name, deviceType).length">
+            <div class="option-mapping-fields padding-left padding-bottom">
+              <div class="padding-bottom padding-top">
+                <b>Mapping options for {{ attribute.label }}</b>
+              </div>
+              <f7-list no-hairlines-md>
+                <f7-list-input
+                  v-for="option in getAttributeOptions(attribute.name, deviceType)"
+                  :key="option.label"
+                  type="text"
+                  :label="option.label"
+                  :value="getChildMapping(attribute.name, option.label, option.value)"
+                  :disabled="!editable ? true : null"
+                  @input="setChildMapping(attribute.name, option.label, $event.target.value)" />
+              </f7-list>
+            </div>
+          </template>
+        </div>
+      </f7-block>
+      <f7-block-footer>
+        <small class="text-color-gray">* indicates mandatory mapping</small>
+      </f7-block-footer>
+      <f7-block-footer v-if="dirtyItem.size">
+        <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
+      </f7-block-footer>
+    </f7-block>
+    <p class="padding">
+      <f7-link color="blue" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/matter`">
+        Matter integration documentation
+      </f7-link>
+    </p>
   </div>
   <div v-else class="text-align-center">
     <f7-preloader />

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -1,10 +1,12 @@
 <template>
   <div v-if="ready">
-    <div>
-      <div v-if="editable" style="text-align: right" class="padding-right">
-        <label @click="toggleMultiple" style="cursor: pointer">Multiple</label>
-        <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
-      </div>
+    <group-box title="Matter Device Types">
+      <template v-if="editable || true" #after-title>
+        <label>
+          <f7-checkbox :checked="multiple ? true : null" @change="toggleMultiple" />
+          Multiple
+        </label>
+      </template>
       <f7-list v-if="deviceTypes">
         <f7-list-item
           :key="classSelectKey"
@@ -25,76 +27,72 @@
           </select>
         </f7-list-item>
       </f7-list>
-      <div v-if="parameters && parameters.length">
-        <config-sheet
-          :parameterGroups="parametersGroups"
-          :parameters="parameters"
-          :configuration="metadata.config"
-          :read-only="!editable" />
-      </div>
-      <f7-block v-if="shouldShowAttributeMapping" class="padding-top no-padding no-margin">
-        <f7-block-title class="padding-horizontal" medium> Matter Attributes Mapping </f7-block-title>
-        <f7-block-footer v-if="dirtyItem.size">
-          <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
-        </f7-block-footer>
-        <f7-block v-for="deviceType in classesAsArray" :key="deviceType" class="no-padding">
-          <f7-block-title class="padding-left">
-            {{ deviceType }}
-          </f7-block-title>
-          <f7-list>
-            <f7-list-item
-              v-for="attribute in deviceTypes[deviceType]?.attributes"
-              :key="attribute.name"
-              :disabled="!editable ? true : null"
-              smart-select
-              :title="attribute.mandatory ? attribute.label + '*' : attribute.label"
-              :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }">
-              <select @change="updateLinkedItem(deviceType, attribute.name, $event.target.value)">
-                <option value="" />
-                <option
-                  v-for="mbr in item.members"
-                  :value="mbr.name"
-                  :key="mbr.id"
-                  :selected="isLinked(deviceType, attribute.name, mbr) ? true : null">
-                  {{ mbr.label }} ({{ mbr.name }})
-                </option>
-              </select>
-            </f7-list-item>
-          </f7-list>
-          <!-- Option mapping UI: separate from item mapping list -->
-          <div v-for="attribute in deviceTypes[deviceType]?.attributes" :key="attribute.name + '-mapping'">
-            <template v-if="getMappedChild(attribute.name) && getAttributeOptions(attribute.name, deviceType).length">
-              <div class="option-mapping-fields padding-left padding-bottom">
-                <div class="padding-bottom padding-top">
-                  <b>Mapping options for {{ attribute.label }}</b>
-                </div>
-                <f7-list no-hairlines-md>
-                  <f7-list-input
-                    v-for="option in getAttributeOptions(attribute.name, deviceType)"
-                    :key="option.label"
-                    type="text"
-                    :label="option.label"
-                    :value="getChildMapping(attribute.name, option.label, option.value)"
-                    :disabled="!editable ? true : null"
-                    @input="setChildMapping(attribute.name, option.label, $event.target.value)" />
-                </f7-list>
-              </div>
-            </template>
-          </div>
-        </f7-block>
-        <f7-block-footer>
-          <small class="text-color-gray">* indicates mandatory mapping</small>
-        </f7-block-footer>
-        <f7-block-footer v-if="dirtyItem.size">
-          <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
-        </f7-block-footer>
-      </f7-block>
-      <p class="padding">
-        <f7-link color="theme-alt" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/matter`">
-          Matter integration documentation
-        </f7-link>
-      </p>
+    </group-box>
+    <div v-if="parameters && parameters.length">
+      <config-sheet :parameterGroups="parametersGroups" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
+    <f7-block v-if="shouldShowAttributeMapping" class="padding-top no-padding no-margin">
+      <f7-block-title class="padding-horizontal" medium> Matter Attributes Mapping </f7-block-title>
+      <f7-block-footer v-if="dirtyItem.size">
+        <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
+      </f7-block-footer>
+      <f7-block v-for="deviceType in classesAsArray" :key="deviceType" class="no-padding">
+        <f7-block-title class="padding-left">
+          {{ deviceType }}
+        </f7-block-title>
+        <f7-list>
+          <f7-list-item
+            v-for="attribute in deviceTypes[deviceType]?.attributes"
+            :key="attribute.name"
+            :disabled="!editable ? true : null"
+            smart-select
+            :title="attribute.mandatory ? attribute.label + '*' : attribute.label"
+            :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true }">
+            <select @change="updateLinkedItem(deviceType, attribute.name, $event.target.value)">
+              <option value="" />
+              <option
+                v-for="mbr in item.members"
+                :value="mbr.name"
+                :key="mbr.id"
+                :selected="isLinked(deviceType, attribute.name, mbr) ? true : null">
+                {{ mbr.label }} ({{ mbr.name }})
+              </option>
+            </select>
+          </f7-list-item>
+        </f7-list>
+        <!-- Option mapping UI: separate from item mapping list -->
+        <div v-for="attribute in deviceTypes[deviceType]?.attributes" :key="attribute.name + '-mapping'">
+          <template v-if="getMappedChild(attribute.name) && getAttributeOptions(attribute.name, deviceType).length">
+            <div class="option-mapping-fields padding-left padding-bottom">
+              <div class="padding-bottom padding-top">
+                <b>Mapping options for {{ attribute.label }}</b>
+              </div>
+              <f7-list no-hairlines-md>
+                <f7-list-input
+                  v-for="option in getAttributeOptions(attribute.name, deviceType)"
+                  :key="option.label"
+                  type="text"
+                  :label="option.label"
+                  :value="getChildMapping(attribute.name, option.label, option.value)"
+                  :disabled="!editable ? true : null"
+                  @input="setChildMapping(attribute.name, option.label, $event.target.value)" />
+              </f7-list>
+            </div>
+          </template>
+        </div>
+      </f7-block>
+      <f7-block-footer>
+        <small class="text-color-gray">* indicates mandatory mapping</small>
+      </f7-block-footer>
+      <f7-block-footer v-if="dirtyItem.size">
+        <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
+      </f7-block-footer>
+    </f7-block>
+    <p class="padding">
+      <f7-link color="theme-alt" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/matter`">
+        Matter integration documentation
+      </f7-link>
+    </p>
   </div>
   <div v-else class="text-align-center">
     <f7-preloader />

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -1,38 +1,37 @@
 <template>
-  <f7-card>
-    <f7-card-content v-if="this.editableNamespaces.length > 0">
-      <f7-list>
-        <ul>
-          <f7-list-item
-            v-for="namespace in wellKnownNamespaces"
-            :key="namespace.name"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
-            :title="namespace.label"
-            :after="namespace.value || 'Not Set'">
-            <template #title>
-              <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </ul>
-        <ul v-if="customNamespaces.length > 0">
-          <f7-list-item divider />
-          <f7-list-item
-            v-for="namespace in customNamespaces"
-            :key="namespace.name"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
-            :title="namespace.label"
-            :after="namespace.value || 'Not Set'">
-            <template #title>
-              <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-card-content>
+  <group-box title="Metadata">
+    <f7-list v-if="this.editableNamespaces.length > 0">
+      <ul v-if="wellKnownNamespaces.length > 0">
+        <f7-list-item divider title="Well-known Namespaces" />
+        <f7-list-item
+          v-for="namespace in wellKnownNamespaces"
+          :key="namespace.name"
+          :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+          :title="namespace.label"
+          :after="$oh.utils.truncateString(namespace.value, 80) || 'Not Set'">
+          <template #title>
+            <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
+          </template>
+        </f7-list-item>
+      </ul>
+      <ul v-if="customNamespaces.length > 0">
+        <f7-list-item divider title="Custom Namespaces" />
+        <f7-list-item
+          v-for="namespace in customNamespaces"
+          :key="namespace.name"
+          :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+          :title="namespace.label"
+          :after="namespace.value || 'Not Set'">
+          <template #title>
+            <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
+          </template>
+        </f7-list-item>
+      </ul>
+    </f7-list>
     <f7-card-footer>
       <f7-button color="theme-alt" @click="addMetadata"> Add Metadata </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <script>
@@ -72,13 +71,14 @@ export default {
         })
     },
     wellKnownNamespaces() {
-      return this.editableNamespaces
-        .filter((n) => this.metadataNamespaces.some((wk) => wk.name === n.name))
-        .map((n) => {
-          const wellKnown = this.metadataNamespaces.find((wk) => wk.name === n.name)
+      // Return the item metadata but adopt the ordering of the well-known namespaces
+      return this.metadataNamespaces
+        .filter((wk) => this.editableNamespaces.some((n) => n.name === wk.name))
+        .map((wk) => {
+          const editable = this.editableNamespaces.find((n) => n.name === wk.name)
           return {
-            ...n,
-            label: wellKnown.label
+            ...editable,
+            label: wk.label
           }
         })
     },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -1,6 +1,6 @@
 <template>
   <group-box title="Metadata">
-    <f7-list v-if="this.editableNamespaces.length > 0">
+    <f7-list v-if="this.editableNamespaces.length > 0" class="metadata-list">
       <ul v-if="wellKnownNamespaces.length > 0">
         <f7-list-item divider title="Well-known Namespaces" />
         <f7-list-item
@@ -8,7 +8,7 @@
           :key="namespace.name"
           :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
           :title="namespace.label"
-          :after="$oh.utils.truncateString(namespace.value, 80) || 'Not Set'">
+          :after="namespace.value || 'Not Set'">
           <template #title>
             <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
           </template>
@@ -33,6 +33,23 @@
     </f7-card-footer>
   </group-box>
 </template>
+
+<style lang="stylus">
+.metadata-list
+  .item-title
+    flex-shrink 0
+    margin-right 16px
+  .item-after
+    display flex
+    flex 1 1 0
+    min-width 0
+    justify-content flex-end
+    span
+      max-width 100%
+      text-overflow ellipsis
+      white-space nowrap
+      overflow hidden
+</style>
 
 <script>
 import MetadataNamespaces from '@/assets/definitions/metadata/namespaces.js'

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -1,38 +1,37 @@
 <template>
-  <f7-card>
-    <f7-card-content v-if="this.editableNamespaces.length > 0">
-      <f7-list>
-        <ul>
-          <f7-list-item
-            v-for="namespace in wellKnownNamespaces"
-            :key="namespace.name"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
-            :title="namespace.label"
-            :after="namespace.value || 'Not Set'">
-            <template #title>
-              <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </ul>
-        <ul v-if="customNamespaces.length > 0">
-          <f7-list-item divider />
-          <f7-list-item
-            v-for="namespace in customNamespaces"
-            :key="namespace.name"
-            :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
-            :title="namespace.label"
-            :after="namespace.value || 'Not Set'">
-            <template #title>
-              <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-card-content>
+  <group-box title="Metadata">
+    <f7-list v-if="this.editableNamespaces.length > 0">
+      <ul v-if="wellKnownNamespaces.length > 0">
+        <f7-list-item divider title="Well-known Namespaces" />
+        <f7-list-item
+          v-for="namespace in wellKnownNamespaces"
+          :key="namespace.name"
+          :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+          :title="namespace.label"
+          :after="$oh.utils.truncateString(namespace.value, 80) || 'Not Set'">
+          <template #title>
+            <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
+          </template>
+        </f7-list-item>
+      </ul>
+      <ul v-if="customNamespaces.length > 0">
+        <f7-list-item divider title="Custom Namespaces" />
+        <f7-list-item
+          v-for="namespace in customNamespaces"
+          :key="namespace.name"
+          :link="'/settings/items/' + item.name + '/metadata/' + namespace.name"
+          :title="namespace.label"
+          :after="namespace.value || 'Not Set'">
+          <template #title>
+            <f7-icon v-if="!namespace.editable" f7="lock_fill" size="1rem" color="gray" />
+          </template>
+        </f7-list-item>
+      </ul>
+    </f7-list>
     <f7-card-footer>
       <f7-button color="blue" @click="addMetadata"> Add Metadata </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <script>
@@ -72,13 +71,14 @@ export default {
         })
     },
     wellKnownNamespaces() {
-      return this.editableNamespaces
-        .filter((n) => this.metadataNamespaces.some((wk) => wk.name === n.name))
-        .map((n) => {
-          const wellKnown = this.metadataNamespaces.find((wk) => wk.name === n.name)
+      // Return the item metadata but adopt the ordering of the well-known namespaces
+      return this.metadataNamespaces
+        .filter((wk) => this.editableNamespaces.some((n) => n.name === wk.name))
+        .map((wk) => {
+          const editable = this.editableNamespaces.find((n) => n.name === wk.name)
           return {
-            ...n,
-            label: wellKnown.label
+            ...editable,
+            label: wk.label
           }
         })
     },

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-synonyms.vue
@@ -1,11 +1,10 @@
 <template>
-  <div>
+  <group-box title="Synonyms">
     <f7-list>
       <f7-list-input
         ref="input"
         type="textarea"
         :floating-label="theme.md"
-        :label="'Synonyms'"
         name="synonyms"
         :value="synonyms"
         :disabled="!editable ? true : null"
@@ -16,7 +15,7 @@
         </f7-block-footer>
       </template>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-unit.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <group-box title="Unit Metadata">
     <f7-block-header class="padding-horizontal">
       <b style="color: var(--f7-theme-color) !important">WARNING: Changing the internal unit can corrupt your persisted data!</b>
     </f7-block-header>
@@ -27,7 +27,7 @@
         used for display purpose only, it can contain any compatible unit and will not affect the internal <code>unit</code>.
       </small>
     </f7-block-footer>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-voicesystem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <group-box title="Voice System">
     <f7-list>
       <f7-list-input
         ref="input"
@@ -16,8 +16,8 @@
         </f7-block-footer>
       </template>
     </f7-list>
-    <config-sheet :parameterGroups="[]" :parameters="ruleOptionParameters" :configuration="metadata.config" :read-only="!editable" />
-  </div>
+  </group-box>
+  <config-sheet :parameterGroups="[]" :parameters="ruleOptionParameters" :configuration="metadata.config" :read-only="!editable" />
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widget.vue
@@ -1,65 +1,64 @@
 <template>
   <div>
-    <f7-block class="block-narrow widget-preview">
-      <f7-col>
-        <generic-widget-component v-if="previewContext.component" :context="previewContext" :key="previewWidgetKey" />
-      </f7-col>
-    </f7-block>
-
     <f7-block-header v-if="!editable" class="padding-horizontal">
       <b style="color: var(--f7-theme-color) !important"
         >INFO: This metadata is not editable as it has not been created through the UI. <br />You can try out changes here, but you cannot
         save them.</b
       >
     </f7-block-header>
-    <f7-list v-if="defaultComponent.component">
-      <f7-list-item
-        :title="'Widget'"
-        smart-select
-        :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }"
-        ref="widgets">
-        <select name="widgets" @change="updateComponent">
-          <option value="">Default ({{ defaultComponent.component }})</option>
-          <optgroup v-if="namespace === 'listWidget'" label="Standard Library (List)">
-            <option
-              v-for="widget in standardListWidgets"
-              :key="widget.name"
-              :value="widget.name"
-              :selected="metadata.value === widget.name ? true : null">
-              {{ widget.label }}
-            </option>
-          </optgroup>
-          <optgroup v-else-if="namespace === 'cellWidget'" label="Standard Library (Cell)">
-            <option
-              v-for="widget in standardCellWidgets"
-              :key="widget.name"
-              :value="widget.name"
-              :selected="metadata.value === widget.name">
-              {{ widget.label }}
-            </option>
-          </optgroup>
-          <optgroup v-else label="Standard Library">
-            <option v-for="widget in standardWidgets" :key="widget.name" :value="widget.name" :selected="metadata.value === widget.name">
-              {{ widget.label }}
-            </option>
-          </optgroup>
-          <optgroup v-if="componentsStore.widgets().length" label="Personal Widgets">
-            <option
-              v-for="widget in personalWidgets"
-              :value="'widget:' + widget.uid"
-              :key="widget.uid"
-              :selected="metadata.value.replace('widget:', '') === widget.uid ? true : null">
-              {{ widget.uid }}
-            </option>
-          </optgroup>
-          <!-- <optgroup label="System Widgets">
+    <group-box v-if="defaultComponent.component" title="Standalone Widget">
+      <f7-list>
+        <f7-list-item
+          :title="'Widget'"
+          smart-select
+          :smart-select-params="{ openIn: 'popup', searchbar: true, closeOnSelect: true, scrollToSelectedItem: true }"
+          ref="widgets">
+          <select name="widgets" @change="updateComponent">
+            <option value="">Default ({{ defaultComponent.component }})</option>
+            <optgroup v-if="namespace === 'listWidget'" label="Standard Library (List)">
+              <option
+                v-for="widget in standardListWidgets"
+                :key="widget.name"
+                :value="widget.name"
+                :selected="metadata.value === widget.name ? true : null">
+                {{ widget.label }}
+              </option>
+            </optgroup>
+            <optgroup v-else-if="namespace === 'cellWidget'" label="Standard Library (Cell)">
+              <option
+                v-for="widget in standardCellWidgets"
+                :key="widget.name"
+                :value="widget.name"
+                :selected="metadata.value === widget.name">
+                {{ widget.label }}
+              </option>
+            </optgroup>
+            <optgroup v-else label="Standard Library">
+              <option v-for="widget in standardWidgets" :key="widget.name" :value="widget.name" :selected="metadata.value === widget.name">
+                {{ widget.label }}
+              </option>
+            </optgroup>
+            <optgroup v-if="componentsStore.widgets().length" label="Personal Widgets">
+              <option
+                v-for="widget in personalWidgets"
+                :value="'widget:' + widget.uid"
+                :key="widget.uid"
+                :selected="metadata.value.replace('widget:', '') === widget.uid ? true : null">
+                {{ widget.uid }}
+              </option>
+            </optgroup>
+            <!-- <optgroup label="System Widgets">
             <option v-for="widget in systemWidgets" :key="widget.name" :value="widget.name">{{widget.label}}</option>
           </optgroup> -->
-        </select>
-      </f7-list-item>
-    </f7-list>
+          </select>
+        </f7-list-item>
+      </f7-list>
+      <div v-if="previewContext.component" class="widget-preview">
+        <generic-widget-component :context="previewContext" :key="previewWidgetKey" />
+      </div>
+    </group-box>
+
     <div v-if="configDescriptions.parameters" class="widget-metadata-config-sheet">
-      <f7-block-title>Configuration</f7-block-title>
       <f7-block-footer class="padding-horizontal margin-bottom">
         Note: the parameter named 'item' will be set automatically with the name of the item ({{ this.item.name }}) unless it's set
         explicitely.
@@ -85,6 +84,11 @@
   z-index 10500
 .widget-preview
   z-index auto
+  // background rgba(0, 0, 0, 0.25) !important
+  margin 0
+  padding 10px
+  background rgba(0, 0, 0, 0.2) !important
+  // background transparent !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-widgetorder.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <group-box title="Widget Order">
     <f7-list>
       <f7-list-input
         label="Order in Lists"
@@ -21,7 +21,7 @@
         last, in alphabetical order.</small
       >
     </f7-block-footer>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/details-pane.vue
@@ -12,9 +12,7 @@
       @item-created="$emit('item-created')"
       @item-removed="$emit('item-removed')"
       @cancel-create="$emit('cancel-create')" />
-    <f7-block-title v-if="model.item.created !== false"> Metadata </f7-block-title>
     <metadata-menu v-if="model.item.created !== false" :item="model.item" :f7router />
-    <f7-block-title v-if="model.item.type !== 'Group' && model.item.created !== false"> Channel Links </f7-block-title>
     <link-details :item="model.item" :links="links" :f7router />
   </div>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -1,33 +1,31 @@
 <template>
-  <f7-card v-if="item.type !== 'Group' && item.created !== false">
-    <f7-card-content v-if="enrichedLinks.length > 0">
-      <f7-list media-list>
-        <ul>
-          <f7-list-item
-            v-for="l in enrichedLinks"
-            :key="l.itemName"
-            media-item
-            :title="l.thing.label"
-            :subtitle="l.channel.label || '?'"
-            :footer="l.link.channelUID"
-            :badge="thingStatusBadgeText(l.thing.statusInfo)"
-            :badge-color="thingStatusBadgeColor(l.thing.statusInfo)"
-            :link="!l.link.editable && l._invalid ? undefined : '#'"
-            @click="!l.link.editable && l._invalid ? undefined : editLink(l)">
-            <template #media>
-              <span class="item-initial">{{ !l._invalid && l.channel.label ? l.channel.label[0] : '?' }}</span>
-            </template>
-            <template #title>
-              <f7-icon v-if="!l.link.editable" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-card-content>
+  <group-box v-if="item.type !== 'Group' && item.created !== false" title="Channel Links">
+    <f7-list v-if="enrichedLinks.length > 0" media-list>
+      <ul>
+        <f7-list-item
+          v-for="l in enrichedLinks"
+          :key="l.itemName"
+          media-item
+          :title="l.thing.label"
+          :subtitle="l.channel.label || '?'"
+          :footer="l.link.channelUID"
+          :badge="thingStatusBadgeText(l.thing.statusInfo)"
+          :badge-color="thingStatusBadgeColor(l.thing.statusInfo)"
+          :link="!l.link.editable && l._invalid ? undefined : '#'"
+          @click="!l.link.editable && l._invalid ? undefined : editLink(l)">
+          <template #media>
+            <span class="item-initial">{{ !l._invalid && l.channel.label ? l.channel.label[0] : '?' }}</span>
+          </template>
+          <template #title>
+            <f7-icon v-if="!l.link.editable" f7="lock_fill" size="1rem" color="gray" />
+          </template>
+        </f7-list-item>
+      </ul>
+    </f7-list>
     <f7-card-footer>
       <f7-button color="blue" @click="addLink"> Add Link </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -1,33 +1,31 @@
 <template>
-  <f7-card v-if="item.type !== 'Group' && item.created !== false">
-    <f7-card-content v-if="enrichedLinks.length > 0">
-      <f7-list media-list>
-        <ul>
-          <f7-list-item
-            v-for="l in enrichedLinks"
-            :key="l.itemName"
-            media-item
-            :title="l.thing.label"
-            :subtitle="l.channel.label || '?'"
-            :footer="l.link.channelUID"
-            :badge="thingStatusBadgeText(l.thing.statusInfo)"
-            :badge-color="thingStatusBadgeColor(l.thing.statusInfo)"
-            :link="!l.link.editable && l._invalid ? undefined : '#'"
-            @click="!l.link.editable && l._invalid ? undefined : editLink(l)">
-            <template #media>
-              <span class="item-initial">{{ !l._invalid && l.channel.label ? l.channel.label[0] : '?' }}</span>
-            </template>
-            <template #title>
-              <f7-icon v-if="!l.link.editable" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </ul>
-      </f7-list>
-    </f7-card-content>
+  <group-box v-if="item.type !== 'Group' && item.created !== false" title="Channel Links">
+    <f7-list v-if="enrichedLinks.length > 0" media-list>
+      <ul>
+        <f7-list-item
+          v-for="l in enrichedLinks"
+          :key="l.itemName"
+          media-item
+          :title="l.thing.label"
+          :subtitle="l.channel.label || '?'"
+          :footer="l.link.channelUID"
+          :badge="thingStatusBadgeText(l.thing.statusInfo)"
+          :badge-color="thingStatusBadgeColor(l.thing.statusInfo)"
+          :link="!l.link.editable && l._invalid ? undefined : '#'"
+          @click="!l.link.editable && l._invalid ? undefined : editLink(l)">
+          <template #media>
+            <span class="item-initial">{{ !l._invalid && l.channel.label ? l.channel.label[0] : '?' }}</span>
+          </template>
+          <template #title>
+            <f7-icon v-if="!l.link.editable" f7="lock_fill" size="1rem" color="gray" />
+          </template>
+        </f7-list-item>
+      </ul>
+    </f7-list>
     <f7-card-footer>
       <f7-button color="theme-alt" @click="addLink"> Add Link </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
+++ b/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
@@ -93,6 +93,8 @@ defineSlots<{
 
 const { t } = useI18n({ useScope: 'local' })
 
+console.log('nav router', props.f7router)
+
 function back() {
   if (props.backLinkUrl) return
   if (props.backLinkUrl === null) {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -1,21 +1,26 @@
 <template>
   <div>
     <f7-block v-if="context.editmode?.isEditable" class="block-narrow margin-bottom" inset>
-      <f7-block-title>Coordinate Systems</f7-block-title>
-      <f7-row class="margin-bottom">
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="addGrid">
-            <img src="./gridSimple.svg" width="80px" />
-            Add<br />Grid
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="addCalendar">
-            <img src="./calendar.svg" width="80px" />
-            Add<br />Calendar
-          </f7-link>
-        </f7-col>
-      </f7-row>
+      <f7-col>
+        <group-box title="Coordinate Systems">
+          <div style="background: rgba(0, 0, 0, 0.2); padding: 8px">
+            <f7-row>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="addGrid">
+                  <img src="./gridSimple.svg" width="80px" />
+                  Add<br />Grid
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="addCalendar">
+                  <img src="./calendar.svg" width="80px" />
+                  Add<br />Calendar
+                </f7-link>
+              </f7-col>
+            </f7-row>
+          </div>
+        </group-box>
+      </f7-col>
     </f7-block>
 
     <!-- Grids -->
@@ -193,65 +198,70 @@
 
     <!-- Other Components -->
     <f7-block class="block-narrow margin-bottom" inset>
-      <f7-block-title>Other Components</f7-block-title>
-      <f7-row class="margin-bottom">
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('tooltip')">
-            <f7-badge v-if="context.component.slots.tooltip" color="theme-alt" class="count-badge">
-              {{ context.component.slots.tooltip.length }}
-            </f7-badge>
-            <img src="./tooltip.svg" width="80px" />
-            Tooltip
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('visualMap')">
-            <f7-badge v-if="context.component.slots.visualMap" color="theme-alt" class="count-badge">
-              {{ context.component.slots.visualMap.length }}
-            </f7-badge>
-            <img src="./visualMap.svg" width="80px" />
-            Visual Map
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlot('dataZoom')">
-            <f7-badge v-if="context.component.slots.dataZoom" color="theme-alt" class="count-badge">
-              {{ context.component.slots.dataZoom.length }}
-            </f7-badge>
-            <img src="./dataZoom.svg" width="80px" />
-            Data Zoom
-          </f7-link>
-        </f7-col>
-      </f7-row>
-      <f7-row class="margin-bottom">
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('legend')">
-            <f7-badge v-if="context.component.slots.legend" color="theme-alt" class="count-badge">
-              {{ context.component.slots.legend.length }}
-            </f7-badge>
-            <img src="./legend.svg" width="80px" />
-            Legend
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('title')">
-            <f7-badge v-if="context.component.slots.title" color="theme-alt" class="count-badge">
-              {{ context.component.slots.title.length }}
-            </f7-badge>
-            <img src="./title.svg" width="80px" />
-            Title
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('toolbox')">
-            <f7-badge v-if="context.component.slots.toolbox" color="theme-alt" class="count-badge">
-              {{ context.component.slots.toolbox.length }}
-            </f7-badge>
-            <img src="./toolbox.svg" width="80px" />
-            Toolbox
-          </f7-link>
-        </f7-col>
-      </f7-row>
+      <f7-col>
+        <group-box title="Other Components">
+          <div style="background: rgba(0, 0, 0, 0.2); padding: 12px">
+            <f7-row class="margin-bottom">
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('tooltip')">
+                  <f7-badge v-if="context.component.slots.tooltip" color="theme-alt" class="count-badge">
+                    {{ context.component.slots.tooltip.length }}
+                  </f7-badge>
+                  <img src="./tooltip.svg" width="80px" />
+                  Tooltip
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('visualMap')">
+                  <f7-badge v-if="context.component.slots.visualMap" color="theme-alt" class="count-badge">
+                    {{ context.component.slots.visualMap.length }}
+                  </f7-badge>
+                  <img src="./visualMap.svg" width="80px" />
+                  Visual Map
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlot('dataZoom')">
+                  <f7-badge v-if="context.component.slots.dataZoom" color="theme-alt" class="count-badge">
+                    {{ context.component.slots.dataZoom.length }}
+                  </f7-badge>
+                  <img src="./dataZoom.svg" width="80px" />
+                  Data Zoom
+                </f7-link>
+              </f7-col>
+            </f7-row>
+            <f7-row>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('legend')">
+                  <f7-badge v-if="context.component.slots.legend" color="theme-alt" class="count-badge">
+                    {{ context.component.slots.legend.length }}
+                  </f7-badge>
+                  <img src="./legend.svg" width="80px" />
+                  Legend
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('title')">
+                  <f7-badge v-if="context.component.slots.title" color="theme-alt" class="count-badge">
+                    {{ context.component.slots.title.length }}
+                  </f7-badge>
+                  <img src="./title.svg" width="80px" />
+                  Title
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('toolbox')">
+                  <f7-badge v-if="context.component.slots.toolbox" color="theme-alt" class="count-badge">
+                    {{ context.component.slots.toolbox.length }}
+                  </f7-badge>
+                  <img src="./toolbox.svg" width="80px" />
+                  Toolbox
+                </f7-link>
+              </f7-col>
+            </f7-row>
+          </div>
+        </group-box>
+      </f7-col>
     </f7-block>
   </div>
 </template>
@@ -292,7 +302,7 @@
 </style>
 
 <script>
-import { f7 } from 'framework7-vue'
+import { f7, f7Col } from 'framework7-vue'
 
 import { computed } from 'vue'
 import { useWidgetContext } from '@/components/widgets/useWidgetContext'

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -1,21 +1,26 @@
 <template>
   <div>
     <f7-block v-if="context.editmode?.isEditable" class="block-narrow margin-bottom" inset>
-      <f7-block-title>Coordinate Systems</f7-block-title>
-      <f7-row class="margin-bottom">
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="addGrid">
-            <img src="./gridSimple.svg" width="80px" />
-            Add<br />Grid
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="addCalendar">
-            <img src="./calendar.svg" width="80px" />
-            Add<br />Calendar
-          </f7-link>
-        </f7-col>
-      </f7-row>
+      <f7-col>
+        <group-box title="Coordinate Systems">
+          <div style="background: rgba(0, 0, 0, 0.2); padding: 8px">
+            <f7-row>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="addGrid">
+                  <img src="./gridSimple.svg" width="80px" />
+                  Add<br />Grid
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="addCalendar">
+                  <img src="./calendar.svg" width="80px" />
+                  Add<br />Calendar
+                </f7-link>
+              </f7-col>
+            </f7-row>
+          </div>
+        </group-box>
+      </f7-col>
     </f7-block>
 
     <!-- Grids -->
@@ -193,65 +198,70 @@
 
     <!-- Other Components -->
     <f7-block class="block-narrow margin-bottom" inset>
-      <f7-block-title>Other Components</f7-block-title>
-      <f7-row class="margin-bottom">
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('tooltip')">
-            <f7-badge v-if="context.component.slots.tooltip" color="blue" class="count-badge">
-              {{ context.component.slots.tooltip.length }}
-            </f7-badge>
-            <img src="./tooltip.svg" width="80px" />
-            Tooltip
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('visualMap')">
-            <f7-badge v-if="context.component.slots.visualMap" color="blue" class="count-badge">
-              {{ context.component.slots.visualMap.length }}
-            </f7-badge>
-            <img src="./visualMap.svg" width="80px" />
-            Visual Map
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlot('dataZoom')">
-            <f7-badge v-if="context.component.slots.dataZoom" color="blue" class="count-badge">
-              {{ context.component.slots.dataZoom.length }}
-            </f7-badge>
-            <img src="./dataZoom.svg" width="80px" />
-            Data Zoom
-          </f7-link>
-        </f7-col>
-      </f7-row>
-      <f7-row class="margin-bottom">
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('legend')">
-            <f7-badge v-if="context.component.slots.legend" color="blue" class="count-badge">
-              {{ context.component.slots.legend.length }}
-            </f7-badge>
-            <img src="./legend.svg" width="80px" />
-            Legend
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('title')">
-            <f7-badge v-if="context.component.slots.title" color="blue" class="count-badge">
-              {{ context.component.slots.title.length }}
-            </f7-badge>
-            <img src="./title.svg" width="80px" />
-            Title
-          </f7-link>
-        </f7-col>
-        <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('toolbox')">
-            <f7-badge v-if="context.component.slots.toolbox" color="blue" class="count-badge">
-              {{ context.component.slots.toolbox.length }}
-            </f7-badge>
-            <img src="./toolbox.svg" width="80px" />
-            Toolbox
-          </f7-link>
-        </f7-col>
-      </f7-row>
+      <f7-col>
+        <group-box title="Other Components">
+          <div style="background: rgba(0, 0, 0, 0.2); padding: 12px">
+            <f7-row class="margin-bottom">
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('tooltip')">
+                  <f7-badge v-if="context.component.slots.tooltip" color="blue" class="count-badge">
+                    {{ context.component.slots.tooltip.length }}
+                  </f7-badge>
+                  <img src="./tooltip.svg" width="80px" />
+                  Tooltip
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('visualMap')">
+                  <f7-badge v-if="context.component.slots.visualMap" color="blue" class="count-badge">
+                    {{ context.component.slots.visualMap.length }}
+                  </f7-badge>
+                  <img src="./visualMap.svg" width="80px" />
+                  Visual Map
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlot('dataZoom')">
+                  <f7-badge v-if="context.component.slots.dataZoom" color="blue" class="count-badge">
+                    {{ context.component.slots.dataZoom.length }}
+                  </f7-badge>
+                  <img src="./dataZoom.svg" width="80px" />
+                  Data Zoom
+                </f7-link>
+              </f7-col>
+            </f7-row>
+            <f7-row>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('legend')">
+                  <f7-badge v-if="context.component.slots.legend" color="blue" class="count-badge">
+                    {{ context.component.slots.legend.length }}
+                  </f7-badge>
+                  <img src="./legend.svg" width="80px" />
+                  Legend
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('title')">
+                  <f7-badge v-if="context.component.slots.title" color="blue" class="count-badge">
+                    {{ context.component.slots.title.length }}
+                  </f7-badge>
+                  <img src="./title.svg" width="80px" />
+                  Title
+                </f7-link>
+              </f7-col>
+              <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
+                <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('toolbox')">
+                  <f7-badge v-if="context.component.slots.toolbox" color="blue" class="count-badge">
+                    {{ context.component.slots.toolbox.length }}
+                  </f7-badge>
+                  <img src="./toolbox.svg" width="80px" />
+                  Toolbox
+                </f7-link>
+              </f7-col>
+            </f7-row>
+          </div>
+        </group-box>
+      </f7-col>
     </f7-block>
   </div>
 </template>
@@ -292,7 +302,7 @@
 </style>
 
 <script>
-import { f7 } from 'framework7-vue'
+import { f7, f7Col } from 'framework7-vue'
 
 import { computed } from 'vue'
 import { useWidgetContext } from '@/components/widgets/useWidgetContext'

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -1,104 +1,104 @@
 <template>
   <f7-col>
-    <f7-list inline-labels accordion-list no-hairline-md class="no-margin-top">
-      <f7-list-input
-        ref="pageId"
-        label="Page ID"
-        type="text"
-        placeholder="A unique identifier for the page"
-        :value="page.uid"
-        @input="page.uid = $event.target.value"
-        :clear-button="createMode && !readOnly"
-        :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
-        input-id="input"
-        required
-        validate
-        pattern="[A-Za-z0-9_]+"
-        error-message="Required. A-Z,a-z,0-9,_ only"
-        :disabled="readOnly || !createMode">
-        <template #inner>
-          <f7-link
-            v-if="createMode && $refs.pageId?.state?.inputInvalid && page.uid.trim()"
-            icon-f7="hammer_fill"
-            style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-            tooltip="Fix ID"
-            @click="$oh.utils.normalizeInput('#input')" />
-        </template>
-      </f7-list-input>
-      <f7-list-input
-        label="Label"
-        type="text"
-        placeholder="Page label used for display purposes"
-        :info="createMode ? 'Required' : ''"
-        :value="page.config.label"
-        @input="page.config.label = $event.target.value"
-        required
-        validate
-        :disabled="readOnly"
-        :clear-button="!readOnly" />
-      <f7-list-item v-if="page.uid !== 'overview'" accordion-item title="Sidebar &amp; Visibility">
-        <f7-accordion-content>
-          <f7-list-item
-            ref="pageVisibility"
-            title="Visible only to"
-            smart-select
-            :smart-select-params="{ openIn: 'popover' }"
-            :disabled="readOnly">
-            <select name="pagevisibility" multiple @change="updatePageVisibility">
-              <optgroup label="Roles">
-                <option value="role:administrator" :selected="isVisibleTo('role:administrator') ? true : null">Administrators</option>
-                <option value="role:user" :selected="isVisibleTo('role:user') ? true : null">Users</option>
-              </optgroup>
-            </select>
-          </f7-list-item>
-          <f7-list inline-labels no-hairline-md>
-            <f7-list-item title="Show on sidebar">
-              <template #after>
-                <f7-toggle
-                  :checked="page.config.sidebar ? true : null"
-                  @toggle:change="page.config.sidebar = $event"
-                  :disabled="readOnly" />
-              </template>
+    <group-box title="Page Details">
+      <f7-list inline-labels accordion-list no-hairline-md class="no-margin-top">
+        <f7-list-input
+          ref="pageId"
+          label="Page ID"
+          type="text"
+          placeholder="A unique identifier for the page"
+          :value="page.uid"
+          @input="page.uid = $event.target.value"
+          :clear-button="createMode && !readOnly"
+          :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
+          input-id="input"
+          required
+          validate
+          pattern="[A-Za-z0-9_]+"
+          error-message="Required. A-Z,a-z,0-9,_ only"
+          :disabled="readOnly || !createMode">
+          <template #inner>
+            <f7-link
+              v-if="createMode && $refs.pageId?.state?.inputInvalid && page.uid.trim()"
+              icon-f7="hammer_fill"
+              style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+              tooltip="Fix ID"
+              @click="$oh.utils.normalizeInput('#input')" />
+          </template>
+        </f7-list-input>
+        <f7-list-input
+          label="Label"
+          type="text"
+          placeholder="Page label used for display purposes"
+          :info="createMode ? 'Required' : ''"
+          :value="page.config.label"
+          @input="page.config.label = $event.target.value"
+          required
+          validate
+          :disabled="readOnly"
+          :clear-button="!readOnly" />
+        <f7-list-item v-if="page.uid !== 'overview'" accordion-item title="Sidebar &amp; Visibility">
+          <f7-accordion-content>
+            <f7-list-item
+              ref="pageVisibility"
+              title="Visible only to"
+              smart-select
+              :smart-select-params="{ openIn: 'popover' }"
+              :disabled="readOnly">
+              <select name="pagevisibility" multiple @change="updatePageVisibility">
+                <optgroup label="Roles">
+                  <option value="role:administrator" :selected="isVisibleTo('role:administrator') ? true : null">Administrators</option>
+                  <option value="role:user" :selected="isVisibleTo('role:user') ? true : null">Users</option>
+                </optgroup>
+              </select>
             </f7-list-item>
-            <f7-list-input
-              label="Sidebar order"
-              type="number"
-              placeholder="Assign order index to rearrange pages on sidebar"
-              :value="page.config.order"
-              @input="page.config.order = $event.target.value"
-              :disabled="readOnly ? true : null"
-              :clear-button="!readOnly" />
-            <f7-list-input
-              label="Icon"
-              type="text"
-              placeholder="Assign a custom icon"
-              :value="page.config.icon"
-              @input="page.config.icon = $event.target.value"
-              :disabled="readOnly ? true : null"
-              :clear-button="!readOnly" />
-            <f7-list-input
-              label="Browser Title"
-              type="text"
-              placeholder="A custom browser title instead of the label"
-              :value="page.config.browserTitle"
-              @input="page.config.browserTitle = $event.target.value"
-              :disabled="readOnly ? true : null"
-              :clear-button="!readOnly" />
-          </f7-list>
-        </f7-accordion-content>
-      </f7-list-item>
-    </f7-list>
-    <template v-if="page.uid !== 'overview'">
-      <f7-list inline-labels no-hairline-md>
-        <div>
-          <tag-input :item="page" :disabled="readOnly" />
-        </div>
+            <f7-list inline-labels no-hairline-md>
+              <f7-list-item title="Show on sidebar">
+                <template #after>
+                  <f7-toggle
+                    :checked="page.config.sidebar ? true : null"
+                    @toggle:change="page.config.sidebar = $event"
+                    :disabled="readOnly" />
+                </template>
+              </f7-list-item>
+              <f7-list-input
+                label="Sidebar order"
+                type="number"
+                placeholder="Assign order index to rearrange pages on sidebar"
+                :value="page.config.order"
+                @input="page.config.order = $event.target.value"
+                :disabled="readOnly ? true : null"
+                :clear-button="!readOnly" />
+              <f7-list-input
+                label="Icon"
+                type="text"
+                placeholder="Assign a custom icon"
+                :value="page.config.icon"
+                @input="page.config.icon = $event.target.value"
+                :disabled="readOnly ? true : null"
+                :clear-button="!readOnly" />
+              <f7-list-input
+                label="Browser Title"
+                type="text"
+                placeholder="A custom browser title instead of the label"
+                :value="page.config.browserTitle"
+                @input="page.config.browserTitle = $event.target.value"
+                :disabled="readOnly ? true : null"
+                :clear-button="!readOnly" />
+            </f7-list>
+          </f7-accordion-content>
+        </f7-list-item>
       </f7-list>
-      <f7-list v-if="!createMode" inline-labels no-hairline-md>
+    </group-box>
+
+    <tag-input v-if="page.uid !== 'overview'" :item="page" :disabled="readOnly" />
+
+    <group-box v-if="page.uid !== 'overview' && !createMode">
+      <f7-list inline-labels no-hairline-md>
         <f7-list-button color="theme-alt" @click="duplicatePage"> Duplicate Page </f7-list-button>
         <f7-list-button v-if="!readOnly" color="red" @click="deletePage"> Remove Page </f7-list-button>
       </f7-list>
-    </template>
+    </group-box>
   </f7-col>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -1,104 +1,104 @@
 <template>
   <f7-col>
-    <f7-list inline-labels accordion-list no-hairline-md class="no-margin-top">
-      <f7-list-input
-        ref="pageId"
-        label="Page ID"
-        type="text"
-        placeholder="A unique identifier for the page"
-        :value="page.uid"
-        @input="page.uid = $event.target.value"
-        :clear-button="createMode && !readOnly"
-        :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
-        input-id="input"
-        required
-        validate
-        pattern="[A-Za-z0-9_]+"
-        error-message="Required. A-Z,a-z,0-9,_ only"
-        :disabled="readOnly || !createMode">
-        <template #inner>
-          <f7-link
-            v-if="createMode && $refs.pageId?.state?.inputInvalid && page.uid.trim()"
-            icon-f7="hammer_fill"
-            style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-            tooltip="Fix ID"
-            @click="$oh.utils.normalizeInput('#input')" />
-        </template>
-      </f7-list-input>
-      <f7-list-input
-        label="Label"
-        type="text"
-        placeholder="Page label used for display purposes"
-        :info="createMode ? 'Required' : ''"
-        :value="page.config.label"
-        @input="page.config.label = $event.target.value"
-        required
-        validate
-        :disabled="readOnly"
-        :clear-button="!readOnly" />
-      <f7-list-item v-if="page.uid !== 'overview'" accordion-item title="Sidebar &amp; Visibility">
-        <f7-accordion-content>
-          <f7-list-item
-            ref="pageVisibility"
-            title="Visible only to"
-            smart-select
-            :smart-select-params="{ openIn: 'popover' }"
-            :disabled="readOnly">
-            <select name="pagevisibility" multiple @change="updatePageVisibility">
-              <optgroup label="Roles">
-                <option value="role:administrator" :selected="isVisibleTo('role:administrator') ? true : null">Administrators</option>
-                <option value="role:user" :selected="isVisibleTo('role:user') ? true : null">Users</option>
-              </optgroup>
-            </select>
-          </f7-list-item>
-          <f7-list inline-labels no-hairline-md>
-            <f7-list-item title="Show on sidebar">
-              <template #after>
-                <f7-toggle
-                  :checked="page.config.sidebar ? true : null"
-                  @toggle:change="page.config.sidebar = $event"
-                  :disabled="readOnly" />
-              </template>
+    <group-box title="Page Details">
+      <f7-list inline-labels accordion-list no-hairline-md class="no-margin-top">
+        <f7-list-input
+          ref="pageId"
+          label="Page ID"
+          type="text"
+          placeholder="A unique identifier for the page"
+          :value="page.uid"
+          @input="page.uid = $event.target.value"
+          :clear-button="createMode && !readOnly"
+          :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
+          input-id="input"
+          required
+          validate
+          pattern="[A-Za-z0-9_]+"
+          error-message="Required. A-Z,a-z,0-9,_ only"
+          :disabled="readOnly || !createMode">
+          <template #inner>
+            <f7-link
+              v-if="createMode && $refs.pageId?.state?.inputInvalid && page.uid.trim()"
+              icon-f7="hammer_fill"
+              style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+              tooltip="Fix ID"
+              @click="$oh.utils.normalizeInput('#input')" />
+          </template>
+        </f7-list-input>
+        <f7-list-input
+          label="Label"
+          type="text"
+          placeholder="Page label used for display purposes"
+          :info="createMode ? 'Required' : ''"
+          :value="page.config.label"
+          @input="page.config.label = $event.target.value"
+          required
+          validate
+          :disabled="readOnly"
+          :clear-button="!readOnly" />
+        <f7-list-item v-if="page.uid !== 'overview'" accordion-item title="Sidebar &amp; Visibility">
+          <f7-accordion-content>
+            <f7-list-item
+              ref="pageVisibility"
+              title="Visible only to"
+              smart-select
+              :smart-select-params="{ openIn: 'popover' }"
+              :disabled="readOnly">
+              <select name="pagevisibility" multiple @change="updatePageVisibility">
+                <optgroup label="Roles">
+                  <option value="role:administrator" :selected="isVisibleTo('role:administrator') ? true : null">Administrators</option>
+                  <option value="role:user" :selected="isVisibleTo('role:user') ? true : null">Users</option>
+                </optgroup>
+              </select>
             </f7-list-item>
-            <f7-list-input
-              label="Sidebar order"
-              type="number"
-              placeholder="Assign order index to rearrange pages on sidebar"
-              :value="page.config.order"
-              @input="page.config.order = $event.target.value"
-              :disabled="readOnly ? true : null"
-              :clear-button="!readOnly" />
-            <f7-list-input
-              label="Icon"
-              type="text"
-              placeholder="Assign a custom icon"
-              :value="page.config.icon"
-              @input="page.config.icon = $event.target.value"
-              :disabled="readOnly ? true : null"
-              :clear-button="!readOnly" />
-            <f7-list-input
-              label="Browser Title"
-              type="text"
-              placeholder="A custom browser title instead of the label"
-              :value="page.config.browserTitle"
-              @input="page.config.browserTitle = $event.target.value"
-              :disabled="readOnly ? true : null"
-              :clear-button="!readOnly" />
-          </f7-list>
-        </f7-accordion-content>
-      </f7-list-item>
-    </f7-list>
-    <template v-if="page.uid !== 'overview'">
-      <f7-list inline-labels no-hairline-md>
-        <div>
-          <tag-input :item="page" :disabled="readOnly" />
-        </div>
+            <f7-list inline-labels no-hairline-md>
+              <f7-list-item title="Show on sidebar">
+                <template #after>
+                  <f7-toggle
+                    :checked="page.config.sidebar ? true : null"
+                    @toggle:change="page.config.sidebar = $event"
+                    :disabled="readOnly" />
+                </template>
+              </f7-list-item>
+              <f7-list-input
+                label="Sidebar order"
+                type="number"
+                placeholder="Assign order index to rearrange pages on sidebar"
+                :value="page.config.order"
+                @input="page.config.order = $event.target.value"
+                :disabled="readOnly ? true : null"
+                :clear-button="!readOnly" />
+              <f7-list-input
+                label="Icon"
+                type="text"
+                placeholder="Assign a custom icon"
+                :value="page.config.icon"
+                @input="page.config.icon = $event.target.value"
+                :disabled="readOnly ? true : null"
+                :clear-button="!readOnly" />
+              <f7-list-input
+                label="Browser Title"
+                type="text"
+                placeholder="A custom browser title instead of the label"
+                :value="page.config.browserTitle"
+                @input="page.config.browserTitle = $event.target.value"
+                :disabled="readOnly ? true : null"
+                :clear-button="!readOnly" />
+            </f7-list>
+          </f7-accordion-content>
+        </f7-list-item>
       </f7-list>
-      <f7-list v-if="!createMode" inline-labels no-hairline-md>
+    </group-box>
+
+    <tag-input v-if="page.uid !== 'overview'" :item="page" :disabled="readOnly" />
+
+    <group-box v-if="page.uid !== 'overview' && !createMode">
+      <f7-list inline-labels no-hairline-md>
         <f7-list-button color="blue" @click="duplicatePage"> Duplicate Page </f7-list-button>
         <f7-list-button v-if="!readOnly" color="red" @click="deletePage"> Remove Page </f7-list-button>
       </f7-list>
-    </template>
+    </group-box>
   </f7-col>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
@@ -1,30 +1,28 @@
 <template>
-  <f7-card v-if="item.type !== 'Group' || 'groupType' in item">
-    <f7-card-content v-if="loaded && services.length > 0">
-      <f7-list media-list>
-        <f7-list-item
-          v-for="p in services"
-          :key="p.id"
-          media-item
-          :title="p.label"
-          :subtitle="strategies[p.id]?.join(', ') || 'Not persisted'"
-          :badge="persistedBadges[p.id]"
-          :badge-color="persistedBadges[p.id] === '0' ? 'red' : 'green'"
-          :class="!p.editable ? 'item-persistence-badge-non-editable' : ''"
-          :link="p.editable ? '/settings/persistence/' + p.id : null">
-          <template #media>
-            <span class="item-initial">{{ p.id ? p.id[0] : '?' }}</span>
-          </template>
-          <template #after>
-            <f7-icon v-if="!p.editable" f7="lock_fill" size="1rem" color="gray" />
-          </template>
-        </f7-list-item>
-      </f7-list>
-    </f7-card-content>
+  <group-box v-if="item.type !== 'Group' || 'groupType' in item" title="Persistence Policies">
+    <f7-list v-if="loaded && services.length > 0" media-list>
+      <f7-list-item
+        v-for="p in services"
+        :key="p.id"
+        media-item
+        :title="p.label"
+        :subtitle="strategies[p.id]?.join(', ') || 'Not persisted'"
+        :badge="persistedBadges[p.id]"
+        :badge-color="persistedBadges[p.id] === '0' ? 'red' : 'green'"
+        :class="!p.editable ? 'item-persistence-badge-non-editable' : ''"
+        :link="p.editable ? '/settings/persistence/' + p.id : null">
+        <template #media>
+          <span class="item-initial">{{ p.id ? p.id[0] : '?' }}</span>
+        </template>
+        <template #after>
+          <f7-icon v-if="!p.editable" f7="lock_fill" size="1rem" color="gray" />
+        </template>
+      </f7-list-item>
+    </f7-list>
     <f7-card-footer>
-      <f7-button color="blue" href="/settings/persistence/"> Configure Persistence Policies </f7-button>
+      <f7-button color="blue" href="/settings/persistence/"> Configure Policies </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
@@ -1,30 +1,28 @@
 <template>
-  <f7-card v-if="item.type !== 'Group' || 'groupType' in item">
-    <f7-card-content v-if="loaded && services.length > 0">
-      <f7-list media-list>
-        <f7-list-item
-          v-for="p in services"
-          :key="p.id"
-          media-item
-          :title="p.label"
-          :subtitle="strategies[p.id]?.join(', ') || 'Not persisted'"
-          :badge="persistedBadges[p.id]"
-          :badge-color="persistedBadges[p.id] === '0' ? 'red' : 'green'"
-          :class="!p.editable ? 'item-persistence-badge-non-editable' : ''"
-          :link="p.editable ? '/settings/persistence/' + p.id : null">
-          <template #media>
-            <span class="item-initial">{{ p.id ? p.id[0] : '?' }}</span>
-          </template>
-          <template #after>
-            <f7-icon v-if="!p.editable" f7="lock_fill" size="1rem" color="gray" />
-          </template>
-        </f7-list-item>
-      </f7-list>
-    </f7-card-content>
+  <group-box v-if="item.type !== 'Group' || 'groupType' in item" title="Persistence Policies">
+    <f7-list v-if="loaded && services.length > 0" media-list>
+      <f7-list-item
+        v-for="p in services"
+        :key="p.id"
+        media-item
+        :title="p.label"
+        :subtitle="strategies[p.id]?.join(', ') || 'Not persisted'"
+        :badge="persistedBadges[p.id]"
+        :badge-color="persistedBadges[p.id] === '0' ? 'red' : 'green'"
+        :class="!p.editable ? 'item-persistence-badge-non-editable' : ''"
+        :link="p.editable ? '/settings/persistence/' + p.id : null">
+        <template #media>
+          <span class="item-initial">{{ p.id ? p.id[0] : '?' }}</span>
+        </template>
+        <template #after>
+          <f7-icon v-if="!p.editable" f7="lock_fill" size="1rem" color="gray" />
+        </template>
+      </f7-list-item>
+    </f7-list>
     <f7-card-footer>
-      <f7-button color="theme-alt" href="/settings/persistence/"> Configure Persistence Policies </f7-button>
+      <f7-button color="theme-alt" href="/settings/persistence/"> Configure Policies </f7-button>
     </f7-card-footer>
-  </f7-card>
+  </group-box>
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -2,63 +2,62 @@
   <div>
     <f7-block v-if="ready" class="block-narrow">
       <f7-col>
-        <f7-list inline-labels no-hairlines-md>
-          <f7-list-input
-            ref="ruleUid"
-            :label="`${type} UID`"
-            type="text"
-            :placeholder="`A unique identifier for the ${type.toLowerCase()}`"
-            :value="rule.uid || ''"
-            required
-            :validate="editable"
-            :disabled="!createMode ? true : null"
-            :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
-            input-id="input"
-            :pattern="uidPattern"
-            error-message="Invalid rule UID. It can't contain '/', '\' or have leading or trailing whitespace"
-            @input="rule.uid = $event.target.value || undefined"
-            :clear-button="createMode">
-            <template #inner>
-              <f7-link
-                v-if="createMode && !uidValid"
-                icon-f7="hammer_fill"
-                style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-                tooltip="Fix UID"
-                @click="normalizeUid()" />
-            </template>
-          </f7-list-input>
-          <f7-list-input v-if="!createMode && templateName" label="Template" type="text" :value="templateName" disabled />
-          <f7-list-input
-            label="Label"
-            type="text"
-            :placeholder="`${type} label for display purposes`"
-            :info="createMode ? 'Required' : ''"
-            :value="rule.name || ''"
-            required
-            validate
-            :disabled="!editable ? true : null"
-            @input="rule.name = $event.target.value || undefined"
-            :clear-button="editable" />
-          <f7-list-input
-            label="Description"
-            type="text"
-            :value="rule.description || ''"
-            :disabled="!editable ? true : null"
-            @input="rule.description = $event.target.value || undefined"
-            :clear-button="editable" />
-        </f7-list>
-        <f7-list inline-labels no-hairlines-md>
-          <div>
-            <tag-input
-              v-if="!stubMode"
-              title="Tags"
-              :item="rule"
+        <group-box title="Rule Properties">
+          <f7-list inline-labels no-hairlines-md>
+            <f7-list-input
+              ref="ruleUid"
+              :label="`${type} UID`"
+              type="text"
+              :placeholder="`A unique identifier for the ${type.toLowerCase()}`"
+              :value="rule.uid || ''"
+              required
+              :validate="editable"
+              :disabled="!createMode ? true : null"
+              :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
+              input-id="input"
+              :pattern="uidPattern"
+              error-message="Invalid rule UID. It can't contain '/', '\' or have leading or trailing whitespace"
+              @input="rule.uid = $event.target.value || undefined"
+              :clear-button="createMode">
+              <template #inner>
+                <f7-link
+                  v-if="createMode && !uidValid"
+                  icon-f7="hammer_fill"
+                  style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+                  tooltip="Fix UID"
+                  @click="normalizeUid()" />
+              </template>
+            </f7-list-input>
+            <f7-list-input v-if="!createMode && templateName" label="Template" type="text" :value="templateName" disabled />
+            <f7-list-input
+              label="Label"
+              type="text"
+              :placeholder="`${type} label for display purposes`"
+              :info="createMode ? 'Required' : ''"
+              :value="rule.name || ''"
+              required
+              validate
               :disabled="!editable ? true : null"
-              :showSemanticTags="true"
-              :inScriptEditor="inScriptEditor"
-              :inSceneEditor="inSceneEditor" />
-          </div>
-        </f7-list>
+              @input="rule.name = $event.target.value || undefined"
+              :clear-button="editable" />
+            <f7-list-input
+              label="Description"
+              type="text"
+              :value="rule.description || ''"
+              :disabled="!editable ? true : null"
+              @input="rule.description = $event.target.value || undefined"
+              :clear-button="editable" />
+          </f7-list>
+        </group-box>
+        <tag-input
+          v-if="!stubMode"
+          title="Tags"
+          :item="rule"
+          :disabled="!editable ? true : null"
+          :showSemanticTags="true"
+          :inScriptEditor="inScriptEditor"
+          :inSceneEditor="inSceneEditor" />
+        <not-editable-notice v-if="!editable" :subject="inScriptEditor ? 'script' : inSceneEditor ? 'scene' : 'rule'" />
       </f7-col>
     </f7-block>
 
@@ -98,6 +97,7 @@
 <script>
 import TagInput from '@/components/tags/tag-input.vue'
 import { RULE_UID_PATTERN } from '@/js/openhab/uid.ts'
+import NotEditableNotice from '@/components/util/not-editable-notice.vue'
 
 const UID_REGEX = new RegExp('^' + RULE_UID_PATTERN + '$')
 
@@ -113,7 +113,8 @@ export default {
     inSceneEditor: Boolean
   },
   components: {
-    TagInput
+    TagInput,
+    NotEditableNotice
   },
   data() {
     return {

--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="item && item.tags" class="tag-editor">
+  <group-box v-if="item && item.tags" class="tag-editor">
     <f7-list>
       <f7-list-item :title="title || 'Tags'" :badge="tags.length.toString()" />
       <f7-list-item v-if="tags.length > 0">
@@ -28,7 +28,7 @@
         </template>
       </f7-list-input>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -1,160 +1,164 @@
 <template>
-  <f7-block class="theme-switcher">
-    <f7-block-title class="padding-left">
-      {{ t('about.theme') }}
-    </f7-block-title>
-    <f7-row>
-      <f7-col width="25" class="theme-picker auto" @click="switchTheme('auto')">
-        <span class="text-color-gray"> {{ t('about.theme.auto') }}</span>
-        <f7-checkbox v-if="theme === 'auto'" checked disabled />
-      </f7-col>
-      <f7-col width="25" class="theme-picker" @click="switchTheme('md')">
-        <span><f7-icon f7="logo_android" size="20" color="gray" /></span>
-        <f7-checkbox v-if="theme === 'md'" checked disabled />
-      </f7-col>
-      <f7-col width="25" class="theme-picker" @click="switchTheme('ios')">
-        <span><f7-icon f7="logo_ios" size="25" color="gray" /></span>
-        <f7-checkbox v-if="theme === 'ios'" checked disabled />
-      </f7-col>
-      <f7-col width="25" class="theme-picker" @click="switchTheme('aurora')">
-        <span><f7-icon f7="desktopcomputer" size="20" color="gray" /></span>
-        <f7-checkbox v-if="theme === 'aurora'" checked disabled />
-      </f7-col>
-    </f7-row>
-    <f7-block-title>{{ t('about.darkMode') }}</f7-block-title>
-    <f7-row>
-      <f7-col width="33" class="theme-picker auto" @click="uiOptionsStore.darkMode = 'auto'">
-        <span class="text-color-gray">{{ t('about.darkMode.auto') }}</span>
-        <f7-checkbox v-if="uiOptionsStore.storedDarkMode === 'auto'" checked disabled />
-      </f7-col>
-      <f7-col width="33" class="bg-color-white theme-picker" @click="uiOptionsStore.darkMode = 'light'">
-        <span class="text-color-gray">{{ t('about.darkMode.light') }}</span>
-        <f7-checkbox v-if="uiOptionsStore.storedDarkMode === 'light'" checked disabled />
-      </f7-col>
-      <f7-col width="33" class="bg-color-black theme-picker" @click="uiOptionsStore.darkMode = 'dark'">
-        <span class="text-color-gray">{{ t('about.darkMode.dark') }}</span>
-        <f7-checkbox v-if="uiOptionsStore.storedDarkMode === 'dark'" checked disabled />
-      </f7-col>
-    </f7-row>
-    <f7-block-title>{{ t('about.navigationBarsStyle') }}</f7-block-title>
-    <f7-row>
-      <f7-col width="50" class="nav-bars-picker nav-bars-picker-empty" @click="bars = 'light'">
-        <div class="demo-navbar" />
-        <f7-checkbox v-if="bars === 'light'" checked disabled />
-      </f7-col>
-      <f7-col width="50" class="nav-bars-picker nav-bars-picker-fill" @click="bars = 'filled'">
-        <div class="demo-navbar" />
-        <f7-checkbox v-if="bars === 'filled'" checked disabled />
-      </f7-col>
-    </f7-row>
+  <f7-block class="theme-switcher block-narrow">
+    <group-box :title="t('about.theme')">
+      <f7-row class="padding">
+        <f7-col width="25" :class="['theme-picker', 'auto', { selected: theme === 'auto' }]" @click="switchTheme('auto')">
+          <span class="text-color-gray"> {{ t('about.theme.auto') }}</span>
+        </f7-col>
+        <f7-col width="25" :class="['theme-picker', { selected: theme === 'md' }]" @click="switchTheme('md')">
+          <span><f7-icon f7="logo_android" size="20" color="gray" /></span>
+        </f7-col>
+        <f7-col width="25" :class="['theme-picker', { selected: theme === 'ios' }]" @click="switchTheme('ios')">
+          <span><f7-icon f7="logo_ios" size="25" color="gray" /></span>
+        </f7-col>
+        <f7-col width="25" :class="['theme-picker', { selected: theme === 'aurora' }]" @click="switchTheme('aurora')">
+          <span><f7-icon f7="desktopcomputer" size="20" color="gray" /></span>
+        </f7-col>
+      </f7-row>
+    </group-box>
 
-    <f7-row>
-      <f7-col>
-        <f7-block-title>{{ t('about.miscellaneous') }}</f7-block-title>
-        <f7-list>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.home.navbar') }}</span>
-            <f7-segmented class="home-navbar-selection">
-              <f7-button
-                v-for="navbarstyle in ['default', 'simple', 'large']"
-                outline
-                small
-                :active="homeNavBar === navbarstyle"
-                @click="homeNavBar = navbarstyle"
-                :text="t('about.miscellaneous.home.navbar.' + navbarstyle)"
-                :key="navbarstyle" />
-            </f7-segmented>
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.home.background') }}</span>
-            <f7-segmented class="home-navbar-selection">
-              <f7-button
-                v-for="background in ['default', 'standard', 'white']"
-                outline
-                small
-                :active="homeBackground === background"
-                @click="homeBackground = background"
-                :text="t('about.miscellaneous.home.background.' + background)"
-                :key="background" />
-            </f7-segmented>
-          </f7-list-item>
-          <f7-list-item v-show="runtimeStore.apiEndpoint('habot')">
-            <span>{{ t('about.miscellaneous.home.hideChatInput') }}</span>
-            <f7-toggle v-model:checked="hideChatInput" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.home.disableCardExpansionAnimation') }}</span>
-            <f7-toggle v-model:checked="disableExpandableCardAnimation" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.theme.disableLeftPanelSwipe') }}</span>
-            <f7-toggle v-model:checked="disableLeftPanelSwipe" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.theme.disablePageTransition') }}</span>
-            <f7-toggle v-model:checked="disablePageTransitionAnimation" />
-          </f7-list-item>
+    <group-box :title="t('about.darkMode')">
+      <f7-row class="padding">
+        <f7-col
+          width="33"
+          :class="['theme-picker', 'auto', { selected: uiOptionsStore.storedDarkMode === 'auto' }]"
+          @click="uiOptionsStore.darkMode = 'auto'">
+          <span class="text-color-gray">{{ t('about.darkMode.auto') }}</span>
+        </f7-col>
+        <f7-col
+          width="33"
+          :class="['theme-picker', 'bg-color-white', { selected: uiOptionsStore.storedDarkMode === 'light' }]"
+          @click="uiOptionsStore.darkMode = 'light'">
+          <span class="text-color-gray">{{ t('about.darkMode.light') }}</span>
+        </f7-col>
+        <f7-col
+          width="33"
+          :class="['theme-picker', 'bg-color-black', { selected: uiOptionsStore.storedDarkMode === 'dark' }]"
+          @click="uiOptionsStore.darkMode = 'dark'">
+          <span class="text-color-gray">{{ t('about.darkMode.dark') }}</span>
+        </f7-col>
+      </f7-row>
+    </group-box>
+
+    <group-box :title="t('about.navigationBarsStyle')">
+      <f7-row class="padding">
+        <f7-col
+          width="50"
+          :class="['nav-bars-picker', 'theme-picker', 'nav-bars-picker-empty', { selected: bars === 'light' }]"
+          @click="bars = 'light'">
+          <div class="demo-navbar" />
+          <span class="text-color-gray">Light</span>
+        </f7-col>
+        <f7-col
+          width="50"
+          :class="['nav-bars-picker', 'theme-picker', 'nav-bars-picker-fill', { selected: bars === 'filled' }]"
+          @click="bars = 'filled'">
+          <div class="demo-navbar" />
+          <span class="text-color-gray">Filled</span>
+        </f7-col>
+      </f7-row>
+    </group-box>
+
+    <group-box :title="t('about.miscellaneous')">
+      <f7-list>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.home.navbar') }}</span>
+          <f7-segmented class="home-navbar-selection">
+            <f7-button
+              v-for="navbarstyle in ['default', 'simple', 'large']"
+              outline
+              small
+              :active="homeNavBar === navbarstyle"
+              @click="homeNavBar = navbarstyle"
+              :text="t('about.miscellaneous.home.navbar.' + navbarstyle)"
+              :key="navbarstyle" />
+          </f7-segmented>
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.home.background') }}</span>
+          <f7-segmented class="home-navbar-selection">
+            <f7-button
+              v-for="background in ['default', 'standard', 'white']"
+              outline
+              small
+              :active="homeBackground === background"
+              @click="homeBackground = background"
+              :text="t('about.miscellaneous.home.background.' + background)"
+              :key="background" />
+          </f7-segmented>
+        </f7-list-item>
+        <f7-list-item v-show="runtimeStore.apiEndpoint('habot')">
+          <span>{{ t('about.miscellaneous.home.hideChatInput') }}</span>
+          <f7-toggle v-model:checked="hideChatInput" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.home.disableCardExpansionAnimation') }}</span>
+          <f7-toggle v-model:checked="disableExpandableCardAnimation" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.theme.disableLeftPanelSwipe') }}</span>
+          <f7-toggle v-model:checked="disableLeftPanelSwipe" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.theme.disablePageTransition') }}</span>
+          <f7-toggle v-model:checked="disablePageTransitionAnimation" />
+        </f7-list-item>
           <f7-list-item>
             <span>{{ t('about.miscellaneous.theme.disableHideBarsOnScroll') }}</span>
             <f7-toggle v-model:checked="disableHideBarsOnScroll" />
           </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.webaudio.enable') }}</span>
-            <f7-toggle v-model:checked="webAudio" />
-          </f7-list-item>
-          <f7-list-group>
-            <item-picker
-              :label="t('about.miscellaneous.commandItem.title')"
-              :multiple="false"
-              :value="commandItem"
-              @input="setCommandItem" />
-          </f7-list-group>
-        </f7-list>
-      </f7-col>
-    </f7-row>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.webaudio.enable') }}</span>
+          <f7-toggle v-model:checked="webAudio" />
+        </f7-list-item>
+        <f7-list-group>
+          <item-picker :label="t('about.miscellaneous.commandItem.title')" :multiple="false" :value="commandItem" @input="setCommandItem" />
+        </f7-list-group>
+      </f7-list>
+    </group-box>
 
-    <f7-row v-if="showDialogOptions" class="dialog-options">
-      <f7-col>
-        <f7-block-title>{{ t('about.dialog') }}</f7-block-title>
-        <f7-list>
-          <f7-list-item>
-            <span>{{ t('about.dialog.enable') }}</span>
-            <f7-toggle v-model:checked="dialogEnabled" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.dialog.id') }}</span>
-            <f7-input type="button" :value="dialogIdentifier" />
-          </f7-list-item>
-          <f7-list-group>
-            <item-picker
-              :label="t('about.dialog.listeningItem')"
-              :multiple="false"
-              :value="dialogListeningItem"
-              @input="setDialogListeningItem" />
-          </f7-list-group>
-          <f7-list-group>
-            <item-picker
-              :label="t('about.dialog.locationItem')"
-              :multiple="false"
-              :value="dialogLocationItem"
-              @input="setDialogLocationItem" />
-          </f7-list-group>
-          <f7-list-item>
-            <span>{{ t('about.dialog.connectOnWindowEvent') }}</span>
-            <f7-toggle v-model:checked="dialogConnectOnWindowEvent" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.dialog.triggerOnConnect') }}</span>
-            <f7-toggle v-model:checked="dialogTriggerOnConnect" />
-          </f7-list-item>
-        </f7-list>
-      </f7-col>
-    </f7-row>
+    <group-box v-if="showDialogOptions" :title="t('about.dialog')" class="dialog-options">
+      <f7-list>
+        <f7-list-item>
+          <span>{{ t('about.dialog.enable') }}</span>
+          <f7-toggle v-model:checked="dialogEnabled" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.dialog.id') }}</span>
+          <f7-input type="button" :value="dialogIdentifier" />
+        </f7-list-item>
+        <f7-list-group>
+          <item-picker
+            :label="t('about.dialog.listeningItem')"
+            :multiple="false"
+            :value="dialogListeningItem"
+            @input="setDialogListeningItem" />
+        </f7-list-group>
+        <f7-list-group>
+          <item-picker
+            :label="t('about.dialog.locationItem')"
+            :multiple="false"
+            :value="dialogLocationItem"
+            @input="setDialogLocationItem" />
+        </f7-list-group>
+        <f7-list-item>
+          <span>{{ t('about.dialog.connectOnWindowEvent') }}</span>
+          <f7-toggle v-model:checked="dialogConnectOnWindowEvent" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.dialog.triggerOnConnect') }}</span>
+          <f7-toggle v-model:checked="dialogTriggerOnConnect" />
+        </f7-list-item>
+      </f7-list>
+    </group-box>
   </f7-block>
 </template>
 
 <style lang="stylus">
 .theme-switcher
+  .row.padding
+    box-sizing border-box
+
   .home-navbar-selection
     .button
       width auto
@@ -163,6 +167,107 @@
       width 200%
     .input-right input
       text-align right
+
+.theme-picker
+  cursor pointer
+  height 100px
+  padding 40px 20px
+  border-radius 10px
+  box-shadow 0px 5px 20px rgba(0,0,0,0.2)
+  border 1px solid rgba(255,255,255,0.2)
+  box-sizing border-box
+  position relative
+  display flex
+  align-content center
+  font-size 16px
+  span
+    width 100%
+    text-align center
+  i.f7-icons
+    width 100%
+    text-align center
+  .checkbox
+    position absolute
+    left 10px
+    bottom 10px
+
+.theme-picker.selected, .nav-bars-picker.selected
+  overflow visible
+
+  &::after
+    content ''
+    position absolute
+    top -6px
+    left -6px
+    right -6px
+    bottom -6px
+    border-radius inherit
+    pointer-events none
+    box-shadow: 0 0 0 3px var(--f7-theme-color)
+
+.nav-bars-picker
+  height 200px
+  border-radius 10px
+  box-shadow 0px 5px 20px rgba(0,0,0,0.2)
+  cursor pointer
+  position relative
+  background var(--f7-page-bg-color)
+  border 1px solid rgba(255,255,255,0.2)
+  align-items center
+
+.nav-bars-picker .checkbox
+  position absolute
+  left 10px
+  bottom 10px
+
+.nav-bars-picker .demo-navbar
+  position absolute
+  left 0
+  width 100%
+  height 30px
+  top 0
+  border-bottom 1px solid transparent
+  // prevents the navbar from cutting into the parent's rounded corners
+  // without using overflow: hidden on the parent, which would hide the selection shadow
+  border-top-left-radius 9px
+  border-top-right-radius 9px
+
+.nav-bars-picker .demo-navbar:before
+  content ''
+  position absolute
+  left 10px
+  width 20px
+  height 10px
+  top 50%
+  margin-top -5px
+
+.nav-bars-picker .demo-navbar:after
+  content ''
+  position absolute
+  right 10px
+  width 20px
+  height 10px
+  top 50%
+  margin-top -5px
+
+.nav-bars-picker-empty .demo-navbar
+  background #f7f7f8
+  border-color rgba(0,0,0,0.1)
+
+.dark .nav-bars-picker-empty .demo-navbar
+  background #1b1b1b
+  border-color #282829
+
+.nav-bars-picker-empty .demo-navbar:before,
+.nav-bars-picker-empty .demo-navbar:after
+  background var(--f7-theme-color)
+
+.nav-bars-picker-fill .demo-navbar
+  background var(--f7-theme-color)
+
+.nav-bars-picker-fill .demo-navbar:before,
+.nav-bars-picker-fill .demo-navbar:after
+  background #fff
 </style>
 
 <script>
@@ -238,88 +343,3 @@ export default {
   }
 }
 </script>
-
-<style lang="stylus">
-.theme-picker
-  cursor pointer
-  height 100px
-  padding 40px 20px
-  border-radius 10px
-  box-shadow 0px 5px 20px rgba(0,0,0,0.1)
-  border 1px solid rgba(255,255,255,0.2)
-  box-sizing border-box
-  position relative
-  display flex
-  align-content center
-  font-size 16px
-  span
-    width 100%
-    text-align center
-  i.f7-icons
-    width 100%
-    text-align center
-  .checkbox
-    position absolute
-    left 10px
-    bottom 10px
-
-.nav-bars-picker
-  height 200px
-  border-radius 10px
-  box-shadow 0px 5px 20px rgba(0,0,0,0.1)
-  cursor pointer
-  position relative
-  overflow hidden
-  background var(--f7-page-bg-color)
-  border 1px solid rgba(255,255,255,0.2)
-
-.nav-bars-picker .checkbox
-  position absolute
-  left 10px
-  bottom 10px
-
-.nav-bars-picker .demo-navbar
-  position absolute
-  left 0
-  width 100%
-  height 30px
-  top 0
-  border-bottom 1px solid transparent
-
-.nav-bars-picker .demo-navbar:before
-  content ''
-  position absolute
-  left 10px
-  width 20px
-  height 10px
-  top 50%
-  margin-top -5px
-
-.nav-bars-picker .demo-navbar:after
-  content ''
-  position absolute
-  right 10px
-  width 20px
-  height 10px
-  top 50%
-  margin-top -5px
-
-.nav-bars-picker-empty .demo-navbar
-  background #f7f7f8
-  border-color rgba(0,0,0,0.1)
-
-.dark .nav-bars-picker-empty .demo-navbar
-  background #1b1b1b
-  border-color #282829
-
-.nav-bars-picker-empty .demo-navbar:before,
-.nav-bars-picker-empty .demo-navbar:after
-  background var(--f7-theme-color)
-
-.nav-bars-picker-fill .demo-navbar
-  background var(--f7-theme-color)
-
-.nav-bars-picker-fill .demo-navbar:before,
-.nav-bars-picker-fill .demo-navbar:after
-  background #fff
-</style>

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -103,10 +103,10 @@
           <span>{{ t('about.miscellaneous.theme.disablePageTransition') }}</span>
           <f7-toggle v-model:checked="disablePageTransitionAnimation" />
         </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.theme.disableHideBarsOnScroll') }}</span>
-            <f7-toggle v-model:checked="disableHideBarsOnScroll" />
-          </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.theme.disableHideBarsOnScroll') }}</span>
+          <f7-toggle v-model:checked="disableHideBarsOnScroll" />
+        </f7-list-item>
         <f7-list-item>
           <span>{{ t('about.miscellaneous.webaudio.enable') }}</span>
           <f7-toggle v-model:checked="webAudio" />

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -1,156 +1,160 @@
 <template>
-  <f7-block class="theme-switcher">
-    <f7-block-title class="padding-left">
-      {{ t('about.theme') }}
-    </f7-block-title>
-    <f7-row>
-      <f7-col width="25" class="theme-picker auto" @click="switchTheme('auto')">
-        <span class="text-color-gray"> {{ t('about.theme.auto') }}</span>
-        <f7-checkbox v-if="theme === 'auto'" checked disabled />
-      </f7-col>
-      <f7-col width="25" class="theme-picker" @click="switchTheme('md')">
-        <span><f7-icon f7="logo_android" size="20" color="gray" /></span>
-        <f7-checkbox v-if="theme === 'md'" checked disabled />
-      </f7-col>
-      <f7-col width="25" class="theme-picker" @click="switchTheme('ios')">
-        <span><f7-icon f7="logo_ios" size="25" color="gray" /></span>
-        <f7-checkbox v-if="theme === 'ios'" checked disabled />
-      </f7-col>
-      <f7-col width="25" class="theme-picker" @click="switchTheme('aurora')">
-        <span><f7-icon f7="desktopcomputer" size="20" color="gray" /></span>
-        <f7-checkbox v-if="theme === 'aurora'" checked disabled />
-      </f7-col>
-    </f7-row>
-    <f7-block-title>{{ t('about.darkMode') }}</f7-block-title>
-    <f7-row>
-      <f7-col width="33" class="theme-picker auto" @click="uiOptionsStore.darkMode = 'auto'">
-        <span class="text-color-gray">{{ t('about.darkMode.auto') }}</span>
-        <f7-checkbox v-if="uiOptionsStore.storedDarkMode === 'auto'" checked disabled />
-      </f7-col>
-      <f7-col width="33" class="bg-color-white theme-picker" @click="uiOptionsStore.darkMode = 'light'">
-        <span class="text-color-gray">{{ t('about.darkMode.light') }}</span>
-        <f7-checkbox v-if="uiOptionsStore.storedDarkMode === 'light'" checked disabled />
-      </f7-col>
-      <f7-col width="33" class="bg-color-black theme-picker" @click="uiOptionsStore.darkMode = 'dark'">
-        <span class="text-color-gray">{{ t('about.darkMode.dark') }}</span>
-        <f7-checkbox v-if="uiOptionsStore.storedDarkMode === 'dark'" checked disabled />
-      </f7-col>
-    </f7-row>
-    <f7-block-title>{{ t('about.navigationBarsStyle') }}</f7-block-title>
-    <f7-row>
-      <f7-col width="50" class="nav-bars-picker nav-bars-picker-empty" @click="bars = 'light'">
-        <div class="demo-navbar" />
-        <f7-checkbox v-if="bars === 'light'" checked disabled />
-      </f7-col>
-      <f7-col width="50" class="nav-bars-picker nav-bars-picker-fill" @click="bars = 'filled'">
-        <div class="demo-navbar" />
-        <f7-checkbox v-if="bars === 'filled'" checked disabled />
-      </f7-col>
-    </f7-row>
+  <f7-block class="theme-switcher block-narrow">
+    <group-box :title="t('about.theme')">
+      <f7-row class="padding">
+        <f7-col width="25" :class="['theme-picker', 'auto', { selected: theme === 'auto' }]" @click="switchTheme('auto')">
+          <span class="text-color-gray"> {{ t('about.theme.auto') }}</span>
+        </f7-col>
+        <f7-col width="25" :class="['theme-picker', { selected: theme === 'md' }]" @click="switchTheme('md')">
+          <span><f7-icon f7="logo_android" size="20" color="gray" /></span>
+        </f7-col>
+        <f7-col width="25" :class="['theme-picker', { selected: theme === 'ios' }]" @click="switchTheme('ios')">
+          <span><f7-icon f7="logo_ios" size="25" color="gray" /></span>
+        </f7-col>
+        <f7-col width="25" :class="['theme-picker', { selected: theme === 'aurora' }]" @click="switchTheme('aurora')">
+          <span><f7-icon f7="desktopcomputer" size="20" color="gray" /></span>
+        </f7-col>
+      </f7-row>
+    </group-box>
 
-    <f7-row>
-      <f7-col>
-        <f7-block-title>{{ t('about.miscellaneous') }}</f7-block-title>
-        <f7-list>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.home.navbar') }}</span>
-            <f7-segmented class="home-navbar-selection">
-              <f7-button
-                v-for="navbarstyle in ['default', 'simple', 'large']"
-                outline
-                small
-                :active="homeNavBar === navbarstyle"
-                @click="homeNavBar = navbarstyle"
-                :text="t('about.miscellaneous.home.navbar.' + navbarstyle)"
-                :key="navbarstyle" />
-            </f7-segmented>
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.home.background') }}</span>
-            <f7-segmented class="home-navbar-selection">
-              <f7-button
-                v-for="background in ['default', 'standard', 'white']"
-                outline
-                small
-                :active="homeBackground === background"
-                @click="homeBackground = background"
-                :text="t('about.miscellaneous.home.background.' + background)"
-                :key="background" />
-            </f7-segmented>
-          </f7-list-item>
-          <f7-list-item v-show="runtimeStore.apiEndpoint('habot')">
-            <span>{{ t('about.miscellaneous.home.hideChatInput') }}</span>
-            <f7-toggle v-model:checked="hideChatInput" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.home.disableCardExpansionAnimation') }}</span>
-            <f7-toggle v-model:checked="disableExpandableCardAnimation" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.theme.disableLeftPanelSwipe') }}</span>
-            <f7-toggle v-model:checked="disableLeftPanelSwipe" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.theme.disablePageTransition') }}</span>
-            <f7-toggle v-model:checked="disablePageTransitionAnimation" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.miscellaneous.webaudio.enable') }}</span>
-            <f7-toggle v-model:checked="webAudio" />
-          </f7-list-item>
-          <f7-list-group>
-            <item-picker
-              :label="t('about.miscellaneous.commandItem.title')"
-              :multiple="false"
-              :value="commandItem"
-              @input="setCommandItem" />
-          </f7-list-group>
-        </f7-list>
-      </f7-col>
-    </f7-row>
+    <group-box :title="t('about.darkMode')">
+      <f7-row class="padding">
+        <f7-col
+          width="33"
+          :class="['theme-picker', 'auto', { selected: uiOptionsStore.storedDarkMode === 'auto' }]"
+          @click="uiOptionsStore.darkMode = 'auto'">
+          <span class="text-color-gray">{{ t('about.darkMode.auto') }}</span>
+        </f7-col>
+        <f7-col
+          width="33"
+          :class="['theme-picker', 'bg-color-white', { selected: uiOptionsStore.storedDarkMode === 'light' }]"
+          @click="uiOptionsStore.darkMode = 'light'">
+          <span class="text-color-gray">{{ t('about.darkMode.light') }}</span>
+        </f7-col>
+        <f7-col
+          width="33"
+          :class="['theme-picker', 'bg-color-black', { selected: uiOptionsStore.storedDarkMode === 'dark' }]"
+          @click="uiOptionsStore.darkMode = 'dark'">
+          <span class="text-color-gray">{{ t('about.darkMode.dark') }}</span>
+        </f7-col>
+      </f7-row>
+    </group-box>
 
-    <f7-row v-if="showDialogOptions" class="dialog-options">
-      <f7-col>
-        <f7-block-title>{{ t('about.dialog') }}</f7-block-title>
-        <f7-list>
-          <f7-list-item>
-            <span>{{ t('about.dialog.enable') }}</span>
-            <f7-toggle v-model:checked="dialogEnabled" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.dialog.id') }}</span>
-            <f7-input type="button" :value="dialogIdentifier" />
-          </f7-list-item>
-          <f7-list-group>
-            <item-picker
-              :label="t('about.dialog.listeningItem')"
-              :multiple="false"
-              :value="dialogListeningItem"
-              @input="setDialogListeningItem" />
-          </f7-list-group>
-          <f7-list-group>
-            <item-picker
-              :label="t('about.dialog.locationItem')"
-              :multiple="false"
-              :value="dialogLocationItem"
-              @input="setDialogLocationItem" />
-          </f7-list-group>
-          <f7-list-item>
-            <span>{{ t('about.dialog.connectOnWindowEvent') }}</span>
-            <f7-toggle v-model:checked="dialogConnectOnWindowEvent" />
-          </f7-list-item>
-          <f7-list-item>
-            <span>{{ t('about.dialog.triggerOnConnect') }}</span>
-            <f7-toggle v-model:checked="dialogTriggerOnConnect" />
-          </f7-list-item>
-        </f7-list>
-      </f7-col>
-    </f7-row>
+    <group-box :title="t('about.navigationBarsStyle')">
+      <f7-row class="padding">
+        <f7-col
+          width="50"
+          :class="['nav-bars-picker', 'theme-picker', 'nav-bars-picker-empty', { selected: bars === 'light' }]"
+          @click="bars = 'light'">
+          <div class="demo-navbar" />
+          <span class="text-color-gray">Light</span>
+        </f7-col>
+        <f7-col
+          width="50"
+          :class="['nav-bars-picker', 'theme-picker', 'nav-bars-picker-fill', { selected: bars === 'filled' }]"
+          @click="bars = 'filled'">
+          <div class="demo-navbar" />
+          <span class="text-color-gray">Filled</span>
+        </f7-col>
+      </f7-row>
+    </group-box>
+
+    <group-box :title="t('about.miscellaneous')">
+      <f7-list>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.home.navbar') }}</span>
+          <f7-segmented class="home-navbar-selection">
+            <f7-button
+              v-for="navbarstyle in ['default', 'simple', 'large']"
+              outline
+              small
+              :active="homeNavBar === navbarstyle"
+              @click="homeNavBar = navbarstyle"
+              :text="t('about.miscellaneous.home.navbar.' + navbarstyle)"
+              :key="navbarstyle" />
+          </f7-segmented>
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.home.background') }}</span>
+          <f7-segmented class="home-navbar-selection">
+            <f7-button
+              v-for="background in ['default', 'standard', 'white']"
+              outline
+              small
+              :active="homeBackground === background"
+              @click="homeBackground = background"
+              :text="t('about.miscellaneous.home.background.' + background)"
+              :key="background" />
+          </f7-segmented>
+        </f7-list-item>
+        <f7-list-item v-show="runtimeStore.apiEndpoint('habot')">
+          <span>{{ t('about.miscellaneous.home.hideChatInput') }}</span>
+          <f7-toggle v-model:checked="hideChatInput" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.home.disableCardExpansionAnimation') }}</span>
+          <f7-toggle v-model:checked="disableExpandableCardAnimation" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.theme.disableLeftPanelSwipe') }}</span>
+          <f7-toggle v-model:checked="disableLeftPanelSwipe" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.theme.disablePageTransition') }}</span>
+          <f7-toggle v-model:checked="disablePageTransitionAnimation" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.miscellaneous.webaudio.enable') }}</span>
+          <f7-toggle v-model:checked="webAudio" />
+        </f7-list-item>
+        <f7-list-group>
+          <item-picker :label="t('about.miscellaneous.commandItem.title')" :multiple="false" :value="commandItem" @input="setCommandItem" />
+        </f7-list-group>
+      </f7-list>
+    </group-box>
+
+    <group-box v-if="showDialogOptions" :title="t('about.dialog')" class="dialog-options">
+      <f7-list>
+        <f7-list-item>
+          <span>{{ t('about.dialog.enable') }}</span>
+          <f7-toggle v-model:checked="dialogEnabled" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.dialog.id') }}</span>
+          <f7-input type="button" :value="dialogIdentifier" />
+        </f7-list-item>
+        <f7-list-group>
+          <item-picker
+            :label="t('about.dialog.listeningItem')"
+            :multiple="false"
+            :value="dialogListeningItem"
+            @input="setDialogListeningItem" />
+        </f7-list-group>
+        <f7-list-group>
+          <item-picker
+            :label="t('about.dialog.locationItem')"
+            :multiple="false"
+            :value="dialogLocationItem"
+            @input="setDialogLocationItem" />
+        </f7-list-group>
+        <f7-list-item>
+          <span>{{ t('about.dialog.connectOnWindowEvent') }}</span>
+          <f7-toggle v-model:checked="dialogConnectOnWindowEvent" />
+        </f7-list-item>
+        <f7-list-item>
+          <span>{{ t('about.dialog.triggerOnConnect') }}</span>
+          <f7-toggle v-model:checked="dialogTriggerOnConnect" />
+        </f7-list-item>
+      </f7-list>
+    </group-box>
   </f7-block>
 </template>
 
 <style lang="stylus">
 .theme-switcher
+  .row.padding
+    box-sizing border-box
+
   .home-navbar-selection
     .button
       width auto
@@ -159,6 +163,107 @@
       width 200%
     .input-right input
       text-align right
+
+.theme-picker
+  cursor pointer
+  height 100px
+  padding 40px 20px
+  border-radius 10px
+  box-shadow 0px 5px 20px rgba(0,0,0,0.2)
+  border 1px solid rgba(255,255,255,0.2)
+  box-sizing border-box
+  position relative
+  display flex
+  align-content center
+  font-size 16px
+  span
+    width 100%
+    text-align center
+  i.f7-icons
+    width 100%
+    text-align center
+  .checkbox
+    position absolute
+    left 10px
+    bottom 10px
+
+.theme-picker.selected, .nav-bars-picker.selected
+  overflow visible
+
+  &::after
+    content ''
+    position absolute
+    top -6px
+    left -6px
+    right -6px
+    bottom -6px
+    border-radius inherit
+    pointer-events none
+    box-shadow: 0 0 0 3px var(--f7-theme-color)
+
+.nav-bars-picker
+  height 200px
+  border-radius 10px
+  box-shadow 0px 5px 20px rgba(0,0,0,0.2)
+  cursor pointer
+  position relative
+  background var(--f7-page-bg-color)
+  border 1px solid rgba(255,255,255,0.2)
+  align-items center
+
+.nav-bars-picker .checkbox
+  position absolute
+  left 10px
+  bottom 10px
+
+.nav-bars-picker .demo-navbar
+  position absolute
+  left 0
+  width 100%
+  height 30px
+  top 0
+  border-bottom 1px solid transparent
+  // prevents the navbar from cutting into the parent's rounded corners
+  // without using overflow: hidden on the parent, which would hide the selection shadow
+  border-top-left-radius 9px
+  border-top-right-radius 9px
+
+.nav-bars-picker .demo-navbar:before
+  content ''
+  position absolute
+  left 10px
+  width 20px
+  height 10px
+  top 50%
+  margin-top -5px
+
+.nav-bars-picker .demo-navbar:after
+  content ''
+  position absolute
+  right 10px
+  width 20px
+  height 10px
+  top 50%
+  margin-top -5px
+
+.nav-bars-picker-empty .demo-navbar
+  background #f7f7f8
+  border-color rgba(0,0,0,0.1)
+
+.dark .nav-bars-picker-empty .demo-navbar
+  background #1b1b1b
+  border-color #282829
+
+.nav-bars-picker-empty .demo-navbar:before,
+.nav-bars-picker-empty .demo-navbar:after
+  background var(--f7-theme-color)
+
+.nav-bars-picker-fill .demo-navbar
+  background var(--f7-theme-color)
+
+.nav-bars-picker-fill .demo-navbar:before,
+.nav-bars-picker-fill .demo-navbar:after
+  background #fff
 </style>
 
 <script>
@@ -233,88 +338,3 @@ export default {
   }
 }
 </script>
-
-<style lang="stylus">
-.theme-picker
-  cursor pointer
-  height 100px
-  padding 40px 20px
-  border-radius 10px
-  box-shadow 0px 5px 20px rgba(0,0,0,0.1)
-  border 1px solid rgba(255,255,255,0.2)
-  box-sizing border-box
-  position relative
-  display flex
-  align-content center
-  font-size 16px
-  span
-    width 100%
-    text-align center
-  i.f7-icons
-    width 100%
-    text-align center
-  .checkbox
-    position absolute
-    left 10px
-    bottom 10px
-
-.nav-bars-picker
-  height 200px
-  border-radius 10px
-  box-shadow 0px 5px 20px rgba(0,0,0,0.1)
-  cursor pointer
-  position relative
-  overflow hidden
-  background var(--f7-page-bg-color)
-  border 1px solid rgba(255,255,255,0.2)
-
-.nav-bars-picker .checkbox
-  position absolute
-  left 10px
-  bottom 10px
-
-.nav-bars-picker .demo-navbar
-  position absolute
-  left 0
-  width 100%
-  height 30px
-  top 0
-  border-bottom 1px solid transparent
-
-.nav-bars-picker .demo-navbar:before
-  content ''
-  position absolute
-  left 10px
-  width 20px
-  height 10px
-  top 50%
-  margin-top -5px
-
-.nav-bars-picker .demo-navbar:after
-  content ''
-  position absolute
-  right 10px
-  width 20px
-  height 10px
-  top 50%
-  margin-top -5px
-
-.nav-bars-picker-empty .demo-navbar
-  background #f7f7f8
-  border-color rgba(0,0,0,0.1)
-
-.dark .nav-bars-picker-empty .demo-navbar
-  background #1b1b1b
-  border-color #282829
-
-.nav-bars-picker-empty .demo-navbar:before,
-.nav-bars-picker-empty .demo-navbar:after
-  background var(--f7-theme-color)
-
-.nav-bars-picker-fill .demo-navbar
-  background var(--f7-theme-color)
-
-.nav-bars-picker-fill .demo-navbar:before,
-.nav-bars-picker-fill .demo-navbar:after
-  background #fff
-</style>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
@@ -16,7 +16,7 @@
       :checked="isSelected(c.channel) ? true : null"
       name="channel-picker"
       media-item
-      class="channel-item"
+      :class="['channel-item', { 'advanced-channel': c.channelType.advanced }]"
       :subtitle="c.channel.id + ' (' + getItemType(c.channelType) + ')'"
       :badge="getLinkedItems(c.channel).length || ''"
       badge-color="theme-alt"
@@ -62,6 +62,9 @@
   overflow hidden
   .item-title
     font-weight var(--f7-list-group-title-font-weight)
+
+.channel-item.advanced-channel
+  border-left 2px solid var(--f7-color-blue)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
@@ -16,7 +16,7 @@
       :checked="isSelected(c.channel) ? true : null"
       name="channel-picker"
       media-item
-      class="channel-item"
+      :class="['channel-item', { 'advanced-channel': c.channelType.advanced }]"
       :subtitle="c.channel.id + ' (' + getItemType(c.channelType) + ')'"
       :badge="getLinkedItems(c.channel).length || ''"
       badge-color="blue"
@@ -62,6 +62,9 @@
   overflow hidden
   .item-title
     font-weight var(--f7-list-group-title-font-weight)
+
+.channel-item.advanced-channel
+  border-left 2px solid var(--f7-color-blue)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -1,24 +1,28 @@
 <template>
   <f7-block v-if="thingType" class="channel-list no-margin">
-    <f7-block v-show="thing.channels.length > 0">
-      <f7-col>
-        <f7-searchbar
-          ref="searchbar"
-          :disable-button="false"
-          inline
-          disable-link-text="Cancel"
-          placeholder="Search channels"
-          search-container=".channel-group"
-          search-in=".channel-item .item-title, .channel-item .item-subtitle, .channel-item .item-footer"
-          search-group=".channel-group .row"
-          :clear-button="true" />
-      </f7-col>
-    </f7-block>
-    <div v-if="hasAdvanced" style="text-align: right" class="padding-right">
-      <label class="advanced-label">
-        <f7-checkbox name="channel-advanced" v-model:checked="showAdvanced" />
-        Show advanced</label
-      >
+    <div v-show="showFilterControls" class="channel-filters">
+      <f7-searchbar
+        v-show="thing.channels.length > 0"
+        ref="searchbar"
+        :disable-button="false"
+        inline
+        disable-link-text="Cancel"
+        placeholder="Search channels"
+        search-container=".channel-group"
+        search-in=".channel-item .item-title, .channel-item .item-subtitle, .channel-item .item-footer"
+        search-group=".channel-group .row"
+        :clear-button="true" />
+      <f7-chip
+        v-if="hasAdvanced"
+        media-bg-color="blue"
+        :color="showAdvanced ? 'blue' : ''"
+        class="advanced-chip not-selectable"
+        text="Advanced"
+        @click="showAdvanced = !showAdvanced">
+        <template #media>
+          <f7-icon v-if="showAdvanced" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
+        </template>
+      </f7-chip>
     </div>
     <f7-col v-if="thing.channels.length > 0">
       <f7-block width="100" class="channel-group no-margin no-padding" ref="channelList">
@@ -36,66 +40,71 @@
             </f7-segmented>
           </f7-col>
         </f7-row>
-        <f7-row v-for="group in channelGroups" :key="group.id">
-          <f7-col>
-            <!-- <f7-block-title class="channel-group-title">{{group.label}}</f7-block-title>
+
+        <group-box>
+          <f7-row v-for="group in channelGroups" :key="group.id">
+            <f7-col>
+              <!-- <f7-block-title class="channel-group-title">{{group.label}}</f7-block-title>
             <f7-block-footer class="channel-description param-description" v-if="group.description">
               {{group.description}}
             </f7-block-footer> -->
 
-            <channel-group
-              :group="group"
-              :thing="thing"
-              :picker-mode="pickerMode"
-              :multiple-links-mode="multipleLinksMode"
-              :item-type-filter="itemTypeFilter"
-              :selection="multipleLinksMode ? selectedChannels : selectedChannel"
-              @selected="selectChannel"
-              @channel-opened="channelOpened">
-              <template v-if="!pickerMode && !multipleLinksMode" #default="{ channelId, channelType, channel, extensible }">
-                <channel-link
-                  :opened="openedChannelId === channelId"
-                  :thing="thing"
-                  :thingType="thingType"
-                  :channelId="channelId"
-                  :channelType="channelType"
-                  :channel="channel"
-                  :extensible="extensible"
-                  :context="context"
-                  :f7router
-                  @channel-updated="(e) => $emit('channels-updated', e)" />
-              </template>
-              <template v-else-if="multipleLinksMode" #default="{ channelType, channel }">
-                <item-picker
-                  v-if="isChecked(channel) && hasLinks(channel)"
-                  :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
-                  textColor="blue"
-                  :hideIcon="true"
-                  :items="items.filter((i) => channel.linkedItems.includes(i.name))"
-                  :multiple="false"
-                  :noModelPicker="true"
-                  :setValueText="false"
-                  :value="selectedItem(channel)?.name"
-                  @input="selectExistingItem($event, channel, channelType)" />
-                <item-form v-if="selectedItem(channel)" :item="selectedItem(channel)" :items="items" :createMode="false" />
-                <item-form
-                  v-else-if="isChecked(channel)"
-                  :item="newItem(channel)"
-                  :items="items"
-                  :createMode="true"
-                  :unitHint="getUnitHint(channel, channelType)"
-                  :stateDescription="stateDescription(channelType)" />
-              </template>
-              <!-- <channel-link #default="{ channelId }" /> -->
-            </channel-group>
-          </f7-col>
-        </f7-row>
-        <f7-list v-if="multipleLinksMode">
-          <f7-list-button style="padding-left: 0; text-align: left" color="blue" @click="toggleAllChecks(true, $event)">
-            Select All
-          </f7-list-button>
-          <f7-list-button color="blue" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
-        </f7-list>
+              <channel-group
+                :group="group"
+                :thing="thing"
+                :picker-mode="pickerMode"
+                :multiple-links-mode="multipleLinksMode"
+                :item-type-filter="itemTypeFilter"
+                :selection="multipleLinksMode ? selectedChannels : selectedChannel"
+                @selected="selectChannel"
+                @channel-opened="channelOpened">
+                <template v-if="!pickerMode && !multipleLinksMode" #default="{ channelId, channelType, channel, extensible }">
+                  <channel-link
+                    :opened="openedChannelId === channelId"
+                    :thing="thing"
+                    :thingType="thingType"
+                    :channelId="channelId"
+                    :channelType="channelType"
+                    :channel="channel"
+                    :extensible="extensible"
+                    :context="context"
+                    :f7router
+                    @channel-updated="(e) => $emit('channels-updated', e)" />
+                </template>
+                <template v-else-if="multipleLinksMode" #default="{ channelType, channel }">
+                  <item-picker
+                    v-if="isChecked(channel) && hasLinks(channel)"
+                    :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
+                    textColor="blue"
+                    :hideIcon="true"
+                    :items="items.filter((i) => channel.linkedItems.includes(i.name))"
+                    :multiple="false"
+                    :noModelPicker="true"
+                    :setValueText="false"
+                    :value="selectedItem(channel)?.name"
+                    @input="selectExistingItem($event, channel, channelType)" />
+                  <div style="padding: 0 10px 10px 55px">
+                    <item-form v-if="selectedItem(channel)" :item="selectedItem(channel)" :items="items" :createMode="false" />
+                    <item-form
+                      v-else-if="isChecked(channel)"
+                      :item="newItem(channel)"
+                      :items="items"
+                      :createMode="true"
+                      :unitHint="getUnitHint(channel, channelType)"
+                      :stateDescription="stateDescription(channelType)" />
+                  </div>
+                </template>
+                <!-- <channel-link #default="{ channelId }" /> -->
+              </channel-group>
+            </f7-col>
+          </f7-row>
+          <f7-list v-if="multipleLinksMode">
+            <f7-list-button style="padding-left: 0; text-align: left" color="blue" @click="toggleAllChecks(true, $event)">
+              Select All
+            </f7-list-button>
+            <f7-list-button color="blue" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
+          </f7-list>
+        </group-box>
       </f7-block>
     </f7-col>
     <f7-col v-else>
@@ -111,6 +120,39 @@
 </template>
 
 <style lang="stylus">
+.channel-filters
+  display flex
+  align-items center
+  gap 8px
+  padding 8px var(--f7-block-padding-horizontal)
+
+  .searchbar
+    flex 1 1 auto
+    min-width 0
+    margin 0
+    padding 0
+    background transparent
+    box-shadow none
+
+    &:before, &:after
+      display none !important
+
+  .searchbar-inner
+    padding 0
+
+  .searchbar-input-wrap
+    margin 0
+
+  .advanced-chip
+    margin-left auto
+    cursor pointer
+
+  .not-selectable
+    -webkit-user-select none
+    -moz-user-select none
+    -ms-user-select none
+    user-select none
+
 .channel-list
   margin-left calc(-1*var(--f7-block-padding-horizontal))
   padding-left 0
@@ -224,6 +266,9 @@ export default {
     },
     hasAdvanced() {
       return this.channelGroups && Array.isArray(this.channelGroups) && this.channelGroups?.some((g) => g.hasAdvanced)
+    },
+    showFilterControls() {
+      return this.thing.channels.length > 0 || this.hasAdvanced
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -1,24 +1,28 @@
 <template>
   <f7-block v-if="thingType" class="channel-list no-margin">
-    <f7-block v-show="thing.channels.length > 0">
-      <f7-col>
-        <f7-searchbar
-          ref="searchbar"
-          :disable-button="false"
-          inline
-          disable-link-text="Cancel"
-          placeholder="Search channels"
-          search-container=".channel-group"
-          search-in=".channel-item .item-title, .channel-item .item-subtitle, .channel-item .item-footer"
-          search-group=".channel-group .row"
-          :clear-button="true" />
-      </f7-col>
-    </f7-block>
-    <div v-if="hasAdvanced" style="text-align: right" class="padding-right">
-      <label class="advanced-label">
-        <f7-checkbox name="channel-advanced" v-model:checked="showAdvanced" />
-        Show advanced</label
-      >
+    <div v-show="showFilterControls" class="channel-filters">
+      <f7-searchbar
+        v-show="thing.channels.length > 0"
+        ref="searchbar"
+        :disable-button="false"
+        inline
+        disable-link-text="Cancel"
+        placeholder="Search channels"
+        search-container=".channel-group"
+        search-in=".channel-item .item-title, .channel-item .item-subtitle, .channel-item .item-footer"
+        search-group=".channel-group .row"
+        :clear-button="true" />
+      <f7-chip
+        v-if="hasAdvanced"
+        media-bg-color="blue"
+        :color="showAdvanced ? 'blue' : ''"
+        class="advanced-chip not-selectable"
+        text="Advanced"
+        @click="showAdvanced = !showAdvanced">
+        <template #media>
+          <f7-icon v-if="showAdvanced" ios="f7:checkmark_circle_fill" md="material:check_circle" aurora="f7:checkmark_circle_fill" />
+        </template>
+      </f7-chip>
     </div>
     <f7-col v-if="thing.channels.length > 0">
       <f7-block width="100" class="channel-group no-margin no-padding" ref="channelList">
@@ -36,66 +40,71 @@
             </f7-segmented>
           </f7-col>
         </f7-row>
-        <f7-row v-for="group in channelGroups" :key="group.id">
-          <f7-col>
-            <!-- <f7-block-title class="channel-group-title">{{group.label}}</f7-block-title>
+
+        <group-box>
+          <f7-row v-for="group in channelGroups" :key="group.id">
+            <f7-col>
+              <!-- <f7-block-title class="channel-group-title">{{group.label}}</f7-block-title>
             <f7-block-footer class="channel-description param-description" v-if="group.description">
               {{group.description}}
             </f7-block-footer> -->
 
-            <channel-group
-              :group="group"
-              :thing="thing"
-              :picker-mode="pickerMode"
-              :multiple-links-mode="multipleLinksMode"
-              :item-type-filter="itemTypeFilter"
-              :selection="multipleLinksMode ? selectedChannels : selectedChannel"
-              @selected="selectChannel"
-              @channel-opened="channelOpened">
-              <template v-if="!pickerMode && !multipleLinksMode" #default="{ channelId, channelType, channel, extensible }">
-                <channel-link
-                  :opened="openedChannelId === channelId"
-                  :thing="thing"
-                  :thingType="thingType"
-                  :channelId="channelId"
-                  :channelType="channelType"
-                  :channel="channel"
-                  :extensible="extensible"
-                  :context="context"
-                  :f7router
-                  @channel-updated="(e) => $emit('channels-updated', e)" />
-              </template>
-              <template v-else-if="multipleLinksMode" #default="{ channelType, channel }">
-                <item-picker
-                  v-if="isChecked(channel) && hasLinks(channel)"
-                  :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
-                  textColor="theme-alt"
-                  :hideIcon="true"
-                  :items="items.filter((i) => channel.linkedItems.includes(i.name))"
-                  :multiple="false"
-                  :noModelPicker="true"
-                  :setValueText="false"
-                  :value="selectedItem(channel)?.name"
-                  @input="selectExistingItem($event, channel, channelType)" />
-                <item-form v-if="selectedItem(channel)" :item="selectedItem(channel)" :items="items" :createMode="false" />
-                <item-form
-                  v-else-if="isChecked(channel)"
-                  :item="newItem(channel)"
-                  :items="items"
-                  :createMode="true"
-                  :unitHint="getUnitHint(channel, channelType)"
-                  :stateDescription="stateDescription(channelType)" />
-              </template>
-              <!-- <channel-link #default="{ channelId }" /> -->
-            </channel-group>
-          </f7-col>
-        </f7-row>
-        <f7-list v-if="multipleLinksMode">
-          <f7-list-button style="padding-left: 0; text-align: left" color="theme-alt" @click="toggleAllChecks(true, $event)">
-            Select All
-          </f7-list-button>
-          <f7-list-button color="theme-alt" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
-        </f7-list>
+              <channel-group
+                :group="group"
+                :thing="thing"
+                :picker-mode="pickerMode"
+                :multiple-links-mode="multipleLinksMode"
+                :item-type-filter="itemTypeFilter"
+                :selection="multipleLinksMode ? selectedChannels : selectedChannel"
+                @selected="selectChannel"
+                @channel-opened="channelOpened">
+                <template v-if="!pickerMode && !multipleLinksMode" #default="{ channelId, channelType, channel, extensible }">
+                  <channel-link
+                    :opened="openedChannelId === channelId"
+                    :thing="thing"
+                    :thingType="thingType"
+                    :channelId="channelId"
+                    :channelType="channelType"
+                    :channel="channel"
+                    :extensible="extensible"
+                    :context="context"
+                    :f7router
+                    @channel-updated="(e) => $emit('channels-updated', e)" />
+                </template>
+                <template v-else-if="multipleLinksMode" #default="{ channelType, channel }">
+                  <item-picker
+                    v-if="isChecked(channel) && hasLinks(channel)"
+                    :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
+                    textColor="theme-alt"
+                    :hideIcon="true"
+                    :items="items.filter((i) => channel.linkedItems.includes(i.name))"
+                    :multiple="false"
+                    :noModelPicker="true"
+                    :setValueText="false"
+                    :value="selectedItem(channel)?.name"
+                    @input="selectExistingItem($event, channel, channelType)" />
+                  <div style="padding: 0 10px 10px 55px">
+                    <item-form v-if="selectedItem(channel)" :item="selectedItem(channel)" :items="items" :createMode="false" />
+                    <item-form
+                      v-else-if="isChecked(channel)"
+                      :item="newItem(channel)"
+                      :items="items"
+                      :createMode="true"
+                      :unitHint="getUnitHint(channel, channelType)"
+                      :stateDescription="stateDescription(channelType)" />
+                  </div>
+                </template>
+                <!-- <channel-link #default="{ channelId }" /> -->
+              </channel-group>
+            </f7-col>
+          </f7-row>
+          <f7-list v-if="multipleLinksMode">
+            <f7-list-button style="padding-left: 0; text-align: left" color="theme-alt" @click="toggleAllChecks(true, $event)">
+              Select All
+            </f7-list-button>
+            <f7-list-button color="theme-alt" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
+          </f7-list>
+        </group-box>
       </f7-block>
     </f7-col>
     <f7-col v-else>
@@ -111,6 +120,39 @@
 </template>
 
 <style lang="stylus">
+.channel-filters
+  display flex
+  align-items center
+  gap 8px
+  padding 8px var(--f7-block-padding-horizontal)
+
+  .searchbar
+    flex 1 1 auto
+    min-width 0
+    margin 0
+    padding 0
+    background transparent
+    box-shadow none
+
+    &:before, &:after
+      display none !important
+
+  .searchbar-inner
+    padding 0
+
+  .searchbar-input-wrap
+    margin 0
+
+  .advanced-chip
+    margin-left auto
+    cursor pointer
+
+  .not-selectable
+    -webkit-user-select none
+    -moz-user-select none
+    -ms-user-select none
+    user-select none
+
 .channel-list
   margin-left calc(-1*var(--f7-block-padding-horizontal))
   padding-left 0
@@ -224,6 +266,9 @@ export default {
     },
     hasAdvanced() {
       return this.channelGroups && Array.isArray(this.channelGroups) && this.channelGroups?.some((g) => g.hasAdvanced)
+    },
+    showFilterControls() {
+      return this.thing.channels.length > 0 || this.hasAdvanced
     }
   },
   methods: {

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -14,8 +14,8 @@
         :clear-button="true" />
       <f7-chip
         v-if="hasAdvanced"
-        media-bg-color="blue"
-        :color="showAdvanced ? 'blue' : ''"
+        media-bg-color="theme-alt"
+        :color="showAdvanced ? 'theme-alt' : ''"
         class="advanced-chip not-selectable"
         text="Advanced"
         @click="showAdvanced = !showAdvanced">

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -4,76 +4,78 @@
       <f7-block width="100" class="parameter-group no-margin">
         <f7-row>
           <f7-col>
-            <f7-list inline-labels no-hairlines-md class="no-margin">
-              <f7-list-input
-                v-if="createMode"
-                label="Thing ID"
-                type="text"
-                placeholder="Required"
-                :value="thing.ID"
-                input-id="input"
-                @input="changeUID"
-                info="Note: cannot be changed after the creation"
-                clear-button
-                required
-                :error-message="idErrorMessage"
-                :error-message-force="!!idErrorMessage">
-                <template #inner>
-                  <f7-link
-                    v-if="createMode && idErrorMessage && !idErrorMessage.includes('exists') && thing.ID"
-                    icon-f7="hammer_fill"
-                    style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-                    tooltip="Fix ID"
-                    @click="$oh.utils.normalizeInputForThingId('#input')" />
-                </template>
-              </f7-list-input>
-              <f7-list-input label="Thing UID" type="text" :input="false" disabled>
-                <template #input>
-                  <span>
-                    {{ thing.UID }}
-                    <clipboard-icon
-                      v-if="thing.UID && ready"
-                      :value="thing.UID"
-                      tooltip="Copy UID"
-                      style="pointer-events: initial !important" />
-                  </span>
-                </template>
-              </f7-list-input>
-              <f7-list-input
-                label="Label"
-                type="text"
-                :disabled="!ready || readOnly ? true : null"
-                placeholder="e.g. My Thing"
-                :value="thing.label"
-                @input="thing.label = $event.target.value"
-                required
-                validate />
-              <f7-list-input
-                label="Location"
-                type="text"
-                :disabled="!ready || readOnly ? true : null"
-                placeholder="e.g. Kitchen"
-                :value="thing.location"
-                @input="thing.location = $event.target.value"
-                :clear-button="ready && !readOnly" />
-            </f7-list>
-            <f7-block-title v-if="ready && thingType?.supportedBridgeTypeUIDs?.length"> Parent Bridge </f7-block-title>
-            <f7-block-footer
-              v-if="ready && thingType?.supportedBridgeTypeUIDs?.length && !thing.bridgeUID"
-              class="padding-left padding-right">
-              This type of Thing needs to be associated to a working Bridge to function properly.
-            </f7-block-footer>
-            <f7-list v-if="ready && thingType?.supportedBridgeTypeUIDs?.length" inline-labels no-hairlines-md>
-              <f7-list-group v-if="editable">
-                <thing-picker
-                  title="Bridge"
-                  name="bridge"
-                  :value="thing.bridgeUID"
-                  @input="updateBridge"
-                  :filterType="thingType?.supportedBridgeTypeUIDs" />
-              </f7-list-group>
-              <f7-list-item v-else title="Bridge" :after="thing.bridgeUID" />
-            </f7-list>
+            <group-box title="Thing Details">
+              <f7-list inline-labels no-hairlines-md class="no-margin">
+                <f7-list-input
+                  v-if="createMode"
+                  label="Thing ID"
+                  type="text"
+                  placeholder="Required"
+                  :value="thing.ID"
+                  input-id="input"
+                  @input="changeUID"
+                  info="Note: cannot be changed after the creation"
+                  clear-button
+                  required
+                  :error-message="idErrorMessage"
+                  :error-message-force="!!idErrorMessage">
+                  <template #inner>
+                    <f7-link
+                      v-if="createMode && idErrorMessage && !idErrorMessage.includes('exists') && thing.ID"
+                      icon-f7="hammer_fill"
+                      style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+                      tooltip="Fix ID"
+                      @click="$oh.utils.normalizeInputForThingId('#input')" />
+                  </template>
+                </f7-list-input>
+                <f7-list-input label="Thing UID" type="text" :input="false" disabled>
+                  <template #input>
+                    <span>
+                      {{ thing.UID }}
+                      <clipboard-icon
+                        v-if="thing.UID && ready"
+                        :value="thing.UID"
+                        tooltip="Copy UID"
+                        style="pointer-events: initial !important" />
+                    </span>
+                  </template>
+                </f7-list-input>
+                <f7-list-input
+                  label="Label"
+                  type="text"
+                  :disabled="!ready || readOnly ? true : null"
+                  placeholder="e.g. My Thing"
+                  :value="thing.label"
+                  @input="thing.label = $event.target.value"
+                  required
+                  validate />
+                <f7-list-input
+                  label="Location"
+                  type="text"
+                  :disabled="!ready || readOnly ? true : null"
+                  placeholder="e.g. Kitchen"
+                  :value="thing.location"
+                  @input="thing.location = $event.target.value"
+                  :clear-button="ready && !readOnly" />
+              </f7-list>
+            </group-box>
+            <group-box
+              v-if="ready && thingType?.supportedBridgeTypeUIDs?.length"
+              title="Parent Bridge"
+              :description="!thing.bridgeUID ? 'This type of Thing needs to be associated to a working Bridge to function properly.' : ''"
+              full-width>
+              <f7-list v-if="ready && thingType?.supportedBridgeTypeUIDs?.length" inline-labels no-hairlines-md>
+                <f7-list-group v-if="editable">
+                  <thing-picker
+                    title="Bridge"
+                    name="bridge"
+                    :value="thing.bridgeUID"
+                    @input="updateBridge"
+                    :filterType="thingType?.supportedBridgeTypeUIDs" />
+                </f7-list-group>
+                <f7-list-item v-else title="Bridge" :after="thing.bridgeUID" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-row>
       </f7-block>

--- a/bundles/org.openhab.ui/web/src/components/util/group-box.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/group-box.vue
@@ -10,7 +10,7 @@
       class="group-box-header"
       :role="accordion ? 'button' : undefined"
       :tabindex="accordion ? 0 : undefined"
-      :aria-expanded="accordion ? String(isAccordionOpened) : undefined"
+      :aria-expanded="accordion ? isAccordionOpened : undefined"
       @click="toggleAccordion"
       @keydown.enter.prevent="toggleAccordion"
       @keydown.space.prevent="toggleAccordion">
@@ -227,21 +227,23 @@ flush-styles()
       border-top 1px solid var(--group-box-divider-color)
 </style>
 
-<script setup>
+<script setup lang="ts">
+import { ref, watch, useTemplateRef } from 'vue'
 import { f7 } from 'framework7-vue'
-import { ref, watch } from 'vue'
 
-const props = defineProps({
-  title: String,
-  description: String,
-  accordion: Boolean,
-  accordionOpened: {
-    type: Boolean,
-    default: false
+const props = withDefaults(
+  defineProps<{
+    title: string
+    description: string
+    accordion: boolean
+    accordionOpened?: boolean
+  }>(),
+  {
+    accordionOpened: false
   }
-})
+)
 
-const container = ref()
+const container = useTemplateRef('container')
 const isAccordionOpened = ref(props.accordionOpened)
 
 watch(

--- a/bundles/org.openhab.ui/web/src/components/util/group-box.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/group-box.vue
@@ -1,0 +1,272 @@
+<template>
+  <f7-card
+    ref="container"
+    class="group-box"
+    @accordion:open="onAccordionOpen"
+    @accordion:close="onAccordionClose"
+    :class="{ 'accordion-item': accordion }">
+    <div
+      v-if="title || description || $slots['before-title'] || $slots['after-title']"
+      class="group-box-header"
+      :role="accordion ? 'button' : undefined"
+      :tabindex="accordion ? 0 : undefined"
+      :aria-expanded="accordion ? String(isAccordionOpened) : undefined"
+      @click="toggleAccordion"
+      @keydown.enter.prevent="toggleAccordion"
+      @keydown.space.prevent="toggleAccordion">
+      <div v-if="title || description || $slots['before-title'] || $slots['after-title']" class="group-box-header-text">
+        <div v-if="title || $slots['before-title'] || $slots['after-title']" class="group-box-title-row">
+          <div v-if="$slots['before-title']" class="group-box-before-title">
+            <slot name="before-title" />
+          </div>
+          <f7-block-title v-if="title">
+            {{ title }}
+          </f7-block-title>
+          <div v-if="$slots['after-title']" class="group-box-after-title">
+            <slot name="after-title" />
+          </div>
+        </div>
+        <f7-block-footer v-if="description" class="group-box-description">
+          <div v-html="description" />
+        </f7-block-footer>
+      </div>
+      <f7-icon v-if="accordion" f7="chevron_down" class="group-box-chevron" />
+    </div>
+
+    <div v-if="accordion" class="accordion-item-content">
+      <slot />
+    </div>
+    <slot v-else />
+  </f7-card>
+</template>
+
+<style lang="stylus">
+// Shared style for flush containers, used on smaller screens and in popups.
+// Remove the outer breathing room, rounded corners, and left/right borders
+// so the container fills the available width.
+flush-styles()
+  margin-left 0 !important
+  margin-right 0 !important
+  border-radius 0 !important
+  border-left 0
+  border-right 0
+  box-shadow none
+
+.group-box
+  // Shared knobs for spacing and separators inside the container.
+  --group-box-divider-color var(--f7-list-border-color, var(--f7-border-color))
+  --group-box-list-edge-spacing 0
+  --group-box-config-item-padding calc(var(--f7-list-item-padding-vertical) + 2px)
+  --group-box-config-item-margin-top 8px
+  --group-box-config-item-margin-bottom 8px
+
+  width 100%
+  margin var(--f7-card-margin-vertical) 0 var(--f7-list-margin-vertical) !important
+  border 1px solid var(--group-box-divider-color)
+  overflow hidden
+
+  // Revert to full-width, flush style on smaller screens
+  @media (max-width 1024px)
+    flush-styles()
+
+  // Popups are also narrow; keep containers flush there as well.
+  .popup &
+    flush-styles()
+
+  // Shared shaded header used by title and optional description.
+  .group-box-header
+    background var(--f7-list-item-divider-bg-color)
+    border-bottom 1px solid var(--group-box-divider-color)
+    padding 0
+
+    .group-box-header-text
+      min-width 0
+      width 100%
+      padding var(--f7-card-header-padding-vertical) 0
+
+    .group-box-title-row
+      display flex
+      align-items center
+      width 100%
+
+    .group-box-before-title
+      display flex
+      align-items center
+      gap 8px
+      padding-left var(--f7-block-padding-horizontal)
+
+    .group-box-after-title
+      margin-left auto
+      display flex
+      align-items center
+      justify-content flex-end
+      // flex 1 1 0
+      min-width 0
+      // text-align right
+      gap 8px
+      padding-right var(--f7-block-padding-horizontal)
+
+      > *
+        margin-left auto
+
+    .block-title
+      margin 0 !important
+      padding 0 var(--f7-block-padding-horizontal)
+      background transparent
+      font-size var(--f7-block-title-font-size)
+      color var(--f7-block-title-text-color, var(--f7-text-color))
+
+    .group-box-description
+      margin 0
+      padding 0 var(--f7-block-padding-horizontal)
+      font-weight normal
+
+      p
+        margin 0
+
+  &.accordion-item
+    .group-box-header
+      display flex
+      align-items center
+      cursor pointer
+      user-select none
+
+    .group-box-header-text
+      flex 1 1 auto
+
+    .group-box-chevron
+      margin-right var(--f7-block-padding-horizontal)
+      color var(--f7-list-item-after-text-color, var(--f7-text-color))
+      opacity 0.5
+      transition transform 0.3s
+
+  &:not(.accordion-item-opened).accordion-item
+    .group-box-header
+      border-bottom 0
+
+  &.accordion-item-opened
+    .group-box-chevron
+      transform rotate(180deg)
+
+  // Regular Framework7 lists are used by settings, developer tools and theme switcher.
+  // We hide Framework7's indented hairlines and draw one full-width divider per row.
+  > .list:not(.config-parameter),
+  > .accordion-item-content > .list:not(.config-parameter)
+    margin 0 !important
+
+    > ul
+      padding-left 0
+      background transparent
+      padding-top var(--group-box-list-edge-spacing)
+      padding-bottom var(--group-box-list-edge-spacing) !important
+
+      &:before, &:after
+        display none !important
+
+    > ul > li
+      position relative
+
+      &:after
+        content ''
+        position absolute
+        left 0
+        right 0
+        bottom 0
+        height 1px
+        background var(--group-box-divider-color)
+
+      &:last-child:after
+        display none
+
+      .item-inner:after
+        display none !important
+
+  // Config sheets render each control as its own root .config-parameter list.
+  // Keep the outer breathing room on the sheet, then strip internal Framework7
+  // hairlines so we only show one separator between sibling parameters.
+  > .config-sheet,
+  > .accordion-item-content > .config-sheet
+    margin 0
+    width 100%
+    padding-bottom var(--group-box-list-edge-spacing)
+
+  > .config-parameter,
+  > .accordion-item-content > .config-parameter,
+  > .config-sheet .config-parameter,
+  > .accordion-item-content > .config-sheet .config-parameter
+    margin-top 0 !important
+    padding-top var(--group-box-config-item-margin-top) !important
+    margin-bottom 0 !important
+    padding-bottom var(--group-box-config-item-margin-bottom) !important
+    --f7-list-item-padding-vertical var(--group-box-config-item-padding)
+
+    .list-group:before, .list-group:after
+      display none !important
+
+    .list-group > ul:before,
+    .list-group > ul:after,
+    > ul:before,
+    > ul:after,
+    ul:before,
+    ul:after
+      display none !important
+
+    .item-inner:after
+      display none !important
+
+    .item-content:after
+      display none !important
+
+    .param-description.block-footer
+      margin-top 0
+      margin-bottom 0
+      padding-bottom var(--group-box-config-item-margin-bottom)
+
+    & + .config-parameter
+      padding-top var(--group-box-config-item-margin-top)
+      border-top 1px solid var(--group-box-divider-color)
+</style>
+
+<script setup>
+import { f7 } from 'framework7-vue'
+import { ref, watch } from 'vue'
+
+const props = defineProps({
+  title: String,
+  description: String,
+  accordion: Boolean,
+  accordionOpened: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const container = ref()
+const isAccordionOpened = ref(props.accordionOpened)
+
+watch(
+  () => props.accordionOpened,
+  (accordionOpened) => {
+    isAccordionOpened.value = accordionOpened
+    if (!props.accordion || !container.value?.$el) return
+    if (accordionOpened) {
+      f7.accordion.open(container.value?.$el)
+    } else {
+      f7.accordion.close(container.value?.$el)
+    }
+  }
+)
+
+function toggleAccordion() {
+  if (!props.accordion || !container.value?.$el) return
+  f7.accordion.toggle(container.value?.$el)
+}
+
+function onAccordionOpen() {
+  isAccordionOpened.value = true
+}
+
+function onAccordionClose() {
+  isAccordionOpened.value = false
+}
+</script>

--- a/bundles/org.openhab.ui/web/src/components/util/list-filter.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/list-filter.vue
@@ -1,45 +1,41 @@
 <template>
-  <f7-list>
-    <f7-list-item accordion-item>
-      <template #title>
-        Filter
-        <template v-if="filtered">
-          (active)
-          <f7-link @click="resetFilters" text="Reset filters" class="margin-right" href="javascript:void(0)" />
-        </template>
-      </template>
-      <f7-accordion-content>
-        <f7-list class="no-hairlines-between">
-          <div v-for="(filter, type) in filters" :key="type">
-            <f7-list-item group-title style="height: 2em"> Filter by {{ filter.label }} </f7-list-item>
-            <f7-list-item class="padding-bottom">
-              <div v-if="Object.keys(filter.options).length === 0" class="text-color-gray" style="font-size: 0.9em">
-                None of the items have any {{ filter.label.toLowerCase() }} assigned
-              </div>
-              <div v-else class="chip-wrap">
-                <f7-chip
-                  v-for="(label, value) in filter.options"
-                  :key="value"
-                  :text="label"
-                  :color="isFilteredBy(type, value) ? 'blue' : ''"
-                  media-bg-color="blue"
-                  style="margin-right: 6px; cursor: pointer"
-                  @click="toggleFilter(type, value)">
-                  <template #media>
-                    <f7-icon
-                      v-if="isFilteredBy(type, value)"
-                      ios="f7:checkmark_circle_fill"
-                      md="material:check_circle"
-                      aurora="f7:checkmark_circle_fill" />
-                  </template>
-                </f7-chip>
-              </div>
-            </f7-list-item>
+  <group-box class="list-filter" title="Filter" accordion>
+    <template #before-title>
+      <f7-icon f7="slider_horizontal_3" />
+    </template>
+    <template v-if="filtered" #after-title>
+      (active)
+      <f7-link @click.stop="resetFilters" text="Clear filters" class="margin-right" href="javascript:void(0)" />
+    </template>
+    <f7-list class="no-hairlines-between">
+      <div v-for="(filter, type) in filters" :key="type">
+        <f7-list-item group-title style="height: 2em"> Filter by {{ filter.label }} </f7-list-item>
+        <f7-list-item class="padding-bottom">
+          <div v-if="Object.keys(filter.options).length === 0" class="text-color-gray" style="font-size: 0.9em">
+            None of the items have any {{ filter.label.toLowerCase() }} assigned
           </div>
-        </f7-list>
-      </f7-accordion-content>
-    </f7-list-item>
-  </f7-list>
+          <div v-else class="chip-wrap">
+            <f7-chip
+              v-for="(label, value) in filter.options"
+              :key="value"
+              :text="label"
+              :color="isFilteredBy(type, value) ? 'blue' : ''"
+              media-bg-color="blue"
+              style="margin-right: 6px; cursor: pointer"
+              @click="toggleFilter(type, value)">
+              <template #media>
+                <f7-icon
+                  v-if="isFilteredBy(type, value)"
+                  ios="f7:checkmark_circle_fill"
+                  md="material:check_circle"
+                  aurora="f7:checkmark_circle_fill" />
+              </template>
+            </f7-chip>
+          </div>
+        </f7-list-item>
+      </div>
+    </f7-list>
+  </group-box>
 </template>
 
 <style scoped>

--- a/bundles/org.openhab.ui/web/src/components/util/list-filter.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/list-filter.vue
@@ -1,45 +1,41 @@
 <template>
-  <f7-list>
-    <f7-list-item accordion-item>
-      <template #title>
-        Filter
-        <template v-if="filtered">
-          (active)
-          <f7-link @click="resetFilters" text="Reset filters" class="margin-right" href="javascript:void(0)" />
-        </template>
-      </template>
-      <f7-accordion-content>
-        <f7-list class="no-hairlines-between">
-          <div v-for="(filter, type) in filters" :key="type">
-            <f7-list-item group-title style="height: 2em"> Filter by {{ filter.label }} </f7-list-item>
-            <f7-list-item class="padding-bottom">
-              <div v-if="Object.keys(filter.options).length === 0" class="text-color-gray" style="font-size: 0.9em">
-                None of the items have any {{ filter.label.toLowerCase() }} assigned
-              </div>
-              <div v-else class="chip-wrap">
-                <f7-chip
-                  v-for="(label, value) in filter.options"
-                  :key="value"
-                  :text="label"
-                  :color="isFilteredBy(type, value) ? 'theme-alt' : ''"
-                  media-bg-color="theme-alt"
-                  style="margin-right: 6px; cursor: pointer"
-                  @click="toggleFilter(type, value)">
-                  <template #media>
-                    <f7-icon
-                      v-if="isFilteredBy(type, value)"
-                      ios="f7:checkmark_circle_fill"
-                      md="material:check_circle"
-                      aurora="f7:checkmark_circle_fill" />
-                  </template>
-                </f7-chip>
-              </div>
-            </f7-list-item>
+  <group-box class="list-filter" title="Filter" accordion>
+    <template #before-title>
+      <f7-icon f7="slider_horizontal_3" />
+    </template>
+    <template v-if="filtered" #after-title>
+      (active)
+      <f7-link @click.stop="resetFilters" text="Clear filters" class="margin-right" href="javascript:void(0)" />
+    </template>
+    <f7-list class="no-hairlines-between">
+      <div v-for="(filter, type) in filters" :key="type">
+        <f7-list-item group-title style="height: 2em"> Filter by {{ filter.label }} </f7-list-item>
+        <f7-list-item class="padding-bottom">
+          <div v-if="Object.keys(filter.options).length === 0" class="text-color-gray" style="font-size: 0.9em">
+            None of the items have any {{ filter.label.toLowerCase() }} assigned
           </div>
-        </f7-list>
-      </f7-accordion-content>
-    </f7-list-item>
-  </f7-list>
+          <div v-else class="chip-wrap">
+            <f7-chip
+              v-for="(label, value) in filter.options"
+              :key="value"
+              :text="label"
+              :color="isFilteredBy(type, value) ? 'theme-alt' : ''"
+              media-bg-color="theme-alt"
+              style="margin-right: 6px; cursor: pointer"
+              @click="toggleFilter(type, value)">
+              <template #media>
+                <f7-icon
+                  v-if="isFilteredBy(type, value)"
+                  ios="f7:checkmark_circle_fill"
+                  md="material:check_circle"
+                  aurora="f7:checkmark_circle_fill" />
+              </template>
+            </f7-chip>
+          </div>
+        </f7-list-item>
+      </div>
+    </f7-list>
+  </group-box>
 </template>
 
 <style scoped>

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -15,7 +15,7 @@ html
   --f7-inline-label-font-size 14px
   --f7-input-font-size 14px
   --f7-button-height 28px
-  --f7-input-height 24px
+  --f7-input-height 34px
   // list
   --f7-list-item-header-line-height 1.3
   --f7-list-item-after-line-height 1.3
@@ -83,6 +83,31 @@ html
     padding-top 0
     padding-bottom 0
 
+/*
+  Add an outline around focused input fields
+  But not on Android because it already adds an underscore
+*/
+.aurora, .ios
+  input:focus, .input-with-value:focus
+    outline none !important
+    box-shadow inset 0 0 0 1px
+
+.item-input, .item-input-wrap, .input, .input-with-value
+  // Space label from input
+  .item-title, .item-label
+    margin-bottom 4px
+
+  // Rounded corners and background tint
+  input, .input-with-value
+    border-radius 6px !important
+    background-color rgba(0,0,0,0.08) !important // light mode
+    .dark &
+      background-color rgba(255,255,255,0.16) !important // dark mode
+
+  .input-clear-button
+    // Offset clear button for custom input background
+    margin-right 6px
+
 /* Fixes for smart select popups with searchbar */
 .popup.smart-select-popup.modal-in
   .page-content
@@ -100,6 +125,8 @@ html
   --f7-button-text-transform none
   --f7-button-large-text-transform none
   --f7-button-small-text-transform none
+  --f7-input-padding-left 8px
+  --f7-input-padding-right 24px
 
 /* Custom Dialog Sizes */
 .dialog.dialog-medium

--- a/bundles/org.openhab.ui/web/src/js/openhab/utils.ts
+++ b/bundles/org.openhab.ui/web/src/js/openhab/utils.ts
@@ -1,7 +1,6 @@
 import { f7 } from 'framework7-vue'
 // eslint-disable-next-line import-x/named
 import { clean as cleanDiacritics } from 'diacritic'
-import truncate from 'lodash/truncate'
 
 export function normalizeLabel(label: string) {
   return cleanDiacritics(label.normalize('NFKD'))
@@ -60,16 +59,6 @@ export function simpleHash(obj: object | string): string {
   }
   return (hash >>> 0).toString(36)
 }
-/**
- * Truncate a string to a given length, adding an ellipsis if necessary.
- *
- * @param string the string to truncate
- * @param length the maximum length of the string
- * @returns the truncated string
- */
-export function truncateString(string: string, length: number): string {
-  return truncate(string, { length, separator: ' ' })
-}
 
 export default {
   normalizeLabel,
@@ -77,6 +66,5 @@ export default {
   normalizeInput,
   normalizeInputForThingId,
   hsbToRgb,
-  simpleHash,
-  truncateString
+  simpleHash
 }

--- a/bundles/org.openhab.ui/web/src/js/openhab/utils.ts
+++ b/bundles/org.openhab.ui/web/src/js/openhab/utils.ts
@@ -1,6 +1,7 @@
 import { f7 } from 'framework7-vue'
 // eslint-disable-next-line import-x/named
 import { clean as cleanDiacritics } from 'diacritic'
+import truncate from 'lodash/truncate'
 
 export function normalizeLabel(label: string) {
   return cleanDiacritics(label.normalize('NFKD'))
@@ -59,6 +60,16 @@ export function simpleHash(obj: object | string): string {
   }
   return (hash >>> 0).toString(36)
 }
+/**
+ * Truncate a string to a given length, adding an ellipsis if necessary.
+ *
+ * @param string the string to truncate
+ * @param length the maximum length of the string
+ * @returns the truncated string
+ */
+export function truncateString(string: string, length: number): string {
+  return truncate(string, { length, separator: ' ' })
+}
 
 export default {
   normalizeLabel,
@@ -66,5 +77,6 @@ export default {
   normalizeInput,
   normalizeInputForThingId,
   hsbToRgb,
-  simpleHash
+  simpleHash,
+  truncateString
 }

--- a/bundles/org.openhab.ui/web/src/main.ts
+++ b/bundles/org.openhab.ui/web/src/main.ts
@@ -12,6 +12,7 @@ import OhNavContent from '@/components/navigation/oh-nav-content.vue'
 import DeveloperDockIcon from './components/developer/developer-dock-icon.vue'
 import OhIconComponent from './components/widgets/system/oh-icon.vue'
 import GenericWidgetComponent from './components/widgets/generic-widget-component.vue'
+import GroupBox from './components/util/group-box.vue'
 
 import { registerWidgets } from '@/components/oh-component-registry'
 
@@ -73,7 +74,7 @@ app.component('OhNavContent', OhNavContent)
 app.component('DeveloperDockIcon', DeveloperDockIcon)
 app.component('OhIcon', OhIconComponent)
 app.component('GenericWidgetComponent', GenericWidgetComponent)
-
+app.component('GroupBox', GroupBox)
 registerWidgets(app)
 
 app.mount('#app')

--- a/bundles/org.openhab.ui/web/src/pages/about.vue
+++ b/bundles/org.openhab.ui/web/src/pages/about.vue
@@ -21,95 +21,77 @@
             </p>
             <p>
               <f7-link external target="_blank" href="https://www.openhab.org/" :text="t('about.homePage')" />
-            </p>
-            <p>
+              &nbsp;
               <f7-link external target="_blank" href="https://www.openhab.org/docs/" :text="t('about.documentation')" />
-            </p>
-            <p>
+              &nbsp;
               <f7-link external target="_blank" href="https://community.openhab.org/" :text="t('about.communityForum')" />
             </p>
           </f7-block>
         </f7-col>
       </f7-row>
-      <f7-row v-if="systemInfo">
-        <f7-col>
-          <f7-list accordion-list>
-            <f7-list-item :title="t('about.technicalInformation')" accordion-item>
-              <f7-accordion-content>
-                <f7-list>
-                  <f7-list-item :title="t('about.technicalInformation.configurationFolder')" :after="systemInfo.configFolder" />
-                  <f7-list-item :title="t('about.technicalInformation.userdataFolder')" :after="systemInfo.userdataFolder" />
-                  <f7-list-item :title="t('about.technicalInformation.logsFolder')" :after="systemInfo.logFolder" />
-                  <f7-list-item
-                    :title="t('about.technicalInformation.operatingSystem')"
-                    :after="`${systemInfo.osName}/${systemInfo.osVersion} (${systemInfo.osArchitecture})`" />
-                  <f7-list-item
-                    :title="t('about.technicalInformation.javaRuntime')"
-                    :footer="systemInfo.javaVendor"
-                    :after="`${systemInfo.javaVersion} (${systemInfo.javaVendorVersion})`">
-                    <template #root-end>
-                      <div class="item-content" style="flex-direction: column">
-                        <f7-progressbar
-                          class="margin-top"
-                          style="width: 90%"
-                          color="blue"
-                          :progress="(systemInfo.freeMemory * 100) / systemInfo.totalMemory" />
-                        <small class="margin-bottom text-color-gray">
-                          {{
-                            t('about.technicalInformation.resourceStats', {
-                              nbproc: systemInfo.availableProcessors,
-                              ram:
-                                Math.round(systemInfo.freeMemory / 1024 / 1024) +
-                                '/' +
-                                Math.round(systemInfo.totalMemory / 1024 / 1024) +
-                                'MB'
-                            })
-                          }}
-                        </small>
-                      </div>
-                    </template>
-                  </f7-list-item>
-                  <f7-list-button color="blue" @click="textualSystemInfoOpened = true">
-                    {{ t('about.technicalInformation.viewDetails') }}
-                  </f7-list-button>
-                </f7-list>
-              </f7-accordion-content>
+
+      <f7-block v-if="systemInfo" class="block-narrow">
+        <group-box :title="t('about.technicalInformation')" accordion>
+          <f7-list class="no-margin-top no-margin-bottom">
+            <f7-list-item :title="t('about.technicalInformation.configurationFolder')" :after="systemInfo.configFolder" />
+            <f7-list-item :title="t('about.technicalInformation.userdataFolder')" :after="systemInfo.userdataFolder" />
+            <f7-list-item :title="t('about.technicalInformation.logsFolder')" :after="systemInfo.logFolder" />
+            <f7-list-item
+              :title="t('about.technicalInformation.operatingSystem')"
+              :after="`${systemInfo.osName}/${systemInfo.osVersion} (${systemInfo.osArchitecture})`" />
+            <f7-list-item
+              :title="t('about.technicalInformation.javaRuntime')"
+              :footer="systemInfo.javaVendor"
+              :after="
+                systemInfo.javaVendorVersion ? `${systemInfo.javaVersion} (${systemInfo.javaVendorVersion})` : systemInfo.javaVersion
+              ">
+              <template #root-end>
+                <div class="item-content padding-bottom flex-direction-column">
+                  <f7-progressbar
+                    class="margin-top"
+                    style="width: 90%"
+                    color="blue"
+                    :progress="(systemInfo.freeMemory * 100) / systemInfo.totalMemory" />
+                  <div class="item-footer margin-top-half text-align-center">
+                    {{
+                      t('about.technicalInformation.resourceStats', {
+                        nbproc: systemInfo.availableProcessors,
+                        ram: Math.round(systemInfo.freeMemory / 1024 / 1024) + '/' + Math.round(systemInfo.totalMemory / 1024 / 1024) + 'MB'
+                      })
+                    }}
+                  </div>
+                </div>
+              </template>
             </f7-list-item>
+
+            <f7-list-button color="blue" @click="textualSystemInfoOpened = true">
+              {{ t('about.technicalInformation.viewDetails') }}
+            </f7-list-button>
           </f7-list>
-        </f7-col>
-      </f7-row>
+        </group-box>
+      </f7-block>
 
       <f7-block-title>
         <h4>{{ t('about.appearanceOptions') }}</h4>
       </f7-block-title>
+
       <theme-switcher />
 
-      <f7-block-title>
-        <h4>
-          {{ t('about.reload') }}
-        </h4>
-      </f7-block-title>
-      <f7-col v-if="showCachePurgeOption">
-        <p class="padding-horizontal">
-          {{ t('about.reload.purgeExplanation1') }}
-        </p>
-        <p class="padding-horizontal">
-          {{ t('about.reload.purgeExplanation2') }}
-        </p>
-      </f7-col>
-      <f7-col>
-        <f7-list>
-          <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches()">
-            {{ t('about.reload.purgeCachesAndRefresh') }}
-          </f7-list-button>
-          <f7-list-button color="blue" @click="reload">
-            {{ t('about.reload.reloadApp') }}
-          </f7-list-button>
-          <f7-list-button color="blue" href="/setup-wizard/">
-            {{ t('about.reload.setupWizard') }}
-          </f7-list-button>
-        </f7-list>
-      </f7-col>
+      <f7-block class="block-narrow">
+        <group-box :title="t('about.reload')" :description="cachePurgeDescription">
+          <f7-list>
+            <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches()">
+              {{ t('about.reload.purgeCachesAndRefresh') }}
+            </f7-list-button>
+            <f7-list-button color="blue" @click="reload">
+              {{ t('about.reload.reloadApp') }}
+            </f7-list-button>
+            <f7-list-button color="blue" href="/setup-wizard/">
+              {{ t('about.reload.setupWizard') }}
+            </f7-list-button>
+          </f7-list>
+        </group-box>
+      </f7-block>
     </f7-block>
     <f7-popup :opened="textualSystemInfoOpened" close-on-escape @popup:closed="textualSystemInfoOpened = false">
       <f7-navbar>
@@ -213,6 +195,11 @@ export default {
         },
         timestamp: new Date()
       })
+    },
+    cachePurgeDescription() {
+      if (!this.showCachePurgeOption) return ''
+
+      return '<p>' + this.t('about.reload.purgeExplanation1') + '</p><p>' + this.t('about.reload.purgeExplanation2') + '</p>'
     },
     ...mapStores(useUIOptionsStore, useRuntimeStore)
   },

--- a/bundles/org.openhab.ui/web/src/pages/about.vue
+++ b/bundles/org.openhab.ui/web/src/pages/about.vue
@@ -21,95 +21,77 @@
             </p>
             <p>
               <f7-link external target="_blank" href="https://www.openhab.org/" :text="t('about.homePage')" />
-            </p>
-            <p>
+              &nbsp;
               <f7-link external target="_blank" href="https://www.openhab.org/docs/" :text="t('about.documentation')" />
-            </p>
-            <p>
+              &nbsp;
               <f7-link external target="_blank" href="https://community.openhab.org/" :text="t('about.communityForum')" />
             </p>
           </f7-block>
         </f7-col>
       </f7-row>
-      <f7-row v-if="systemInfo">
-        <f7-col>
-          <f7-list accordion-list>
-            <f7-list-item :title="t('about.technicalInformation')" accordion-item>
-              <f7-accordion-content>
-                <f7-list>
-                  <f7-list-item :title="t('about.technicalInformation.configurationFolder')" :after="systemInfo.configFolder" />
-                  <f7-list-item :title="t('about.technicalInformation.userdataFolder')" :after="systemInfo.userdataFolder" />
-                  <f7-list-item :title="t('about.technicalInformation.logsFolder')" :after="systemInfo.logFolder" />
-                  <f7-list-item
-                    :title="t('about.technicalInformation.operatingSystem')"
-                    :after="`${systemInfo.osName}/${systemInfo.osVersion} (${systemInfo.osArchitecture})`" />
-                  <f7-list-item
-                    :title="t('about.technicalInformation.javaRuntime')"
-                    :footer="systemInfo.javaVendor"
-                    :after="`${systemInfo.javaVersion} (${systemInfo.javaVendorVersion})`">
-                    <template #root-end>
-                      <div class="item-content" style="flex-direction: column">
-                        <f7-progressbar
-                          class="margin-top"
-                          style="width: 90%"
-                          color="theme-alt"
-                          :progress="(systemInfo.freeMemory * 100) / systemInfo.totalMemory" />
-                        <small class="margin-bottom text-color-gray">
-                          {{
-                            t('about.technicalInformation.resourceStats', {
-                              nbproc: systemInfo.availableProcessors,
-                              ram:
-                                Math.round(systemInfo.freeMemory / 1024 / 1024) +
-                                '/' +
-                                Math.round(systemInfo.totalMemory / 1024 / 1024) +
-                                'MB'
-                            })
-                          }}
-                        </small>
-                      </div>
-                    </template>
-                  </f7-list-item>
-                  <f7-list-button color="theme-alt" @click="textualSystemInfoOpened = true">
-                    {{ t('about.technicalInformation.viewDetails') }}
-                  </f7-list-button>
-                </f7-list>
-              </f7-accordion-content>
+
+      <f7-block v-if="systemInfo" class="block-narrow">
+        <group-box :title="t('about.technicalInformation')" accordion>
+          <f7-list class="no-margin-top no-margin-bottom">
+            <f7-list-item :title="t('about.technicalInformation.configurationFolder')" :after="systemInfo.configFolder" />
+            <f7-list-item :title="t('about.technicalInformation.userdataFolder')" :after="systemInfo.userdataFolder" />
+            <f7-list-item :title="t('about.technicalInformation.logsFolder')" :after="systemInfo.logFolder" />
+            <f7-list-item
+              :title="t('about.technicalInformation.operatingSystem')"
+              :after="`${systemInfo.osName}/${systemInfo.osVersion} (${systemInfo.osArchitecture})`" />
+            <f7-list-item
+              :title="t('about.technicalInformation.javaRuntime')"
+              :footer="systemInfo.javaVendor"
+              :after="
+                systemInfo.javaVendorVersion ? `${systemInfo.javaVersion} (${systemInfo.javaVendorVersion})` : systemInfo.javaVersion
+              ">
+              <template #root-end>
+                <div class="item-content padding-bottom flex-direction-column">
+                  <f7-progressbar
+                    class="margin-top"
+                    style="width: 90%"
+                    color="theme-alt"
+                    :progress="(systemInfo.freeMemory * 100) / systemInfo.totalMemory" />
+                  <div class="item-footer margin-top-half text-align-center">
+                    {{
+                      t('about.technicalInformation.resourceStats', {
+                        nbproc: systemInfo.availableProcessors,
+                        ram: Math.round(systemInfo.freeMemory / 1024 / 1024) + '/' + Math.round(systemInfo.totalMemory / 1024 / 1024) + 'MB'
+                      })
+                    }}
+                  </div>
+                </div>
+              </template>
             </f7-list-item>
+
+            <f7-list-button color="theme-alt" @click="textualSystemInfoOpened = true">
+              {{ t('about.technicalInformation.viewDetails') }}
+            </f7-list-button>
           </f7-list>
-        </f7-col>
-      </f7-row>
+        </group-box>
+      </f7-block>
 
       <f7-block-title>
         <h4>{{ t('about.appearanceOptions') }}</h4>
       </f7-block-title>
+
       <theme-switcher />
 
-      <f7-block-title>
-        <h4>
-          {{ t('about.reload') }}
-        </h4>
-      </f7-block-title>
-      <f7-col v-if="showCachePurgeOption">
-        <p class="padding-horizontal">
-          {{ t('about.reload.purgeExplanation1') }}
-        </p>
-        <p class="padding-horizontal">
-          {{ t('about.reload.purgeExplanation2') }}
-        </p>
-      </f7-col>
-      <f7-col>
-        <f7-list>
-          <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches()">
-            {{ t('about.reload.purgeCachesAndRefresh') }}
-          </f7-list-button>
-          <f7-list-button color="theme-alt" @click="reload">
-            {{ t('about.reload.reloadApp') }}
-          </f7-list-button>
-          <f7-list-button color="theme-alt" href="/setup-wizard/">
-            {{ t('about.reload.setupWizard') }}
-          </f7-list-button>
-        </f7-list>
-      </f7-col>
+      <f7-block class="block-narrow">
+        <group-box :title="t('about.reload')" :description="cachePurgeDescription">
+          <f7-list>
+            <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches()">
+              {{ t('about.reload.purgeCachesAndRefresh') }}
+            </f7-list-button>
+            <f7-list-button color="theme-alt" @click="reload">
+              {{ t('about.reload.reloadApp') }}
+            </f7-list-button>
+            <f7-list-button color="theme-alt" href="/setup-wizard/">
+              {{ t('about.reload.setupWizard') }}
+            </f7-list-button>
+          </f7-list>
+        </group-box>
+      </f7-block>
     </f7-block>
     <f7-popup :opened="textualSystemInfoOpened" close-on-escape @popup:closed="textualSystemInfoOpened = false">
       <f7-navbar>
@@ -213,6 +195,11 @@ export default {
         },
         timestamp: new Date()
       })
+    },
+    cachePurgeDescription() {
+      if (!this.showCachePurgeOption) return ''
+
+      return '<p>' + this.t('about.reload.purgeExplanation1') + '</p><p>' + this.t('about.reload.purgeExplanation2') + '</p>'
     },
     ...mapStores(useUIOptionsStore, useRuntimeStore)
   },

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-config.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-config.vue
@@ -14,10 +14,11 @@
         </f7-button>
       </f7-col>
     </f7-block>
+
     <f7-block v-if="configDescription && config" form class="block-narrow">
       <f7-col>
-        <f7-block-title medium> Add-on configuration </f7-block-title>
         <config-sheet
+          title="Add-on Configuration"
           :parameter-groups="configDescription.parameterGroups"
           :parameters="configDescription.parameters"
           :configuration="config" />
@@ -25,19 +26,26 @@
     </f7-block>
     <f7-block v-if="loggerPackages.length > 0" form class="block-narrow">
       <f7-col>
-        <f7-block-title medium> Add-on log settings </f7-block-title>
-        <f7-list class="col wide">
-          <f7-list-item v-for="loggerPackage in loggerPackages" :key="loggerPackage.loggerName" :title="loggerPackage.loggerName">
-            <f7-input type="select" :value="loggerPackage.level" @input="loggerPackage.level = $event.target.value">
-              <option value="DEFAULT">Default</option>
-              <option value="TRACE">Trace</option>
-              <option value="DEBUG">Debug</option>
-              <option value="INFO">Info</option>
-              <option value="WARN">Warning</option>
-              <option value="ERROR">Error</option>
-            </f7-input>
-          </f7-list-item>
-        </f7-list>
+        <group-box :title="'Logging Levels'">
+          <f7-list class="no-margin-top no-margin-bottom">
+            <f7-list-item v-for="loggerPackage in loggerPackages" :key="loggerPackage.loggerName" class="logger-row-stacked">
+              <div class="logger-container">
+                <div class="logger-name">{{ loggerPackage.loggerName }}</div>
+
+                <div class="custom-segmented-track">
+                  <button
+                    v-for="level in ['DEFAULT', 'OFF', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR']"
+                    :key="level"
+                    type="button"
+                    :class="{ 'segment-active': loggerPackage.level === level }"
+                    @click="loggerPackage.level = level">
+                    {{ level }}
+                  </button>
+                </div>
+              </div>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
   </f7-page>
@@ -53,6 +61,92 @@
   @media (max-width 1023px)
     margin-left 16px
     margin-right 16px
+
+.config-page-header
+  margin-top 24px !important
+  margin-bottom 8px !important
+
+  .header-flex-wrapper
+    display flex // <-- CRITICAL: Tells the browser to use flexbox rules
+    flex-direction column // Stacks nicely on small mobile screens
+    justify-content space-between
+    gap 12px
+    padding-bottom 12px
+    border-bottom 1px solid rgba(255, 255, 255, 0.08)
+
+    // Snap to side-by-side layout on tablets & desktop screens
+    @media (min-width: 768px)
+      flex-direction row
+      align-items flex-end // Snaps the toggle to the bottom line of the text description
+
+  .header-main-text
+    h2
+      margin 0 0 4px 0
+      font-size 18px // Sized down slightly to match standard dashboard headers
+      font-weight 600
+    p
+      margin 0
+      font-size 13px
+      color rgba(255, 255, 255, 0.45)
+      line-height 1.4
+
+  .advanced-toggle-label
+    display flex
+    align-items center
+    gap 8px
+    cursor pointer
+    user-select none
+    font-size 13px
+    font-weight 500
+    color var(--f7-theme-color, #ff9500) // Keeps your unified theme tint matching
+    white-space nowrap
+
+    @media (min-width: 768px)
+      padding-bottom 4px // Matches alignment beautifully to description baseline on desktop
+
+    input[type="checkbox"]
+      accent-color var(--f7-theme-color, #ff9500)
+
+.logger-row-stacked
+  .item-content, .item-inner
+    display block
+
+  .logger-container
+    padding 12px 0 14px
+
+  .logger-name
+    margin-bottom 12px
+
+  .custom-segmented-track
+    display flex
+    border 1px solid var(--f7-theme-color)
+    border-radius 6px
+    overflow hidden
+
+    button
+      // flex 1
+      background transparent
+      border none
+      color var(--f7-theme-color-text)
+      opacity 0.45
+      font-size 11px
+      font-weight 600
+      height 2em
+      cursor pointer
+
+      &:hover:not(.segment-active)
+        background var(--f7-theme-color)
+        color var(--f7-theme-color-text)
+        opacity 0.65
+
+      &.segment-active
+        background var(--f7-theme-color, #ff9500)
+        color var(--f7-theme-color-text, #fff)
+        opacity 1
+        font-weight 700
+
+      & + button
+        border-left 1px solid var(--f7-theme-color)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -47,10 +47,6 @@
       </div>
     </f7-toolbar>
 
-    <f7-list class="searchbar-not-found">
-      <f7-list-item title="Nothing found" />
-    </f7-list>
-
     <f7-block v-show="!nowidgetEngine" class="block-narrow">
       <!-- skeleton for not ready -->
       <f7-col v-show="!ready">
@@ -68,42 +64,47 @@
         </f7-list>
       </f7-col>
       <f7-col v-if="ready">
-        <f7-block-title class="searchbar-hide-on-search"> {{ blocks.length }} block libraries </f7-block-title>
-        <f7-list v-show="blocks.length > 0" class="searchbar-found col blocks-list" ref="blocksList" media-list>
-          <f7-list-item
-            v-for="(b, index) in blocks"
-            :key="index"
-            media-item
-            class="blockslist-item"
-            :checkbox="showCheckboxes"
-            :checked="isChecked(b.uid) ? true : null"
-            prevent-router
-            @click.ctrl="ctrlClick($event, b)"
-            @click.meta="ctrlClick($event, b)"
-            @click.exact="click($event, b)"
-            :link="`${b.uid}`"
-            :title="b.uid">
-            <template #subtitle>
-              <div>
-                <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                  <template #media>
-                    <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                  </template>
-                </f7-chip>
-              </div>
-            </template>
-            <template #media>
-              <span class="item-initial">{{ b.uid[0].toUpperCase() }}</span>
-            </template>
-            <template #after>
-              <!-- This is here to push the after-title icon so it would appear immediately after the title
-                    for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
-            </template>
-            <template #after-title>
-              <f7-icon v-if="b.editable === false" f7="lock_fill" color="gray" />
-            </template>
-          </f7-list-item>
+        <f7-list class="searchbar-not-found">
+          <f7-list-item title="Nothing found" />
         </f7-list>
+
+        <group-box v-if="ready" :title="blocks.length + ' block libraries'">
+          <f7-list v-show="blocks.length > 0" class="searchbar-found col blocks-list" ref="blocksList" media-list>
+            <f7-list-item
+              v-for="(b, index) in blocks"
+              :key="index"
+              media-item
+              class="blockslist-item"
+              :checkbox="showCheckboxes"
+              :checked="isChecked(b.uid) ? true : null"
+              prevent-router
+              @click.ctrl="ctrlClick($event, b)"
+              @click.meta="ctrlClick($event, b)"
+              @click.exact="click($event, b)"
+              :link="`${b.uid}`"
+              :title="b.uid">
+              <template #subtitle>
+                <div>
+                  <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                    <template #media>
+                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                    </template>
+                  </f7-chip>
+                </div>
+              </template>
+              <template #media>
+                <span class="item-initial">{{ b.uid[0].toUpperCase() }}</span>
+              </template>
+              <template #after>
+                <!-- This is here to push the after-title icon so it would appear immediately after the title
+                    for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
+              </template>
+              <template #after-title>
+                <f7-icon v-if="b.editable === false" f7="lock_fill" color="gray" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <template #fixed>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -47,10 +47,6 @@
       </div>
     </f7-toolbar>
 
-    <f7-list class="searchbar-not-found">
-      <f7-list-item title="Nothing found" />
-    </f7-list>
-
     <f7-block v-show="!nowidgetEngine" class="block-narrow">
       <!-- skeleton for not ready -->
       <f7-col v-show="!ready">
@@ -68,42 +64,47 @@
         </f7-list>
       </f7-col>
       <f7-col v-if="ready">
-        <f7-block-title class="searchbar-hide-on-search"> {{ blocks.length }} block libraries </f7-block-title>
-        <f7-list v-show="blocks.length > 0" class="searchbar-found col blocks-list" ref="blocksList" media-list>
-          <f7-list-item
-            v-for="(b, index) in blocks"
-            :key="index"
-            media-item
-            class="blockslist-item"
-            :checkbox="showCheckboxes"
-            :checked="isChecked(b.uid) ? true : null"
-            prevent-router
-            @click.ctrl="ctrlClick($event, b)"
-            @click.meta="ctrlClick($event, b)"
-            @click.exact="click($event, b)"
-            :link="`${b.uid}`"
-            :title="b.uid">
-            <template #subtitle>
-              <div>
-                <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
-                  <template #media>
-                    <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                  </template>
-                </f7-chip>
-              </div>
-            </template>
-            <template #media>
-              <span class="item-initial">{{ b.uid[0].toUpperCase() }}</span>
-            </template>
-            <template #after>
-              <!-- This is here to push the after-title icon so it would appear immediately after the title
-                    for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
-            </template>
-            <template #after-title>
-              <f7-icon v-if="b.editable === false" f7="lock_fill" color="gray" />
-            </template>
-          </f7-list-item>
+        <f7-list class="searchbar-not-found">
+          <f7-list-item title="Nothing found" />
         </f7-list>
+
+        <group-box v-if="ready" :title="blocks.length + ' block libraries'">
+          <f7-list v-show="blocks.length > 0" class="searchbar-found col blocks-list" ref="blocksList" media-list>
+            <f7-list-item
+              v-for="(b, index) in blocks"
+              :key="index"
+              media-item
+              class="blockslist-item"
+              :checkbox="showCheckboxes"
+              :checked="isChecked(b.uid) ? true : null"
+              prevent-router
+              @click.ctrl="ctrlClick($event, b)"
+              @click.meta="ctrlClick($event, b)"
+              @click.exact="click($event, b)"
+              :link="`${b.uid}`"
+              :title="b.uid">
+              <template #subtitle>
+                <div>
+                  <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
+                    <template #media>
+                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                    </template>
+                  </f7-chip>
+                </div>
+              </template>
+              <template #media>
+                <span class="item-initial">{{ b.uid[0].toUpperCase() }}</span>
+              </template>
+              <template #after>
+                <!-- This is here to push the after-title icon so it would appear immediately after the title
+                    for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
+              </template>
+              <template #after-title>
+                <f7-icon v-if="b.editable === false" f7="lock_fill" color="gray" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <template #fixed>

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -17,8 +17,7 @@
               :key="column"
               width="100"
               :medium="developerNavigationColumns.length > 1 ? '50' : '100'">
-              <template v-for="section in developerColumnSections(column)" :key="section.id">
-                <f7-block-title>{{ $t(section.titleKey) }}</f7-block-title>
+              <group-box v-for="section in developerColumnSections(column)" :key="section.id" :title="$t(section.titleKey)">
                 <f7-list>
                   <template v-for="item in section.items" :key="item.id">
                     <f7-list-item
@@ -84,7 +83,7 @@
                     </f7-list-item>
                   </template>
                 </f7-list>
-              </template>
+              </group-box>
             </f7-col>
           </f7-row>
           <f7-block-footer v-if="$t('home.overview.title') !== 'Overview'" class="margin text-align-center">

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -64,52 +64,50 @@
       </f7-col>
 
       <f7-col v-if="ready">
-        <f7-block-title>
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <f7-list v-if="!listedItems.length && widgets.length" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list v-show="listedItems.length > 0" class="col widgets-list" ref="widgetsList" media-list>
-          <f7-list-item
-            v-for="widget in listedItems"
-            :key="widget.uid"
-            media-item
-            class="widgetlist-item"
-            :checkbox="showCheckboxes"
-            :checked="isChecked(widget.uid)"
-            prevent-router
-            @click.ctrl="ctrlClick($event, widget)"
-            @click.meta="ctrlClick($event, widget)"
-            @click.exact="click($event, widget)"
-            :link="`${encodeURIComponent(widget.uid)}`"
-            :title="widget.uid">
-            <template #subtitle>
-              <div>
-                <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                  <template #media>
-                    <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                  </template>
-                </f7-chip>
-              </div>
-            </template>
-            <template #media>
-              <span class="item-initial">{{ widget.uid[0].toUpperCase() }}</span>
-            </template>
-            <template #after>
-              <!-- This is here to push the after-title icon so it would appear immediately after the title
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && listedItems.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list v-show="listedItems.length > 0" class="col widgets-list" ref="widgetsList" media-list>
+            <f7-list-item
+              v-for="widget in listedItems"
+              :key="widget.uid"
+              media-item
+              class="widgetlist-item"
+              :checkbox="showCheckboxes"
+              :checked="isChecked(widget.uid)"
+              prevent-router
+              @click.ctrl="ctrlClick($event, widget)"
+              @click.meta="ctrlClick($event, widget)"
+              @click.exact="click($event, widget)"
+              :link="`${encodeURIComponent(widget.uid)}`"
+              :title="widget.uid">
+              <template #subtitle>
+                <div>
+                  <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                    <template #media>
+                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                    </template>
+                  </f7-chip>
+                </div>
+              </template>
+              <template #media>
+                <span class="item-initial">{{ widget.uid[0].toUpperCase() }}</span>
+              </template>
+              <template #after>
+                <!-- This is here to push the after-title icon so it would appear immediately after the title
                     for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
-            </template>
-            <template #after-title>
-              <f7-icon v-if="widget.editable === false" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </f7-list>
+              </template>
+              <template #after-title>
+                <f7-icon v-if="widget.editable === false" f7="lock_fill" size="1rem" color="gray" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <template #fixed>

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -64,52 +64,50 @@
       </f7-col>
 
       <f7-col v-if="ready">
-        <f7-block-title>
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <f7-list v-if="!listedItems.length && widgets.length" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list v-show="listedItems.length > 0" class="col widgets-list" ref="widgetsList" media-list>
-          <f7-list-item
-            v-for="widget in listedItems"
-            :key="widget.uid"
-            media-item
-            class="widgetlist-item"
-            :checkbox="showCheckboxes"
-            :checked="isChecked(widget.uid)"
-            prevent-router
-            @click.ctrl="ctrlClick($event, widget)"
-            @click.meta="ctrlClick($event, widget)"
-            @click.exact="click($event, widget)"
-            :link="`${encodeURIComponent(widget.uid)}`"
-            :title="widget.uid">
-            <template #subtitle>
-              <div>
-                <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
-                  <template #media>
-                    <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                  </template>
-                </f7-chip>
-              </div>
-            </template>
-            <template #media>
-              <span class="item-initial">{{ widget.uid[0].toUpperCase() }}</span>
-            </template>
-            <template #after>
-              <!-- This is here to push the after-title icon so it would appear immediately after the title
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && listedItems.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list v-show="listedItems.length > 0" class="col widgets-list" ref="widgetsList" media-list>
+            <f7-list-item
+              v-for="widget in listedItems"
+              :key="widget.uid"
+              media-item
+              class="widgetlist-item"
+              :checkbox="showCheckboxes"
+              :checked="isChecked(widget.uid)"
+              prevent-router
+              @click.ctrl="ctrlClick($event, widget)"
+              @click.meta="ctrlClick($event, widget)"
+              @click.exact="click($event, widget)"
+              :link="`${encodeURIComponent(widget.uid)}`"
+              :title="widget.uid">
+              <template #subtitle>
+                <div>
+                  <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
+                    <template #media>
+                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                    </template>
+                  </f7-chip>
+                </div>
+              </template>
+              <template #media>
+                <span class="item-initial">{{ widget.uid[0].toUpperCase() }}</span>
+              </template>
+              <template #after>
+                <!-- This is here to push the after-title icon so it would appear immediately after the title
                     for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
-            </template>
-            <template #after-title>
-              <f7-icon v-if="widget.editable === false" f7="lock_fill" size="1rem" color="gray" />
-            </template>
-          </f7-list-item>
-        </f7-list>
+              </template>
+              <template #after-title>
+                <f7-icon v-if="widget.editable === false" f7="lock_fill" size="1rem" color="gray" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <template #fixed>

--- a/bundles/org.openhab.ui/web/src/pages/profile.vue
+++ b/bundles/org.openhab.ui/web/src/pages/profile.vue
@@ -20,22 +20,20 @@
     <f7-block class="block-narrow after-profile-header">
       <f7-row>
         <f7-col>
-          <f7-list>
-            <f7-list-button color="blue" :external="true" href="/changePassword">
-              {{ t('profile.changePassword') }}
-            </f7-list-button>
-          </f7-list>
+          <group-box title="Account">
+            <f7-list>
+              <f7-list-button color="blue" :external="true" href="/changePassword">
+                {{ t('profile.changePassword') }}
+              </f7-list-button>
+            </f7-list>
+          </group-box>
         </f7-col>
       </f7-row>
     </f7-block>
     <f7-block class="block-narrow">
       <f7-row>
         <f7-col>
-          <f7-block-title>{{ t('profile.sessions') }}</f7-block-title>
-          <f7-block-footer class="padding-horizontal">
-            {{ t('profile.sessions.header') }}
-          </f7-block-footer>
-          <f7-card>
+          <group-box :title="t('profile.sessions')" :description="t('profile.sessions.header')">
             <f7-list media-list swipeout>
               <f7-list-item
                 v-for="session in filteredSessions"
@@ -68,18 +66,14 @@
                 {{ t('profile.sessions.signOut') }}
               </f7-list-button>
             </f7-list>
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
     </f7-block>
     <f7-block class="block-narrow margin-bottom padding-bottom">
       <f7-row>
         <f7-col>
-          <f7-block-title>{{ t('profile.apiTokens') }}</f7-block-title>
-          <f7-block-footer class="padding-horizontal">
-            {{ t('profile.apiTokens.header') }}
-          </f7-block-footer>
-          <f7-card>
+          <group-box :title="t('profile.apiTokens')" :description="t('profile.apiTokens.header')">
             <f7-list media-list swipeout>
               <f7-list-item
                 v-for="apiToken in apiTokens"
@@ -109,7 +103,7 @@
                 {{ t('profile.apiTokens.create') }}
               </f7-list-button>
             </f7-list>
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
     </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/profile.vue
+++ b/bundles/org.openhab.ui/web/src/pages/profile.vue
@@ -20,22 +20,20 @@
     <f7-block class="block-narrow after-profile-header">
       <f7-row>
         <f7-col>
-          <f7-list>
-            <f7-list-button color="theme-alt" :external="true" href="/changePassword">
-              {{ t('profile.changePassword') }}
-            </f7-list-button>
-          </f7-list>
+          <group-box title="Account">
+            <f7-list>
+              <f7-list-button color="theme-alt" :external="true" href="/changePassword">
+                {{ t('profile.changePassword') }}
+              </f7-list-button>
+            </f7-list>
+          </group-box>
         </f7-col>
       </f7-row>
     </f7-block>
     <f7-block class="block-narrow">
       <f7-row>
         <f7-col>
-          <f7-block-title>{{ t('profile.sessions') }}</f7-block-title>
-          <f7-block-footer class="padding-horizontal">
-            {{ t('profile.sessions.header') }}
-          </f7-block-footer>
-          <f7-card>
+          <group-box :title="t('profile.sessions')" :description="t('profile.sessions.header')">
             <f7-list media-list swipeout>
               <f7-list-item
                 v-for="session in filteredSessions"
@@ -71,18 +69,14 @@
                 {{ t('profile.sessions.signOut') }}
               </f7-list-button>
             </f7-list>
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
     </f7-block>
     <f7-block class="block-narrow margin-bottom padding-bottom">
       <f7-row>
         <f7-col>
-          <f7-block-title>{{ t('profile.apiTokens') }}</f7-block-title>
-          <f7-block-footer class="padding-horizontal">
-            {{ t('profile.apiTokens.header') }}
-          </f7-block-footer>
-          <f7-card>
+          <group-box :title="t('profile.apiTokens')" :description="t('profile.apiTokens.header')">
             <f7-list media-list swipeout>
               <f7-list-item
                 v-for="apiToken in apiTokens"
@@ -112,7 +106,7 @@
                 {{ t('profile.apiTokens.create') }}
               </f7-list-button>
             </f7-list>
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
     </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -36,25 +36,27 @@
     <f7-block v-if="item" class="block-narrow after-item-header">
       <f7-row v-if="item.state">
         <f7-col>
-          <item-state-preview :item="item" :context="context" />
+          <group-box title="Item State">
+            <item-state-preview :item="item" :context="context" />
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="nonSemanticTags?.length > 0">
         <f7-col>
-          <f7-block-title>Non-Semantic Tags</f7-block-title>
-          <f7-block strong class="tags-block">
-            <f7-chip v-for="tag in nonSemanticTags" :key="tag" :text="tag" media-bg-color="theme-alt">
-              <template #media>
-                <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-              </template>
-            </f7-chip>
-          </f7-block>
+          <group-box title="Non-Semantic Tags">
+            <f7-block class="tags-block">
+              <f7-chip v-for="tag in nonSemanticTags" :key="tag" :text="tag" media-bg-color="theme-alt">
+                <template #media>
+                  <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                </template>
+              </f7-chip>
+            </f7-block>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="item?.metadata?.semantics?.value">
         <f7-col>
-          <f7-block-title>Semantic Model</f7-block-title>
-          <f7-card>
+          <group-box title="Semantic Model">
             <model-treeview
               class="model-treeview no-selection-style"
               :rootNodes="rootElements"
@@ -62,54 +64,51 @@
               :includeItemTags="true"
               :selected="modelItem(item)"
               @selected="navigateToItem" />
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="item?.groupNames?.length > 0">
         <f7-col>
-          <f7-block-title>Parent Groups</f7-block-title>
-          <f7-card>
+          <group-box title="Parent Groups">
             <f7-list>
               <ul>
                 <item v-for="group in itemGroups" :key="group.name" :item="group" :link="itemLink(group.name)" :context="context" />
               </ul>
             </f7-list>
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="item?.type === 'Group'">
         <f7-col>
-          <f7-block-title>Members</f7-block-title>
           <group-members :group-item="item" :context="context" @updated="load" />
         </f7-col>
       </f7-row>
       <f7-row v-if="item.name">
         <f7-col>
-          <f7-block-title>Metadata</f7-block-title>
           <metadata-menu :item="item" :f7router />
         </f7-col>
       </f7-row>
       <f7-row v-if="item.name && item.type !== 'Group'">
         <f7-col>
-          <f7-block-title>Channel Links</f7-block-title>
           <link-details :item="item" :links="links" :f7router />
         </f7-col>
       </f7-row>
       <f7-row v-if="item.name && (item.type !== 'Group' || item.groupType)">
         <f7-col>
-          <f7-block-title>Persistence</f7-block-title>
           <item-persistence-details :item="item" :f7router />
         </f7-col>
       </f7-row>
       <f7-row>
         <f7-col>
-          <f7-list>
-            <f7-list-button color="theme-alt" @click="duplicateItem"> Duplicate Item </f7-list-button>
-            <f7-list-button color="theme-alt" @click="copyFileDefinitionToClipboard(ObjectType.ITEM, [item.name])">
-              Copy File Definition
-            </f7-list-button>
-            <f7-list-button v-if="item.editable" color="red" @click="deleteItem"> Remove Item </f7-list-button>
-          </f7-list>
+          <group-box>
+            <f7-list>
+              <f7-list-button color="theme-alt" @click="duplicateItem"> Duplicate Item </f7-list-button>
+              <f7-list-button color="theme-alt" @click="copyFileDefinitionToClipboard(ObjectType.ITEM, [item.name])">
+                Copy File Definition
+              </f7-list-button>
+              <f7-list-button v-if="item.editable" color="red" @click="deleteItem"> Remove Item </f7-list-button>
+            </f7-list>
+          </group-box>
           <p class="developer-sidebar-tip text-align-center">
             Tip: Use the developer sidebar (Shift+Alt+D) to
             <f7-link text="search for usages of this Item" @click="searchInSidebar" />
@@ -162,7 +161,6 @@
   .after-item-header
     margin-bottom 0 !important
 .tags-block
-  margin-bottom 0
   text-align center
   .chip
     margin-left 3px

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -36,25 +36,27 @@
     <f7-block v-if="item" class="block-narrow after-item-header">
       <f7-row v-if="item.state">
         <f7-col>
-          <item-state-preview :item="item" :context="context" />
+          <group-box title="Item State">
+            <item-state-preview :item="item" :context="context" />
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="nonSemanticTags?.length > 0">
         <f7-col>
-          <f7-block-title>Non-Semantic Tags</f7-block-title>
-          <f7-block strong class="tags-block">
-            <f7-chip v-for="tag in nonSemanticTags" :key="tag" :text="tag" media-bg-color="blue">
-              <template #media>
-                <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-              </template>
-            </f7-chip>
-          </f7-block>
+          <group-box title="Non-Semantic Tags">
+            <f7-block class="tags-block">
+              <f7-chip v-for="tag in nonSemanticTags" :key="tag" :text="tag" media-bg-color="blue">
+                <template #media>
+                  <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                </template>
+              </f7-chip>
+            </f7-block>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="item?.metadata?.semantics?.value">
         <f7-col>
-          <f7-block-title>Semantic Model</f7-block-title>
-          <f7-card>
+          <group-box title="Semantic Model">
             <model-treeview
               class="model-treeview no-selection-style"
               :rootNodes="rootElements"
@@ -62,54 +64,51 @@
               :includeItemTags="true"
               :selected="modelItem(item)"
               @selected="navigateToItem" />
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="item?.groupNames?.length > 0">
         <f7-col>
-          <f7-block-title>Parent Groups</f7-block-title>
-          <f7-card>
+          <group-box title="Parent Groups">
             <f7-list>
               <ul>
                 <item v-for="group in itemGroups" :key="group.name" :item="group" :link="itemLink(group.name)" :context="context" />
               </ul>
             </f7-list>
-          </f7-card>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-row v-if="item?.type === 'Group'">
         <f7-col>
-          <f7-block-title>Members</f7-block-title>
           <group-members :group-item="item" :context="context" @updated="load" />
         </f7-col>
       </f7-row>
       <f7-row v-if="item.name">
         <f7-col>
-          <f7-block-title>Metadata</f7-block-title>
           <metadata-menu :item="item" :f7router />
         </f7-col>
       </f7-row>
       <f7-row v-if="item.name && item.type !== 'Group'">
         <f7-col>
-          <f7-block-title>Channel Links</f7-block-title>
           <link-details :item="item" :links="links" :f7router />
         </f7-col>
       </f7-row>
       <f7-row v-if="item.name && (item.type !== 'Group' || item.groupType)">
         <f7-col>
-          <f7-block-title>Persistence</f7-block-title>
           <item-persistence-details :item="item" :f7router />
         </f7-col>
       </f7-row>
       <f7-row>
         <f7-col>
-          <f7-list>
-            <f7-list-button color="blue" @click="duplicateItem"> Duplicate Item </f7-list-button>
-            <f7-list-button color="blue" @click="copyFileDefinitionToClipboard(ObjectType.ITEM, [item.name])">
-              Copy File Definition
-            </f7-list-button>
-            <f7-list-button v-if="item.editable" color="red" @click="deleteItem"> Remove Item </f7-list-button>
-          </f7-list>
+          <group-box>
+            <f7-list>
+              <f7-list-button color="blue" @click="duplicateItem"> Duplicate Item </f7-list-button>
+              <f7-list-button color="blue" @click="copyFileDefinitionToClipboard(ObjectType.ITEM, [item.name])">
+                Copy File Definition
+              </f7-list-button>
+              <f7-list-button v-if="item.editable" color="red" @click="deleteItem"> Remove Item </f7-list-button>
+            </f7-list>
+          </group-box>
           <p class="developer-sidebar-tip text-align-center">
             Tip: Use the developer sidebar (Shift+Alt+D) to
             <f7-link text="search for usages of this Item" @click="searchInSidebar" />
@@ -162,7 +161,6 @@
   .after-item-header
     margin-bottom 0 !important
 .tags-block
-  margin-bottom 0
   text-align center
   .chip
     margin-left 3px

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -80,63 +80,57 @@
       </f7-col>
 
       <f7-col v-if="ready && items.length > 0">
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
+        <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="processFilter" @reset="resetFilter" />
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && listedItems.length" #after-title>
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
-        </f7-block-title>
-        <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="processFilter" @reset="resetFilter" />
-
-        <f7-list v-if="!listedItems.length">
-          <f7-list-item title="Nothing found" />
-        </f7-list>
-        <f7-list class="searchbar-found col" ref="itemsList" media-list virtual-list :virtual-list-params="vlParams">
-          <ul>
-            <f7-list-item
-              v-for="(item, index) in vlData.items"
-              :key="index"
-              media-item
-              class="itemlist-item"
-              :checkbox="showCheckboxes"
-              :checked="isChecked(item.name)"
-              prevent-router
-              @click.ctrl="ctrlClick($event, item)"
-              @click.meta="ctrlClick($event, item)"
-              @click.exact="click($event, item)"
-              :link="`${encodeURIComponent(item.name)}`"
-              :title="item.label ? item.label : item.name"
-              :footer="item.label ? item.name : '\xa0'"
-              :subtitle="getItemTypeAndMetaLabel(item)"
-              :style="`top: ${vlData.topPosition}px`"
-              :after="item.state ? item.state : '\xa0'">
-              <!-- Note: Using dynamic states is not possible since state tracking has a heavy performance impact -->
-              <template #media>
-                <oh-icon
-                  v-if="item.category"
-                  :icon="item.category"
-                  :state="item.type === 'Image' ? null : item.state"
-                  height="32"
-                  width="32" />
-                <span v-else class="item-initial">{{ item.name[0] }}</span>
-              </template>
-              <template #after-title>
-                <f7-icon v-if="!item.editable" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-              <!-- <f7-button color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
-              <template #subtitle>
-                <div>
-                  <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-            </f7-list-item>
-          </ul>
-        </f7-list>
+          <f7-list class="searchbar-found col" ref="itemsList" media-list virtual-list :virtual-list-params="vlParams">
+            <ul>
+              <f7-list-item
+                v-for="(item, index) in vlData.items"
+                :key="index"
+                media-item
+                class="itemlist-item"
+                :checkbox="showCheckboxes"
+                :checked="isChecked(item.name)"
+                prevent-router
+                @click.ctrl="ctrlClick($event, item)"
+                @click.meta="ctrlClick($event, item)"
+                @click.exact="click($event, item)"
+                :link="`${encodeURIComponent(item.name)}`"
+                :title="item.label ? item.label : item.name"
+                :footer="item.label ? item.name : '\xa0'"
+                :subtitle="getItemTypeAndMetaLabel(item)"
+                :style="`top: ${vlData.topPosition}px`"
+                :after="item.state ? item.state : '\xa0'">
+                <!-- Note: Using dynamic states is not possible since state tracking has a heavy performance impact -->
+                <template #media>
+                  <oh-icon
+                    v-if="item.category"
+                    :icon="item.category"
+                    :state="item.type === 'Image' ? null : item.state"
+                    height="32"
+                    width="32" />
+                  <span v-else class="item-initial">{{ item.name[0] }}</span>
+                </template>
+                <template #after-title>
+                  <f7-icon v-if="!item.editable" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+                <!-- <f7-button color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
+                <template #subtitle>
+                  <div>
+                    <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                      </template>
+                    </f7-chip>
+                  </div>
+                </template>
+              </f7-list-item>
+            </ul>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -80,68 +80,62 @@
       </f7-col>
 
       <f7-col v-if="ready && items.length > 0">
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
+        <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="processFilter" @reset="resetFilter" />
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && listedItems.length" #after-title>
             <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
           </template>
-        </f7-block-title>
-        <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="processFilter" @reset="resetFilter" />
-
-        <f7-list v-if="!listedItems.length">
-          <f7-list-item title="Nothing found" />
-        </f7-list>
-        <f7-list class="searchbar-found col" ref="itemsList" media-list virtual-list :virtual-list-params="vlParams">
-          <ul>
-            <f7-list-item
-              v-for="(item, index) in vlData.items"
-              :key="index"
-              media-item
-              class="itemlist-item"
-              :checkbox="showCheckboxes"
-              :checked="isChecked(item.name)"
-              prevent-router
-              @click.ctrl="ctrlClick($event, item)"
-              @click.meta="ctrlClick($event, item)"
-              @click.exact="click($event, item)"
-              :link="`${encodeURIComponent(item.name)}`"
-              :title="item.label ? item.label : item.name"
-              :footer="item.label ? item.name : '\xa0'"
-              :subtitle="getItemTypeAndMetaLabel(item)"
-              :style="`top: ${vlData.topPosition}px`"
-              :after="item.state ? item.state : '\xa0'">
-              <!-- Note: Using dynamic states is not possible since state tracking has a heavy performance impact -->
-              <template #media>
-                <oh-icon
-                  v-if="item.category"
-                  :icon="item.category"
-                  :state="item.type === 'Image' ? null : item.state"
-                  height="32"
-                  width="32" />
-                <span v-else class="item-initial">{{ item.name[0] }}</span>
-              </template>
-              <template #after-title>
-                <f7-icon v-if="!item.editable" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-              <!-- <f7-button color="theme-alt" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
-              <template #subtitle>
-                <div>
-                  <f7-chip
+          <f7-list class="searchbar-found col" ref="itemsList" media-list virtual-list :virtual-list-params="vlParams">
+            <ul>
+              <f7-list-item
+                v-for="(item, index) in vlData.items"
+                :key="index"
+                media-item
+                class="itemlist-item"
+                :checkbox="showCheckboxes"
+                :checked="isChecked(item.name)"
+                prevent-router
+                @click.ctrl="ctrlClick($event, item)"
+                @click.meta="ctrlClick($event, item)"
+                @click.exact="click($event, item)"
+                :link="`${encodeURIComponent(item.name)}`"
+                :title="item.label ? item.label : item.name"
+                :footer="item.label ? item.name : '\xa0'"
+                :subtitle="getItemTypeAndMetaLabel(item)"
+                :style="`top: ${vlData.topPosition}px`"
+                :after="item.state ? item.state : '\xa0'">
+                <!-- Note: Using dynamic states is not possible since state tracking has a heavy performance impact -->
+                <template #media>
+                  <oh-icon
+                    v-if="item.category"
+                    :icon="item.category"
+                    :state="item.type === 'Image' ? null : item.state"
+                    height="32"
+                    width="32" />
+                  <span v-else class="item-initial">{{ item.name[0] }}</span>
+                </template>
+                <template #after-title>
+                  <f7-icon v-if="!item.editable" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+                <!-- <f7-button color="theme-alt" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
+                <template #subtitle>
+                  <div>
+                    <f7-chip
                     v-for="tag in getNonSemanticTags(item)"
                     :key="tag"
                     :text="tag"
                     media-bg-color="theme-alt"
                     style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-            </f7-list-item>
-          </ul>
-        </f7-list>
+                      <template #media>
+                        <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                      </template>
+                    </f7-chip>
+                  </div>
+                </template>
+              </f7-list-item>
+            </ul>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -121,11 +121,11 @@
                 <template #subtitle>
                   <div>
                     <f7-chip
-                    v-for="tag in getNonSemanticTags(item)"
-                    :key="tag"
-                    :text="tag"
-                    media-bg-color="theme-alt"
-                    style="margin-right: 6px">
+                      v-for="tag in getNonSemanticTags(item)"
+                      :key="tag"
+                      :text="tag"
+                      media-bg-color="theme-alt"
+                      style="margin-right: 6px">
                       <template #media>
                         <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                       </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/metadata/item-metadata-edit.vue
@@ -23,11 +23,13 @@
             <component :is="editorControl" :item="item" :metadata="metadata" :namespace="namespace" />
           </f7-col>
         </f7-block>
-        <f7-block v-if="ready" class="block-narrow">
+        <f7-block v-if="ready && !creationMode && editable" class="block-narrow">
           <f7-col>
-            <f7-list>
-              <f7-list-button v-if="!creationMode && editable" color="red" @click="remove()"> Remove metadata </f7-list-button>
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button color="red" @click="remove()"> Remove metadata </f7-list-button>
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -169,6 +171,7 @@ export default {
   methods: {
     onPageBeforeIn() {
       this.load()
+      console.log('router', this.f7router)
     },
     onEditorInput(value) {
       this.yaml = value

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
@@ -1,13 +1,12 @@
 <template>
-  <div>
-    <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
+  <group-box :title="$t('settings.groups.addon-settings')">
     <f7-list class="search-list">
       <f7-list-item v-for="a in addonsSettings" v-show="!a.hidden" :key="a.uid" :link="'addons/' + a.uid" :title="a.label" />
       <f7-list-button v-if="!expanded && addonsSettings.find((a) => a.hidden)" color="blue" @click="$emit('expand')">
         {{ $t('dialogs.showAll') }}
       </f7-list-button>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
@@ -1,13 +1,12 @@
 <template>
-  <div class="addon-section">
-    <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
+  <group-box class="addon-section" :title="$t('settings.groups.addon-settings')">
     <f7-list class="search-list">
       <f7-list-item v-for="a in addonsSettings" v-show="!a.hidden" :key="a.uid" :link="'addons/' + a.uid" :title="a.label" />
       <f7-list-button v-if="!expanded && addonsSettings.find((a) => a.hidden)" color="theme-alt" @click="$emit('expand')">
         {{ $t('dialogs.showAll') }}
       </f7-list-button>
     </f7-list>
-  </div>
+  </group-box>
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -23,8 +23,7 @@
     <f7-block class="block-narrow after-big-title settings-menu">
       <f7-row>
         <f7-col :class="!addonsLoaded || (addonsLoaded && addonsInstalled.length > 0) ? 'settings-col' : ''" width="100" medium="50">
-          <template v-for="section in settingsNavigationSections" :key="section.id">
-            <f7-block-title>{{ $t(section.titleKey) }}</f7-block-title>
+          <group-box v-for="section in settingsNavigationSections" :key="section.id" :title="$t(section.titleKey)">
             <f7-list media-list class="search-list">
               <f7-list-item
                 v-for="item in section.items"
@@ -42,63 +41,58 @@
                 </template>
               </f7-list-item>
             </f7-list>
-          </template>
+          </group-box>
         </f7-col>
         <f7-col :class="!addonsLoaded || (addonsLoaded && addonsInstalled.length > 0) ? 'settings-col' : ''" width="100" medium="50">
-          <div v-show="servicesLoaded">
-            <f7-block-title>{{ $t('settings.groups.system-settings') }}</f7-block-title>
-            <f7-list class="search-list">
+          <group-box v-show="servicesLoaded" :title="$t('settings.groups.system-settings')">
+            <f7-list class="search-list no-margin-top">
               <f7-list-item
                 v-for="service in systemSettings"
                 v-show="!service.hidden"
                 :key="service.id"
                 :link="'services/' + service.id"
                 :title="service.label" />
+
               <f7-list-button v-if="!expandedTypes.systemSettingsExpanded" color="blue" @click="expand('systemSettingsExpanded')">
                 {{ $t('dialogs.showAll') }}
               </f7-list-button>
             </f7-list>
-          </div>
+          </group-box>
           <!-- skeleton for not servicesLoaded -->
-          <div v-if="!servicesLoaded">
-            <f7-block-title>{{ $t('settings.groups.system-settings') }}</f7-block-title>
+          <group-box v-if="!servicesLoaded" :title="$t('settings.groups.system-settings')">
             <f7-list>
               <f7-list-item v-for="n in 9" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
             </f7-list>
-          </div>
+          </group-box>
           <div v-show="$f7dim.width < 1450">
-            <div v-show="addonsLoaded && addonsInstalled.length > 0">
-              <addon-section
-                class="add-on-section"
-                :addonsInstalled="addonsInstalled"
-                :addonsServices="addonsServices"
-                :expanded="expandedTypes.addonsExpanded"
-                @expand="expand('addonsExpanded')" />
-            </div>
-            <!-- skeleton for not addonsLoaded -->
-            <div v-if="!addonsLoaded">
-              <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
-              <f7-list>
-                <f7-list-item v-for="n in 4" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
-              </f7-list>
-            </div>
-          </div>
-        </f7-col>
-        <f7-col v-show="$f7dim.width >= 1450" width="33" class="add-on-col">
-          <div v-show="addonsLoaded && addonsInstalled.length > 0">
             <addon-section
+              v-show="addonsLoaded && addonsInstalled.length > 0"
+              class="add-on-section"
               :addonsInstalled="addonsInstalled"
               :addonsServices="addonsServices"
               :expanded="expandedTypes.addonsExpanded"
               @expand="expand('addonsExpanded')" />
+            <!-- skeleton for not addonsLoaded -->
+            <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')">
+              <f7-list>
+                <f7-list-item v-for="n in 4" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
+              </f7-list>
+            </group-box>
           </div>
+        </f7-col>
+        <f7-col v-show="$f7dim.width >= 1450" width="33" class="add-on-col">
+          <addon-section
+            v-show="addonsLoaded && addonsInstalled.length > 0"
+            :addonsInstalled="addonsInstalled"
+            :addonsServices="addonsServices"
+            :expanded="expandedTypes.addonsExpanded"
+            @expand="expand('addonsExpanded')" />
           <!-- skeleton for not addonsLoaded -->
-          <div v-if="!addonsLoaded">
-            <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
+          <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')">
             <f7-list>
               <f7-list-item v-for="n in 9" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
             </f7-list>
-          </div>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-block-footer v-if="$t('home.overview.title') !== 'Overview'" class="margin text-align-center">
@@ -120,6 +114,20 @@
     height calc(var(--f7-searchbar-input-height) + var(--f7-searchbar-inner-padding-left))
     .searchbar
       top calc(0.5 * var(--f7-searchbar-inner-padding-left))
+
+  .list-group
+    background var(--f7-list-bg-color, #fff)
+    border-radius 16px
+    overflow hidden
+    margin-bottom 20px
+
+    .list
+      margin-bottom 6px
+      ul:after
+        display none !important
+      li:first-child
+        padding-top 6px
+        border-top 1px solid var(--f7-list-border-color)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -23,8 +23,7 @@
     <f7-block class="block-narrow after-big-title settings-menu">
       <f7-row>
         <f7-col :class="!addonsLoaded || (addonsLoaded && addonsInstalled.length > 0) ? 'settings-col' : ''" width="100" medium="50">
-          <template v-for="section in settingsNavigationSections" :key="section.id">
-            <f7-block-title>{{ $t(section.titleKey) }}</f7-block-title>
+          <group-box v-for="section in settingsNavigationSections" :key="section.id" :title="$t(section.titleKey)">
             <f7-list media-list class="search-list">
               <f7-list-item
                 v-for="item in section.items"
@@ -42,63 +41,58 @@
                 </template>
               </f7-list-item>
             </f7-list>
-          </template>
+          </group-box>
         </f7-col>
         <f7-col :class="!addonsLoaded || (addonsLoaded && addonsInstalled.length > 0) ? 'settings-col' : ''" width="100" medium="50">
-          <div v-show="servicesLoaded">
-            <f7-block-title>{{ $t('settings.groups.system-settings') }}</f7-block-title>
-            <f7-list class="search-list">
+          <group-box v-show="servicesLoaded" :title="$t('settings.groups.system-settings')">
+            <f7-list class="search-list no-margin-top">
               <f7-list-item
                 v-for="service in systemSettings"
                 v-show="!service.hidden"
                 :key="service.id"
                 :link="'services/' + service.id"
                 :title="service.label" />
+
               <f7-list-button v-if="!expandedTypes.systemSettingsExpanded" color="theme-alt" @click="expand('systemSettingsExpanded')">
                 {{ $t('dialogs.showAll') }}
               </f7-list-button>
             </f7-list>
-          </div>
+          </group-box>
           <!-- skeleton for not servicesLoaded -->
-          <div v-if="!servicesLoaded">
-            <f7-block-title>{{ $t('settings.groups.system-settings') }}</f7-block-title>
+          <group-box v-if="!servicesLoaded" :title="$t('settings.groups.system-settings')">
             <f7-list>
               <f7-list-item v-for="n in 9" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
             </f7-list>
-          </div>
+          </group-box>
           <div v-show="$f7dim.width < 1450">
-            <div v-show="addonsLoaded && addonsInstalled.length > 0">
-              <addon-section
-                class="add-on-section"
-                :addonsInstalled="addonsInstalled"
-                :addonsServices="addonsServices"
-                :expanded="expandedTypes.addonsExpanded"
-                @expand="expand('addonsExpanded')" />
-            </div>
-            <!-- skeleton for not addonsLoaded -->
-            <div v-if="!addonsLoaded">
-              <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
-              <f7-list>
-                <f7-list-item v-for="n in 4" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
-              </f7-list>
-            </div>
-          </div>
-        </f7-col>
-        <f7-col v-show="$f7dim.width >= 1450" width="33" class="add-on-col">
-          <div v-show="addonsLoaded && addonsInstalled.length > 0">
             <addon-section
+              v-show="addonsLoaded && addonsInstalled.length > 0"
+              class="add-on-section"
               :addonsInstalled="addonsInstalled"
               :addonsServices="addonsServices"
               :expanded="expandedTypes.addonsExpanded"
               @expand="expand('addonsExpanded')" />
+            <!-- skeleton for not addonsLoaded -->
+            <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')">
+              <f7-list>
+                <f7-list-item v-for="n in 4" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
+              </f7-list>
+            </group-box>
           </div>
+        </f7-col>
+        <f7-col v-show="$f7dim.width >= 1450" width="33" class="add-on-col">
+          <addon-section
+            v-show="addonsLoaded && addonsInstalled.length > 0"
+            :addonsInstalled="addonsInstalled"
+            :addonsServices="addonsServices"
+            :expanded="expandedTypes.addonsExpanded"
+            @expand="expand('addonsExpanded')" />
           <!-- skeleton for not addonsLoaded -->
-          <div v-if="!addonsLoaded">
-            <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
+          <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')">
             <f7-list>
               <f7-list-item v-for="n in 9" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
             </f7-list>
-          </div>
+          </group-box>
         </f7-col>
       </f7-row>
       <f7-block-footer v-if="$t('home.overview.title') !== 'Overview'" class="margin text-align-center">
@@ -120,6 +114,20 @@
     height calc(var(--f7-searchbar-input-height) + var(--f7-searchbar-inner-padding-left))
     .searchbar
       top calc(0.5 * var(--f7-searchbar-inner-padding-left))
+
+  .list-group
+    background var(--f7-list-bg-color, #fff)
+    border-radius 16px
+    overflow hidden
+    margin-bottom 20px
+
+    .list
+      margin-bottom 6px
+      ul:after
+        display none !important
+      li:first-child
+        padding-top 6px
+        border-top 1px solid var(--f7-list-border-color)
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/chart/chart-edit.vue
@@ -28,8 +28,8 @@
         <f7-block v-if="ready && !previewMode" class="block-narrow">
           <not-editable-notice v-if="!isEditable" subject="chart" />
           <page-settings :page="page" :createMode="createMode" :readOnly="!isEditable" :f7router />
-          <f7-block-title>Chart Configuration</f7-block-title>
           <config-sheet
+            title="Chart Configuration"
             :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
             :parameters="pageWidgetDefinition.props.parameters || []"
             :configuration="page.config"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/home/home-edit.vue
@@ -39,16 +39,14 @@
         <div v-else-if="!previewMode">
           <f7-block class="block-narrow no-padding">
             <not-editable-notice v-if="!isEditable" />
-            <f7-col>
-              <f7-block-title>Page Configuration</f7-block-title>
-              <config-sheet
-                :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
-                :parameters="pageWidgetDefinition.props.parameters || []"
-                :configuration="page.config"
-                :f7router
-                :read-only="!isEditable"
-                @updated="dirty = true" />
-            </f7-col>
+            <config-sheet
+              title="Home Page Configuration"
+              :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
+              :parameters="pageWidgetDefinition.props.parameters || []"
+              :configuration="page.config"
+              :f7router
+              :read-only="!isEditable"
+              @updated="dirty = true" />
           </f7-block>
 
           <f7-block class="block-narrow no-margin-bottom">
@@ -63,25 +61,25 @@
                   :text="tab.label" />
               </f7-segmented>
 
-              <div class="cards-title-row">
-                <f7-block-title class="no-margin-bottom">Cards</f7-block-title>
-                <f7-button
-                  v-if="isEditable"
-                  @click="showCardControls = !showCardControls"
-                  small
-                  outline
-                  :fill="showCardControls"
-                  sortable-toggle=".sortable"
-                  color="gray"
-                  icon-size="12"
-                  icon-ios="material:wrap_text"
-                  icon-md="material:wrap_text"
-                  icon-aurora="material:wrap_text"
-                  style="margin-left: 8px">
-                  &nbsp;Reorder
-                </f7-button>
-              </div>
-              <div>
+              <group-box title="Cards">
+                <template #after-title>
+                  <f7-button
+                    v-if="isEditable"
+                    @click="showCardControls = !showCardControls"
+                    small
+                    outline
+                    :fill="showCardControls"
+                    sortable-toggle=".sortable"
+                    color="gray"
+                    icon-size="12"
+                    icon-ios="material:wrap_text"
+                    icon-md="material:wrap_text"
+                    icon-aurora="material:wrap_text"
+                    style="margin-left: 8px">
+                    &nbsp;Reorder
+                  </f7-button>
+                </template>
+
                 <f7-list
                   media-list
                   class="homecards-list"
@@ -130,41 +128,38 @@
                     </template>
                   </f7-list-item>
                 </f7-list>
-              </div>
+              </group-box>
             </f7-col>
           </f7-block>
 
           <f7-block class="block-narrow homecards-settings">
             <f7-col>
-              <div v-if="currentModelTab === 'locations'">
-                <config-sheet
-                  :parameterGroups="locationsTabParameters.props.parameterGroups || []"
-                  :parameters="locationsTabParameters.props.parameters || []"
-                  :configuration="page.slots.locations[0].config"
-                  :f7router
-                  :read-only="!isEditable"
-                  @updated="dirty = true" />
-              </div>
+              <config-sheet
+                v-if="currentModelTab === 'locations'"
+                :parameterGroups="locationsTabParameters.props.parameterGroups || []"
+                :parameters="locationsTabParameters.props.parameters || []"
+                :configuration="page.slots.locations[0].config"
+                :f7router
+                :read-only="!isEditable"
+                @updated="dirty = true" />
 
-              <div v-if="currentModelTab === 'equipment'">
-                <config-sheet
-                  :parameterGroups="equipmentTabParameters.props.parameterGroups || []"
-                  :parameters="equipmentTabParameters.props.parameters || []"
-                  :configuration="page.slots.equipment[0].config"
-                  :f7router
-                  :read-only="!isEditable"
-                  @updated="dirty = true" />
-              </div>
+              <config-sheet
+                v-if="currentModelTab === 'equipment'"
+                :parameterGroups="equipmentTabParameters.props.parameterGroups || []"
+                :parameters="equipmentTabParameters.props.parameters || []"
+                :configuration="page.slots.equipment[0].config"
+                :f7router
+                :read-only="!isEditable"
+                @updated="dirty = true" />
 
-              <div v-if="currentModelTab === 'properties'">
-                <config-sheet
-                  :parameterGroups="propertiesTabParameters.props.parameterGroups || []"
-                  :parameters="propertiesTabParameters.props.parameters || []"
-                  :configuration="page.slots.properties[0].config"
-                  :f7router
-                  :read-only="!isEditable"
-                  @updated="dirty = true" />
-              </div>
+              <config-sheet
+                v-if="currentModelTab === 'properties'"
+                :parameterGroups="propertiesTabParameters.props.parameterGroups || []"
+                :parameters="propertiesTabParameters.props.parameters || []"
+                :configuration="page.slots.properties[0].config"
+                :f7router
+                :read-only="!isEditable"
+                @updated="dirty = true" />
             </f7-col>
           </f7-block>
         </div>
@@ -218,10 +213,10 @@
       margin-right 10px
   .homecards-settings
     margin-top 0
-    .parameter-group
-      margin-top 0
-    .parameter-group-title
-      margin-top 0
+//    .parameter-group
+//      margin-top 0
+//    .parameter-group-title
+//      margin-top 0
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -58,42 +58,38 @@
           "
           class="block-narrow no-padding">
           <f7-col>
-            <f7-list accordion-list>
-              <f7-block-title class="margin-left"> Layout Type </f7-block-title>
-              <f7-list-item accordion-item title="Switch to Fixed Layout">
-                <f7-accordion-content>
-                  <f7-block class="margin text-align-center">
-                    Switch to a fixed layout type, suitable for e.g. wall mounted tablets:
-                  </f7-block>
-                  <f7-row class="text-align-center align-items-stretch margin-vertical" no-gap>
-                    <f7-col width="50">
-                      <f7-link
-                        @click="setLayoutType('fixed', 'grid')"
-                        class="flex-direction-column padding margin-left-half elevation-1 elevation-hover-3"
-                        style="color: var(--f7-theme-color-text-color)">
-                        <f7-icon size="70px" f7="grid" />
-                        <div class="margin-bottom">Fixed Grid</div>
-                        <f7-block-footer class="margin-top">
-                          <small>Position and resize widgets on a grid with fixed dimensions.</small>
-                        </f7-block-footer>
-                      </f7-link>
-                    </f7-col>
-                    <f7-col width="50">
-                      <f7-link
-                        @click="setLayoutType('fixed', 'canvas')"
-                        class="flex-direction-column padding margin-right-half elevation-1 elevation-hover-3"
-                        style="color: var(--f7-theme-color-text-color)">
-                        <f7-icon size="70px" f7="rectangle_3_offgrid" />
-                        <div class="margin-bottom">Fixed Canvas</div>
-                        <f7-block-footer class="margin-top">
-                          <small>Position and resize widgets freely over a fixed background.</small>
-                        </f7-block-footer>
-                      </f7-link>
-                    </f7-col>
-                  </f7-row>
-                </f7-accordion-content>
-              </f7-list-item>
-            </f7-list>
+            <!-- <f7-list accordion-list> -->
+            <!-- <f7-block-title class="margin-left"> Layout Type </f7-block-title> -->
+            <group-box title="Switch to Fixed Layout" accordion>
+              <f7-block class="margin text-align-center"> Switch to a fixed layout type, suitable for e.g. wall mounted tablets: </f7-block>
+              <f7-row class="text-align-center align-items-stretch margin-vertical" no-gap>
+                <f7-col width="50">
+                  <f7-link
+                    @click="setLayoutType('fixed', 'grid')"
+                    class="flex-direction-column padding margin-left-half elevation-1 elevation-hover-3"
+                    style="color: var(--f7-theme-color-text-color)">
+                    <f7-icon size="70px" f7="grid" />
+                    <div class="margin-bottom">Fixed Grid</div>
+                    <f7-block-footer class="margin-top">
+                      <small>Position and resize widgets on a grid with fixed dimensions.</small>
+                    </f7-block-footer>
+                  </f7-link>
+                </f7-col>
+                <f7-col width="50">
+                  <f7-link
+                    @click="setLayoutType('fixed', 'canvas')"
+                    class="flex-direction-column padding margin-right-half elevation-1 elevation-hover-3"
+                    style="color: var(--f7-theme-color-text-color)">
+                    <f7-icon size="70px" f7="rectangle_3_offgrid" />
+                    <div class="margin-bottom">Fixed Canvas</div>
+                    <f7-block-footer class="margin-top">
+                      <small>Position and resize widgets freely over a fixed background.</small>
+                    </f7-block-footer>
+                  </f7-link>
+                </f7-col>
+              </f7-row>
+            </group-box>
+            <!-- </f7-list> -->
           </f7-col>
         </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -32,8 +32,8 @@
 
         <f7-block v-if="ready && !previewMode" class="block-narrow" style="padding-bottom: 8rem">
           <f7-col>
-            <f7-block-title>Page Configuration</f7-block-title>
             <config-sheet
+              :title="'Map Page Configuration'"
               :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
               :parameters="pageWidgetDefinition.props.parameters || []"
               :configuration="page.config"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -79,13 +79,6 @@
       </f7-col>
 
       <f7-col v-show="ready">
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && pageUids.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <div v-show="ready && pages.length > 0" class="padding-left padding-right">
           <f7-segmented strong tag="p">
@@ -94,66 +87,68 @@
           </f7-segmented>
         </div>
 
-        <f7-list v-if="pages.length > 0 && filteredPages.length === 0" class="searchbar-not-found">
-          <f7-list-item title="Nothing found" />
-        </f7-list>
-        <f7-list
-          v-show="filteredPages.length > 0"
-          class="col pages-list"
-          ref="pagesList"
-          :contacts-list="groupBy === 'alphabetical'"
-          media-list>
-          <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
-            <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
-            <f7-list-item
-              v-for="page in pagesWithInitial"
-              :key="page.uid"
-              media-item
-              class="pagelist-item"
-              :checkbox="showCheckboxes"
-              :checked="isChecked(page.uid) ? true : null"
-              prevent-router
-              @click.ctrl="ctrlClick($event, page)"
-              @click.meta="ctrlClick($event, page)"
-              @click.exact="click($event, page)"
-              :link="getPageLink(page)"
-              :title="page.config?.label || page.uid"
-              :subtitle="getPageType(page).label"
-              :footer="page.uid"
-              :badge="page.config?.order">
-              <template #subtitle>
-                <div>
-                  <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                  <f7-chip
-                    v-for="userrole in page.config?.visibleTo || []"
-                    :key="userrole"
-                    :text="userrole"
-                    media-bg-color="green"
-                    style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon f7="person_crop_circle_fill_badge_checkmark" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-              <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
-              <template #after>
-                <!-- This is here to push the after-title icon so it would appear immediately after the title
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && pageUids.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list
+            v-show="filteredPages.length > 0"
+            class="col pages-list"
+            ref="pagesList"
+            :contacts-list="groupBy === 'alphabetical'"
+            media-list>
+            <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
+              <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
+              <f7-list-item
+                v-for="page in pagesWithInitial"
+                :key="page.uid"
+                media-item
+                class="pagelist-item"
+                :checkbox="showCheckboxes"
+                :checked="isChecked(page.uid) ? true : null"
+                prevent-router
+                @click.ctrl="ctrlClick($event, page)"
+                @click.meta="ctrlClick($event, page)"
+                @click.exact="click($event, page)"
+                :link="getPageLink(page)"
+                :title="page.config?.label || page.uid"
+                :subtitle="getPageType(page).label"
+                :footer="page.uid"
+                :badge="page.config?.order">
+                <template #subtitle>
+                  <div>
+                    <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                      </template>
+                    </f7-chip>
+                    <f7-chip
+                      v-for="userrole in page.config?.visibleTo || []"
+                      :key="userrole"
+                      :text="userrole"
+                      media-bg-color="green"
+                      style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon f7="person_crop_circle_fill_badge_checkmark" />
+                      </template>
+                    </f7-chip>
+                  </div>
+                </template>
+                <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
+                <template #after>
+                  <!-- This is here to push the after-title icon so it would appear immediately after the title
                      for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
-              </template>
-              <template #after-title>
-                <f7-icon v-if="page.editable === false" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-              <template #media>
-                <oh-icon :color="page.config?.sidebar ? '' : 'gray'" :icon="getPageIcon(page)" :height="32" :width="32" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+                </template>
+                <template #after-title>
+                  <f7-icon v-if="page.editable === false" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+                <template #media>
+                  <oh-icon :color="page.config?.sidebar ? '' : 'gray'" :icon="getPageIcon(page)" :height="32" :width="32" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -79,13 +79,6 @@
       </f7-col>
 
       <f7-col v-show="ready">
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && pageUids.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <div v-show="ready && pages.length > 0" class="padding-left padding-right">
           <f7-segmented strong tag="p">
@@ -94,66 +87,68 @@
           </f7-segmented>
         </div>
 
-        <f7-list v-if="pages.length > 0 && filteredPages.length === 0" class="searchbar-not-found">
-          <f7-list-item title="Nothing found" />
-        </f7-list>
-        <f7-list
-          v-show="filteredPages.length > 0"
-          class="col pages-list"
-          ref="pagesList"
-          :contacts-list="groupBy === 'alphabetical'"
-          media-list>
-          <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
-            <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
-            <f7-list-item
-              v-for="page in pagesWithInitial"
-              :key="page.uid"
-              media-item
-              class="pagelist-item"
-              :checkbox="showCheckboxes"
-              :checked="isChecked(page.uid) ? true : null"
-              prevent-router
-              @click.ctrl="ctrlClick($event, page)"
-              @click.meta="ctrlClick($event, page)"
-              @click.exact="click($event, page)"
-              :link="getPageLink(page)"
-              :title="page.config?.label || page.uid"
-              :subtitle="getPageType(page).label"
-              :footer="page.uid"
-              :badge="page.config?.order">
-              <template #subtitle>
-                <div>
-                  <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                  <f7-chip
-                    v-for="userrole in page.config?.visibleTo || []"
-                    :key="userrole"
-                    :text="userrole"
-                    media-bg-color="green"
-                    style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon f7="person_crop_circle_fill_badge_checkmark" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-              <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
-              <template #after>
-                <!-- This is here to push the after-title icon so it would appear immediately after the title
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && pageUids.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list
+            v-show="filteredPages.length > 0"
+            class="col pages-list"
+            ref="pagesList"
+            :contacts-list="groupBy === 'alphabetical'"
+            media-list>
+            <f7-list-group v-for="(pagesWithInitial, initial) in indexedPages" :key="initial">
+              <f7-list-item v-if="pagesWithInitial.length" :title="initial" group-title />
+              <f7-list-item
+                v-for="page in pagesWithInitial"
+                :key="page.uid"
+                media-item
+                class="pagelist-item"
+                :checkbox="showCheckboxes"
+                :checked="isChecked(page.uid) ? true : null"
+                prevent-router
+                @click.ctrl="ctrlClick($event, page)"
+                @click.meta="ctrlClick($event, page)"
+                @click.exact="click($event, page)"
+                :link="getPageLink(page)"
+                :title="page.config?.label || page.uid"
+                :subtitle="getPageType(page).label"
+                :footer="page.uid"
+                :badge="page.config?.order">
+                <template #subtitle>
+                  <div>
+                    <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                      </template>
+                    </f7-chip>
+                    <f7-chip
+                      v-for="userrole in page.config?.visibleTo || []"
+                      :key="userrole"
+                      :text="userrole"
+                      media-bg-color="green"
+                      style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon f7="person_crop_circle_fill_badge_checkmark" />
+                      </template>
+                    </f7-chip>
+                  </div>
+                </template>
+                <!-- <span class="item-initial">{{page.config.label[0].toUpperCase()}}</span> -->
+                <template #after>
+                  <!-- This is here to push the after-title icon so it would appear immediately after the title
                      for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
-              </template>
-              <template #after-title>
-                <f7-icon v-if="page.editable === false" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-              <template #media>
-                <oh-icon :color="page.config?.sidebar ? '' : 'gray'" :icon="getPageIcon(page)" :height="32" :width="32" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+                </template>
+                <template #after-title>
+                  <f7-icon v-if="page.editable === false" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+                <template #media>
+                  <oh-icon :color="page.config?.sidebar ? '' : 'gray'" :icon="getPageIcon(page)" :height="32" :width="32" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -34,8 +34,8 @@
 
         <f7-block v-if="ready && !previewMode" class="block-narrow" style="padding-bottom: 8rem">
           <f7-col>
-            <f7-block-title>Background Configuration</f7-block-title>
             <config-sheet
+              title="Background Configuration"
               :parameterGroups="pageWidgetDefinition.props.parameterGroups || []"
               :parameters="pageWidgetDefinition.props.parameters || []"
               :configuration="page.config"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -60,47 +60,44 @@
 
     <f7-block class="block-narrow">
       <f7-col v-show="ready">
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && selectableSitemapNames.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <f7-list v-if="sitemaps.length > 0 && filteredSitemaps.length === 0" class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-
-        <f7-list v-show="filteredSitemaps.length > 0" class="col sitemaps-list" ref="sitemapsList" :contacts-list="true" media-list>
-          <f7-list-group v-for="(sitemapsWithInitial, initial) in indexedSitemaps" :key="initial">
-            <f7-list-item v-if="sitemapsWithInitial.length" :title="initial" group-title />
-            <f7-list-item
-              v-for="sitemap in sitemapsWithInitial"
-              :key="sitemap.name"
-              media-item
-              :checkbox="showCheckboxes"
-              :checked="isChecked(sitemap.name) ? true : null"
-              prevent-router
-              @click.ctrl="ctrlClick($event, sitemap)"
-              @click.meta="ctrlClick($event, sitemap)"
-              @click.exact="click($event, sitemap)"
-              :link="encodeURIComponent(sitemap.name)"
-              :title="sitemap.label || sitemap.name"
-              :footer="sitemap.name">
-              <template #media>
-                <oh-icon :icon="sitemap.icon || 'f7:menu'" :height="32" :width="32" />
-              </template>
-              <template #after>
-                <!-- push the lock icon so it appears immediately after the title,
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && selectableSitemapNames.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list v-show="filteredSitemaps.length > 0" class="col sitemaps-list" ref="sitemapsList" :contacts-list="true" media-list>
+            <f7-list-group v-for="(sitemapsWithInitial, initial) in indexedSitemaps" :key="initial">
+              <f7-list-item v-if="sitemapsWithInitial.length" :title="initial" group-title />
+              <f7-list-item
+                v-for="sitemap in sitemapsWithInitial"
+                :key="sitemap.name"
+                media-item
+                :checkbox="showCheckboxes"
+                :checked="isChecked(sitemap.name) ? true : null"
+                prevent-router
+                @click.ctrl="ctrlClick($event, sitemap)"
+                @click.meta="ctrlClick($event, sitemap)"
+                @click.exact="click($event, sitemap)"
+                :link="encodeURIComponent(sitemap.name)"
+                :title="sitemap.label || sitemap.name"
+                :footer="sitemap.name">
+                <template #media>
+                  <oh-icon :icon="sitemap.icon || 'f7:menu'" :height="32" :width="32" />
+                </template>
+                <template #after>
+                  <!-- push the lock icon so it appears immediately after the title,
                  consistent with other list items (Things, Items, etc) -->
-              </template>
-              <template #after-title>
-                <f7-icon v-if="!sitemap.editable" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+                </template>
+                <template #after-title>
+                  <f7-icon v-if="!sitemap.editable" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
 
         <f7-block v-if="!sitemaps.length" class="block-narrow">
           <empty-state-placeholder icon="square_on_circle" title="sitemaps.title" text="sitemaps.text" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -25,48 +25,49 @@
 
         <f7-block v-if="ready" class="block-narrow no-margin-top" style="padding-bottom: 10rem">
           <f7-col>
-            <f7-block-title>Tabs</f7-block-title>
-            <f7-menu v-if="isEditable && clipboardType === 'oh-tab'">
-              <f7-menu-item style="margin-left: auto" icon-f7="squares_below_rectangle" dropdown>
-                <f7-menu-dropdown right>
-                  <f7-menu-dropdown-item @click="pasteWidget(page, null)" href="#" text="Paste" />
-                </f7-menu-dropdown>
-              </f7-menu-item>
-            </f7-menu>
+            <group-box title="Tabs">
+              <f7-menu v-if="isEditable && clipboardType === 'oh-tab'">
+                <f7-menu-item style="margin-left: auto" icon-f7="squares_below_rectangle" dropdown>
+                  <f7-menu-dropdown right>
+                    <f7-menu-dropdown-item @click="pasteWidget(page, null)" href="#" text="Paste" />
+                  </f7-menu-dropdown>
+                </f7-menu-item>
+              </f7-menu>
 
-            <f7-list media-list class="tabs-list">
-              <f7-list-item
-                v-for="(tab, idx) in page.slots.default"
-                media-item
-                :key="idx"
-                :title="tabEvaluateExpression(tab, idx, 'title')"
-                :subtitle="tab.config.page"
-                link="#"
-                @click="(ev) => configureTab(ev, tab, context)">
-                <template #media>
-                  <oh-icon :icon="tabEvaluateExpression(tab, idx, 'icon')" :color="'gray'" :width="32" :height="32" />
-                </template>
-                <template #content-start>
-                  <f7-menu v-if="isEditable" class="configure-tabs-menu">
-                    <f7-menu-item icon-f7="list_bullet" dropdown>
-                      <f7-menu-dropdown>
-                        <f7-menu-dropdown-item @click="configureWidget(tab, { component: page })" href="#" text="Tab Settings" />
-                        <f7-menu-dropdown-item @click="editWidgetCode(tab, { component: page })" href="#" text="Edit YAML" />
-                        <f7-menu-dropdown-item divider />
-                        <f7-menu-dropdown-item @click="cutWidget(tab, { component: page })" href="#" text="Cut" />
-                        <f7-menu-dropdown-item @click="copyWidget(tab, { component: page })" href="#" text="Copy" />
-                        <f7-menu-dropdown-item divider />
-                        <f7-menu-dropdown-item @click="moveWidgetUp(tab, { component: page })" href="#" text="Move Up" />
-                        <f7-menu-dropdown-item @click="moveWidgetDown(tab, { component: page })" href="#" text="Move Down" />
-                        <f7-menu-dropdown-item divider />
-                        <f7-menu-dropdown-item @click="removeWidget(tab, { component: page })" href="#" text="Remove Tab" />
-                      </f7-menu-dropdown>
-                    </f7-menu-item>
-                  </f7-menu>
-                </template>
-              </f7-list-item>
-              <f7-list-button v-if="isEditable" color="theme-alt" title="Add tab" @click="addWidget(page, 'oh-tab')" />
-            </f7-list>
+              <f7-list media-list class="tabs-list">
+                <f7-list-item
+                  v-for="(tab, idx) in page.slots.default"
+                  media-item
+                  :key="idx"
+                  :title="tabEvaluateExpression(tab, idx, 'title')"
+                  :subtitle="tab.config.page"
+                  link="#"
+                  @click="(ev) => configureTab(ev, tab, context)">
+                  <template #media>
+                    <oh-icon :icon="tabEvaluateExpression(tab, idx, 'icon')" :color="'gray'" :width="32" :height="32" />
+                  </template>
+                  <template #content-start>
+                    <f7-menu v-if="isEditable" class="configure-tabs-menu">
+                      <f7-menu-item icon-f7="list_bullet" dropdown>
+                        <f7-menu-dropdown>
+                          <f7-menu-dropdown-item @click="configureWidget(tab, { component: page })" href="#" text="Tab Settings" />
+                          <f7-menu-dropdown-item @click="editWidgetCode(tab, { component: page })" href="#" text="Edit YAML" />
+                          <f7-menu-dropdown-item divider />
+                          <f7-menu-dropdown-item @click="cutWidget(tab, { component: page })" href="#" text="Cut" />
+                          <f7-menu-dropdown-item @click="copyWidget(tab, { component: page })" href="#" text="Copy" />
+                          <f7-menu-dropdown-item divider />
+                          <f7-menu-dropdown-item @click="moveWidgetUp(tab, { component: page })" href="#" text="Move Up" />
+                          <f7-menu-dropdown-item @click="moveWidgetDown(tab, { component: page })" href="#" text="Move Down" />
+                          <f7-menu-dropdown-item divider />
+                          <f7-menu-dropdown-item @click="removeWidget(tab, { component: page })" href="#" text="Remove Tab" />
+                        </f7-menu-dropdown>
+                      </f7-menu-item>
+                    </f7-menu>
+                  </template>
+                </f7-list-item>
+                <f7-list-button v-if="isEditable" color="theme-alt" title="Add tab" @click="addWidget(page, 'oh-tab')" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -25,48 +25,49 @@
 
         <f7-block v-if="ready" class="block-narrow no-margin-top" style="padding-bottom: 10rem">
           <f7-col>
-            <f7-block-title>Tabs</f7-block-title>
-            <f7-menu v-if="isEditable && clipboardType === 'oh-tab'">
-              <f7-menu-item style="margin-left: auto" icon-f7="squares_below_rectangle" dropdown>
-                <f7-menu-dropdown right>
-                  <f7-menu-dropdown-item @click="pasteWidget(page, null)" href="#" text="Paste" />
-                </f7-menu-dropdown>
-              </f7-menu-item>
-            </f7-menu>
+            <group-box title="Tabs">
+              <f7-menu v-if="isEditable && clipboardType === 'oh-tab'">
+                <f7-menu-item style="margin-left: auto" icon-f7="squares_below_rectangle" dropdown>
+                  <f7-menu-dropdown right>
+                    <f7-menu-dropdown-item @click="pasteWidget(page, null)" href="#" text="Paste" />
+                  </f7-menu-dropdown>
+                </f7-menu-item>
+              </f7-menu>
 
-            <f7-list media-list class="tabs-list">
-              <f7-list-item
-                v-for="(tab, idx) in page.slots.default"
-                media-item
-                :key="idx"
-                :title="tabEvaluateExpression(tab, idx, 'title')"
-                :subtitle="tab.config.page"
-                link="#"
-                @click="(ev) => configureTab(ev, tab, context)">
-                <template #media>
-                  <oh-icon :icon="tabEvaluateExpression(tab, idx, 'icon')" :color="'gray'" :width="32" :height="32" />
-                </template>
-                <template #content-start>
-                  <f7-menu v-if="isEditable" class="configure-tabs-menu">
-                    <f7-menu-item icon-f7="list_bullet" dropdown>
-                      <f7-menu-dropdown>
-                        <f7-menu-dropdown-item @click="configureWidget(tab, { component: page })" href="#" text="Tab Settings" />
-                        <f7-menu-dropdown-item @click="editWidgetCode(tab, { component: page })" href="#" text="Edit YAML" />
-                        <f7-menu-dropdown-item divider />
-                        <f7-menu-dropdown-item @click="cutWidget(tab, { component: page })" href="#" text="Cut" />
-                        <f7-menu-dropdown-item @click="copyWidget(tab, { component: page })" href="#" text="Copy" />
-                        <f7-menu-dropdown-item divider />
-                        <f7-menu-dropdown-item @click="moveWidgetUp(tab, { component: page })" href="#" text="Move Up" />
-                        <f7-menu-dropdown-item @click="moveWidgetDown(tab, { component: page })" href="#" text="Move Down" />
-                        <f7-menu-dropdown-item divider />
-                        <f7-menu-dropdown-item @click="removeWidget(tab, { component: page })" href="#" text="Remove Tab" />
-                      </f7-menu-dropdown>
-                    </f7-menu-item>
-                  </f7-menu>
-                </template>
-              </f7-list-item>
-              <f7-list-button v-if="isEditable" color="blue" title="Add tab" @click="addWidget(page, 'oh-tab')" />
-            </f7-list>
+              <f7-list media-list class="tabs-list">
+                <f7-list-item
+                  v-for="(tab, idx) in page.slots.default"
+                  media-item
+                  :key="idx"
+                  :title="tabEvaluateExpression(tab, idx, 'title')"
+                  :subtitle="tab.config.page"
+                  link="#"
+                  @click="(ev) => configureTab(ev, tab, context)">
+                  <template #media>
+                    <oh-icon :icon="tabEvaluateExpression(tab, idx, 'icon')" :color="'gray'" :width="32" :height="32" />
+                  </template>
+                  <template #content-start>
+                    <f7-menu v-if="isEditable" class="configure-tabs-menu">
+                      <f7-menu-item icon-f7="list_bullet" dropdown>
+                        <f7-menu-dropdown>
+                          <f7-menu-dropdown-item @click="configureWidget(tab, { component: page })" href="#" text="Tab Settings" />
+                          <f7-menu-dropdown-item @click="editWidgetCode(tab, { component: page })" href="#" text="Edit YAML" />
+                          <f7-menu-dropdown-item divider />
+                          <f7-menu-dropdown-item @click="cutWidget(tab, { component: page })" href="#" text="Cut" />
+                          <f7-menu-dropdown-item @click="copyWidget(tab, { component: page })" href="#" text="Copy" />
+                          <f7-menu-dropdown-item divider />
+                          <f7-menu-dropdown-item @click="moveWidgetUp(tab, { component: page })" href="#" text="Move Up" />
+                          <f7-menu-dropdown-item @click="moveWidgetDown(tab, { component: page })" href="#" text="Move Down" />
+                          <f7-menu-dropdown-item divider />
+                          <f7-menu-dropdown-item @click="removeWidget(tab, { component: page })" href="#" text="Remove Tab" />
+                        </f7-menu-dropdown>
+                      </f7-menu-item>
+                    </f7-menu>
+                  </template>
+                </f7-list-item>
+                <f7-list-button v-if="isEditable" color="blue" title="Add tab" @click="addWidget(page, 'oh-tab')" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -14,67 +14,74 @@
       </f7-navbar>
       <f7-col>
         <f7-block-title medium>Items</f7-block-title>
-        <f7-list>
-          <f7-list-item title="Persist all Items">
-            <template #after>
-              <f7-toggle v-model:checked="allItemsSelected" />
-            </template>
-          </f7-list-item>
-        </f7-list>
-        <f7-list>
-          <f7-list-group>
-            <item-picker
-              key="groups"
-              label="Select groups"
-              name="groupItems"
-              :multiple="true"
-              filterType="Group"
-              :disabled="allItemsSelected ? true : null"
-              :value="groupItems"
-              @input="groupItems = $event" />
-          </f7-list-group>
-          <f7-list-item>... whose members are to be persisted.</f7-list-item>
-        </f7-list>
-        <f7-list>
-          <f7-list-group>
-            <item-picker
-              key="items"
-              label="Select Items"
-              name="items"
-              :multiple="true"
-              :disabled="allItemsSelected ? true : null"
-              :value="items"
-              @input="items = $event" />
-          </f7-list-group>
-          <f7-list-item>... to be persisted.</f7-list-item>
-        </f7-list>
-        <f7-list>
-          <f7-list-group>
-            <item-picker
-              key="exclude-groups"
-              label="Select exclude groups"
-              name="excludeGroupItems"
-              :multiple="true"
-              filterType="Group"
-              :disabled="!anySelected ? true : null"
-              :value="excludeGroupItems"
-              @input="excludeGroupItems = $event" />
-          </f7-list-group>
-          <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
-        </f7-list>
-        <f7-list>
-          <f7-list-group>
-            <item-picker
-              key="exclude-items"
-              label="Select exclude Items"
-              name="excludeItems"
-              :multiple="true"
-              :disabled="!anySelected ? true : null"
-              :value="excludeItems"
-              @input="excludeItems = $event" />
-          </f7-list-group>
-          <f7-list-item>... to be excluded from persistence.</f7-list-item>
-        </f7-list>
+        <group-box title="What to persist" description="Select the Items or groups of Items to be persisted.">
+          <f7-list>
+            <f7-list-item title="Persist all Items">
+              <template #after>
+                <f7-toggle v-model:checked="allItemsSelected" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+          <template v-if="!allItemsSelected">
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="groups"
+                  label="Select groups"
+                  name="groupItems"
+                  :multiple="true"
+                  filterType="Group"
+                  :disabled="allItemsSelected ? true : null"
+                  :value="groupItems"
+                  @input="groupItems = $event" />
+              </f7-list-group>
+              <f7-list-item>... whose members are to be persisted.</f7-list-item>
+            </f7-list>
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="items"
+                  label="Select Items"
+                  name="items"
+                  :multiple="true"
+                  :disabled="allItemsSelected ? true : null"
+                  :value="items"
+                  @input="items = $event" />
+              </f7-list-group>
+              <f7-list-item>... to be persisted.</f7-list-item>
+            </f7-list>
+          </template>
+        </group-box>
+
+        <group-box title="What to exclude" description="Select the Items or groups of Items to be excluded from persistence.">
+          <f7-list>
+            <f7-list-group>
+              <item-picker
+                key="exclude-groups"
+                label="Select exclude groups"
+                name="excludeGroupItems"
+                :multiple="true"
+                filterType="Group"
+                :disabled="!anySelected ? true : null"
+                :value="excludeGroupItems"
+                @input="excludeGroupItems = $event" />
+            </f7-list-group>
+            <f7-list-item>... whose members are to be excluded from persistence.</f7-list-item>
+          </f7-list>
+          <f7-list>
+            <f7-list-group>
+              <item-picker
+                key="exclude-items"
+                label="Select exclude Items"
+                name="excludeItems"
+                :multiple="true"
+                :disabled="!anySelected ? true : null"
+                :value="excludeItems"
+                @input="excludeItems = $event" />
+            </f7-list-group>
+            <f7-list-item>... to be excluded from persistence.</f7-list-item>
+          </f7-list>
+        </group-box>
         <f7-col>
           <f7-block-title medium class="padding-top">Strategies</f7-block-title>
           <strategy-picker v-model:cron-strategies="cronStrategies" v-model:selected-strategies="localItemConfiguration.strategies" />
@@ -99,6 +106,7 @@ import FilterPicker from '@/pages/settings/persistence/filter-picker.vue'
 import { FilterTypeName, type FiltersDefinition, emptyPersistenceServiceConfig } from '@/assets/definitions/persistence'
 import * as api from '@/api'
 import cloneDeep from 'lodash/cloneDeep'
+import GroupBox from '@/components/util/group-box.vue'
 
 // Props and emits
 const opened = defineModel<boolean>('opened')

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/configuration-popup.vue
@@ -106,7 +106,6 @@ import FilterPicker from '@/pages/settings/persistence/filter-picker.vue'
 import { FilterTypeName, type FiltersDefinition, emptyPersistenceServiceConfig } from '@/assets/definitions/persistence'
 import * as api from '@/api'
 import cloneDeep from 'lodash/cloneDeep'
-import GroupBox from '@/components/util/group-box.vue'
 
 // Props and emits
 const opened = defineModel<boolean>('opened')

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/filter-popup.vue
@@ -44,7 +44,6 @@
           </f7-list>
         </f7-col>
         <f7-col>
-          <f7-block-title medium>Configuration</f7-block-title>
           <config-sheet
             ref="config-sheet"
             :parameter-groups="[]"

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -36,129 +36,133 @@
           <f7-col class="modules">
             <!-- Configuration -->
             <f7-block>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)">Configurations</f7-block-title>
-              <f7-block-header style="padding-right: 16px">Items to persist with strategies to use.</f7-block-header>
-              <f7-list v-if="editable || persistence!.configs.length > 0" :media-list="editable" swipeout>
-                <f7-list-item
-                  v-for="(cfg, index) in persistence!.configs"
-                  :key="cfg.items.join()"
-                  :link="editable"
-                  @click="(ev: MouseEvent) => editConfiguration(ev, index, cfg)"
-                  swipeout>
-                  <template #media>
-                    <f7-link
-                      v-if="editable"
-                      icon-color="red"
-                      icon-aurora="f7:minus_circle_filled"
-                      icon-ios="f7:minus_circle_filled"
-                      icon-md="material:remove_circle_outline"
-                      @click.stop="showSwipeout" />
-                  </template>
-                  <template #title>
-                    <div v-text="configurationAllItemsTitle(cfg.items)" />
-                    <div v-text="configurationGroupsTitle(cfg.items)" />
-                    <div v-text="configurationItemsTitle(cfg.items)" />
-                    <div v-text="configurationGroupsTitle(cfg.items, true)" />
-                    <div v-text="configurationItemsTitle(cfg.items, true)" />
-                  </template>
-                  <template #footer>
-                    <div v-if="cfg.strategies?.length">{{ configurationStrategiesTitle(cfg.strategies) }}</div>
-                    <div v-if="cfg.filters?.length">{{ configurationFiltersTitle(cfg.filters) }}</div>
-                  </template>
-                  <f7-swipeout-actions v-if="editable" right>
-                    <f7-swipeout-button
-                      @click.stop="(ev: MouseEvent) => deleteConfiguration(ev, index)"
-                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                      Delete
-                    </f7-swipeout-button>
-                  </f7-swipeout-actions>
-                </f7-list-item>
-              </f7-list>
-              <f7-list v-else-if="!editable">
-                <f7-list-item>No configurations defined</f7-list-item>
-              </f7-list>
-              <f7-list v-if="editable">
-                <f7-list-item
-                  link
-                  no-chevron
-                  media-item
-                  subtitle="Add configuration"
-                  @click="(ev: MouseEvent) => editConfiguration(ev, -1, null)">
-                  <template #media>
-                    <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                  </template>
-                </f7-list-item>
-              </f7-list>
+              <group-box title="Configurations" description="Items to persist with strategies to use.">
+                <f7-list v-if="editable || persistence!.configs.length > 0" :media-list="editable" swipeout>
+                  <f7-list-item
+                    v-for="(cfg, index) in persistence!.configs"
+                    :key="cfg.items.join()"
+                    :link="editable"
+                    @click="(ev: MouseEvent) => editConfiguration(ev, index, cfg)"
+                    swipeout>
+                    <template #media>
+                      <f7-link
+                        v-if="editable"
+                        icon-color="red"
+                        icon-aurora="f7:minus_circle_filled"
+                        icon-ios="f7:minus_circle_filled"
+                        icon-md="material:remove_circle_outline"
+                        @click.stop="showSwipeout" />
+                    </template>
+                    <template #title>
+                      <div v-text="configurationAllItemsTitle(cfg.items)" />
+                      <div v-text="configurationGroupsTitle(cfg.items)" />
+                      <div v-text="configurationItemsTitle(cfg.items)" />
+                      <div v-text="configurationGroupsTitle(cfg.items, true)" />
+                      <div v-text="configurationItemsTitle(cfg.items, true)" />
+                    </template>
+                    <template #footer>
+                      <div v-if="cfg.strategies?.length">{{ configurationStrategiesTitle(cfg.strategies) }}</div>
+                      <div v-if="cfg.filters?.length">{{ configurationFiltersTitle(cfg.filters) }}</div>
+                    </template>
+                    <f7-swipeout-actions v-if="editable" right>
+                      <f7-swipeout-button
+                        @click.stop="(ev: MouseEvent) => deleteConfiguration(ev, index)"
+                        style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                        Delete
+                      </f7-swipeout-button>
+                    </f7-swipeout-actions>
+                  </f7-list-item>
+                </f7-list>
+                <f7-list v-else-if="!editable">
+                  <f7-list-item>No configurations defined</f7-list-item>
+                </f7-list>
+                <f7-list v-if="editable">
+                  <f7-list-item
+                    link
+                    no-chevron
+                    media-item
+                    subtitle="Add configuration"
+                    @click="(ev: MouseEvent) => editConfiguration(ev, -1, null)">
+                    <template #media>
+                      <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+                    </template>
+                  </f7-list-item>
+                </f7-list>
+              </group-box>
             </f7-block>
             <f7-block class="padding-top">
               <!-- Aliases -->
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)">Aliases</f7-block-title>
-              <f7-block-header style="padding-right: 16px">Item names mapped to aliases used in persistence store.</f7-block-header>
-              <f7-list v-if="editable || currentItemsWithAlias.length > 0" :media-list="editable" swipeout no-swipeout-opened>
-                <f7-list-item v-for="(i, index) in currentItemsWithAlias" class="swipeout list-alias-item" :key="i">
-                  <template #media>
-                    <f7-link
-                      v-if="editable"
-                      icon-color="red"
-                      icon-aurora="f7:minus_circle_filled"
-                      icon-ios="f7:minus_circle_filled"
-                      icon-md="material:remove_circle_outline"
-                      @click.stop="showSwipeout" />
-                  </template>
-                  <div class="alias-label">
-                    {{ i }}
-                  </div>
-                  <div class="alias-input">
-                    <f7-input
-                      type="text"
-                      placeholder="alias"
-                      validate
-                      :read-only="!editable"
-                      pattern="[A-Za-z_][A-Za-z0-9_]*"
-                      error-message="Required. Must not start with a number. A-Z,a-z,0-9,_ only"
-                      :value="persistence?.aliases[i]"
-                      @input="editAlias(i, $event.target.value)"
-                      @blur="checkAliasForDuplicates(i, $event.target.value)"
-                      @keydown.stop.prevent.tab="onAliasTab($event, index)" />
-                  </div>
-                  <f7-swipeout-actions v-if="editable" right>
-                    <f7-swipeout-button
-                      @click.stop="(ev: MouseEvent) => deleteAlias(ev, i)"
-                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                      Delete
-                    </f7-swipeout-button>
-                  </f7-swipeout-actions>
-                </f7-list-item>
-              </f7-list>
-              <f7-list v-else-if="!editable">
-                <f7-list-item> No aliases defined </f7-list-item>
-              </f7-list>
-              <f7-list v-if="editable">
-                <f7-list-group>
-                  <item-picker
-                    class="alias-item-picker"
-                    label="Select Items to Alias"
-                    name="items"
-                    :multiple="true"
-                    :noModelPicker="true"
-                    :setValueText="false"
-                    iconColor="green"
-                    auroraIcon="f7:plus_circle_fill"
-                    iosIcon="f7:plus_circle_fill"
-                    mdIcon="material:control_point"
-                    :value="currentItemsWithAlias"
-                    @input="updateAliasItems($event)" />
-                </f7-list-group>
-              </f7-list>
+              <group-box title="Aliases" description="Item names mapped to aliases used in persistence store.">
+                <f7-list v-if="editable || currentItemsWithAlias.length > 0" :media-list="editable" swipeout no-swipeout-opened>
+                  <f7-list-item v-for="(i, index) in currentItemsWithAlias" class="swipeout list-alias-item" :key="i">
+                    <template #media>
+                      <f7-link
+                        v-if="editable"
+                        icon-color="red"
+                        icon-aurora="f7:minus_circle_filled"
+                        icon-ios="f7:minus_circle_filled"
+                        icon-md="material:remove_circle_outline"
+                        @click.stop="showSwipeout" />
+                    </template>
+                    <div class="alias-label">
+                      {{ i }}
+                    </div>
+                    <div class="alias-input">
+                      <f7-input
+                        type="text"
+                        placeholder="alias"
+                        validate
+                        :read-only="!editable"
+                        pattern="[A-Za-z_][A-Za-z0-9_]*"
+                        error-message="Required. Must not start with a number. A-Z,a-z,0-9,_ only"
+                        :value="persistence?.aliases[i]"
+                        @input="editAlias(i, $event.target.value)"
+                        @blur="checkAliasForDuplicates(i, $event.target.value)"
+                        @keydown.stop.prevent.tab="onAliasTab($event, index)" />
+                    </div>
+                    <f7-swipeout-actions v-if="editable" right>
+                      <f7-swipeout-button
+                        @click.stop="(ev: MouseEvent) => deleteAlias(ev, i)"
+                        style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                        Delete
+                      </f7-swipeout-button>
+                    </f7-swipeout-actions>
+                  </f7-list-item>
+                </f7-list>
+                <f7-list v-else-if="!editable">
+                  <f7-list-item> No aliases defined </f7-list-item>
+                </f7-list>
+                <f7-list v-if="editable">
+                  <f7-list-group>
+                    <item-picker
+                      class="alias-item-picker"
+                      label="Select Items to Alias"
+                      name="items"
+                      :multiple="true"
+                      :noModelPicker="true"
+                      :setValueText="false"
+                      iconColor="green"
+                      auroraIcon="f7:plus_circle_fill"
+                      iosIcon="f7:plus_circle_fill"
+                      mdIcon="material:control_point"
+                      :value="currentItemsWithAlias"
+                      @input="updateAliasItems($event)" />
+                  </f7-list-group>
+                </f7-list>
+              </group-box>
             </f7-block>
           </f7-col>
           <f7-col v-if="editable" class="persistence-config-links">
-            <f7-list>
-              <f7-list-button color="blue" @click="definitionsPopupOpen = true">
-                {{ 'Manage Definitions' }}
-              </f7-list-button>
-              <f7-list-button v-if="!createMode" color="red" @click="deletePersistence"> Remove persistence configuration </f7-list-button>
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button color="blue" @click="definitionsPopupOpen = true">
+                  {{ 'Manage Definitions' }}
+                </f7-list-button>
+                <f7-list-button v-if="!createMode" color="red" @click="deletePersistence">
+                  Remove persistence configuration
+                </f7-list-button>
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -12,8 +12,8 @@
 
     <f7-block v-if="ready && persistenceList.length" form class="block-narrow">
       <f7-col>
-        <f7-block-title medium> General Settings </f7-block-title>
         <config-sheet
+          title="Default Persistence Configuration"
           :parameter-groups="configDescriptions?.parameterGroups"
           :parameters="configDescriptions?.parameters"
           :configuration="config"
@@ -22,21 +22,22 @@
     </f7-block>
     <f7-block v-if="ready && persistenceList.length" class="block-narrow">
       <f7-col>
-        <f7-block-title medium> Configure Persistence Policies </f7-block-title>
-        <f7-list>
-          <f7-list-item
-            v-for="persistence in persistenceList"
-            media-item
-            :key="persistence.id"
-            :link="persistence.id"
-            :title="persistence.label"
-            :footer="persistence.id" />
-          <f7-list-item link="/addons/persistence/" no-chevron media-item subtitle="Install more persistence add-ons">
-            <template #media>
-              <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-            </template>
-          </f7-list-item>
-        </f7-list>
+        <group-box title="Configure Persistence Policies">
+          <f7-list>
+            <f7-list-item
+              v-for="persistence in persistenceList"
+              media-item
+              :key="persistence.id"
+              :link="persistence.id"
+              :title="persistence.label"
+              :footer="persistence.id" />
+            <f7-list-item link="/addons/persistence/" no-chevron media-item subtitle="Install more persistence add-ons">
+              <template #media>
+                <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -86,111 +86,113 @@
         <rule-general-settings :rule="rule" :ready="ready" :createMode="createMode" :stubMode="stubMode" :templateName="templateName" />
 
         <f7-block v-if="ready" class="block-narrow">
-          <f7-block-footer v-if="!isEditable" class="no-margin padding-left">
-            <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: this rule is not editable.
-          </f7-block-footer>
+          <!-- Template Selection -->
           <f7-col v-if="createMode && templates.length > 0 && !ruleCopy" class="new-rule-from-template">
-            <f7-list>
-              <f7-list-item ref="templateAccordion" accordion-item>
-                <template #title>
-                  <template v-if="currentTemplate"> Create from Template: {{ currentTemplate.label }} </template>
-                  <template v-else> Create a new rule from scratch (or expand to select a template) </template>
-                </template>
-                <f7-accordion-content>
-                  <f7-list media-list>
-                    <f7-list-item
-                      title="No template"
-                      footer="Create a new rule from scratch"
-                      radio
-                      :checked="!hasTemplate"
-                      radio-icon="start"
-                      :value="''"
-                      @change="selectTemplate(null)" />
-                  </f7-list>
-                  <f7-block-header class="margin-left margin-top"> or choose a rule template: </f7-block-header>
-                  <f7-list media-list>
-                    <f7-list-item
-                      v-for="template in templates"
-                      :key="template.uid"
-                      :footer="template.description"
-                      :value="template.uid"
-                      radio
-                      :checked="currentTemplate && currentTemplate.uid === template.uid ? true : null"
-                      radio-icon="start"
-                      @change="selectTemplate(template.uid)">
-                      <template #title>
-                        {{ template.label }}
-                        <template v-if="getTopicLink(template)">
-                          &nbsp;
-                          <f7-link
-                            :href="getTopicLink(template)"
-                            tooltip="View openHAB Community Marketplace topic for this template"
-                            target="_blank"
-                            class="external"
-                            color="gray"
-                            :icon-size="18"
-                            icon="info_circle"
-                            icon-ios="f7:info_circle"
-                            icon-md="f7:info_circle"
-                            icon-aurora="f7:info_circle" />
-                        </template>
-                      </template>
-                    </f7-list-item>
-                  </f7-list>
-                </f7-accordion-content>
-              </f7-list-item>
-            </f7-list>
+            <group-box
+              ref="templateAccordion"
+              :title="
+                currentTemplate
+                  ? 'Create from Template: ' + currentTemplate.label
+                  : 'Create a new rule from scratch (or expand to select a template)'
+              "
+              full-width
+              accordion>
+              <f7-list media-list>
+                <f7-list-item
+                  title="No template"
+                  footer="Create a new rule from scratch"
+                  radio
+                  :checked="!hasTemplate"
+                  radio-icon="start"
+                  :value="''"
+                  @change="selectTemplate(null)" />
+              </f7-list>
+              <f7-block-header class="margin-left margin-top"> or choose a rule template: </f7-block-header>
+              <f7-list media-list>
+                <f7-list-item
+                  v-for="template in templates"
+                  :key="template.uid"
+                  :footer="template.description"
+                  :value="template.uid"
+                  radio
+                  :checked="currentTemplate && currentTemplate.uid === template.uid ? true : null"
+                  radio-icon="start"
+                  @change="selectTemplate(template.uid)">
+                  <template #title>
+                    {{ template.label }}
+                    <template v-if="getTopicLink(template)">
+                      &nbsp;
+                      <f7-link
+                        :href="getTopicLink(template)"
+                        tooltip="View openHAB Community Marketplace topic for this template"
+                        target="_blank"
+                        class="external"
+                        color="gray"
+                        :icon-size="18"
+                        icon="info_circle"
+                        icon-ios="f7:info_circle"
+                        icon-md="f7:info_circle"
+                        icon-aurora="f7:info_circle" />
+                    </template>
+                  </template>
+                </f7-list-item>
+              </f7-list>
+            </group-box>
           </f7-col>
           <f7-col v-if="currentTemplate && (createMode || stubMode)">
-            <f7-block-title medium> Template </f7-block-title>
-            <f7-list media-list>
-              <f7-list-item :footer="currentTemplate.description">
-                <template #title>
-                  {{ currentTemplate.label }}
-                  <template v-if="currentTemplateTopicLink">
-                    &nbsp;
-                    <f7-link
-                      :href="currentTemplateTopicLink"
-                      tooltip="View openHAB Community Marketplace topic for this template"
-                      target="_blank"
-                      class="external"
-                      color="gray"
-                      :icon-size="18"
-                      icon="info_circle"
-                      icon-ios="f7:info_circle"
-                      icon-md="f7:info_circle"
-                      icon-aurora="f7:info_circle" />
+            <group-box title="Template">
+              <f7-list media-list>
+                <f7-list-item :footer="currentTemplate.description">
+                  <template #title>
+                    {{ currentTemplate.label }}
+                    <template v-if="currentTemplateTopicLink">
+                      &nbsp;
+                      <f7-link
+                        :href="currentTemplateTopicLink"
+                        tooltip="View openHAB Community Marketplace topic for this template"
+                        target="_blank"
+                        class="external"
+                        color="gray"
+                        :icon-size="18"
+                        icon="info_circle"
+                        icon-ios="f7:info_circle"
+                        icon-md="f7:info_circle"
+                        icon-aurora="f7:info_circle" />
+                    </template>
                   </template>
-                </template>
-              </f7-list-item>
-            </f7-list>
-            <!-- Show radio options only if integrating template (createMode && ruleCopy?.templateUID) -->
-            <f7-list v-if="createMode && ruleCopy?.templateUID" media-list>
-              <f7-list-item
-                title="Keep template"
-                footer="The rule will still be linked to the template and can be regenerated if the template changes."
-                :value="currentTemplate.uid"
-                radio
-                :checked="Boolean(rule.templateUID) ? true : null"
-                radio-icon="start"
-                @change="keepTemplate(true)" />
-              <f7-list-item
-                title="Integrate template"
-                footer="Integrates the template in the rule so that the rule is no longer linked to the template."
-                value="integrate"
-                radio
-                :checked="!rule.templateUID ? true : null"
-                radio-icon="start"
-                @change="keepTemplate(false)" />
-            </f7-list>
-            <!-- Show Template Configuration only if template is kept or not integrating -->
-            <template v-if="rule.templateUID || !createMode || !ruleCopy?.templateUID">
-              <f7-block-title medium class="margin-vertical padding-top"> Template Configuration </f7-block-title>
+                </f7-list-item>
+              </f7-list>
+            </group-box>
+            <group-box v-if="createMode && ruleCopy?.templateUID" title="Template Integration Options">
+              <!-- Show radio options only if integrating template (createMode && ruleCopy?.templateUID) -->
+              <f7-list media-list>
+                <f7-list-item
+                  title="Keep template"
+                  footer="The rule will still be linked to the template and can be regenerated if the template changes."
+                  :value="currentTemplate.uid"
+                  radio
+                  :checked="Boolean(rule.templateUID) ? true : null"
+                  radio-icon="start"
+                  @change="keepTemplate(true)" />
+                <f7-list-item
+                  title="Integrate template"
+                  footer="Integrates the template in the rule so that the rule is no longer linked to the template."
+                  value="integrate"
+                  radio
+                  :checked="!rule.templateUID ? true : null"
+                  radio-icon="start"
+                  @change="keepTemplate(false)" />
+              </f7-list>
+            </group-box>
+            <group-box v-if="rule.templateUID || !createMode || !ruleCopy?.templateUID" title="Template Configuration">
+              <!-- Show Template Configuration only if template is kept or not integrating -->
               <config-sheet :parameter-groups="[]" :parameters="currentTemplate.configDescriptions" :configuration="rule.configuration" />
-            </template>
+            </group-box>
           </f7-col>
+
+          <!-- Module Reorder Control -->
           <f7-col v-if="!hasTemplate || (createMode && ruleCopy?.templateUID && !rule.templateUID)" class="rule-modules">
-            <div v-if="isEditable" class="no-padding float-right">
+            <div v-if="isEditable" class="no-padding float-right margin-top margin-bottom">
               <f7-button
                 @click="toggleModuleControls"
                 small
@@ -206,71 +208,75 @@
                 &nbsp;Reorder
               </f7-button>
             </div>
+
+            <!-- Module Sections -->
             <div v-for="section in ['triggers', 'actions', 'conditions']" :key="section">
-              <template v-if="isEditable || rule[section].length > 0">
-                <f7-block-title medium class="no-margin-bottom">
-                  {{ SECTION_LABELS[section][0] }}
-                </f7-block-title>
-                <f7-block-footer class="no-margin-top margin-horizontal" style="margin-bottom: var(--f7-list-margin-vertical)">
-                  {{ SECTION_LABELS[section][1] }}
-                </f7-block-footer>
-              </template>
-              <f7-list sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, section)">
-                <f7-list-item
-                  v-for="mod in rule[section]"
-                  media
-                  :title="mod.label || suggestedModuleTitle(mod, null, section)"
-                  :footer="mod.description || suggestedModuleDescription(mod, null, section)"
-                  :key="mod.id"
-                  :link="!showModuleControls && !isOpaqueModule(mod)"
-                  @click="(ev) => editModule(ev, section, mod)"
-                  swipeout>
-                  <template #media>
-                    <f7-link
-                      v-if="isEditable"
-                      icon-color="red"
-                      icon-aurora="f7:minus_circle_filled"
-                      icon-ios="f7:minus_circle_filled"
-                      icon-md="material:remove_circle_outline"
-                      @click="showSwipeout" />
-                  </template>
-                  <f7-swipeout-actions v-if="isEditable" right>
-                    <f7-swipeout-button
-                      @click="(ev) => deleteModule(ev, section, mod)"
-                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                      Delete
-                    </f7-swipeout-button>
-                  </f7-swipeout-actions>
-                </f7-list-item>
-              </f7-list>
-              <f7-list v-if="isEditable">
-                <f7-list-item
-                  link
-                  no-chevron
-                  media-item
-                  :color="uiOptionsStore.darkMode === 'dark' ? 'black' : 'white'"
-                  :subtitle="SECTION_LABELS[section][2]"
-                  @click="addModule(section)">
-                  <template #media>
-                    <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                  </template>
-                </f7-list-item>
-                <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'blue'" :title="sectionLabels[section][1]"></f7-list-button> -->
-              </f7-list>
+              <group-box :title="SECTION_LABELS[section][0]" :description="SECTION_LABELS[section][1]">
+                <f7-list sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, section)">
+                  <f7-list-item
+                    v-for="mod in rule[section]"
+                    media
+                    :title="mod.label || suggestedModuleTitle(mod, null, section)"
+                    :footer="mod.description || suggestedModuleDescription(mod, null, section)"
+                    :key="mod.id"
+                    :link="!showModuleControls && !isOpaqueModule(mod)"
+                    @click="(ev) => editModule(ev, section, mod)"
+                    swipeout>
+                    <template #media>
+                      <f7-link
+                        v-if="isEditable"
+                        icon-color="red"
+                        icon-aurora="f7:minus_circle_filled"
+                        icon-ios="f7:minus_circle_filled"
+                        icon-md="material:remove_circle_outline"
+                        @click="showSwipeout" />
+                    </template>
+                    <f7-swipeout-actions v-if="isEditable" right>
+                      <f7-swipeout-button
+                        @click="(ev) => deleteModule(ev, section, mod)"
+                        style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                        Delete
+                      </f7-swipeout-button>
+                    </f7-swipeout-actions>
+                  </f7-list-item>
+                  <f7-list-item v-if="!rule[section].length">
+                    <template #title>
+                      <em>No {{ section }}<template v-if="createMode"> added yet</template>.</em>
+                    </template>
+                  </f7-list-item>
+                </f7-list>
+                <f7-list v-if="isEditable">
+                  <f7-list-item
+                    link
+                    no-chevron
+                    media-item
+                    class="add-module-item"
+                    :color="uiOptionsStore.darkMode === 'dark' ? 'black' : 'white'"
+                    :subtitle="SECTION_LABELS[section][2]"
+                    @click="addModule(section)">
+                    <template #media>
+                      <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+                    </template>
+                  </f7-list-item>
+                  <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'blue'" :title="sectionLabels[section][1]"></f7-list-button> -->
+                </f7-list>
+              </group-box>
             </div>
           </f7-col>
           <f7-col v-if="!createMode && !stubMode">
-            <f7-list>
-              <f7-list-button v-if="isEditable || (!hasOpaqueModule && !hasSharedContextModule)" color="blue" @click="duplicateRule">
-                Duplicate Rule
-              </f7-list-button>
-              <f7-list-button
-                v-if="!hasOpaqueModule"
-                color="blue"
-                title="Copy File Definition"
-                @click="copyPopupOpened = !copyPopupOpened" />
-              <f7-list-button v-if="isEditable" color="red" @click="deleteRule"> Delete Rule </f7-list-button>
-            </f7-list>
+            <group-box v-if="isEditable || !hasOpaqueModule">
+              <f7-list>
+                <f7-list-button v-if="isEditable || (!hasOpaqueModule && !hasSharedContextModule)" color="blue" @click="duplicateRule">
+                  Duplicate Rule
+                </f7-list-button>
+                <f7-list-button
+                  v-if="!hasOpaqueModule"
+                  color="blue"
+                  title="Copy File Definition"
+                  @click="copyPopupOpened = !copyPopupOpened" />
+                <f7-list-button v-if="isEditable" color="red" @click="deleteRule"> Delete Rule </f7-list-button>
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -480,6 +486,8 @@
     margin-bottom 0
   .list
     margin-top 0
+  .add-module-item
+    border-top 1px solid var(--f7-list-border-color, var(--f7-border-color))
 .rule-code-editor
 .rule-source-viewer.code-editor-fit
   position absolute

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -86,111 +86,113 @@
         <rule-general-settings :rule="rule" :ready="ready" :createMode="createMode" :stubMode="stubMode" :templateName="templateName" />
 
         <f7-block v-if="ready" class="block-narrow">
-          <f7-block-footer v-if="!isEditable" class="no-margin padding-left">
-            <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: this rule is not editable.
-          </f7-block-footer>
+          <!-- Template Selection -->
           <f7-col v-if="createMode && templates.length > 0 && !ruleCopy" class="new-rule-from-template">
-            <f7-list>
-              <f7-list-item ref="templateAccordion" accordion-item>
-                <template #title>
-                  <template v-if="currentTemplate"> Create from Template: {{ currentTemplate.label }} </template>
-                  <template v-else> Create a new rule from scratch (or expand to select a template) </template>
-                </template>
-                <f7-accordion-content>
-                  <f7-list media-list>
-                    <f7-list-item
-                      title="No template"
-                      footer="Create a new rule from scratch"
-                      radio
-                      :checked="!hasTemplate"
-                      radio-icon="start"
-                      :value="''"
-                      @change="selectTemplate(null)" />
-                  </f7-list>
-                  <f7-block-header class="margin-left margin-top"> or choose a rule template: </f7-block-header>
-                  <f7-list media-list>
-                    <f7-list-item
-                      v-for="template in templates"
-                      :key="template.uid"
-                      :footer="template.description"
-                      :value="template.uid"
-                      radio
-                      :checked="currentTemplate && currentTemplate.uid === template.uid ? true : null"
-                      radio-icon="start"
-                      @change="selectTemplate(template.uid)">
-                      <template #title>
-                        {{ template.label }}
-                        <template v-if="getTopicLink(template)">
-                          &nbsp;
-                          <f7-link
-                            :href="getTopicLink(template)"
-                            tooltip="View openHAB Community Marketplace topic for this template"
-                            target="_blank"
-                            class="external"
-                            color="gray"
-                            :icon-size="18"
-                            icon="info_circle"
-                            icon-ios="f7:info_circle"
-                            icon-md="f7:info_circle"
-                            icon-aurora="f7:info_circle" />
-                        </template>
-                      </template>
-                    </f7-list-item>
-                  </f7-list>
-                </f7-accordion-content>
-              </f7-list-item>
-            </f7-list>
+            <group-box
+              ref="templateAccordion"
+              :title="
+                currentTemplate
+                  ? 'Create from Template: ' + currentTemplate.label
+                  : 'Create a new rule from scratch (or expand to select a template)'
+              "
+              full-width
+              accordion>
+              <f7-list media-list>
+                <f7-list-item
+                  title="No template"
+                  footer="Create a new rule from scratch"
+                  radio
+                  :checked="!hasTemplate"
+                  radio-icon="start"
+                  :value="''"
+                  @change="selectTemplate(null)" />
+              </f7-list>
+              <f7-block-header class="margin-left margin-top"> or choose a rule template: </f7-block-header>
+              <f7-list media-list>
+                <f7-list-item
+                  v-for="template in templates"
+                  :key="template.uid"
+                  :footer="template.description"
+                  :value="template.uid"
+                  radio
+                  :checked="currentTemplate && currentTemplate.uid === template.uid ? true : null"
+                  radio-icon="start"
+                  @change="selectTemplate(template.uid)">
+                  <template #title>
+                    {{ template.label }}
+                    <template v-if="getTopicLink(template)">
+                      &nbsp;
+                      <f7-link
+                        :href="getTopicLink(template)"
+                        tooltip="View openHAB Community Marketplace topic for this template"
+                        target="_blank"
+                        class="external"
+                        color="gray"
+                        :icon-size="18"
+                        icon="info_circle"
+                        icon-ios="f7:info_circle"
+                        icon-md="f7:info_circle"
+                        icon-aurora="f7:info_circle" />
+                    </template>
+                  </template>
+                </f7-list-item>
+              </f7-list>
+            </group-box>
           </f7-col>
           <f7-col v-if="currentTemplate && (createMode || stubMode)">
-            <f7-block-title medium> Template </f7-block-title>
-            <f7-list media-list>
-              <f7-list-item :footer="currentTemplate.description">
-                <template #title>
-                  {{ currentTemplate.label }}
-                  <template v-if="currentTemplateTopicLink">
-                    &nbsp;
-                    <f7-link
-                      :href="currentTemplateTopicLink"
-                      tooltip="View openHAB Community Marketplace topic for this template"
-                      target="_blank"
-                      class="external"
-                      color="gray"
-                      :icon-size="18"
-                      icon="info_circle"
-                      icon-ios="f7:info_circle"
-                      icon-md="f7:info_circle"
-                      icon-aurora="f7:info_circle" />
+            <group-box title="Template">
+              <f7-list media-list>
+                <f7-list-item :footer="currentTemplate.description">
+                  <template #title>
+                    {{ currentTemplate.label }}
+                    <template v-if="currentTemplateTopicLink">
+                      &nbsp;
+                      <f7-link
+                        :href="currentTemplateTopicLink"
+                        tooltip="View openHAB Community Marketplace topic for this template"
+                        target="_blank"
+                        class="external"
+                        color="gray"
+                        :icon-size="18"
+                        icon="info_circle"
+                        icon-ios="f7:info_circle"
+                        icon-md="f7:info_circle"
+                        icon-aurora="f7:info_circle" />
+                    </template>
                   </template>
-                </template>
-              </f7-list-item>
-            </f7-list>
-            <!-- Show radio options only if integrating template (createMode && ruleCopy?.templateUID) -->
-            <f7-list v-if="createMode && ruleCopy?.templateUID" media-list>
-              <f7-list-item
-                title="Keep template"
-                footer="The rule will still be linked to the template and can be regenerated if the template changes."
-                :value="currentTemplate.uid"
-                radio
-                :checked="Boolean(rule.templateUID) ? true : null"
-                radio-icon="start"
-                @change="keepTemplate(true)" />
-              <f7-list-item
-                title="Integrate template"
-                footer="Integrates the template in the rule so that the rule is no longer linked to the template."
-                value="integrate"
-                radio
-                :checked="!rule.templateUID ? true : null"
-                radio-icon="start"
-                @change="keepTemplate(false)" />
-            </f7-list>
-            <!-- Show Template Configuration only if template is kept or not integrating -->
-            <template v-if="rule.templateUID || !createMode || !ruleCopy?.templateUID">
-              <f7-block-title medium class="margin-vertical padding-top"> Template Configuration </f7-block-title>
+                </f7-list-item>
+              </f7-list>
+            </group-box>
+            <group-box v-if="createMode && ruleCopy?.templateUID" title="Template Integration Options">
+              <!-- Show radio options only if integrating template (createMode && ruleCopy?.templateUID) -->
+              <f7-list media-list>
+                <f7-list-item
+                  title="Keep template"
+                  footer="The rule will still be linked to the template and can be regenerated if the template changes."
+                  :value="currentTemplate.uid"
+                  radio
+                  :checked="Boolean(rule.templateUID) ? true : null"
+                  radio-icon="start"
+                  @change="keepTemplate(true)" />
+                <f7-list-item
+                  title="Integrate template"
+                  footer="Integrates the template in the rule so that the rule is no longer linked to the template."
+                  value="integrate"
+                  radio
+                  :checked="!rule.templateUID ? true : null"
+                  radio-icon="start"
+                  @change="keepTemplate(false)" />
+              </f7-list>
+            </group-box>
+            <group-box v-if="rule.templateUID || !createMode || !ruleCopy?.templateUID" title="Template Configuration">
+              <!-- Show Template Configuration only if template is kept or not integrating -->
               <config-sheet :parameter-groups="[]" :parameters="currentTemplate.configDescriptions" :configuration="rule.configuration" />
-            </template>
+            </group-box>
           </f7-col>
+
+          <!-- Module Reorder Control -->
           <f7-col v-if="!hasTemplate || (createMode && ruleCopy?.templateUID && !rule.templateUID)" class="rule-modules">
-            <div v-if="isEditable" class="no-padding float-right">
+            <div v-if="isEditable" class="no-padding float-right margin-top margin-bottom">
               <f7-button
                 @click="toggleModuleControls"
                 small
@@ -206,71 +208,75 @@
                 &nbsp;Reorder
               </f7-button>
             </div>
+
+            <!-- Module Sections -->
             <div v-for="section in ['triggers', 'actions', 'conditions']" :key="section">
-              <template v-if="isEditable || rule[section].length > 0">
-                <f7-block-title medium class="no-margin-bottom">
-                  {{ SECTION_LABELS[section][0] }}
-                </f7-block-title>
-                <f7-block-footer class="no-margin-top margin-horizontal" style="margin-bottom: var(--f7-list-margin-vertical)">
-                  {{ SECTION_LABELS[section][1] }}
-                </f7-block-footer>
-              </template>
-              <f7-list sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, section)">
-                <f7-list-item
-                  v-for="mod in rule[section]"
-                  media
-                  :title="mod.label || suggestedModuleTitle(mod, null, section)"
-                  :footer="mod.description || suggestedModuleDescription(mod, null, section)"
-                  :key="mod.id"
-                  :link="!showModuleControls && !isOpaqueModule(mod)"
-                  @click="(ev) => editModule(ev, section, mod)"
-                  swipeout>
-                  <template #media>
-                    <f7-link
-                      v-if="isEditable"
-                      icon-color="red"
-                      icon-aurora="f7:minus_circle_filled"
-                      icon-ios="f7:minus_circle_filled"
-                      icon-md="material:remove_circle_outline"
-                      @click="showSwipeout" />
-                  </template>
-                  <f7-swipeout-actions v-if="isEditable" right>
-                    <f7-swipeout-button
-                      @click="(ev) => deleteModule(ev, section, mod)"
-                      style="background-color: var(--f7-swipeout-delete-button-bg-color)">
-                      Delete
-                    </f7-swipeout-button>
-                  </f7-swipeout-actions>
-                </f7-list-item>
-              </f7-list>
-              <f7-list v-if="isEditable">
-                <f7-list-item
-                  link
-                  no-chevron
-                  media-item
-                  :color="uiOptionsStore.darkMode === 'dark' ? 'black' : 'white'"
-                  :subtitle="SECTION_LABELS[section][2]"
-                  @click="addModule(section)">
-                  <template #media>
-                    <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
-                  </template>
-                </f7-list-item>
-                <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'theme-alt'" :title="sectionLabels[section][1]"></f7-list-button> -->
-              </f7-list>
+              <group-box :title="SECTION_LABELS[section][0]" :description="SECTION_LABELS[section][1]">
+                <f7-list sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, section)">
+                  <f7-list-item
+                    v-for="mod in rule[section]"
+                    media
+                    :title="mod.label || suggestedModuleTitle(mod, null, section)"
+                    :footer="mod.description || suggestedModuleDescription(mod, null, section)"
+                    :key="mod.id"
+                    :link="!showModuleControls && !isOpaqueModule(mod)"
+                    @click="(ev) => editModule(ev, section, mod)"
+                    swipeout>
+                    <template #media>
+                      <f7-link
+                        v-if="isEditable"
+                        icon-color="red"
+                        icon-aurora="f7:minus_circle_filled"
+                        icon-ios="f7:minus_circle_filled"
+                        icon-md="material:remove_circle_outline"
+                        @click="showSwipeout" />
+                    </template>
+                    <f7-swipeout-actions v-if="isEditable" right>
+                      <f7-swipeout-button
+                        @click="(ev) => deleteModule(ev, section, mod)"
+                        style="background-color: var(--f7-swipeout-delete-button-bg-color)">
+                        Delete
+                      </f7-swipeout-button>
+                    </f7-swipeout-actions>
+                  </f7-list-item>
+                  <f7-list-item v-if="!rule[section].length">
+                    <template #title>
+                      <em>No {{ section }}<template v-if="createMode"> added yet</template>.</em>
+                    </template>
+                  </f7-list-item>
+                </f7-list>
+                <f7-list v-if="isEditable">
+                  <f7-list-item
+                    link
+                    no-chevron
+                    media-item
+                    class="add-module-item"
+                    :color="uiOptionsStore.darkMode === 'dark' ? 'black' : 'white'"
+                    :subtitle="SECTION_LABELS[section][2]"
+                    @click="addModule(section)">
+                    <template #media>
+                      <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
+                    </template>
+                  </f7-list-item>
+                  <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'theme-alt'" :title="sectionLabels[section][1]"></f7-list-button> -->
+                </f7-list>
+              </group-box>
             </div>
           </f7-col>
           <f7-col v-if="!createMode && !stubMode">
-            <f7-list>
-              <f7-list-button v-if="isEditable || (!hasOpaqueModule && !hasSharedContextModule)" color="theme-alt" @click="duplicateRule">
-                Duplicate Rule
-              </f7-list-button>
-              <f7-list-button
-                v-if="!hasOpaqueModule"
-                color="theme-alt"
-                title="Copy File Definition"
-                @click="copyPopupOpened = !copyPopupOpened" />
-              <f7-list-button v-if="isEditable" color="red" @click="deleteRule"> Delete Rule </f7-list-button>
-            </f7-list>
+            <group-box v-if="isEditable || !hasOpaqueModule">
+              <f7-list>
+                <f7-list-button v-if="isEditable || (!hasOpaqueModule && !hasSharedContextModule)" color="theme-alt" @click="duplicateRule">
+                  Duplicate Rule
+                </f7-list-button>
+                <f7-list-button
+                  v-if="!hasOpaqueModule"
+                  color="theme-alt"
+                  title="Copy File Definition"
+                  @click="copyPopupOpened = !copyPopupOpened" />
+                <f7-list-button v-if="isEditable" color="red" @click="deleteRule"> Delete Rule </f7-list-button>
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -480,6 +486,8 @@
     margin-bottom 0
   .list
     margin-top 0
+  .add-module-item
+    border-top 1px solid var(--f7-list-border-color, var(--f7-border-color))
 .rule-code-editor
 .rule-source-viewer.code-editor-fit
   position absolute

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -120,7 +120,6 @@
           </f7-list>
         </f7-col>
         <f7-col v-if="ruleModule && currentRuleModuleType && (!ruleModule.new || advancedTypePicker)" class="margin-top">
-          <f7-block-title style="margin-bottom: 0"> Configuration </f7-block-title>
           <config-sheet
             v-if="!(ruleModule.configuration && ruleModule.configuration.blockSource)"
             :key="currentSection + ruleModule.id"

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -169,65 +169,63 @@
     <!-- rule engine available and ready and has rules -->
     <f7-block v-show="!noRuleEngine && ready && rules.length > 0" class="block-narrow">
       <f7-col>
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <f7-list v-if="!listedItems.length">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list v-show="listedItems.length > 0" class="searchbar-found col rules-list" ref="rulesList" media-list contacts-list>
-          <f7-list-group v-for="(rulesWithInitial, initial) in indexedRules" :key="initial">
-            <f7-list-item v-if="rulesWithInitial.length" :title="initial" group-title />
-            <f7-list-item
-              v-for="rule in rulesWithInitial"
-              :key="rule.uid"
-              media-item
-              class="rulelist-item"
-              :checkbox="showCheckboxes ? true : null"
-              :checked="isChecked(rule.uid) ? true : null"
-              prevent-router
-              @click.ctrl="ctrlClick($event, rule)"
-              @click.meta="ctrlClick($event, rule)"
-              @click.exact="click($event, rule)"
-              :link="`${encodeURIComponent(rule.uid)}`"
-              :title="rule.name"
-              :text="rule.uid"
-              :footer="rule.description"
-              :badge="showScenes ? '' : ruleStatusBadgeText(ruleStatuses[rule.uid])"
-              :badge-color="ruleStatusBadgeColor(ruleStatuses[rule.uid])">
-              <template #footer>
-                <div class="footer-inner">
-                  <f7-chip
-                    v-if="rule.templateUID"
-                    :text="templateName(rule)"
-                    @click.ctrl="(e) => templateClick(e, true, rule)"
-                    @click.meta="(e) => templateClick(e, true, rule)"
-                    @click.exact="(e) => templateClick(e, false, rule)"
-                    media-bg-color="orange"
-                    style="margin-right: 2px">
-                    <template #media>
-                      <f7-icon ios="f7:doc_on_doc_fill" md="material:file_copy" aurora="f7:doc_on_doc_fill" />
-                    </template>
-                  </f7-chip>
-                  <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-              <!-- <span slot="media" class="item-initial">{{initial}}</span> -->
-              <template v-if="rule.editable === false" #after-title>
-                <f7-icon f7="lock_fill" size="1rem" color="gray" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && listedItems.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list v-show="listedItems.length > 0" class="searchbar-found col rules-list" ref="rulesList" media-list contacts-list>
+            <f7-list-group v-for="(rulesWithInitial, initial) in indexedRules" :key="initial">
+              <f7-list-item v-if="rulesWithInitial.length" :title="initial" group-title />
+              <f7-list-item
+                v-for="rule in rulesWithInitial"
+                :key="rule.uid"
+                media-item
+                class="rulelist-item"
+                :checkbox="showCheckboxes ? true : null"
+                :checked="isChecked(rule.uid) ? true : null"
+                prevent-router
+                @click.ctrl="ctrlClick($event, rule)"
+                @click.meta="ctrlClick($event, rule)"
+                @click.exact="click($event, rule)"
+                :link="`${encodeURIComponent(rule.uid)}`"
+                :title="rule.name"
+                :text="rule.uid"
+                :footer="rule.description"
+                :badge="showScenes ? '' : ruleStatusBadgeText(ruleStatuses[rule.uid])"
+                :badge-color="ruleStatusBadgeColor(ruleStatuses[rule.uid])">
+                <template #footer>
+                  <div class="footer-inner">
+                    <f7-chip
+                      v-if="rule.templateUID"
+                      :text="templateName(rule)"
+                      @click.ctrl="(e) => templateClick(e, true, rule)"
+                      @click.meta="(e) => templateClick(e, true, rule)"
+                      @click.exact="(e) => templateClick(e, false, rule)"
+                      media-bg-color="orange"
+                      style="margin-right: 2px">
+                      <template #media>
+                        <f7-icon ios="f7:doc_on_doc_fill" md="material:file_copy" aurora="f7:doc_on_doc_fill" />
+                      </template>
+                    </f7-chip>
+                    <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                      </template>
+                    </f7-chip>
+                  </div>
+                </template>
+                <!-- <span slot="media" class="item-initial">{{initial}}</span> -->
+                <template v-if="rule.editable === false" #after-title>
+                  <f7-icon f7="lock_fill" size="1rem" color="gray" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -169,65 +169,63 @@
     <!-- rule engine available and ready and has rules -->
     <f7-block v-show="!noRuleEngine && ready && rules.length > 0" class="block-narrow">
       <f7-col>
-        <f7-block-title class="no-margin-top">
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
         <f7-list v-if="!listedItems.length">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list v-show="listedItems.length > 0" class="searchbar-found col rules-list" ref="rulesList" media-list contacts-list>
-          <f7-list-group v-for="(rulesWithInitial, initial) in indexedRules" :key="initial">
-            <f7-list-item v-if="rulesWithInitial.length" :title="initial" group-title />
-            <f7-list-item
-              v-for="rule in rulesWithInitial"
-              :key="rule.uid"
-              media-item
-              class="rulelist-item"
-              :checkbox="showCheckboxes ? true : null"
-              :checked="isChecked(rule.uid) ? true : null"
-              prevent-router
-              @click.ctrl="ctrlClick($event, rule)"
-              @click.meta="ctrlClick($event, rule)"
-              @click.exact="click($event, rule)"
-              :link="`${encodeURIComponent(rule.uid)}`"
-              :title="rule.name"
-              :text="rule.uid"
-              :footer="rule.description"
-              :badge="showScenes ? '' : ruleStatusBadgeText(ruleStatuses[rule.uid])"
-              :badge-color="ruleStatusBadgeColor(ruleStatuses[rule.uid])">
-              <template #footer>
-                <div class="footer-inner">
-                  <f7-chip
-                    v-if="rule.templateUID"
-                    :text="templateName(rule)"
-                    @click.ctrl="(e) => templateClick(e, true, rule)"
-                    @click.meta="(e) => templateClick(e, true, rule)"
-                    @click.exact="(e) => templateClick(e, false, rule)"
-                    media-bg-color="orange"
-                    style="margin-right: 2px">
-                    <template #media>
-                      <f7-icon ios="f7:doc_on_doc_fill" md="material:file_copy" aurora="f7:doc_on_doc_fill" />
-                    </template>
-                  </f7-chip>
-                  <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
-                    <template #media>
-                      <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
-                    </template>
-                  </f7-chip>
-                </div>
-              </template>
-              <!-- <span slot="media" class="item-initial">{{initial}}</span> -->
-              <template v-if="rule.editable === false" #after-title>
-                <f7-icon f7="lock_fill" size="1rem" color="gray" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+        <group-box :title="listTitle">
+          <template v-if="showCheckboxes && listedItems.length" #after-title>
+            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
+          </template>
+          <f7-list v-show="listedItems.length > 0" class="searchbar-found col rules-list" ref="rulesList" media-list contacts-list>
+            <f7-list-group v-for="(rulesWithInitial, initial) in indexedRules" :key="initial">
+              <f7-list-item v-if="rulesWithInitial.length" :title="initial" group-title />
+              <f7-list-item
+                v-for="rule in rulesWithInitial"
+                :key="rule.uid"
+                media-item
+                class="rulelist-item"
+                :checkbox="showCheckboxes ? true : null"
+                :checked="isChecked(rule.uid) ? true : null"
+                prevent-router
+                @click.ctrl="ctrlClick($event, rule)"
+                @click.meta="ctrlClick($event, rule)"
+                @click.exact="click($event, rule)"
+                :link="`${encodeURIComponent(rule.uid)}`"
+                :title="rule.name"
+                :text="rule.uid"
+                :footer="rule.description"
+                :badge="showScenes ? '' : ruleStatusBadgeText(ruleStatuses[rule.uid])"
+                :badge-color="ruleStatusBadgeColor(ruleStatuses[rule.uid])">
+                <template #footer>
+                  <div class="footer-inner">
+                    <f7-chip
+                      v-if="rule.templateUID"
+                      :text="templateName(rule)"
+                      @click.ctrl="(e) => templateClick(e, true, rule)"
+                      @click.meta="(e) => templateClick(e, true, rule)"
+                      @click.exact="(e) => templateClick(e, false, rule)"
+                      media-bg-color="orange"
+                      style="margin-right: 2px">
+                      <template #media>
+                        <f7-icon ios="f7:doc_on_doc_fill" md="material:file_copy" aurora="f7:doc_on_doc_fill" />
+                      </template>
+                    </f7-chip>
+                    <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                      <template #media>
+                        <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
+                      </template>
+                    </f7-chip>
+                  </div>
+                </template>
+                <!-- <span slot="media" class="item-initial">{{initial}}</span> -->
+                <template v-if="rule.editable === false" #after-title>
+                  <f7-icon f7="lock_fill" size="1rem" color="gray" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -61,15 +61,11 @@
 
         <rule-general-settings :rule="rule" :ready="ready" :createMode="createMode" :inSceneEditor="true" />
 
+        <not-editable-notice v-if="!editable" subject="Thing" />
+
         <f7-block v-if="ready" class="block-narrow">
-          <f7-block-footer v-if="!isEditable" class="no-margin padding-left">
-            <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: this rule is not editable because it has been provisioned from a
-            file.
-          </f7-block-footer>
-          <!-- <f7-col v-if="isEditable" class="text-align-right justify-content-flex-end">
-            </f7-col> -->
           <f7-col class="scene-modules">
-            <div v-if="rule['actions'].length > 0" class="no-padding float-right">
+            <div v-if="rule['actions'].length > 0" class="no-padding float-right margin-top margin-bottom">
               <f7-button
                 @click="toggleModuleControls"
                 small
@@ -85,8 +81,8 @@
                 &nbsp;Reorder
               </f7-button>
             </div>
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Configuration </f7-block-title>
+
+            <group-box title="Scene Configuration">
               <f7-list class="scene-items" sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, 'actions')">
                 <f7-list-item
                   v-for="mod in rule['actions']"
@@ -160,13 +156,15 @@
                   <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'theme-alt'" :title="sectionLabels[section][1]"></f7-list-button> -->
                 </f7-list-group>
               </f7-list>
-            </div>
+            </group-box>
           </f7-col>
           <f7-col v-if="isEditable && !createMode">
-            <f7-list>
-              <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Scene </f7-list-button>
-              <f7-list-button color="red" @click="deleteRule"> Remove Scene </f7-list-button>
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Scene </f7-list-button>
+                <f7-list-button color="red" @click="deleteRule"> Remove Scene </f7-list-button>
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -61,15 +61,11 @@
 
         <rule-general-settings :rule="rule" :ready="ready" :createMode="createMode" :inSceneEditor="true" />
 
+        <not-editable-notice v-if="!editable" subject="Thing" />
+
         <f7-block v-if="ready" class="block-narrow">
-          <f7-block-footer v-if="!isEditable" class="no-margin padding-left">
-            <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: this rule is not editable because it has been provisioned from a
-            file.
-          </f7-block-footer>
-          <!-- <f7-col v-if="isEditable" class="text-align-right justify-content-flex-end">
-            </f7-col> -->
           <f7-col class="scene-modules">
-            <div v-if="rule['actions'].length > 0" class="no-padding float-right">
+            <div v-if="rule['actions'].length > 0" class="no-padding float-right margin-top margin-bottom">
               <f7-button
                 @click="toggleModuleControls"
                 small
@@ -85,8 +81,8 @@
                 &nbsp;Reorder
               </f7-button>
             </div>
-            <div>
-              <f7-block-title medium style="margin-bottom: var(--f7-list-margin-vertical)"> Configuration </f7-block-title>
+
+            <group-box title="Scene Configuration">
               <f7-list class="scene-items" sortable swipeout media-list @sortable:sort="(ev) => reorderModule(ev, 'actions')">
                 <f7-list-item
                   v-for="mod in rule['actions']"
@@ -160,13 +156,15 @@
                   <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'blue'" :title="sectionLabels[section][1]"></f7-list-button> -->
                 </f7-list-group>
               </f7-list>
-            </div>
+            </group-box>
           </f7-col>
           <f7-col v-if="isEditable && !createMode">
-            <f7-list>
-              <f7-list-button color="blue" @click="duplicateRule"> Duplicate Scene </f7-list-button>
-              <f7-list-button color="red" @click="deleteRule"> Remove Scene </f7-list-button>
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button color="blue" @click="duplicateRule"> Duplicate Scene </f7-list-button>
+                <f7-list-button color="red" @click="deleteRule"> Remove Scene </f7-list-button>
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -274,10 +274,12 @@
             @new-language="changeLanguage" />
           <f7-block v-if="editable && isScriptRule" class="block-narrow">
             <f7-col>
-              <f7-list>
-                <f7-list-button color="blue" @click="duplicateRule"> Duplicate Script </f7-list-button>
-                <f7-list-button color="red" @click="deleteRule"> Remove Script </f7-list-button>
-              </f7-list>
+              <group-box>
+                <f7-list>
+                  <f7-list-button color="blue" @click="duplicateRule"> Duplicate Script </f7-list-button>
+                  <f7-list-button color="red" @click="deleteRule"> Remove Script </f7-list-button>
+                </f7-list>
+              </group-box>
             </f7-col>
           </f7-block>
         </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -274,10 +274,12 @@
             @new-language="changeLanguage" />
           <f7-block v-if="editable && isScriptRule" class="block-narrow">
             <f7-col>
-              <f7-list>
-                <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Script </f7-list-button>
-                <f7-list-button color="red" @click="deleteRule"> Remove Script </f7-list-button>
-              </f7-list>
+              <group-box>
+                <f7-list>
+                  <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Script </f7-list-button>
+                  <f7-list-button color="red" @click="deleteRule"> Remove Script </f7-list-button>
+                </f7-list>
+              </group-box>
             </f7-col>
           </f7-block>
         </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-general-settings.vue
@@ -9,46 +9,48 @@
       style="margin-bottom: -15px" />
     <f7-block class="block-narrow" style="margin-top: 0">
       <f7-col v-if="!createMode && languages">
-        <f7-list inline-labels style="margin-top: 0">
-          <template v-if="module && !isScriptRule">
-            <f7-list-input
-              :label="scriptType + ' Title'"
-              type="text"
-              :value="moduleTitle"
-              :placeholder="sugModuleTitle"
-              @input="module.label = $event.target.value"
+        <group-box>
+          <f7-list inline-labels style="margin-top: 0">
+            <template v-if="module && !isScriptRule">
+              <f7-list-input
+                :label="scriptType + ' Title'"
+                type="text"
+                :value="moduleTitle"
+                :placeholder="sugModuleTitle"
+                @input="module.label = $event.target.value"
+                :disabled="!editable ? true : null"
+                :clear-button="editable" />
+              <f7-list-input
+                label="Description"
+                type="text"
+                :value="moduleDescription"
+                :placeholder="sugModuleDescription"
+                @input="module.description = $event.target.value"
+                :disabled="!editable ? true : null"
+                :clear-button="editable" />
+            </template>
+            <f7-list-item
+              title="Scripting Language"
+              class="aligned-smart-select"
               :disabled="!editable ? true : null"
-              :clear-button="editable" />
-            <f7-list-input
-              label="Description"
-              type="text"
-              :value="moduleDescription"
-              :placeholder="sugModuleDescription"
-              @input="module.description = $event.target.value"
-              :disabled="!editable ? true : null"
-              :clear-button="editable" />
-          </template>
-          <f7-list-item
-            title="Scripting Language"
-            class="aligned-smart-select"
-            :disabled="!editable ? true : null"
-            :key="mode"
-            smart-select
-            :smart-select-params="{ openIn: 'sheet', closeOnSelect: true }">
-            <select @change="$emit('new-language', $event.target.value)">
-              <option v-if="!languages.map((l) => l.contentType).includes(mode)" :key="mode" :value="mode" selected="true">
-                {{ mode ? mode + ' (not installed)' : 'Unknown' }}
-              </option>
-              <option
-                v-for="language in languages"
-                :key="language.contentType"
-                :value="language.contentType"
-                :selected="language.contentType === mode ? true : null">
-                {{ language.name }} ({{ language.version }})
-              </option>
-            </select>
-          </f7-list-item>
-        </f7-list>
+              :key="mode"
+              smart-select
+              :smart-select-params="{ openIn: 'sheet', closeOnSelect: true }">
+              <select @change="$emit('new-language', $event.target.value)">
+                <option v-if="!languages.map((l) => l.contentType).includes(mode)" :key="mode" :value="mode" selected="true">
+                  {{ mode ? mode + ' (not installed)' : 'Unknown' }}
+                </option>
+                <option
+                  v-for="language in languages"
+                  :key="language.contentType"
+                  :value="language.contentType"
+                  :selected="language.contentType === mode ? true : null">
+                  {{ language.name }} ({{ language.version }})
+                </option>
+              </select>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
   </div>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -22,45 +22,49 @@
 
     <f7-block class="block-narrow">
       <f7-col>
-        <f7-list v-if="!ready" class="col">
-          <f7-list-group>
+        <group-box title="Installed Bindings">
+          <f7-list v-if="!ready" class="col">
+            <f7-list-group>
+              <f7-list-item
+                v-for="n in 10"
+                media-item
+                :key="n"
+                :class="`skeleton-text skeleton-effect-blink`"
+                title="Label of the binding"
+                header="BindingID"
+                footer="This contains the description of the binding" />
+            </f7-list-group>
+          </f7-list>
+          <f7-list v-else class="col binding-list">
             <f7-list-item
-              v-for="n in 10"
+              v-for="binding in bindings"
               media-item
-              :key="n"
-              :class="`skeleton-text skeleton-effect-blink`"
-              title="Label of the binding"
-              header="BindingID"
-              footer="This contains the description of the binding" />
-          </f7-list-group>
-        </f7-list>
-        <f7-list v-else class="col binding-list">
-          <f7-list-item
-            v-for="binding in bindings"
-            media-item
-            :key="binding.uid"
-            :link="binding.id"
-            :title="binding.label"
-            :badge="inbox.filter((e) => e.thingTypeUID.split(':')[0] === binding.id).length || undefined"
-            badge-color="red"
-            :footer="
-              binding.description && binding.description.indexOf('<br>') >= 0 ? binding.description.split('<br>')[0] : binding.description
-            ">
-            <template #media>
-              <addon-logo class="logo-square" :addon="binding" size="64" />
-            </template>
-            <template #after>
-              <f7-icon f7="info_circle" style="margin-left: 4px" :tooltip="binding.uid" />
-            </template>
-          </f7-list-item>
-        </f7-list>
+              :key="binding.uid"
+              :link="binding.id"
+              :title="binding.label"
+              :badge="inbox.filter((e) => e.thingTypeUID.split(':')[0] === binding.id).length || undefined"
+              badge-color="red"
+              :footer="
+                binding.description && binding.description.indexOf('<br>') >= 0 ? binding.description.split('<br>')[0] : binding.description
+              ">
+              <template #media>
+                <addon-logo class="logo-square" :addon="binding" size="64" />
+              </template>
+              <template #after>
+                <f7-icon f7="info_circle" style="margin-left: 4px" :tooltip="binding.uid" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <f7-block v-if="runtimeStore.apiEndpoint('addons')" class="block-narrow">
       <f7-col v-if="bindings.length">
-        <f7-list>
-          <f7-list-button color="blue" title="Install More Bindings" @click="installBindings" />
-        </f7-list>
+        <group-box>
+          <f7-list>
+            <f7-list-button color="blue" title="Install More Bindings" @click="installBindings" />
+          </f7-list>
+        </group-box>
       </f7-col>
       <f7-row v-else-if="ready" class="display-flex justify-content-center">
         <f7-button large fill color="blue" @click="installBindings"> Install Bindings </f7-button>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -22,45 +22,49 @@
 
     <f7-block class="block-narrow">
       <f7-col>
-        <f7-list v-if="!ready" class="col">
-          <f7-list-group>
+        <group-box title="Installed Bindings">
+          <f7-list v-if="!ready" class="col">
+            <f7-list-group>
+              <f7-list-item
+                v-for="n in 10"
+                media-item
+                :key="n"
+                :class="`skeleton-text skeleton-effect-blink`"
+                title="Label of the binding"
+                header="BindingID"
+                footer="This contains the description of the binding" />
+            </f7-list-group>
+          </f7-list>
+          <f7-list v-else class="col binding-list">
             <f7-list-item
-              v-for="n in 10"
+              v-for="binding in bindings"
               media-item
-              :key="n"
-              :class="`skeleton-text skeleton-effect-blink`"
-              title="Label of the binding"
-              header="BindingID"
-              footer="This contains the description of the binding" />
-          </f7-list-group>
-        </f7-list>
-        <f7-list v-else class="col binding-list">
-          <f7-list-item
-            v-for="binding in bindings"
-            media-item
-            :key="binding.uid"
-            :link="binding.id"
-            :title="binding.label"
-            :badge="inbox.filter((e) => e.thingTypeUID.split(':')[0] === binding.id).length || undefined"
-            badge-color="red"
-            :footer="
-              binding.description && binding.description.indexOf('<br>') >= 0 ? binding.description.split('<br>')[0] : binding.description
-            ">
-            <template #media>
-              <addon-logo class="logo-square" :addon="binding" size="64" />
-            </template>
-            <template #after>
-              <f7-icon f7="info_circle" style="margin-left: 4px" :tooltip="binding.uid" />
-            </template>
-          </f7-list-item>
-        </f7-list>
+              :key="binding.uid"
+              :link="binding.id"
+              :title="binding.label"
+              :badge="inbox.filter((e) => e.thingTypeUID.split(':')[0] === binding.id).length || undefined"
+              badge-color="red"
+              :footer="
+                binding.description && binding.description.indexOf('<br>') >= 0 ? binding.description.split('<br>')[0] : binding.description
+              ">
+              <template #media>
+                <addon-logo class="logo-square" :addon="binding" size="64" />
+              </template>
+              <template #after>
+                <f7-icon f7="info_circle" style="margin-left: 4px" :tooltip="binding.uid" />
+              </template>
+            </f7-list-item>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <f7-block v-if="runtimeStore.apiEndpoint('addons')" class="block-narrow">
       <f7-col v-if="bindings.length">
-        <f7-list>
-          <f7-list-button color="theme-alt" title="Install More Bindings" @click="installBindings" />
-        </f7-list>
+        <group-box>
+          <f7-list>
+            <f7-list-button color="theme-alt" title="Install More Bindings" @click="installBindings" />
+          </f7-list>
+        </group-box>
       </f7-col>
       <f7-row v-else-if="ready" class="display-flex justify-content-center">
         <f7-button large fill color="theme-alt" @click="installBindings"> Install Bindings </f7-button>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -31,52 +31,54 @@
           </div>
         </div>
         <p class="margin-left margin-right no-margin-bottom" style="height: 30px" id="scan-progress" />
-        <f7-block-title v-if="inputSupported"> Scan Input </f7-block-title>
         <config-sheet
           v-if="inputSupported"
+          title="Scan Input"
           class="scan-input"
           :parameter-groups="[]"
           :parameters="inputParameters"
           :configuration="inputConfig" />
-        <f7-block-title v-if="discoverySupported && scanResults.length"> Discovered Things </f7-block-title>
-        <f7-list v-if="scanResults.length" class="col thing-type-list">
-          <f7-list-item
-            v-for="entry in scanResults"
-            :key="entry.thingUID"
-            :link="true"
-            @click="openEntryActions(entry)"
-            media-item
-            :title="entry.label"
-            :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
-            :footer="entry.thingUID" />
-          <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="theme-alt" />
-        </f7-list>
+        <group-box v-if="discoverySupported && scanResults.length" title="Discovered Things">
+          <f7-list v-if="scanResults.length" class="col thing-type-list">
+            <f7-list-item
+              v-for="entry in scanResults"
+              :key="entry.thingUID"
+              :link="true"
+              @click="openEntryActions(entry)"
+              media-item
+              :title="entry.label"
+              :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
+              :footer="entry.thingUID" />
+            <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="theme-alt" />
+          </f7-list>
+        </group-box>
 
-        <f7-block-title>Add Manually</f7-block-title>
-        <f7-list class="thing-type-list">
-          <ul v-if="!ready">
-            <f7-list-item
-              v-for="n in 10"
-              :key="n"
-              :class="`skeleton-text skeleton-effect-blink`"
-              title="Label of the thing type"
-              footer="This contains the description of the thing type"
-              header="thingTypeUID"
-              media-item />
-          </ul>
-          <ul v-else>
-            <f7-list-item
-              v-for="thingType in thingTypes"
-              :key="thingType.UID"
-              :link="thingType.UID"
-              :title="thingType.label"
-              :footer="getHeading(thingType.description)"
-              :header="thingType.UID"
-              :badge="thingType.bridge ? 'Bridge' : ''"
-              badge-color="theme-alt"
-              media-item />
-          </ul>
-        </f7-list>
+        <group-box title="Add Manually">
+          <f7-list class="thing-type-list">
+            <ul v-if="!ready">
+              <f7-list-item
+                v-for="n in 10"
+                :key="n"
+                :class="`skeleton-text skeleton-effect-blink`"
+                title="Label of the thing type"
+                footer="This contains the description of the thing type"
+                header="thingTypeUID"
+                media-item />
+            </ul>
+            <ul v-else>
+              <f7-list-item
+                v-for="thingType in thingTypes"
+                :key="thingType.UID"
+                :link="thingType.UID"
+                :title="thingType.label"
+                :footer="getHeading(thingType.description)"
+                :header="thingType.UID"
+                :badge="thingType.bridge ? 'Bridge' : ''"
+                badge-color="theme-alt"
+                media-item />
+            </ul>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <f7-block v-if="!loading && ready && !thingTypes.length" class="block-narrow">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -31,52 +31,54 @@
           </div>
         </div>
         <p class="margin-left margin-right no-margin-bottom" style="height: 30px" id="scan-progress" />
-        <f7-block-title v-if="inputSupported"> Scan Input </f7-block-title>
         <config-sheet
           v-if="inputSupported"
+          title="Scan Input"
           class="scan-input"
           :parameter-groups="[]"
           :parameters="inputParameters"
           :configuration="inputConfig" />
-        <f7-block-title v-if="discoverySupported && scanResults.length"> Discovered Things </f7-block-title>
-        <f7-list v-if="scanResults.length" class="col thing-type-list">
-          <f7-list-item
-            v-for="entry in scanResults"
-            :key="entry.thingUID"
-            :link="true"
-            @click="openEntryActions(entry)"
-            media-item
-            :title="entry.label"
-            :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
-            :footer="entry.thingUID" />
-          <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="blue" />
-        </f7-list>
+        <group-box v-if="discoverySupported && scanResults.length" title="Discovered Things">
+          <f7-list v-if="scanResults.length" class="col thing-type-list">
+            <f7-list-item
+              v-for="entry in scanResults"
+              :key="entry.thingUID"
+              :link="true"
+              @click="openEntryActions(entry)"
+              media-item
+              :title="entry.label"
+              :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
+              :footer="entry.thingUID" />
+            <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="blue" />
+          </f7-list>
+        </group-box>
 
-        <f7-block-title>Add Manually</f7-block-title>
-        <f7-list class="thing-type-list">
-          <ul v-if="!ready">
-            <f7-list-item
-              v-for="n in 10"
-              :key="n"
-              :class="`skeleton-text skeleton-effect-blink`"
-              title="Label of the thing type"
-              footer="This contains the description of the thing type"
-              header="thingTypeUID"
-              media-item />
-          </ul>
-          <ul v-else>
-            <f7-list-item
-              v-for="thingType in thingTypes"
-              :key="thingType.UID"
-              :link="thingType.UID"
-              :title="thingType.label"
-              :footer="getHeading(thingType.description)"
-              :header="thingType.UID"
-              :badge="thingType.bridge ? 'Bridge' : ''"
-              badge-color="blue"
-              media-item />
-          </ul>
-        </f7-list>
+        <group-box title="Add Manually">
+          <f7-list class="thing-type-list">
+            <ul v-if="!ready">
+              <f7-list-item
+                v-for="n in 10"
+                :key="n"
+                :class="`skeleton-text skeleton-effect-blink`"
+                title="Label of the thing type"
+                footer="This contains the description of the thing type"
+                header="thingTypeUID"
+                media-item />
+            </ul>
+            <ul v-else>
+              <f7-list-item
+                v-for="thingType in thingTypes"
+                :key="thingType.UID"
+                :link="thingType.UID"
+                :title="thingType.label"
+                :footer="getHeading(thingType.description)"
+                :header="thingType.UID"
+                :badge="thingType.bridge ? 'Bridge' : ''"
+                badge-color="blue"
+                media-item />
+            </ul>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
     <f7-block v-if="!loading && ready && !thingTypes.length" class="block-narrow">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -6,11 +6,17 @@
 
     <f7-block v-if="ready" class="block-narrow">
       <f7-col>
-        <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" :things="things" :ready="true" />
         <f7-block-title medium>
           {{ thingType.label }}
         </f7-block-title>
         <div class="margin thing-type-description" v-html="thingType.description" />
+        <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" :things="things" :ready="true" />
+        <config-sheet
+          ref="parameters"
+          :f7router="f7router"
+          :parameter-groups="thingType.parameterGroups"
+          :parameters="thingType.configParameters"
+          :configuration="thing.configuration" />
       </f7-col>
     </f7-block>
     <!-- skeletons for not ready -->
@@ -20,14 +26,6 @@
         <f7-block-title>____ _______</f7-block-title>
         <div class="margin">____ ____ ____ _____ ___ __ ____ __ ________ __ ____ ___ ____</div>
       </f7-col>
-    </f7-block>
-
-    <f7-block v-if="ready" class="block-narrow">
-      <config-sheet
-        ref="parameters"
-        :parameter-groups="thingType.parameterGroups"
-        :parameters="thingType.configParameters"
-        :configuration="thing.configuration" />
     </f7-block>
 
     <div v-if="ready" class="if-aurora display-flex justify-content-center margin">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -12,7 +12,6 @@
     </f7-navbar>
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
-        <f7-block-title>Channel</f7-block-title>
         <channel-general-settings
           :channel="channel"
           :channelType="channelType"
@@ -20,15 +19,17 @@
           :disabled="!thing.editable ? true : null" />
       </f7-col>
       <f7-col v-if="channelType != null">
-        <f7-block-title v-if="configDescription.parameters"> Configuration </f7-block-title>
-        <f7-block-footer v-else-if="noConfig" class="padding">
-          This channel has no configuration.<br /><br /><f7-link back> Go Back </f7-link>
-        </f7-block-footer>
+        <group-box v-if="!configDescription.parameters || noConfig" title="Configuration">
+          <f7-block-footer class="padding"> This channel has no configuration. </f7-block-footer>
+        </group-box>
         <config-sheet
           :parameter-groups="configDescription.parameterGroups"
           :parameters="configDescription.parameters"
           :configuration="config"
           :read-only="!thing.editable" />
+      </f7-col>
+      <f7-col>
+        <f7-link back> Go Back </f7-link>
       </f7-col>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -1,81 +1,83 @@
 <template>
   <f7-block class="channel-general-settings padding-vertical no-padding-horizontal">
     <f7-col>
-      <f7-list class="no-margin" inline-labels no-hairlines-md>
-        <f7-list-input
-          v-if="createMode"
-          ref="channelId"
-          label="Channel ID"
-          type="text"
-          placeholder="A unique identifier for the channel"
-          :value="channel.id"
-          info="Required. Note: cannot be changed after the creation"
-          input-id="input"
-          required
-          validate
-          pattern="[A-Za-z0-9_][A-Za-z0-9_\-]*"
-          error-message="Required. Must not start with a dash. A-Z,a-z,0-9,_,- only"
-          @input="channel.id = $event.target.value">
-          <template #inner>
-            <f7-link
-              v-if="createMode && $refs.channelId?.state?.inputInvalid && channel.id.trim()"
-              icon-f7="hammer_fill"
-              style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-              tooltip="Fix ID"
-              @click="$oh.utils.normalizeInputForThingId('#input')" />
-          </template>
-        </f7-list-input>
-        <f7-list-item v-if="!createMode" media-item class="channel-item" title="Channel UID">
-          <template #subtitle>
-            <div>
-              {{ channel.uid }}
-              <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
-            </div>
-          </template>
-        </f7-list-item>
+      <group-box :title="createMode ? 'Create Channel' : 'Channel Details'">
+        <f7-list class="no-margin" inline-labels no-hairlines-md>
+          <f7-list-input
+            v-if="createMode"
+            ref="channelId"
+            label="Channel ID"
+            type="text"
+            placeholder="A unique identifier for the channel"
+            :value="channel.id"
+            info="Required. Note: cannot be changed after the creation"
+            input-id="input"
+            required
+            validate
+            pattern="[A-Za-z0-9_][A-Za-z0-9_\-]*"
+            error-message="Required. Must not start with a dash. A-Z,a-z,0-9,_,- only"
+            @input="channel.id = $event.target.value">
+            <template #inner>
+              <f7-link
+                v-if="createMode && $refs.channelId?.state?.inputInvalid && channel.id.trim()"
+                icon-f7="hammer_fill"
+                style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+                tooltip="Fix ID"
+                @click="$oh.utils.normalizeInputForThingId('#input')" />
+            </template>
+          </f7-list-input>
+          <f7-list-item v-if="!createMode" media-item class="channel-item" title="Channel UID">
+            <template #subtitle>
+              <div>
+                {{ channel.uid }}
+                <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
+              </div>
+            </template>
+          </f7-list-item>
 
-        <f7-list-input
-          label="Label"
-          type="text"
-          :disabled="disabled ? true : null"
-          :placeholder="channelType !== null ? channelType.label : 'Channel label for display purposes'"
-          :value="channel.label"
-          required
-          validate
-          :info="createMode ? 'Required.' : ''"
-          @input="channel.label = $event.target.value"
-          :clear-button="disabled !== true" />
-        <f7-list-input
-          label="Description"
-          type="text"
-          :disabled="disabled ? true : null"
-          :placeholder="channelType !== null ? channelType.description : ''"
-          :value="channel.description"
-          @input="channel.description = $event.target.value"
-          :clear-button="disabled !== true" />
-        <f7-list-item
-          v-if="channel.properties && Object.keys(channel.properties).length > 0"
-          accordion-item
-          title="Properties"
-          :badge="Object.keys(channel.properties).length">
-          <f7-accordion-content>
-            <f7-list>
-              <f7-list-item v-for="(value, key) in channel.properties" :key="key" class="thing-property">
-                <template #title>
-                  <div class="item-title-content">
-                    <span class="property-key">{{ key }}</span>
-                  </div>
-                </template>
-                <template #after>
-                  <div class="item-after-content">
-                    <span>{{ value }}</span>
-                  </div>
-                </template>
-              </f7-list-item>
-            </f7-list>
-          </f7-accordion-content>
-        </f7-list-item>
-      </f7-list>
+          <f7-list-input
+            label="Label"
+            type="text"
+            :disabled="disabled ? true : null"
+            :placeholder="channelType !== null ? channelType.label : 'Channel label for display purposes'"
+            :value="channel.label"
+            required
+            validate
+            :info="createMode ? 'Required.' : ''"
+            @input="channel.label = $event.target.value"
+            :clear-button="disabled !== true" />
+          <f7-list-input
+            label="Description"
+            type="text"
+            :disabled="disabled ? true : null"
+            :placeholder="channelType !== null ? channelType.description : ''"
+            :value="channel.description"
+            @input="channel.description = $event.target.value"
+            :clear-button="disabled !== true" />
+          <f7-list-item
+            v-if="channel.properties && Object.keys(channel.properties).length > 0"
+            accordion-item
+            title="Properties"
+            :badge="Object.keys(channel.properties).length">
+            <f7-accordion-content>
+              <f7-list>
+                <f7-list-item v-for="(value, key) in channel.properties" :key="key" class="thing-property">
+                  <template #title>
+                    <div class="item-title-content">
+                      <span class="property-key">{{ key }}</span>
+                    </div>
+                  </template>
+                  <template #after>
+                    <div class="item-after-content">
+                      <span>{{ value }}</span>
+                    </div>
+                  </template>
+                </f7-list-item>
+              </f7-list>
+            </f7-accordion-content>
+          </f7-list-item>
+        </f7-list>
+      </group-box>
     </f7-col>
   </f7-block>
 </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -5,15 +5,16 @@
     </f7-navbar>
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
-        <f7-block-title>Channel</f7-block-title>
-        <f7-list media-list>
-          <f7-list-item
-            media-item
-            class="channel-item"
-            :title="channel.label || channelType.label"
-            :footer="channel.description || channelType.description"
-            :subtitle="channel.uid + ' (' + getItemType(channel) + ')'" />
-        </f7-list>
+        <group-box title="Channel">
+          <f7-list media-list>
+            <f7-list-item
+              media-item
+              class="channel-item"
+              :title="channel.label || channelType.label"
+              :footer="channel.description || channelType.description"
+              :subtitle="channel.uid + ' (' + getItemType(channel) + ')'" />
+          </f7-list>
+        </group-box>
       </f7-col>
 
       <div v-if="!item && !items" class="text-align-center">
@@ -23,41 +24,44 @@
       <template v-if="!item && items">
         <!-- Option to create new item (if not supplied by prop) -->
         <f7-col>
-          <f7-block-title>Item</f7-block-title>
-          <f7-list media-list>
-            <f7-list-item
-              radio
-              :checked="!createMode ? true : null"
-              value="false"
-              @change="createMode = false"
-              title="Use an existing Item"
-              name="item-creation-choice" />
-            <f7-list-item
-              radio
-              :checked="createMode ? true : null"
-              value="true"
-              @change="createMode = true"
-              title="Create a new Item"
-              name="item-creation-choice" />
-          </f7-list>
+          <group-box title="Item Creation">
+            <f7-list media-list>
+              <f7-list-item
+                radio
+                :checked="!createMode ? true : null"
+                value="false"
+                @change="createMode = false"
+                title="Use an existing Item"
+                name="item-creation-choice" />
+              <f7-list-item
+                radio
+                :checked="createMode ? true : null"
+                value="true"
+                @change="createMode = true"
+                title="Create a new Item"
+                name="item-creation-choice" />
+            </f7-list>
+          </group-box>
         </f7-col>
 
         <!-- Choose item to link -->
         <f7-col v-if="!createMode">
-          <f7-list>
-            <f7-list-group>
-              <item-picker
-                key="itemLink"
-                label="Item to Link"
-                name="item"
-                :value="selectedItemName"
-                :multiple="false"
-                :items="items"
-                :filterType="getCompatibleItemTypes()"
-                :showFilterToggle="true"
-                @input="(value) => (selectedItemName = value)" />
-            </f7-list-group>
-          </f7-list>
+          <group-box title="Choose an Existing Item">
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="itemLink"
+                  label="Item to Link"
+                  name="item"
+                  :value="selectedItemName"
+                  :multiple="false"
+                  :items="items"
+                  :filterType="getCompatibleItemTypes()"
+                  :showFilterToggle="true"
+                  @input="(value) => (selectedItemName = value)" />
+              </f7-list-group>
+            </f7-list>
+          </group-box>
         </f7-col>
 
         <!-- Create new item -->
@@ -74,20 +78,21 @@
 
       <!-- Item to link supplied as prop -->
       <f7-col v-else-if="item">
-        <f7-block-title>Item</f7-block-title>
-        <f7-list media-list>
-          <ul>
-            <item :item="item" />
-          </ul>
-        </f7-list>
-        <f7-block-title>Thing</f7-block-title>
-        <f7-list inline-labels no-hairlines-md>
-          <f7-list-group>
-            <thing-picker title="Thing" name="thing" :value="selectedThingId" @input="(e) => (selectedThingId = e)" />
-          </f7-list-group>
-        </f7-list>
-        <div v-if="selectedThing.UID && selectedThingType.UID">
-          <f7-block-title>Channel</f7-block-title>
+        <group-box title="Item to Link">
+          <f7-list media-list>
+            <ul>
+              <item :item="item" />
+            </ul>
+          </f7-list>
+        </group-box>
+        <group-box title="Thing to Link">
+          <f7-list inline-labels no-hairlines-md>
+            <f7-list-group>
+              <thing-picker title="Thing" name="thing" :value="selectedThingId" @input="(e) => (selectedThingId = e)" />
+            </f7-list-group>
+          </f7-list>
+        </group-box>
+        <group-box v-if="selectedThing.UID && selectedThingType.UID" title="Channel">
           <channel-list
             :thing="selectedThing"
             :thingType="selectedThingType"
@@ -95,7 +100,7 @@
             :item-type-filter="item.type"
             :channel-types="selectedThingChannelTypes"
             @selected="(channel) => loadProfileTypes(channel)" />
-        </div>
+        </group-box>
       </f7-col>
 
       <f7-block v-if="!ready && !(!item && !items)" class="text-align-center">
@@ -105,35 +110,36 @@
 
       <!-- Profile configuration -->
       <f7-col v-else-if="profileTypes.length && currentItem">
-        <f7-block-title>Profile</f7-block-title>
-        <f7-block-footer class="padding-left padding-right">
-          Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
-            Learn more about profiles.
-          </f7-link>
-        </f7-block-footer>
-        <f7-list class="profile-list">
-          <f7-list-item
-            v-for="profileType in profileTypes"
-            radio
-            class="profile-item"
-            :checked="
-              (!currentProfileType && profileType.uid === 'system:default' && itemTypeCompatibleWithChannelType(currentItem, channel)) ||
-              (currentProfileType && profileType.uid === currentProfileType.uid)
-                ? true
-                : null
-            "
-            :disabled="!compatibleProfileTypes.includes(profileType) ? true : null"
-            :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
-            @change="onProfileTypeChange(profileType.uid)"
-            :key="profileType.uid"
-            :title="profileType.label"
-            name="profile-type" />
-        </f7-list>
+        <group-box title="Profile">
+          <f7-block-footer class="padding-left padding-right">
+            Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
+            <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
+              Learn more about profiles.
+            </f7-link>
+          </f7-block-footer>
+          <f7-list class="profile-list">
+            <f7-list-item
+              v-for="profileType in profileTypes"
+              radio
+              class="profile-item"
+              :checked="
+                (!currentProfileType && profileType.uid === 'system:default' && itemTypeCompatibleWithChannelType(currentItem, channel)) ||
+                (currentProfileType && profileType.uid === currentProfileType.uid)
+                  ? true
+                  : null
+              "
+              :disabled="!compatibleProfileTypes.includes(profileType) ? true : null"
+              :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
+              @change="onProfileTypeChange(profileType.uid)"
+              :key="profileType.uid"
+              :title="profileType.label"
+              name="profile-type" />
+          </f7-list>
+        </group-box>
       </f7-col>
       <f7-col v-if="profileTypeConfiguration != null">
-        <f7-block-title>Profile Configuration</f7-block-title>
         <config-sheet
+          title="Profile Configuration"
           ref="profileConfiguration"
           :key="'profileTypeConfiguration-' + currentProfileType.uid"
           :parameter-groups="profileTypeConfiguration.parameterGroups"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -5,15 +5,16 @@
     </f7-navbar>
     <f7-block class="block-narrow">
       <f7-col v-if="channel">
-        <f7-block-title>Channel</f7-block-title>
-        <f7-list media-list>
-          <f7-list-item
-            media-item
-            class="channel-item"
-            :title="channel.label || channelType.label"
-            :footer="channel.description || channelType.description"
-            :subtitle="channel.uid + ' (' + getItemType(channel) + ')'" />
-        </f7-list>
+        <group-box title="Channel">
+          <f7-list media-list>
+            <f7-list-item
+              media-item
+              class="channel-item"
+              :title="channel.label || channelType.label"
+              :footer="channel.description || channelType.description"
+              :subtitle="channel.uid + ' (' + getItemType(channel) + ')'" />
+          </f7-list>
+        </group-box>
       </f7-col>
 
       <div v-if="!item && !items" class="text-align-center">
@@ -23,41 +24,44 @@
       <template v-if="!item && items">
         <!-- Option to create new item (if not supplied by prop) -->
         <f7-col>
-          <f7-block-title>Item</f7-block-title>
-          <f7-list media-list>
-            <f7-list-item
-              radio
-              :checked="!createMode ? true : null"
-              value="false"
-              @change="createMode = false"
-              title="Use an existing Item"
-              name="item-creation-choice" />
-            <f7-list-item
-              radio
-              :checked="createMode ? true : null"
-              value="true"
-              @change="createMode = true"
-              title="Create a new Item"
-              name="item-creation-choice" />
-          </f7-list>
+          <group-box title="Item Creation">
+            <f7-list media-list>
+              <f7-list-item
+                radio
+                :checked="!createMode ? true : null"
+                value="false"
+                @change="createMode = false"
+                title="Use an existing Item"
+                name="item-creation-choice" />
+              <f7-list-item
+                radio
+                :checked="createMode ? true : null"
+                value="true"
+                @change="createMode = true"
+                title="Create a new Item"
+                name="item-creation-choice" />
+            </f7-list>
+          </group-box>
         </f7-col>
 
         <!-- Choose item to link -->
         <f7-col v-if="!createMode">
-          <f7-list>
-            <f7-list-group>
-              <item-picker
-                key="itemLink"
-                label="Item to Link"
-                name="item"
-                :value="selectedItemName"
-                :multiple="false"
-                :items="items"
-                :filterType="getCompatibleItemTypes()"
-                :showFilterToggle="true"
-                @input="(value) => (selectedItemName = value)" />
-            </f7-list-group>
-          </f7-list>
+          <group-box title="Choose an Existing Item">
+            <f7-list>
+              <f7-list-group>
+                <item-picker
+                  key="itemLink"
+                  label="Item to Link"
+                  name="item"
+                  :value="selectedItemName"
+                  :multiple="false"
+                  :items="items"
+                  :filterType="getCompatibleItemTypes()"
+                  :showFilterToggle="true"
+                  @input="(value) => (selectedItemName = value)" />
+              </f7-list-group>
+            </f7-list>
+          </group-box>
         </f7-col>
 
         <!-- Create new item -->
@@ -74,20 +78,21 @@
 
       <!-- Item to link supplied as prop -->
       <f7-col v-else-if="item">
-        <f7-block-title>Item</f7-block-title>
-        <f7-list media-list>
-          <ul>
-            <item :item="item" />
-          </ul>
-        </f7-list>
-        <f7-block-title>Thing</f7-block-title>
-        <f7-list inline-labels no-hairlines-md>
-          <f7-list-group>
-            <thing-picker title="Thing" name="thing" :value="selectedThingId" @input="(e) => (selectedThingId = e)" />
-          </f7-list-group>
-        </f7-list>
-        <div v-if="selectedThing.UID && selectedThingType.UID">
-          <f7-block-title>Channel</f7-block-title>
+        <group-box title="Item to Link">
+          <f7-list media-list>
+            <ul>
+              <item :item="item" />
+            </ul>
+          </f7-list>
+        </group-box>
+        <group-box title="Thing to Link">
+          <f7-list inline-labels no-hairlines-md>
+            <f7-list-group>
+              <thing-picker title="Thing" name="thing" :value="selectedThingId" @input="(e) => (selectedThingId = e)" />
+            </f7-list-group>
+          </f7-list>
+        </group-box>
+        <group-box v-if="selectedThing.UID && selectedThingType.UID" title="Channel">
           <channel-list
             :thing="selectedThing"
             :thingType="selectedThingType"
@@ -95,7 +100,7 @@
             :item-type-filter="item.type"
             :channel-types="selectedThingChannelTypes"
             @selected="(channel) => loadProfileTypes(channel)" />
-        </div>
+        </group-box>
       </f7-col>
 
       <f7-block v-if="!ready && !(!item && !items)" class="text-align-center">
@@ -105,35 +110,36 @@
 
       <!-- Profile configuration -->
       <f7-col v-else-if="profileTypes.length && currentItem">
-        <f7-block-title>Profile</f7-block-title>
-        <f7-block-footer class="padding-left padding-right">
-          Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
-            Learn more about profiles.
-          </f7-link>
-        </f7-block-footer>
-        <f7-list class="profile-list">
-          <f7-list-item
-            v-for="profileType in profileTypes"
-            radio
-            class="profile-item"
-            :checked="
-              (!currentProfileType && profileType.uid === 'system:default' && itemTypeCompatibleWithChannelType(currentItem, channel)) ||
-              (currentProfileType && profileType.uid === currentProfileType.uid)
-                ? true
-                : null
-            "
-            :disabled="!compatibleProfileTypes.includes(profileType) ? true : null"
-            :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
-            @change="onProfileTypeChange(profileType.uid)"
-            :key="profileType.uid"
-            :title="profileType.label"
-            name="profile-type" />
-        </f7-list>
+        <group-box title="Profile">
+          <f7-block-footer class="padding-left padding-right">
+            Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
+            <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
+              Learn more about profiles.
+            </f7-link>
+          </f7-block-footer>
+          <f7-list class="profile-list">
+            <f7-list-item
+              v-for="profileType in profileTypes"
+              radio
+              class="profile-item"
+              :checked="
+                (!currentProfileType && profileType.uid === 'system:default' && itemTypeCompatibleWithChannelType(currentItem, channel)) ||
+                (currentProfileType && profileType.uid === currentProfileType.uid)
+                  ? true
+                  : null
+              "
+              :disabled="!compatibleProfileTypes.includes(profileType) ? true : null"
+              :class="{ 'profile-disabled': !compatibleProfileTypes.includes(profileType) }"
+              @change="onProfileTypeChange(profileType.uid)"
+              :key="profileType.uid"
+              :title="profileType.label"
+              name="profile-type" />
+          </f7-list>
+        </group-box>
       </f7-col>
       <f7-col v-if="profileTypeConfiguration != null">
-        <f7-block-title>Profile Configuration</f7-block-title>
         <config-sheet
+          title="Profile Configuration"
           ref="profileConfiguration"
           :key="'profileTypeConfiguration-' + currentProfileType.uid"
           :parameter-groups="profileTypeConfiguration.parameterGroups"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -12,36 +12,31 @@
     </f7-navbar>
     <f7-block v-if="ready" class="block-narrow">
       <f7-col>
-        <div v-if="item.state">
+        <group-box v-if="item.state" title="Item State">
           <item-state-preview :item="item" :context="context" />
-        </div>
+        </group-box>
 
-        <f7-block-title>Link</f7-block-title>
-        <f7-card>
-          <f7-card-content>
-            <f7-list media-list>
-              <ul>
-                <f7-list-item divider title="Channel" />
-                <f7-list-item
-                  media-item
-                  class="channel-item"
-                  :title="channel.label || channelType.label"
-                  :footer="channel.uid + ' (' + getItemType(channel) + ')'"
-                  :subtitle="thing.label"
-                  :badge="thingStatusBadgeText(thing.statusInfo)"
-                  :badge-color="thingStatusBadgeColor(thing.statusInfo)"
-                  :link="'/settings/things/' + thing.UID">
-                  <template #media>
-                    <span class="item-initial">{{
-                      channel.label ? channel.label[0] : channelType.label ? channelType.label[0] : '?'
-                    }}</span>
-                  </template>
-                </f7-list-item>
-                <f7-list-item divider title="Item" />
-                <item :item="item" :context="context" :link="'/settings/items/' + item.name" />
-              </ul>
-            </f7-list>
-          </f7-card-content>
+        <group-box title="Link Details">
+          <f7-list media-list>
+            <ul>
+              <f7-list-item divider title="Channel" />
+              <f7-list-item
+                media-item
+                class="channel-item"
+                :title="channel.label || channelType.label"
+                :footer="channel.uid + ' (' + getItemType(channel) + ')'"
+                :subtitle="thing.label"
+                :badge="thingStatusBadgeText(thing.statusInfo)"
+                :badge-color="thingStatusBadgeColor(thing.statusInfo)"
+                :link="'/settings/things/' + thing.UID">
+                <template #media>
+                  <span class="item-initial">{{ channel.label ? channel.label[0] : channelType.label ? channelType.label[0] : '?' }}</span>
+                </template>
+              </f7-list-item>
+              <f7-list-item divider title="Item" />
+              <item :item="item" :context="context" :link="'/settings/items/' + item.name" />
+            </ul>
+          </f7-list>
           <f7-card-footer v-if="item && (item.editable || link.editable)">
             <f7-button v-if="source === 'thing' && item.editable" color="red" fill @click="unlinkAndDelete()">
               Unlink &amp; Remove Item
@@ -50,42 +45,43 @@
               {{ source === 'thing' && link.editable ? 'Unlink Only' : 'Unlink' }}
             </f7-button>
           </f7-card-footer>
-        </f7-card>
+        </group-box>
       </f7-col>
       <f7-col>
-        <f7-block-title>Profile</f7-block-title>
-        <f7-block-footer class="padding-left padding-right">
-          Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
-            Learn more about profiles.
-          </f7-link>
-        </f7-block-footer>
-        <f7-block v-if="!ready" class="text-align-center">
-          <f7-preloader />
-          <div>Loading...</div>
-        </f7-block>
-        <f7-list v-else class="profile-list">
-          <f7-list-item
-            v-for="profileType in profileTypes"
-            radio
-            class="profile-item"
-            :checked="
-              (!currentProfileType && profileType.uid === 'system:default') ||
-              (currentProfileType && profileType.uid === currentProfileType.uid)
-                ? true
-                : null
-            "
-            :disabled="!link.editable ? true : null"
-            :class="{ 'profile-disabled': !link.editable }"
-            @change="onProfileTypeChange(profileType.uid)"
-            :key="profileType.uid"
-            :title="profileType.label"
-            name="profile-type" />
-        </f7-list>
+        <group-box title="Profile">
+          <f7-block-footer class="padding-left padding-right">
+            Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
+            <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
+              Learn more about profiles.
+            </f7-link>
+          </f7-block-footer>
+          <f7-block v-if="!ready" class="text-align-center">
+            <f7-preloader />
+            <div>Loading...</div>
+          </f7-block>
+          <f7-list v-else class="profile-list">
+            <f7-list-item
+              v-for="profileType in profileTypes"
+              radio
+              class="profile-item"
+              :checked="
+                (!currentProfileType && profileType.uid === 'system:default') ||
+                (currentProfileType && profileType.uid === currentProfileType.uid)
+                  ? true
+                  : null
+              "
+              :disabled="!link.editable ? true : null"
+              :class="{ 'profile-disabled': !link.editable }"
+              @change="onProfileTypeChange(profileType.uid)"
+              :key="profileType.uid"
+              :title="profileType.label"
+              name="profile-type" />
+          </f7-list>
+        </group-box>
       </f7-col>
       <f7-col v-if="profileTypeConfiguration != null">
-        <f7-block-title>Profile Configuration</f7-block-title>
         <config-sheet
+          title="Profile Configuration"
           ref="profileConfiguration"
           :key="'profileTypeConfiguration-' + currentProfileType.uid"
           :parameter-groups="profileTypeConfiguration.parameterGroups"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -12,36 +12,31 @@
     </f7-navbar>
     <f7-block v-if="ready" class="block-narrow">
       <f7-col>
-        <div v-if="item.state">
+        <group-box v-if="item.state" title="Item State">
           <item-state-preview :item="item" :context="context" />
-        </div>
+        </group-box>
 
-        <f7-block-title>Link</f7-block-title>
-        <f7-card>
-          <f7-card-content>
-            <f7-list media-list>
-              <ul>
-                <f7-list-item divider title="Channel" />
-                <f7-list-item
-                  media-item
-                  class="channel-item"
-                  :title="channel.label || channelType.label"
-                  :footer="channel.uid + ' (' + getItemType(channel) + ')'"
-                  :subtitle="thing.label"
-                  :badge="thingStatusBadgeText(thing.statusInfo)"
-                  :badge-color="thingStatusBadgeColor(thing.statusInfo)"
-                  :link="'/settings/things/' + thing.UID">
-                  <template #media>
-                    <span class="item-initial">{{
-                      channel.label ? channel.label[0] : channelType.label ? channelType.label[0] : '?'
-                    }}</span>
-                  </template>
-                </f7-list-item>
-                <f7-list-item divider title="Item" />
-                <item :item="item" :context="context" :link="'/settings/items/' + item.name" />
-              </ul>
-            </f7-list>
-          </f7-card-content>
+        <group-box title="Link Details">
+          <f7-list media-list>
+            <ul>
+              <f7-list-item divider title="Channel" />
+              <f7-list-item
+                media-item
+                class="channel-item"
+                :title="channel.label || channelType.label"
+                :footer="channel.uid + ' (' + getItemType(channel) + ')'"
+                :subtitle="thing.label"
+                :badge="thingStatusBadgeText(thing.statusInfo)"
+                :badge-color="thingStatusBadgeColor(thing.statusInfo)"
+                :link="'/settings/things/' + thing.UID">
+                <template #media>
+                  <span class="item-initial">{{ channel.label ? channel.label[0] : channelType.label ? channelType.label[0] : '?' }}</span>
+                </template>
+              </f7-list-item>
+              <f7-list-item divider title="Item" />
+              <item :item="item" :context="context" :link="'/settings/items/' + item.name" />
+            </ul>
+          </f7-list>
           <f7-card-footer v-if="item && (item.editable || link.editable)">
             <f7-button v-if="source === 'thing' && item.editable" color="red" fill @click="unlinkAndDelete()">
               Unlink &amp; Remove Item
@@ -50,42 +45,43 @@
               {{ source === 'thing' && link.editable ? 'Unlink Only' : 'Unlink' }}
             </f7-button>
           </f7-card-footer>
-        </f7-card>
+        </group-box>
       </f7-col>
       <f7-col>
-        <f7-block-title>Profile</f7-block-title>
-        <f7-block-footer class="padding-left padding-right">
-          Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
-            Learn more about profiles.
-          </f7-link>
-        </f7-block-footer>
-        <f7-block v-if="!ready" class="text-align-center">
-          <f7-preloader />
-          <div>Loading...</div>
-        </f7-block>
-        <f7-list v-else class="profile-list">
-          <f7-list-item
-            v-for="profileType in profileTypes"
-            radio
-            class="profile-item"
-            :checked="
-              (!currentProfileType && profileType.uid === 'system:default') ||
-              (currentProfileType && profileType.uid === currentProfileType.uid)
-                ? true
-                : null
-            "
-            :disabled="!link.editable ? true : null"
-            :class="{ 'profile-disabled': !link.editable }"
-            @change="onProfileTypeChange(profileType.uid)"
-            :key="profileType.uid"
-            :title="profileType.label"
-            name="profile-type" />
-        </f7-list>
+        <group-box title="Profile">
+          <f7-block-footer class="padding-left padding-right">
+            Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
+            <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
+              Learn more about profiles.
+            </f7-link>
+          </f7-block-footer>
+          <f7-block v-if="!ready" class="text-align-center">
+            <f7-preloader />
+            <div>Loading...</div>
+          </f7-block>
+          <f7-list v-else class="profile-list">
+            <f7-list-item
+              v-for="profileType in profileTypes"
+              radio
+              class="profile-item"
+              :checked="
+                (!currentProfileType && profileType.uid === 'system:default') ||
+                (currentProfileType && profileType.uid === currentProfileType.uid)
+                  ? true
+                  : null
+              "
+              :disabled="!link.editable ? true : null"
+              :class="{ 'profile-disabled': !link.editable }"
+              @change="onProfileTypeChange(profileType.uid)"
+              :key="profileType.uid"
+              :title="profileType.label"
+              name="profile-type" />
+          </f7-list>
+        </group-box>
       </f7-col>
       <f7-col v-if="profileTypeConfiguration != null">
-        <f7-block-title>Profile Configuration</f7-block-title>
         <config-sheet
+          title="Profile Configuration"
           ref="profileConfiguration"
           :key="'profileTypeConfiguration-' + currentProfileType.uid"
           :parameter-groups="profileTypeConfiguration.parameterGroups"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-action-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-action-popup.vue
@@ -18,9 +18,10 @@
         </f7-block-footer>
         <!-- Action Inputs -->
         <f7-col>
-          <f7-block-title class="parameter-group-title"> Action Input </f7-block-title>
           <config-sheet
             v-if="inputConfigDescriptions.length > 0"
+            title="Action Input"
+            :accordion="actionOutput"
             ref="configSheet"
             :parameter-groups="[]"
             :parameters="inputConfigDescriptions"
@@ -43,12 +44,11 @@
         </f7-col>
         <!-- Action Outputs -->
         <f7-col v-if="!executing && actionOutput">
-          <f7-block-title class="parameter-group-title"> Action Output </f7-block-title>
-          <div v-if="Object.keys(actionOutput).length === 0" class="margin">
-            There is either no output for this action or something went wrong - please check the logs.
-          </div>
-          <div v-else>
-            <f7-list media-list>
+          <group-box title="Action Output">
+            <div v-if="Object.keys(actionOutput).length === 0" class="margin">
+              There is either no output for this action or something went wrong - please check the logs.
+            </div>
+            <f7-list v-else media-list>
               <template v-for="key of Object.keys(actionOutput)" :key="key + '-list-item'">
                 <!-- Render result as a list item, works without action output definition from REST -->
                 <f7-list-item
@@ -94,7 +94,7 @@
                 </f7-accordion-content>
               </f7-list-item>
             </f7-list>
-          </div>
+          </group-box>
         </f7-col>
       </f7-block>
     </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -70,105 +70,104 @@
         <f7-block v-if="ready && !error" class="block-narrow no-margin-bottom">
           <f7-col>
             <thing-general-settings :thing="thing" :thing-type="thingType" :ready="true" :read-only="!editable" />
-            <f7-block-title v-if="thingType && thingType.UID" medium style="margin-bottom: var(--f7-list-margin-vertical)">
-              Information
-            </f7-block-title>
             <not-editable-notice v-if="!editable" subject="Thing" />
-            <f7-list accordion-opposite>
-              <f7-list-item v-if="thingType" accordion-item title="Thing Type" :after="thingType.label">
-                <f7-accordion-content class="thing-type-description">
-                  <div class="margin" v-html="thingType?.description" />
-                </f7-accordion-content>
-              </f7-list-item>
-              <f7-list-item v-else title="Missing Thing-Type (is the binding installed?)" :after="thing.thingTypeUID" text-color="red" />
-              <f7-list-item
-                v-if="thing && Object.keys(thing.properties).length > 0"
-                accordion-item
-                title="Thing Properties"
-                :badge="Object.keys(thing.properties).length">
-                <f7-accordion-content>
-                  <f7-list>
-                    <f7-list-item
-                      v-for="(value, key) in thing.properties"
-                      class="thing-property"
-                      :key="key"
-                      @click="showFullPropertyIfTruncated(key, value)">
-                      <template #title>
-                        <div class="item-title-content">
-                          <span :ref="'titleSpan-' + key">{{ key }}</span>
-                        </div>
-                      </template>
-                      <template #after>
-                        <div class="item-after-content">
-                          <span :ref="'valueSpan-' + key">{{ value }}</span>
-                          <f7-icon
-                            v-if="isTruncated(key, 'title') || isTruncated(key, 'value')"
-                            f7="info_circle"
-                            size="16"
-                            class="truncation-icon" />
-                        </div>
-                      </template>
-                    </f7-list-item>
-                  </f7-list>
-                </f7-accordion-content>
-              </f7-list-item>
-              <f7-list-item
-                v-if="thing.firmwareStatus"
-                accordion-item
-                title="Firmware"
-                :badge="firmwares.length"
-                :badge-color="thing.firmwareStatus.status === 'UPDATE_EXECUTABLE' ? 'green' : 'gray'">
-                <f7-accordion-content>
-                  <f7-list>
-                    <f7-list-item class="thing-property" title="Status" :after="firmwareStatusText" />
-                    <f7-list-item class="thing-property" title="Current Version" :after="thing.properties.firmwareVersion" />
-                    <f7-list-item
-                      v-for="firmware in firmwares"
-                      class="thing-property"
-                      :key="firmware.version"
-                      header="Version"
-                      :title="firmware.version"
-                      :after="firmware.description"
-                      :footer="firmware.changelog">
-                      <div class="item-after">
-                        <f7-badge
-                          :color="
-                            firmware.version === thing.properties.firmwareVersion
-                              ? 'gray'
-                              : firmware.version > thing.properties.firmwareVersion
-                                ? 'green'
-                                : 'red'
-                          ">
-                          {{
-                            compareVersions(firmware.version, thing.properties.firmwareVersion) === 0
-                              ? 'Current Version'
-                              : compareVersions(firmware.version, thing.properties.firmwareVersion) > 0
-                                ? 'Upgrade'
-                                : 'Downgrade'
-                          }}
-                          <f7-link
-                            v-if="compareVersions(firmware.version, thing.properties.firmwareVersion) !== 0 && !firmwareUpdating"
-                            icon-color="white"
-                            :tooltip="
-                              compareVersions(firmware.version, thing.properties.firmwareVersion) === 1
-                                ? 'Start Upgrade'
-                                : 'Start Downgrade'
-                            "
-                            style="margin-left: 4px"
-                            icon-ios="f7:play_fill"
-                            icon-md="f7:play_fill"
-                            icon-aurora="f7:play_fill"
-                            icon-size="16"
-                            @click="startFirmwareUpdate(firmware)" />
-                        </f7-badge>
-                      </div>
-                    </f7-list-item>
-                  </f7-list>
-                </f7-accordion-content>
-              </f7-list-item>
-            </f7-list>
 
-            <f7-block-title medium class="no-margin-bottom"> Configuration </f7-block-title>
+            <group-box v-if="thingType && thingType.UID" title="Information">
+              <f7-list accordion>
+                <f7-list-item v-if="thingType" accordion-item title="Thing Type" :after="thingType.label">
+                  <f7-accordion-content class="thing-type-description">
+                    <div class="margin" v-html="thingType?.description" />
+                  </f7-accordion-content>
+                </f7-list-item>
+                <f7-list-item v-else title="Missing Thing-Type (is the binding installed?)" :after="thing.thingTypeUID" text-color="red" />
+                <f7-list-item
+                  v-if="thing && Object.keys(thing.properties).length > 0"
+                  accordion-item
+                  title="Thing Properties"
+                  :badge="Object.keys(thing.properties).length">
+                  <f7-accordion-content>
+                    <f7-list>
+                      <f7-list-item
+                        v-for="(value, key) in thing.properties"
+                        class="thing-property"
+                        :key="key"
+                        @click="showFullPropertyIfTruncated(key, value)">
+                        <template #title>
+                          <div class="item-title-content">
+                            <span :ref="'titleSpan-' + key">{{ key }}</span>
+                          </div>
+                        </template>
+                        <template #after>
+                          <div class="item-after-content">
+                            <span :ref="'valueSpan-' + key">{{ value }}</span>
+                            <f7-icon
+                              v-if="isTruncated(key, 'title') || isTruncated(key, 'value')"
+                              f7="info_circle"
+                              size="16"
+                              class="truncation-icon" />
+                          </div>
+                        </template>
+                      </f7-list-item>
+                    </f7-list>
+                  </f7-accordion-content>
+                </f7-list-item>
+                <f7-list-item
+                  v-if="thing.firmwareStatus"
+                  accordion-item
+                  title="Firmware"
+                  :badge="firmwares.length"
+                  :badge-color="thing.firmwareStatus.status === 'UPDATE_EXECUTABLE' ? 'green' : 'gray'">
+                  <f7-accordion-content>
+                    <f7-list>
+                      <f7-list-item class="thing-property" title="Status" :after="firmwareStatusText" />
+                      <f7-list-item class="thing-property" title="Current Version" :after="thing.properties.firmwareVersion" />
+                      <f7-list-item
+                        v-for="firmware in firmwares"
+                        class="thing-property"
+                        :key="firmware.version"
+                        header="Version"
+                        :title="firmware.version"
+                        :after="firmware.description"
+                        :footer="firmware.changelog">
+                        <div class="item-after">
+                          <f7-badge
+                            :color="
+                              firmware.version === thing.properties.firmwareVersion
+                                ? 'gray'
+                                : firmware.version > thing.properties.firmwareVersion
+                                  ? 'green'
+                                  : 'red'
+                            ">
+                            {{
+                              compareVersions(firmware.version, thing.properties.firmwareVersion) === 0
+                                ? 'Current Version'
+                                : compareVersions(firmware.version, thing.properties.firmwareVersion) > 0
+                                  ? 'Upgrade'
+                                  : 'Downgrade'
+                            }}
+                            <f7-link
+                              v-if="compareVersions(firmware.version, thing.properties.firmwareVersion) !== 0 && !firmwareUpdating"
+                              icon-color="white"
+                              :tooltip="
+                                compareVersions(firmware.version, thing.properties.firmwareVersion) === 1
+                                  ? 'Start Upgrade'
+                                  : 'Start Downgrade'
+                              "
+                              style="margin-left: 4px"
+                              icon-ios="f7:play_fill"
+                              icon-md="f7:play_fill"
+                              icon-aurora="f7:play_fill"
+                              icon-size="16"
+                              @click="startFirmwareUpdate(firmware)" />
+                          </f7-badge>
+                        </div>
+                      </f7-list-item>
+                    </f7-list>
+                  </f7-accordion-content>
+                </f7-list-item>
+              </f7-list>
+            </group-box>
+
             <config-sheet
               ref="thingConfiguration"
               :parameter-groups="configDescriptions?.parameterGroups"
@@ -180,24 +179,24 @@
               :f7router />
 
             <!-- Thing Actions & UI Actions -->
-            <template v-if="thingActions?.length > 0 || thingType?.UID?.startsWith('zwave:') || hasMatterThreadProperties">
-              <f7-block-title medium class="no-margin-top" style="display: flex; align-items: center; justify-content: space-between">
-                Actions
-                <div v-if="advancedThingActionsCount" class="advanced-actions-toggle">
-                  <label class="advanced-label">
-                    <f7-checkbox v-model:checked="showAdvancedThingActions" />
-                    Show advanced
-                    <f7-badge
-                      v-if="advancedThingActionsCount"
-                      style="margin-left: 2px"
-                      color="theme-alt"
-                      class="count-badge"
-                      tooltip="Advanced/Expert Thing actions">
-                      {{ advancedThingActionsCount }}
-                    </f7-badge>
-                  </label>
-                </div>
-              </f7-block-title>
+            <group-box
+              v-if="thingActions?.length > 0 || thingType?.UID?.startsWith('zwave:') || hasMatterThreadProperties"
+              title="Actions"
+              full-width>
+              <template v-if="advancedThingActionsCount">
+                <label class="advanced-label">
+                  <f7-checkbox v-model:checked="showAdvancedThingActions" />
+                  Show advanced
+                  <f7-badge
+                    v-if="advancedThingActionsCount"
+                    style="margin-left: 2px"
+                    color="theme-alt"
+                    class="count-badge"
+                    tooltip="Advanced/Expert Thing actions">
+                    {{ advancedThingActionsCount }}
+                  </f7-badge>
+                </label>
+              </template>
               <f7-list class="margin-top" media-list>
                 <f7-list-item
                   v-if="thingType?.UID?.startsWith('zwave:')"
@@ -217,7 +216,7 @@
                   link=""
                   @click="doThingAction(action)" />
               </f7-list>
-            </template>
+            </group-box>
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
@@ -253,16 +252,18 @@
 
         <f7-block v-if="ready" class="block-narrow no-margin-top">
           <f7-col>
-            <f7-list>
-              <f7-list-button v-if="offerInstallBinding" color="theme-alt" title="Install Binding" @click="installBinding" />
-              <f7-list-button v-if="!error" color="theme-alt" title="Duplicate Thing" @click="duplicateThing" />
-              <f7-list-button
-                v-if="!error"
-                color="theme-alt"
-                title="Copy File Definition"
-                @click="copyFileDefinitionToClipboard(ObjectType.THING, [thingId])" />
-              <f7-list-button v-if="editable" color="red" title="Remove Thing" @click="deleteThing" />
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button v-if="offerInstallBinding" color="theme-alt" title="Install Binding" @click="installBinding" />
+                <f7-list-button v-if="!error" color="theme-alt" title="Duplicate Thing" @click="duplicateThing" />
+                <f7-list-button
+                  v-if="!error"
+                  color="theme-alt"
+                  title="Copy File Definition"
+                  @click="copyFileDefinitionToClipboard(ObjectType.THING, [thingId])" />
+                <f7-list-button v-if="editable" color="red" title="Remove Thing" @click="deleteThing" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -277,28 +278,30 @@
             :context="context"
             :f7router />
           <f7-col v-if="isExtensible || thing.channels.length > 0">
-            <f7-list>
-              <f7-list-button
-                v-if="isExtensible && editable"
-                class="searchbar-ignore"
-                color="theme-alt"
-                title="Add Channel"
-                @click="addChannel()" />
-              <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Equipment to Model" @click="addToModel(true)" />
-              <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Points to Model" @click="addToModel(false)" />
-              <f7-list-button
-                v-if="hasLinkedItems"
-                class="searchbar-ignore"
-                color="red"
-                title="Unlink all Items"
-                @click="unlinkAll(false)" />
-              <f7-list-button
-                v-if="hasLinkedItems"
-                class="searchbar-ignore"
-                color="red"
-                title="Unlink and Remove all Items"
-                @click="unlinkAll(true)" />
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button
+                  v-if="isExtensible && editable"
+                  class="searchbar-ignore"
+                  color="theme-alt"
+                  title="Add Channel"
+                  @click="addChannel()" />
+                <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Equipment to Model" @click="addToModel(true)" />
+                <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Points to Model" @click="addToModel(false)" />
+                <f7-list-button
+                  v-if="hasLinkedItems"
+                  class="searchbar-ignore"
+                  color="red"
+                  title="Unlink all Items"
+                  @click="unlinkAll(false)" />
+                <f7-list-button
+                  v-if="hasLinkedItems"
+                  class="searchbar-ignore"
+                  color="red"
+                  title="Unlink and Remove all Items"
+                  @click="unlinkAll(true)" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -1191,6 +1194,7 @@ export default {
   },
   mounted() {
     this.checkPropertyTruncation()
+    console.log('advancedThingActionsCount', this.advancedThingActionsCount)
   },
   updated() {
     this.checkPropertyTruncation()

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -70,105 +70,104 @@
         <f7-block v-if="ready && !error" class="block-narrow no-margin-bottom">
           <f7-col>
             <thing-general-settings :thing="thing" :thing-type="thingType" :ready="true" :read-only="!editable" />
-            <f7-block-title v-if="thingType && thingType.UID" medium style="margin-bottom: var(--f7-list-margin-vertical)">
-              Information
-            </f7-block-title>
             <not-editable-notice v-if="!editable" subject="Thing" />
-            <f7-list accordion-opposite>
-              <f7-list-item v-if="thingType" accordion-item title="Thing Type" :after="thingType.label">
-                <f7-accordion-content class="thing-type-description">
-                  <div class="margin" v-html="thingType?.description" />
-                </f7-accordion-content>
-              </f7-list-item>
-              <f7-list-item v-else title="Missing Thing-Type (is the binding installed?)" :after="thing.thingTypeUID" text-color="red" />
-              <f7-list-item
-                v-if="thing && Object.keys(thing.properties).length > 0"
-                accordion-item
-                title="Thing Properties"
-                :badge="Object.keys(thing.properties).length">
-                <f7-accordion-content>
-                  <f7-list>
-                    <f7-list-item
-                      v-for="(value, key) in thing.properties"
-                      class="thing-property"
-                      :key="key"
-                      @click="showFullPropertyIfTruncated(key, value)">
-                      <template #title>
-                        <div class="item-title-content">
-                          <span :ref="'titleSpan-' + key">{{ key }}</span>
-                        </div>
-                      </template>
-                      <template #after>
-                        <div class="item-after-content">
-                          <span :ref="'valueSpan-' + key">{{ value }}</span>
-                          <f7-icon
-                            v-if="isTruncated(key, 'title') || isTruncated(key, 'value')"
-                            f7="info_circle"
-                            size="16"
-                            class="truncation-icon" />
-                        </div>
-                      </template>
-                    </f7-list-item>
-                  </f7-list>
-                </f7-accordion-content>
-              </f7-list-item>
-              <f7-list-item
-                v-if="thing.firmwareStatus"
-                accordion-item
-                title="Firmware"
-                :badge="firmwares.length"
-                :badge-color="thing.firmwareStatus.status === 'UPDATE_EXECUTABLE' ? 'green' : 'gray'">
-                <f7-accordion-content>
-                  <f7-list>
-                    <f7-list-item class="thing-property" title="Status" :after="firmwareStatusText" />
-                    <f7-list-item class="thing-property" title="Current Version" :after="thing.properties.firmwareVersion" />
-                    <f7-list-item
-                      v-for="firmware in firmwares"
-                      class="thing-property"
-                      :key="firmware.version"
-                      header="Version"
-                      :title="firmware.version"
-                      :after="firmware.description"
-                      :footer="firmware.changelog">
-                      <div class="item-after">
-                        <f7-badge
-                          :color="
-                            firmware.version === thing.properties.firmwareVersion
-                              ? 'gray'
-                              : firmware.version > thing.properties.firmwareVersion
-                                ? 'green'
-                                : 'red'
-                          ">
-                          {{
-                            compareVersions(firmware.version, thing.properties.firmwareVersion) === 0
-                              ? 'Current Version'
-                              : compareVersions(firmware.version, thing.properties.firmwareVersion) > 0
-                                ? 'Upgrade'
-                                : 'Downgrade'
-                          }}
-                          <f7-link
-                            v-if="compareVersions(firmware.version, thing.properties.firmwareVersion) !== 0 && !firmwareUpdating"
-                            icon-color="white"
-                            :tooltip="
-                              compareVersions(firmware.version, thing.properties.firmwareVersion) === 1
-                                ? 'Start Upgrade'
-                                : 'Start Downgrade'
-                            "
-                            style="margin-left: 4px"
-                            icon-ios="f7:play_fill"
-                            icon-md="f7:play_fill"
-                            icon-aurora="f7:play_fill"
-                            icon-size="16"
-                            @click="startFirmwareUpdate(firmware)" />
-                        </f7-badge>
-                      </div>
-                    </f7-list-item>
-                  </f7-list>
-                </f7-accordion-content>
-              </f7-list-item>
-            </f7-list>
 
-            <f7-block-title medium class="no-margin-bottom"> Configuration </f7-block-title>
+            <group-box v-if="thingType && thingType.UID" title="Information">
+              <f7-list accordion>
+                <f7-list-item v-if="thingType" accordion-item title="Thing Type" :after="thingType.label">
+                  <f7-accordion-content class="thing-type-description">
+                    <div class="margin" v-html="thingType?.description" />
+                  </f7-accordion-content>
+                </f7-list-item>
+                <f7-list-item v-else title="Missing Thing-Type (is the binding installed?)" :after="thing.thingTypeUID" text-color="red" />
+                <f7-list-item
+                  v-if="thing && Object.keys(thing.properties).length > 0"
+                  accordion-item
+                  title="Thing Properties"
+                  :badge="Object.keys(thing.properties).length">
+                  <f7-accordion-content>
+                    <f7-list>
+                      <f7-list-item
+                        v-for="(value, key) in thing.properties"
+                        class="thing-property"
+                        :key="key"
+                        @click="showFullPropertyIfTruncated(key, value)">
+                        <template #title>
+                          <div class="item-title-content">
+                            <span :ref="'titleSpan-' + key">{{ key }}</span>
+                          </div>
+                        </template>
+                        <template #after>
+                          <div class="item-after-content">
+                            <span :ref="'valueSpan-' + key">{{ value }}</span>
+                            <f7-icon
+                              v-if="isTruncated(key, 'title') || isTruncated(key, 'value')"
+                              f7="info_circle"
+                              size="16"
+                              class="truncation-icon" />
+                          </div>
+                        </template>
+                      </f7-list-item>
+                    </f7-list>
+                  </f7-accordion-content>
+                </f7-list-item>
+                <f7-list-item
+                  v-if="thing.firmwareStatus"
+                  accordion-item
+                  title="Firmware"
+                  :badge="firmwares.length"
+                  :badge-color="thing.firmwareStatus.status === 'UPDATE_EXECUTABLE' ? 'green' : 'gray'">
+                  <f7-accordion-content>
+                    <f7-list>
+                      <f7-list-item class="thing-property" title="Status" :after="firmwareStatusText" />
+                      <f7-list-item class="thing-property" title="Current Version" :after="thing.properties.firmwareVersion" />
+                      <f7-list-item
+                        v-for="firmware in firmwares"
+                        class="thing-property"
+                        :key="firmware.version"
+                        header="Version"
+                        :title="firmware.version"
+                        :after="firmware.description"
+                        :footer="firmware.changelog">
+                        <div class="item-after">
+                          <f7-badge
+                            :color="
+                              firmware.version === thing.properties.firmwareVersion
+                                ? 'gray'
+                                : firmware.version > thing.properties.firmwareVersion
+                                  ? 'green'
+                                  : 'red'
+                            ">
+                            {{
+                              compareVersions(firmware.version, thing.properties.firmwareVersion) === 0
+                                ? 'Current Version'
+                                : compareVersions(firmware.version, thing.properties.firmwareVersion) > 0
+                                  ? 'Upgrade'
+                                  : 'Downgrade'
+                            }}
+                            <f7-link
+                              v-if="compareVersions(firmware.version, thing.properties.firmwareVersion) !== 0 && !firmwareUpdating"
+                              icon-color="white"
+                              :tooltip="
+                                compareVersions(firmware.version, thing.properties.firmwareVersion) === 1
+                                  ? 'Start Upgrade'
+                                  : 'Start Downgrade'
+                              "
+                              style="margin-left: 4px"
+                              icon-ios="f7:play_fill"
+                              icon-md="f7:play_fill"
+                              icon-aurora="f7:play_fill"
+                              icon-size="16"
+                              @click="startFirmwareUpdate(firmware)" />
+                          </f7-badge>
+                        </div>
+                      </f7-list-item>
+                    </f7-list>
+                  </f7-accordion-content>
+                </f7-list-item>
+              </f7-list>
+            </group-box>
+
             <config-sheet
               ref="thingConfiguration"
               :parameter-groups="configDescriptions?.parameterGroups"
@@ -180,24 +179,24 @@
               :f7router />
 
             <!-- Thing Actions & UI Actions -->
-            <template v-if="thingActions?.length > 0 || thingType?.UID?.startsWith('zwave:') || hasMatterThreadProperties">
-              <f7-block-title medium class="no-margin-top" style="display: flex; align-items: center; justify-content: space-between">
-                Actions
-                <div v-if="advancedThingActionsCount" class="advanced-actions-toggle">
-                  <label class="advanced-label">
-                    <f7-checkbox v-model:checked="showAdvancedThingActions" />
-                    Show advanced
-                    <f7-badge
-                      v-if="advancedThingActionsCount"
-                      style="margin-left: 2px"
-                      color="blue"
-                      class="count-badge"
-                      tooltip="Advanced/Expert Thing actions">
-                      {{ advancedThingActionsCount }}
-                    </f7-badge>
-                  </label>
-                </div>
-              </f7-block-title>
+            <group-box
+              v-if="thingActions?.length > 0 || thingType?.UID?.startsWith('zwave:') || hasMatterThreadProperties"
+              title="Actions"
+              full-width>
+              <template v-if="advancedThingActionsCount">
+                <label class="advanced-label">
+                  <f7-checkbox v-model:checked="showAdvancedThingActions" />
+                  Show advanced
+                  <f7-badge
+                    v-if="advancedThingActionsCount"
+                    style="margin-left: 2px"
+                    color="blue"
+                    class="count-badge"
+                    tooltip="Advanced/Expert Thing actions">
+                    {{ advancedThingActionsCount }}
+                  </f7-badge>
+                </label>
+              </template>
               <f7-list class="margin-top" media-list>
                 <f7-list-item
                   v-if="thingType?.UID?.startsWith('zwave:')"
@@ -217,7 +216,7 @@
                   link=""
                   @click="doThingAction(action)" />
               </f7-list>
-            </template>
+            </group-box>
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
@@ -253,16 +252,18 @@
 
         <f7-block v-if="ready" class="block-narrow no-margin-top">
           <f7-col>
-            <f7-list>
-              <f7-list-button v-if="offerInstallBinding" color="blue" title="Install Binding" @click="installBinding" />
-              <f7-list-button v-if="!error" color="blue" title="Duplicate Thing" @click="duplicateThing" />
-              <f7-list-button
-                v-if="!error"
-                color="blue"
-                title="Copy File Definition"
-                @click="copyFileDefinitionToClipboard(ObjectType.THING, [thingId])" />
-              <f7-list-button v-if="editable" color="red" title="Remove Thing" @click="deleteThing" />
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button v-if="offerInstallBinding" color="blue" title="Install Binding" @click="installBinding" />
+                <f7-list-button v-if="!error" color="blue" title="Duplicate Thing" @click="duplicateThing" />
+                <f7-list-button
+                  v-if="!error"
+                  color="blue"
+                  title="Copy File Definition"
+                  @click="copyFileDefinitionToClipboard(ObjectType.THING, [thingId])" />
+                <f7-list-button v-if="editable" color="red" title="Remove Thing" @click="deleteThing" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -277,28 +278,30 @@
             :context="context"
             :f7router />
           <f7-col v-if="isExtensible || thing.channels.length > 0">
-            <f7-list>
-              <f7-list-button
-                v-if="isExtensible && editable"
-                class="searchbar-ignore"
-                color="blue"
-                title="Add Channel"
-                @click="addChannel()" />
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Equipment to Model" @click="addToModel(true)" />
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Points to Model" @click="addToModel(false)" />
-              <f7-list-button
-                v-if="hasLinkedItems"
-                class="searchbar-ignore"
-                color="red"
-                title="Unlink all Items"
-                @click="unlinkAll(false)" />
-              <f7-list-button
-                v-if="hasLinkedItems"
-                class="searchbar-ignore"
-                color="red"
-                title="Unlink and Remove all Items"
-                @click="unlinkAll(true)" />
-            </f7-list>
+            <group-box>
+              <f7-list>
+                <f7-list-button
+                  v-if="isExtensible && editable"
+                  class="searchbar-ignore"
+                  color="blue"
+                  title="Add Channel"
+                  @click="addChannel()" />
+                <f7-list-button class="searchbar-ignore" color="blue" title="Add Equipment to Model" @click="addToModel(true)" />
+                <f7-list-button class="searchbar-ignore" color="blue" title="Add Points to Model" @click="addToModel(false)" />
+                <f7-list-button
+                  v-if="hasLinkedItems"
+                  class="searchbar-ignore"
+                  color="red"
+                  title="Unlink all Items"
+                  @click="unlinkAll(false)" />
+                <f7-list-button
+                  v-if="hasLinkedItems"
+                  class="searchbar-ignore"
+                  color="red"
+                  title="Unlink and Remove all Items"
+                  @click="unlinkAll(true)" />
+              </f7-list>
+            </group-box>
           </f7-col>
         </f7-block>
       </f7-tab>
@@ -1191,6 +1194,7 @@ export default {
   },
   mounted() {
     this.checkPropertyTruncation()
+    console.log('advancedThingActionsCount', this.advancedThingActionsCount)
   },
   updated() {
     this.checkPropertyTruncation()

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -98,21 +98,6 @@
 
     <f7-block class="block-narrow">
       <f7-col v-show="ready">
-        <f7-block-title>
-          <span>{{ listTitle }}</span>
-          <template v-if="showCheckboxes && listedItems.length">
-            -
-            <f7-link @click="selectDeselectAll" :text="allSelected ? 'Deselect all' : 'Select all'" />
-          </template>
-          <template v-if="groupBy === 'location'">
-            <div style="text-align: right" class="padding-right">
-              <label class="advanced-label">
-                <f7-checkbox v-model:checked="showNoLocation" />
-                Show no location</label
-              >
-            </div>
-          </template>
-        </f7-block-title>
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
       </f7-col>
       <!-- skeleton for not ready -->
@@ -140,56 +125,65 @@
             <f7-button :active="groupBy === 'location'" @click="switchGroupOrder('location')"> By location </f7-button>
           </f7-segmented>
         </div>
-        <f7-list v-if="!listedItems.length">
-          <f7-list-item title="Nothing found" />
-        </f7-list>
-        <f7-list v-show="listedItems.length" class="col things-list" :contacts-list="groupBy === 'alphabetical'">
-          <f7-list-group v-for="(thingsWithInitial, initial) in indexedThings" :key="initial">
-            <f7-list-item v-if="thingsWithInitial.length" :title="initial" group-title media-item />
-            <f7-list-item
-              v-for="(thing, index) in thingsWithInitial"
-              :key="index"
-              media-item
-              class="thinglist-item"
-              :checkbox="showCheckboxes"
-              :checked="isChecked(thing.UID) ? true : null"
-              :value="thing.UID"
-              prevent-router
-              @click.ctrl="ctrlClick($event, thing)"
-              @click.meta="ctrlClick($event, thing)"
-              @click.exact="click($event, thing)"
-              :link="`${encodeURIComponent(thing.UID)}`"
-              :title="thing.label || thing.UID">
-              <template #footer>
-                <div>
-                  {{ thing.UID }}
-                  <clipboard-icon :value="thing.UID" tooltip="Copy UID" />
-                </div>
-              </template>
+        <group-box :title="listTitle">
+          <template #after-title>
+            <f7-link
+              v-if="showCheckboxes && listedItems.length"
+              @click="selectDeselectAll"
+              :text="allSelected ? 'Deselect all' : 'Select all'" />
+            <label v-if="groupBy === 'location'" class="advanced-label">
+              <f7-checkbox v-model:checked="showNoLocation" />
+              Show no location
+            </label>
+          </template>
+          <f7-list v-show="listedItems.length" class="col things-list" :contacts-list="groupBy === 'alphabetical'">
+            <f7-list-group v-for="(thingsWithInitial, initial) in indexedThings" :key="initial">
+              <f7-list-item v-if="thingsWithInitial.length" :title="initial" group-title media-item />
+              <f7-list-item
+                v-for="(thing, index) in thingsWithInitial"
+                :key="index"
+                media-item
+                class="thinglist-item"
+                :checkbox="showCheckboxes"
+                :checked="isChecked(thing.UID) ? true : null"
+                :value="thing.UID"
+                prevent-router
+                @click.ctrl="ctrlClick($event, thing)"
+                @click.meta="ctrlClick($event, thing)"
+                @click.exact="click($event, thing)"
+                :link="`${encodeURIComponent(thing.UID)}`"
+                :title="thing.label || thing.UID">
+                <template #footer>
+                  <div>
+                    {{ thing.UID }}
+                    <clipboard-icon :value="thing.UID" tooltip="Copy UID" />
+                  </div>
+                </template>
 
-              <template #subtitle>
-                <div v-if="thing.location && groupBy !== 'location'">
-                  {{ thing.location }}
-                  <f7-icon f7="placemark" color="gray" style="font-size: 16px; width: 16px; height: 16px" />
-                </div>
-              </template>
-              <template #after>
-                <div class="badge-with-marker">
-                  <f7-badge :color="thingStatusBadgeColor(thing.statusInfo)" :tooltip="thing.statusInfo.description || null">
-                    {{ thingStatusBadgeText(thing.statusInfo) }}
-                  </f7-badge>
-                  <span
-                    v-if="thing.statusInfo.status === 'ONLINE' && thing.statusInfo.description && thing.statusInfo.description !== ''"
-                    class="badge-marker-dot">
-                  </span>
-                </div>
-              </template>
-              <template #after-title>
-                <f7-icon v-if="!thing.editable" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+                <template #subtitle>
+                  <div v-if="thing.location && groupBy !== 'location'">
+                    {{ thing.location }}
+                    <f7-icon f7="placemark" color="gray" style="font-size: 16px; width: 16px; height: 16px" />
+                  </div>
+                </template>
+                <template #after>
+                  <div class="badge-with-marker">
+                    <f7-badge :color="thingStatusBadgeColor(thing.statusInfo)" :tooltip="thing.statusInfo.description || null">
+                      {{ thingStatusBadgeText(thing.statusInfo) }}
+                    </f7-badge>
+                    <span
+                      v-if="thing.statusInfo.status === 'ONLINE' && thing.statusInfo.description && thing.statusInfo.description !== ''"
+                      class="badge-marker-dot">
+                    </span>
+                  </div>
+                </template>
+                <template #after-title>
+                  <f7-icon v-if="!thing.editable" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -63,9 +63,6 @@
       </f7-col>
 
       <f7-col v-show="transformations.length > 0">
-        <f7-block-title class="searchbar-hide-on-search">
-          <span>{{ transformations.length }} transformations</span>
-        </f7-block-title>
         <div class="searchbar-found padding-left padding-right">
           <f7-segmented strong tag="p">
             <f7-button :active="groupBy === 'alphabetical'" @click="switchGroupOrder('alphabetical')"> Alphabetical </f7-button>
@@ -76,36 +73,38 @@
         <f7-list class="searchbar-not-found">
           <f7-list-item title="Nothing found" />
         </f7-list>
-        <f7-list
-          class="searchbar-found col transformations-list"
-          ref="transformationsList"
-          :contacts-list="groupBy === 'alphabetical'"
-          media-list>
-          <f7-list-group v-for="(transformationsWithInitial, initial) in indexedTransformations" :key="initial">
-            <f7-list-item v-if="transformationsWithInitial.length" :title="initial" group-title />
-            <f7-list-item
-              v-for="transformation in transformationsWithInitial"
-              :key="transformation.uid"
-              media-item
-              class="transformationlist-item"
-              :checkbox="showCheckboxes && transformation.editable"
-              :checked="isChecked(transformation.uid) ? true : null"
-              @click.ctrl="(e) => ctrlClick(e, transformation)"
-              @click.meta="(e) => ctrlClick(e, transformation)"
-              @click.exact="(e) => click(e, transformation)"
-              link=""
-              :title="transformation.label"
-              :subtitle="transformation.type">
-              <template #after-title>
-                <f7-icon v-if="!transformation.editable" f7="lock_fill" size="1rem" color="gray" />
-              </template>
-              <template #footer>
-                {{ transformation.uid }}
-                <clipboard-icon :value="transformation.uid" tooltip="Copy UID" />
-              </template>
-            </f7-list-item>
-          </f7-list-group>
-        </f7-list>
+        <group-box :title="transformations.length + ' transformations'" full-width>
+          <f7-list
+            class="searchbar-found col transformations-list"
+            ref="transformationsList"
+            :contacts-list="groupBy === 'alphabetical'"
+            media-list>
+            <f7-list-group v-for="(transformationsWithInitial, initial) in indexedTransformations" :key="initial">
+              <f7-list-item v-if="transformationsWithInitial.length" :title="initial" group-title />
+              <f7-list-item
+                v-for="transformation in transformationsWithInitial"
+                :key="transformation.uid"
+                media-item
+                class="transformationlist-item"
+                :checkbox="showCheckboxes && transformation.editable"
+                :checked="isChecked(transformation.uid) ? true : null"
+                @click.ctrl="(e) => ctrlClick(e, transformation)"
+                @click.meta="(e) => ctrlClick(e, transformation)"
+                @click.exact="(e) => click(e, transformation)"
+                link=""
+                :title="transformation.label"
+                :subtitle="transformation.type">
+                <template #after-title>
+                  <f7-icon v-if="!transformation.editable" f7="lock_fill" size="1rem" color="gray" />
+                </template>
+                <template #footer>
+                  {{ transformation.uid }}
+                  <clipboard-icon :value="transformation.uid" tooltip="Copy UID" />
+                </template>
+              </f7-list-item>
+            </f7-list-group>
+          </f7-list>
+        </group-box>
       </f7-col>
     </f7-block>
 


### PR DESCRIPTION
- Convert boxy information groups into rounded rectangle, outlined boxes
- Add a searchbar for the configuration sheet
- Mark advanced configuration parameters and advanced channels with a blue left border for easy identification
- Apply cosmetic improvements to text input fields, including distinct background fills and focused state outlines
- Sort the well-known Item Metadata namespaces according to the well-known namespace ordering
- Add an icon to list filter header


Resolves #4198 - with future enhancement to show category list, possibly in a future PR.

# A Search feature for config sheet:

- Advanced parameters are indicated with a blue left border
- Focused input fields are outlined for better visibility

<img width="634" height="631" alt="image" src="https://github.com/user-attachments/assets/74f74eb5-ef43-404c-87f1-a87317d99104" />

---

# Settings Screen

<img width="1208" height="927" alt="image" src="https://github.com/user-attachments/assets/b3b85aff-881d-4144-9d19-ef7cabc1f7c3" />

## On a narrow screen:

The sides snap to the edges, the rounded corners disappear and left/right borders removed.

<img width="502" height="818" alt="image" src="https://github.com/user-attachments/assets/e4578486-743a-49e2-b948-cccd925fdf25" />

---

# Developer Tools page

<img width="796" height="595" alt="image" src="https://github.com/user-attachments/assets/f3bc8db6-2567-4dc6-87d0-5d8a075d1fab" />


---

# List Pages:

- Add an icon for "Filter"
- The item counter + select all / deselect in the list header. Select All / deselect all right-aligned

<img width="787" height="835" alt="image" src="https://github.com/user-attachments/assets/a2a558dc-3fbc-4392-ad6d-d8348e7bb904" />

---

<img width="768" height="637" alt="image" src="https://github.com/user-attachments/assets/4570629b-9fd9-4ed8-a248-c0fee438faec" />

---

## The advanced channels are also indicated with blue left border

<img width="770" height="540" alt="image" src="https://github.com/user-attachments/assets/a5336f56-d666-4d9e-b92c-43061e1c3d77" />

---

<img width="766" height="1043" alt="image" src="https://github.com/user-attachments/assets/92d278b3-7cce-481a-986f-58f5e0d0e78b" />

---


And more.