### PR TITLE
oh-category-axis: Fix category name is not listed in state charts

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
@@ -85,6 +85,7 @@ export function getCategoryAxisData(config: OhCategoryAxis.Config, startTime: Da
       }
       break
     case OhCategoryAxis.CategoryType.values:
+      data.push(...(config.data || []))
       break
     default:
       const exhaustiveCheck: never = config.categoryType


### PR DESCRIPTION
Reported on the community:
https://community.openhab.org/t/openhab-5-2-milestone-discussion/168410/162

Regression from #4163.