### PR TITLE
Charts: Fix visual map regression

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/misc/oh-chart-tooltip.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/misc/oh-chart-tooltip.ts
@@ -28,13 +28,13 @@ const chartTooltip: MiscChartComponent = {
         let tooltip = ''
         if (!Array.isArray(params)) {
           if (!params.seriesId) return ''
+          const [_seriesType, _itemName, unit, _id] = params.seriesId.split('#')
           // tooltip for aggregate & calendar series:
           // - header: series name
           // - content: category label and formatted value
           if (params.componentType === 'series') {
             if (!Array.isArray(params.data)) return ''
             let state = context.numberFormatter!.format(params.data[1] as number)
-            const unit = params.data[params.data.length - 1] as string | undefined
             if (unit) state += ' ' + unit
             tooltip += `<div>${params.seriesName}</div>`
             if (params.name) {
@@ -76,8 +76,7 @@ const chartTooltip: MiscChartComponent = {
           }
           params.forEach((p) => {
             if (p.seriesId) {
-              const [seriesType, _itemName, _id, markArea] = p.seriesId.split('#')
-              const unit = Array.isArray(p.value) ? (p.value[p.value.length - 1] as string) : undefined
+              const [seriesType, _itemName, unit, _id, markArea] = p.seriesId.split('#')
               if ((seriesType === 'oh-time-series' && !markArea) || seriesType !== 'oh-time-series') {
                 let state = context.numberFormatter!.format((p.data as number[])[1])
                 if (unit) state += ' ' + unit

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/misc/oh-chart-visualmap.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/misc/oh-chart-visualmap.ts
@@ -27,14 +27,12 @@ const chartVisualMap: MiscChartComponent = {
     if (options.min !== undefined) {
       ;(options as VisualMapComponentOption).min = parseFloat(options.min)
     } else if (context.series && context.series[0]) {
-      // second-last element, last element is the unit
-      ;(options as VisualMapComponentOption).min = Math.min(...(context.series[0].data as number[][]).map((p) => p[p.length - 2]))
+      ;(options as VisualMapComponentOption).min = Math.min(...(context.series[0].data as number[][]).map((p) => p[p.length - 1]))
     }
     if (options.max !== undefined) {
       ;(options as VisualMapComponentOption).max = parseFloat(options.max)
     } else if (context.series && context.series[0]) {
-      // second-last element, last element is the unit
-      ;(options as VisualMapComponentOption).max = Math.max(...(context.series[0].data as number[][]).map((p) => p[p.length - 2]))
+      ;(options as VisualMapComponentOption).max = Math.max(...(context.series[0].data as number[][]).map((p) => p[p.length - 1]))
     }
 
     if (!options.formatter && context.numberFormatter) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-aggregate-series.ts
@@ -159,14 +159,13 @@ const aggregateSeries: SeriesComponent = {
         return [
           dimensionFromDate(chartType, startTime, endTime, arr[0], axisX),
           dimensionFromDate(chartType, startTime, endTime, arr[0], axisY, true),
-          formatter.format(value),
-          itemSeries?.unit
+          formatter.format(value)
         ]
       } else {
         if (series.transpose) {
-          return [formatter.format(value), dimensionFromDate(chartType, startTime, endTime, arr[0], dimension1, true), itemSeries?.unit]
+          return [formatter.format(value), dimensionFromDate(chartType, startTime, endTime, arr[0], dimension1, true)]
         } else {
-          return [dimensionFromDate(chartType, startTime, endTime, arr[0], dimension1), formatter.format(value), itemSeries?.unit]
+          return [dimensionFromDate(chartType, startTime, endTime, arr[0], dimension1), formatter.format(value)]
         }
       }
     })
@@ -176,13 +175,12 @@ const aggregateSeries: SeriesComponent = {
     if (series.type === OhAggregateSeries.Type.scatter) {
       const scatterSeries = series as ScatterSeriesOption & { scatterSymbolSizeFactor?: number }
       scatterSeries.symbolSize = (v: number[]) => {
-        const state = v[v.length - 2] // second-last element, last element is the unit
-        return state * (scatterSeries.scatterSymbolSizeFactor ?? 1)
+        return v.pop()! * (scatterSeries.scatterSymbolSizeFactor ?? 1)
       }
     }
 
     if (series.item) {
-      series.id = `oh-aggregate-series#${series.item}#${f7.utils.id()}`
+      series.id = `oh-aggregate-series#${series.item}#${itemSeries?.unit ?? ''}#${f7.utils.id()}`
     }
 
     series.data = data

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-calendar-series.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-calendar-series.ts
@@ -43,7 +43,7 @@ const calendarSeries: SeriesComponent = {
     const data = groups.map((arr, idx, days) => {
       const aggregationFunction = series.aggregationFunction || OhCalendarSeries.AggregationFunction.average
       let value = aggregate(aggregationFunction, arr, idx, days)
-      return [arr[0].toDate(), parseFloat(formatter.format(value)), itemSeries?.unit]
+      return [arr[0].toDate(), parseFloat(formatter.format(value))]
     })
 
     if (!series.type) (series.type as unknown as string) = OhCalendarSeries.Type.heatmap
@@ -52,13 +52,12 @@ const calendarSeries: SeriesComponent = {
     if (series.type === OhCalendarSeries.Type.scatter) {
       const scatterSeries = series as ScatterSeriesOption & { scatterSymbolSizeFactor?: number }
       scatterSeries.symbolSize = (v: number[]) => {
-        const state = v[v.length - 2] // second-last element, last element is the unit
-        return state * (scatterSeries.scatterSymbolSizeFactor ?? 1)
+        return v.pop()! * (scatterSeries.scatterSymbolSizeFactor ?? 1)
       }
     }
 
     if (series.item) {
-      series.id = `oh-calendar-series#${series.item}#${f7.utils.id()}`
+      series.id = `oh-calendar-series#${series.item}#${itemSeries?.unit ?? ''}#${f7.utils.id()}`
     }
 
     series.data = data

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.ts
@@ -34,9 +34,9 @@ const timeSeries: SeriesComponent = {
 
       const formatter = new Intl.NumberFormat('en', { useGrouping: false, maximumFractionDigits: 3 })
       series.data = itemPoints.map((p) => {
-        return [new Date(p.time), formatter.format(Number(p.state)), itemSeries?.unit]
+        return [new Date(p.time), formatter.format(Number(p.state))]
       })
-      series.id = `oh-time-series#${series.item}#${f7.utils.id()}`
+      series.id = `oh-time-series#${series.item}#${itemSeries?.unit ?? ''}#${f7.utils.id()}`
     }
 
     // other things


### PR DESCRIPTION
Fix visual map doesn't render colors.
Regression from #4169.

This fix reverts the passing of the unit with each datapoint from #4169. Instead, the unit is passed through the series id, which is more robust and should require less memory as well.