### PR TITLE
Sitemap edit: Various fixes

### DIFF
--- a/bundles/org.openhab.ui.basic/.classpath
+++ b/bundles/org.openhab.ui.basic/.classpath
@@ -30,16 +30,5 @@
 			<attribute name="annotationpath" value="target/dependency"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="src" path="target/generated-sources/annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-		</attributes>
-	</classpathentry>
-	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
-		<attributes>
-			<attribute name="optional" value="true"/>
-			<attribute name="test" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.ui.basic/.classpath
+++ b/bundles/org.openhab.ui.basic/.classpath
@@ -30,5 +30,16 @@
 			<attribute name="annotationpath" value="target/dependency"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/format-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/format-editor.vue
@@ -319,8 +319,8 @@ export default {
     clearFormat() {
       this.javaFormatValidationMessage = ''
       this.formatModel = { service: '', transformation: '', javaFormat: '' }
-      this.$emit('input', '')
-      this.$emit('update:value', '')
+      this.$emit('input', null)
+      this.$emit('update:value', null)
     },
     onDocumentPointerDown(event) {
       if (!this.isFormatEditing) {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/sitemap-mixin.js
@@ -84,6 +84,7 @@ export default {
   },
   methods: {
     allowedWidgetTypes(parentWidget) {
+      if (!this.canAddChildren(parentWidget)) return []
       let types = this.WIDGET_TYPES.filter((w) => w.type !== 'Sitemap')
       // Button only allowed inside Buttongrid
       if (parentWidget.type === 'Buttongrid') return types.filter((t) => t.type === 'Button')
@@ -104,10 +105,6 @@ export default {
     },
     canAddChildren(widget) {
       if (!widget) return false
-      if (widget.type === 'Buttongrid') {
-        const buttons = widget.buttons
-        if (Array.isArray(buttons) && buttons.length) return false
-      }
       return this.LINKABLE_WIDGET_TYPES.includes(widget.type)
     },
     widgetTypeDef(type) {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -61,6 +61,7 @@
 <script>
 import SitemapMixin from '@/components/pagedesigner/sitemap/sitemap-mixin'
 import { VueDraggableNext as Draggable } from 'vue-draggable-next'
+import { showToast } from '@/js/dialog-promises'
 
 import cloneDeep from 'lodash/cloneDeep'
 
@@ -118,14 +119,24 @@ export default {
       console.debug('Drag end event:', event)
       const widget = this.localMoveState.widget
       const parentWidget = this.localMoveState.newParent
-      if (widget && parentWidget && this.dropAllowed(parentWidget)) {
-        console.debug('Dropping widget:', cloneDeep(widget), 'into parent widget:', cloneDeep(parentWidget))
+      if (!widget || !parentWidget) {
+        this.localMoveState.moving = false
+        return
+      }
+      if (this.dropAllowed(parentWidget)) {
         widget.parent = parentWidget
+        console.debug('Dropping widget:', cloneDeep(widget), 'into parent widget:', cloneDeep(parentWidget))
       } else {
         widget.parent = this.localMoveState.originalParent
         widget.parent.widgets.splice(this.localMoveState.originalIndex, 0, widget)
         this.localMoveState.newParent.widgets.splice(this.localMoveState.newIndex, 1)
         console.debug('Drop not allowed. Resetting widget parent to original parent:', cloneDeep(this.localMoveState.originalParent))
+        showToast(
+          'Widget of type ' +
+            this.widgetTypeLabel(widget.type) +
+            ', drop not allowed in parent of type ' +
+            this.widgetTypeLabel(parentWidget.type)
+        )
       }
       this.localMoveState.moving = false
     },

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -62,6 +62,8 @@
 import SitemapMixin from '@/components/pagedesigner/sitemap/sitemap-mixin'
 import { VueDraggableNext as Draggable } from 'vue-draggable-next'
 
+import cloneDeep from 'lodash/cloneDeep'
+
 export default {
   name: 'sitemap-treeview-item',
   mixins: [SitemapMixin],
@@ -96,12 +98,19 @@ export default {
       console.debug('Drag start event:', event)
       this.localMoveState.moving = true
       this.localMoveState.widget = this.widget.widgets[event.oldIndex]
-      this.localMoveState.newParent = this.parentWidget
+      this.localMoveState.originalParent = this.localMoveState.widget.parent
+      this.localMoveState.originalIndex = event.oldIndex
+      this.localMoveState.newParent = null
+      this.localMoveState.newIndex = null
+      console.debug('Moving:', cloneDeep(this.localMoveState.widget))
     },
     onMove(event) {
       console.debug('Drag move event:', event)
+      if (!this.localMoveState.moving) return
       const newParent = event.relatedContext?.element?.parent
+      this.localMoveState.newIndex = event.newIndex
       if (newParent) {
+        console.debug('New parent:', cloneDeep(newParent))
         this.localMoveState.newParent = newParent
       }
     },
@@ -109,15 +118,18 @@ export default {
       console.debug('Drag end event:', event)
       const widget = this.localMoveState.widget
       const parentWidget = this.localMoveState.newParent
-      if (widget && parentWidget) {
+      if (widget && parentWidget && this.dropAllowed(parentWidget)) {
+        console.debug('Dropping widget:', cloneDeep(widget), 'into parent widget:', cloneDeep(parentWidget))
         widget.parent = parentWidget
+      } else {
+        widget.parent = this.localMoveState.originalParent
+        widget.parent.widgets.splice(this.localMoveState.originalIndex, 0, widget)
+        this.localMoveState.newParent.widgets.splice(this.localMoveState.newIndex, 1)
+        console.debug('Drop not allowed. Resetting widget parent to original parent:', cloneDeep(this.localMoveState.originalParent))
       }
       this.localMoveState.moving = false
-      this.localMoveState.widget = null
-      this.localMoveState.newParent = null
     },
     dropAllowed(widget) {
-      if (!this.canAddChildren(widget)) return false
       if (
         !this.localMoveState.widget ||
         this.allowedWidgetTypes(widget)

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -397,16 +397,16 @@ export default {
         delete this.widget[parameter]
       }
     },
-    updateItemFormat($event) {
-      if ($event === null || $event === undefined || $event.length === 0) {
+    updateItemFormat(event) {
+      if (event === null || event === undefined || event.length === 0) {
         delete this.widget.format
       } else {
-        this.widget.format = $event
+        this.widget.format = event
       }
     },
-    toggleItemFormatOverride($event) {
+    toggleItemFormatOverride(event) {
       if (!this.widget.format?.length) {
-        if ($event) {
+        if (event) {
           this.widget.itemFormatOverride = true
         } else {
           delete this.widget.itemFormatOverride

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -22,8 +22,16 @@
           @input="updateParameter('label', $event)"
           :clear-button="editable"
           :disabled="!editable" />
-        <ul v-if="widget.type !== 'Sitemap'" class="format-editor-wrapper">
-          <format-editor title="Format" :editable="editable" :value="widget.format" @input="(value) => (widget.format = value)" />
+        <ul v-if="widget.type !== 'Sitemap' && !['Frame', 'Buttongrid'].includes(widget.type)" class="format-editor-wrapper">
+          <format-editor title="Format" :editable="editable" :value="widget.format" @input="updateItemFormat" />
+          <f7-list-item title="No state" :disabled="!editable || widget.format?.length > 0">
+            <template #after>
+              <f7-toggle
+                tooltip="Do not show item state"
+                :checked="widget.itemFormatOverride && !widget.format?.length"
+                @toggle:change="toggleItemFormatOverride" />
+            </template>
+          </f7-list-item>
         </ul>
         <ul v-if="widget.type !== 'Sitemap' && !['Frame', 'Buttongrid'].includes(widget.type)">
           <item-picker
@@ -55,7 +63,8 @@
           <f7-list-item title="Static icon" :disabled="!editable || widget.iconRules?.length > 0">
             <template #after>
               <f7-toggle
-                :checked="widget.staticIcon && !widget.iconRules?.length ? true : false"
+                tooltip="openHAB icon does not change with state"
+                :checked="widget.staticIcon && !widget.iconRules?.length"
                 @toggle:change="widget.staticIcon = $event" />
             </template>
           </f7-list-item>
@@ -386,6 +395,22 @@ export default {
         this.widget[parameter] = false
       } else {
         delete this.widget[parameter]
+      }
+    },
+    updateItemFormat($event) {
+      if ($event === null || $event === undefined || $event.length === 0) {
+        delete this.widget.format
+      } else {
+        this.widget.format = $event
+      }
+    },
+    toggleItemFormatOverride($event) {
+      if (!this.widget.format?.length) {
+        if ($event) {
+          this.widget.itemFormatOverride = true
+        } else {
+          delete this.widget.itemFormatOverride
+        }
       }
     },
     remove() {

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -280,8 +280,14 @@
     <f7-card-footer v-if="editable || widget.type === 'Sitemap'" key="sitemap-widget-buttons-edit-mode" class="widget-details-footer">
       <!-- <f7-button v-if="!editMode && !createMode" color="blue" @click="editMode = true" icon-ios="material:expand_more" icon-md="material:expand_more" icon-aurora="material:expand_more">Edit</f7-button> -->
       <f7-segmented v-if="editable && widget.type !== 'Sitemap'">
-        <f7-button color="blue" @click="$emit('moveup', widget)" icon-f7="chevron_up" />
-        <f7-button color="blue" @click="$emit('movedown', widget)" icon-f7="chevron_down" />
+        <f7-button
+          v-if="widget.type === 'Button'"
+          color="blue"
+          @click="$emit('sortbuttons', widget.parent)"
+          icon-f7="sort_down"
+          tooltip="Sort Buttons" />
+        <f7-button color="blue" @click="$emit('moveup', widget)" icon-f7="chevron_up" tooltip="Move Up" />
+        <f7-button color="blue" @click="$emit('movedown', widget)" icon-f7="chevron_down" tooltip="Move Down" />
       </f7-segmented>
       <f7-button v-if="editable || widget.type === 'Sitemap'" color="blue" @click="$emit('duplicate', widget)"> Duplicate </f7-button>
       <f7-button v-if="editable && widget.type !== 'Sitemap'" color="red" @click="$emit('remove', widget)"> Remove </f7-button>
@@ -335,7 +341,7 @@ export default {
     editable: Boolean,
     createMode: Boolean
   },
-  emits: ['moveup', 'movedown', 'duplicate', 'remove'],
+  emits: ['sortbuttons', 'moveup', 'movedown', 'duplicate', 'remove'],
   data() {
     return {
       iconInputId: '',

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -62,7 +62,8 @@
                   @duplicate="duplicateWidget"
                   @remove="removeWidget"
                   @movedown="moveWidgetDown"
-                  @moveup="moveWidgetUp" />
+                  @moveup="moveWidgetUp"
+                  @sortbuttons="sortButtongrid" />
               </f7-block>
               <f7-block v-else>
                 <div class="padding text-align-center">Nothing selected</div>
@@ -252,7 +253,8 @@
             @duplicate="duplicateWidget"
             @remove="removeWidget"
             @movedown="moveWidgetDown"
-            @moveup="moveWidgetUp" />
+            @moveup="moveWidgetUp"
+            @sortbuttons="sortButtongrid" />
         </f7-block>
         <f7-block v-if="selectedWidget && detailsTab === 'visibilityRules'" style="margin-bottom: 6rem">
           <attribute-details :widget="selectedWidget" attribute="visibilityRules" :fields="visibilityRulesFields" :disabled="!isEditable" />
@@ -985,7 +987,9 @@ export default {
               }
             } else {
               if (widget.column && !isNaN(widget.column) && widget.column > this.MAX_BUTTONGRID_COLUMNS) {
-                validationWarnings.push(widget.type + ' widget ' + label + ', invalid column configured: ' + widget.column)
+                validationWarnings.push(
+                  widget.type + ' widget ' + label + ', more than ' + this.MAX_BUTTONGRID_COLUMNS + ' configured: ' + widget.column
+                )
               }
             }
           })
@@ -1123,9 +1127,6 @@ export default {
           delete widget[key]
         }
       }
-      if (widget.type === 'Buttongrid') {
-        widget.widgets?.sort((button1, button2) => (button1.row ?? 0) - (button2.row ?? 0) || (button1.column ?? 0) - (button2.column ?? 0))
-      }
       this.addEmptySlot(widget)
       widget.widgets?.forEach(this.cleanConfig)
     },
@@ -1181,6 +1182,16 @@ export default {
     },
     startEventSource() {},
     stopEventSource() {},
+    sortButtongrid(widget) {
+      if (widget.type === 'Buttongrid' && Array.isArray(widget.widgets)) {
+        widget.widgets.sort(
+          (button1, button2) =>
+            (button1.row ?? 0) - (button2.row ?? 0) ||
+            (button1.column ?? 0) - (button2.column ?? 0) ||
+            (button1.visibilityRules?.length ?? 0) - (button2.visibilityRules?.length ?? 0)
+        )
+      }
+    },
     duplicateWidget() {
       if (this.selectedWidget.type === 'Sitemap') {
         const sitemapCopy = this.preProcessSitemapSave(this.selectedWidget)

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -542,9 +542,13 @@ export default {
     })
   },
   watch: {
+    lastCleanSitemap(newVal) {
+      console.log('lastCleanSitemap updated:', cloneDeep(newVal))
+    },
     sitemap: {
       handler(newVal) {
         if (this.loading) return
+        console.log('Sitemap changed:', cloneDeep(this.stripClosed(newVal)))
         if (!fastDeepEqual(this.stripClosed(newVal), this.lastCleanSitemap)) {
           this.sitemapDirty = true
         } else {
@@ -1148,6 +1152,9 @@ export default {
         if (labelMatch) {
           widget.label = labelMatch[1].trim()
           widget.format = labelMatch[2].trim()
+          if (!widget.format || widget.format.length === 0) {
+            widget.itemFormatOverride = true
+          }
         }
       }
       this.addEmptySlot(widget)
@@ -1168,11 +1175,12 @@ export default {
       return processed
     },
     preProcessWidgetSave(widget) {
-      if (widget.format) {
-        const label = widget.label || ''
-        widget.label = label + (label ? ' ' : '') + '[' + widget.format + ']'
+      if (widget.itemFormatOverride || widget.format?.length) {
+        const label = widget.label?.trim() || ''
+        widget.label = label + (label ? ' ' : '') + '[' + (widget.format?.trim() || '') + ']'
       }
       delete widget.format
+      delete widget.itemFormatOverride
       delete widget.parent // remove parent from widget, as this would cause a circular reference error when converting to JSON
       widget.widgets?.forEach(this.preProcessWidgetSave)
     },

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -174,7 +174,7 @@
         class="add-to-sitemap-fab"
         position="right-center"
         color="blue"
-        @click="$refs.widgetTypeSelection.open()">
+        @click="selectWidgetType">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
       </f7-fab>
@@ -1221,6 +1221,9 @@ export default {
       if (pos <= 0) return
       widgets.splice(pos, 1)
       widgets.splice(pos - 1, 0, this.selectedWidget)
+    },
+    selectWidgetType() {
+      this.$refs.widgetTypeSelection.elRef.f7Modal.open()
     },
     selectWidget(widgets) {
       const widget = widgets[0]

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -542,13 +542,9 @@ export default {
     })
   },
   watch: {
-    lastCleanSitemap(newVal) {
-      console.log('lastCleanSitemap updated:', cloneDeep(newVal))
-    },
     sitemap: {
       handler(newVal) {
         if (this.loading) return
-        console.log('Sitemap changed:', cloneDeep(this.stripClosed(newVal)))
         if (!fastDeepEqual(this.stripClosed(newVal), this.lastCleanSitemap)) {
           this.sitemapDirty = true
         } else {


### PR DESCRIPTION
This solves a few issues in the sitemap editor identified here: https://github.com/openhab/openhab-core/issues/5007#issuecomment-4485207602

- Don't automatically sort the Buttons in a Buttongrid when loaded or saved. The proposed solution is to not do that, but provide a sort button on the Button widget next to the up/down arrows. Instead of moving up/down, it will sort all sibling Buttons by row/column/visibility rule.
- Allow empty format for the label. This will make sure the format from the item itself is not applied and no state is shown. This was always removed before, and therefore the UI was always showing the formatted state if there was a format defined on the item. This is now solved by providing an extra switch 'No state'.

There was a bug when opening the add widget selection action sheet on narrow screens. This is fixed.

There was also a bug in the drag/drop logic. When dropping a widget in a not-allowed parent, it visually showed it could not be dropped, but it was still dropped and not reverted. This has also been fixed.