### PR TITLE
Code editor: Add `input` to globals for JS linter

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/editor/editor-languages.ts
+++ b/bundles/org.openhab.ui/web/src/components/config/editor/editor-languages.ts
@@ -145,10 +145,12 @@ function linterExtension(mode: string): Extension | null {
         languageOptions: {
           globals: {
             ...globals.node,
-            // context:
+            // rule context:
             ctx: 'readonly',
             event: 'readonly',
             ruleUID: 'readonly',
+            // transformation context:
+            input: 'readonly',
             // openhab-js namespaces:
             Java: 'readonly',
             actions: 'readonly',


### PR DESCRIPTION
Fixes an issue where ESLint flags `input` as undefined in JS script transformations.

Reported on the community: 
https://community.openhab.org/t/openhab-5-2-milestone-discussion/168410/168