### PR TITLE
API Explorer: Enable tryItOutEnabled

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/api-explorer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/api-explorer.vue
@@ -133,6 +133,7 @@ function onPageAfterIn() {
     dom_id: '#swaggerUi',
     deepLinking: false,
     defaultModelsExpandDepth: 0,
+    tryItOutEnabled: true,
     tagsSorter: 'alpha',
     operationsSorter: 'alpha',
     filter: true,


### PR DESCRIPTION
I use the API explorer a great deal when testing various things, and I find it extremely annoying to have to press "try it out" before using each individual endpoint.

I don't know what the "design idea" is here, I know that some of what you see below changes when you click the button, but I'm not really sure how it's relevant/what it does. It seems to present some of the information in a slightly different way only.

Luckily, there is an option to make all endpoints be "enabled" by default, which is what this PR does. It is possible to set the default on a per-HTTP method basis, so that e.g. `PUT` and `DELETE` still need this extra click to be "active". I don't know if it would matter though, as I don't know if any of those endpoints will do anything unless you fill in additional information. It would be very strange to make e.g. a `DELETE` endpoint that deletes everything if no ID is specified...

So, this can be tweaked to apply only to `GET` and `POST`, which would already help a lot, but because I don't know if it matters, I've gone the simplest route first: to enable it universally.