### PR TITLE
Widget editor: Fix code editor not full height in vertical split

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -91,7 +91,7 @@
   top 0
   height calc(100%)
   .code-editor-fit
-    height calc(100% - var(--f7-grid-gap))
+    height 100%
   .row
     height 100%
     .widget-preview
@@ -110,7 +110,7 @@
   &.horizontal
     .row
       height 50%
-    .vue-codemirror
+    .code-editor-fit
       height calc(100% - var(--f7-grid-gap))
 </style>
 


### PR DESCRIPTION
Regression from #4115.