### PR TITLE
Add `µg/m³` unit hint for PM sensors

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/units.ts
+++ b/bundles/org.openhab.ui/web/src/assets/units.ts
@@ -92,7 +92,7 @@ export const Units: Unit[] = [
   },
   {
     dimension: 'Density',
-    units: ['g/l', 'g/m³', 'kg/m³'],
+    units: ['g/l', 'µg/m³', 'g/m³', 'kg/m³'],
     baseUnits: ['lb/in³', 'gr/ft³'],
     baseUnitsMetric: ['g/m³', 'g/mm³', 'g/cm³', 'g/dm³', 'g/ml', 'g/cl', 'g/dl', 'g/l']
   },


### PR DESCRIPTION
Resolves #4120