### PR TITLE
Widget edit: Fix widget actions not available anymore

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/types.d.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/types.d.ts
@@ -65,6 +65,11 @@ export interface WidgetContext {
    * Whether the widget is displayed in a tab.
    */
   tab?: boolean
+  /**
+   * Disables the widget expression AST-cache.
+   * Useful when expressions change, but `editmode` is not intended.
+   */
+  noExpressionCache?: boolean
 
   parent?: WidgetContext
 }

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetContext.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetContext.ts
@@ -134,6 +134,7 @@ export function useWidgetContext(context: Ref<WidgetContext>) {
       config: context.value.config,
       editmode: context.value.editmode,
       clipboardtype: context.value.clipboardtype,
+      noExpressionCache: context.value.noExpressionCache,
       parent: context.value.parent
     } satisfies WidgetContext
   })
@@ -157,6 +158,7 @@ export function useWidgetContext(context: Ref<WidgetContext>) {
       config: context.value.config,
       editmode: context.value.editmode,
       clipboardtype: context.value.clipboardtype,
+      noExpressionCache: context.value.noExpressionCache,
       parent: context.value
     }
   }

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetExpression.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetExpression.ts
@@ -163,7 +163,7 @@ export function useWidgetExpression(properties: { context?: WidgetContext; props
       try {
         // we cache the parsed abstract tree to prevent it from being parsed again at runtime
         // if we are in edit-mode according to the context, do not cache because the expression is subject to change
-        if (!exprAst[key] || ctx.editmode) {
+        if (!exprAst[key] || ctx.editmode || ctx.noExpressionCache) {
           exprAst[key] = parse(value.substring(1))
         }
         return evaluate(exprAst[key], {

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-edit.vue
@@ -169,23 +169,6 @@ export default {
     }
   },
   computed: {
-    editmode() {
-      return {
-        isEditable: this.isEditable,
-        addWidget: this.noopEditmodeAction,
-        configureWidget: this.noopEditmodeAction,
-        configureSlot: this.noopEditmodeAction,
-        editWidgetCode: this.noopEditmodeAction,
-        cutWidget: this.noopEditmodeAction,
-        copyWidget: this.noopEditmodeAction,
-        pasteWidget: this.noopEditmodeAction,
-        moveWidgetUp: this.noopEditmodeAction,
-        moveWidgetDown: this.noopEditmodeAction,
-        sendWidgetToBack: this.noopEditmodeAction,
-        bringWidgetToFront: this.noopEditmodeAction,
-        removeWidget: this.noopEditmodeAction
-      }
-    },
     context() {
       return {
         component:
@@ -207,7 +190,7 @@ export default {
         props: this.props,
         vars: this.vars,
         ctxVars: this.ctxVars,
-        editmode: this.editmode
+        noExpressionCache: true
       }
     },
     isEditable() {
@@ -224,7 +207,6 @@ export default {
     }
   },
   methods: {
-    noopEditmodeAction() {},
     onPageAfterIn() {
       if (window) {
         window.addEventListener('keydown', this.keyDown)


### PR DESCRIPTION
Fixes #4226.

Regression from #4134.
While expressions shouldn't be cached in the widget editor, editmode was never activated for the widget preview. Revert the activation of editmode, instead add a new flag to the WidgetContext to disable the AST-cache.