### PR TITLE
Semantic tag editor use conversion REST API

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/media-types.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/media-types.ts
@@ -28,7 +28,7 @@ export const DefaultMediaTypes = {
  * Specific media types supported additionally to the {@link DefaultMediaTypes} for specific configuration.
  */
 export const SupportedMediaTypes = {
-  semanticTags: {
+  tags: {
     YAML: MediaType.TAG_YAML
   },
   items: {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/media-types.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/media-types.ts
@@ -5,6 +5,7 @@ export enum MediaType {
   JSON = 'application/json',
   JAVASCRIPT = 'application/javascript',
   // openHAB vendor specific:
+  TAG_YAML = 'application/yaml+tag',
   THING_YAML = 'application/yaml+thing',
   ITEM_YAML = 'application/yaml+item',
   THING_DSL = 'text/vnd.openhab.dsl.thing',
@@ -27,6 +28,9 @@ export const DefaultMediaTypes = {
  * Specific media types supported additionally to the {@link DefaultMediaTypes} for specific configuration.
  */
 export const SupportedMediaTypes = {
+  semanticTags: {
+    YAML: MediaType.TAG_YAML
+  },
   items: {
     YAML: MediaType.ITEM_YAML,
     DSL: MediaType.ITEM_DSL

--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -134,7 +134,7 @@ export default {
     Editor
   },
   props: {
-    object: Object,
+    object: [Object, Array],
     objectType: String, // the type of the object, e.g. 'items', 'things' which corresponds to the yaml element name.
     objectId: String,
     hintContext: Object,

--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -11,7 +11,7 @@
       @save="$emit('save')" />
   </div>
 
-  <f7-toolbar bottom class="code-editor-toolbar">
+  <f7-toolbar bottom :class="{ 'code-editor-toolbar': true, 'toolbar-narrow': $f7dim.width < 450 }">
     <f7-segmented>
       <f7-button
         v-for="type in Object.keys(mediaTypes)"
@@ -23,13 +23,15 @@
         {{ type }}
       </f7-button>
     </f7-segmented>
+    <slot name="additional-panel-controls" />
     <f7-button
       @click="copy"
       icon-ios="f7:square_on_square"
       icon-aurora="f7:square_on_square"
       color="blue"
+      tooltip="Copy code to clipboard"
       class="copy display-flex flex-direction-row">
-      &nbsp;Copy
+      &nbsp;{{ $f7dim.width < 390 ? '' : 'Copy' }}
     </f7-button>
     <f7-button
       v-if="!readOnly"
@@ -38,8 +40,9 @@
       icon-ios="f7:arrow_2_circlepath"
       icon-aurora="f7:arrow_2_circlepath"
       color="red"
+      tooltip="Revert local changes to the code"
       class="reset display-flex flex-direction-row">
-      &nbsp;Revert
+      &nbsp;{{ $f7dim.width < 390 ? '' : 'Revert' }}
     </f7-button>
   </f7-toolbar>
 
@@ -75,9 +78,36 @@
   position absolute
   .toolbar-inner
     padding-left 8px
+    .toolbar-options
+      align-items center
+      gap 8px
+      .opt-show-all
+        flex-wrap nowrap
+        align-items center
+        flex-direction row
+        span
+          white-space nowrap
+          padding-left 4px
   .segmented
     .button
       width 5em
+
+.code-editor-toolbar.toolbar-narrow
+  --f7-toolbar-height var(--f7-tabbar-labels-height);
+  font-size var(--f7-tabbar-label-font-size)
+  .toolbar-inner
+    padding-left 5px
+    .toolbar-options
+      gap 6px
+      .opt-show-all
+        flex-wrap nowrap
+        align-items center
+        flex-direction column
+        span
+          padding-left 0
+  .segmented
+    .button
+      width auto
 
 .code-editor-errors
   .item-title
@@ -120,7 +150,6 @@ export default {
     return {
       code: null,
       originalCode: null,
-      displayCodeSwitcher: false,
       dirty: false,
       errors: null
     }
@@ -147,18 +176,21 @@ export default {
      *
      * @param {string} codeType - Optional. The type of code to generate (e.g. YAML, DSL)
      * @param {function} onSuccessCallback - Optional. A callback function to call when the code has been generated
-     * @param {object} sourceObject - Optional. The object to generate code from. Defaults to the current prop value.
      */
-    generateCode(codeType, onSuccessCallback, sourceObject = this.object) {
+    generateCode(codeType, onSuccessCallback) {
       codeType ||= this.uiOptionsStore.codeEditorType
       if (!this.mediaTypes[codeType]) {
         codeType = Object.keys(this.mediaTypes)[0]
       }
       const sourceMediaType = MediaType.JSON
       let targetMediaType = this.mediaTypes[codeType]
-      targetMediaType = targetMediaType.split('+')[0] // remove the +thing or +item suffix, if present
+      targetMediaType = targetMediaType.split('+')[0] // remove the +tag, +thing or +item suffix, if present
       const payload = {}
-      payload[this.objectType] = [sourceObject]
+      if (Array.isArray(this.object)) {
+        payload[this.objectType] = this.object
+      } else {
+        payload[this.objectType] = [this.object]
+      }
       this.$oh.api
         .postPlain('/rest/file-format/create', JSON.stringify(payload), null, sourceMediaType, { accept: targetMediaType })
         .then((code) => {
@@ -184,10 +216,11 @@ export default {
      *
      * @param {function} onSuccessCallback - Optional. A callback function to call when the code has been parsed. Receives the parsed object.
      * @param {function} onFailureCallback - Optional. A callback function to call when parsing fails or no object is found
+     * @param {boolean} parseAll - Optional. If true, all parsed objects will be returned as an array. By default, only the first object is returned for backward compatibility with existing code that expects a single object.
      */
-    parseCode(onSuccessCallback, onFailureCallback) {
+    parseCode(onSuccessCallback, onFailureCallback, parseAll = false) {
       let sourceMediaType = this.mediaTypes[this.uiOptionsStore.codeEditorType]
-      sourceMediaType = sourceMediaType.split('+')[0] // remove the +thing or +item suffix, if present
+      sourceMediaType = sourceMediaType.split('+')[0] // remove the +tag, +thing or +item suffix, if present
       const targetMediaType = MediaType.JSON
       this.$oh.api
         .request({
@@ -206,9 +239,16 @@ export default {
           }
           object = object[this.objectType]
           if (object?.length > 0) {
-            this.$emit('parsed', object[0])
-            if (onSuccessCallback) {
-              onSuccessCallback(object[0])
+            if (parseAll) {
+              this.$emit('parsed', object)
+              if (onSuccessCallback) {
+                onSuccessCallback(object)
+              }
+            } else {
+              this.$emit('parsed', object[0])
+              if (onSuccessCallback) {
+                onSuccessCallback(object[0])
+              }
             }
           } else {
             if (onFailureCallback) {
@@ -257,11 +297,13 @@ export default {
     switchCodeType(type) {
       if (this.uiOptionsStore.codeEditorType === type) return
 
-      if (this.readOnly || !this.dirty) {
+      if (!this.dirty) {
         this.generateCode(type)
       } else {
-        this.parseCode((parsedObject) => {
-          this.generateCode(type, null, parsedObject)
+        this.parseCode(() => {
+          this.$nextTick(() => {
+            this.generateCode(type)
+          })
         })
       }
     },

--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -11,7 +11,7 @@
       @save="$emit('save')" />
   </div>
 
-  <f7-toolbar bottom :class="{ 'code-editor-toolbar': true, 'toolbar-narrow': $f7dim.width < 450 }">
+  <f7-toolbar bottom class="code-editor-toolbar">
     <f7-segmented>
       <f7-button
         v-for="type in Object.keys(mediaTypes)"
@@ -31,7 +31,7 @@
       color="blue"
       tooltip="Copy code to clipboard"
       class="copy display-flex flex-direction-row">
-      &nbsp;{{ $f7dim.width < 390 ? '' : 'Copy' }}
+      <span class="button-label">Copy</span>
     </f7-button>
     <f7-button
       v-if="!readOnly"
@@ -42,7 +42,7 @@
       color="red"
       tooltip="Revert local changes to the code"
       class="reset display-flex flex-direction-row">
-      &nbsp;{{ $f7dim.width < 390 ? '' : 'Revert' }}
+      <span class="button-label">Revert</span>
     </f7-button>
   </f7-toolbar>
 
@@ -90,24 +90,26 @@
           padding-left 4px
   .segmented
     .button
-      width 5em
-
-.code-editor-toolbar.toolbar-narrow
-  --f7-toolbar-height var(--f7-tabbar-labels-height);
-  font-size var(--f7-tabbar-label-font-size)
-  .toolbar-inner
-    padding-left 5px
-    .toolbar-options
-      gap 6px
-      .opt-show-all
-        flex-wrap nowrap
-        align-items center
-        flex-direction column
-        span
-          padding-left 0
-  .segmented
-    .button
       width auto
+  .button-label
+    margin-left 4px
+
+@media (max-width: 475px)
+  .code-editor-toolbar
+    --f7-toolbar-height var(--f7-tabbar-labels-height)
+    font-size var(--f7-tabbar-label-font-size)
+    .button-label
+      display none
+    .toolbar-inner
+      padding-left 5px
+      .toolbar-options
+        gap 6px
+        .opt-show-all
+          flex-wrap nowrap
+          align-items center
+          flex-direction column
+          span
+            padding-left 0
 
 .code-editor-errors
   .item-title

--- a/bundles/org.openhab.ui/web/src/components/tags/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/treeview-item.vue
@@ -1,6 +1,7 @@
 <template>
   <f7-treeview-item
     selectable
+    :class="{ 'invalid-drop-target': canDragDrop && moveState.moving && !canAcceptDrop }"
     :label="tag.label + (showNames && tag.name ? ' (' + tag.name + ')' : '')"
     :icon-ios="icon('ios')"
     :icon-aurora="icon('aurora')"
@@ -8,7 +9,7 @@
     :iconColor="iconColor"
     :textColor="iconColor"
     :selected="!picker && selected"
-    :opened="expandedTags[tag.uid]"
+    :opened="!!expandedTags[tag.uid]"
     :toggle="canHaveChildren"
     @treeview:open="setTagOpened(true)"
     @treeview:close="setTagOpened(false)"
@@ -58,6 +59,11 @@
 <style lang="stylus">
 .semantic-tag-tooltip-badge
   background: transparent
+
+.invalid-drop-target
+  opacity 0.45
+  .treeview-item-content
+    cursor not-allowed
 </style>
 
 <script>
@@ -70,7 +76,7 @@ export default {
   name: 'semantics-treeview-item',
   props: {
     semanticTags: Array,
-    expandedTags: Array,
+    expandedTags: Object,
     tag: Object,
     picker: Boolean,
     showNames: Boolean,
@@ -101,6 +107,9 @@ export default {
     },
     canHaveChildren() {
       return (this.children.length > 0 || this.moveState.moving) === true
+    },
+    canAcceptDrop() {
+      return !!(this.tag.defaultTag || this.tag.editable)
     },
     synonyms() {
       return this.tag?.synonyms?.join(', ') || ''
@@ -138,6 +147,15 @@ export default {
     setTagOpened(opened, uid) {
       const tagUid = uid || this.tag.uid
       this.expandedTags[tagUid] = opened
+      if (!opened && this.selectedTag) {
+        let selectedParentUid = this.selectedTag?.parent
+        while (selectedParentUid) {
+          if (!this.expandedTags[selectedParentUid]) {
+            this.$emit('selected', null)
+          }
+          selectedParentUid = this.semanticTags.find((tag) => tag.uid === selectedParentUid)?.parent
+        }
+      }
     },
     onDragStart(event) {
       console.debug('Drag start event:', event)
@@ -161,17 +179,30 @@ export default {
     },
     onDragMove(event) {
       console.debug('Drag move - event:', event)
+      const moveTarget = event.relatedContext?.element
+      if (!moveTarget) return true
+
+      const canAcceptDrop = moveTarget.editable || moveTarget.defaultTag
+      if (!canAcceptDrop) {
+        clearTimeout(this.moveState.moveDelayedOpen)
+        this.moveState.moveDelayedOpen = null
+        this.moveState.moveTarget = null
+        return false
+      }
+
       // Cancel opening previous group we moved over as we moved away from it
-      const movedToSamePlace = event.relatedContext?.element?.uid === this.moveState.moveTarget?.uid
+      const movedToSamePlace = moveTarget.uid === this.moveState.moveTarget?.uid
       if (!movedToSamePlace) {
         clearTimeout(this.moveState.moveDelayedOpen)
         this.moveState.moveDelayedOpen = null
       }
-      this.moveState.moveTarget = event.relatedContext?.element
+      this.moveState.moveTarget = moveTarget
+
       // Open group if not open yet, with a delay so you don't open it if you just drag over it
-      if (this.moveState.moveTarget && !this.moveState.moveTarget.opened) {
+      if (!this.expandedTags[moveTarget.uid] && !this.moveState.moveDelayedOpen) {
         this.moveState.moveDelayedOpen = setTimeout(() => {
-          this.setTagOpened(true, this.moveState.moveTarget.uid)
+          this.setTagOpened(true, moveTarget.uid)
+          this.moveState.moveDelayedOpen = null
         }, 1000)
       }
       return true

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -9,9 +9,19 @@
         @save="save()"
         :f7router />
     </f7-navbar>
-    <f7-toolbar tabbar position="top">
-      <f7-link @click="switchTab('tree', switchTabTree)" :tab-link-active="currentTab === 'tree'"> Design </f7-link>
-      <f7-link @click="switchTab('code', switchTabCode)" :tab-link-active="currentTab === 'code'"> Code </f7-link>
+    <f7-toolbar tabbar position="top" class="semantics-editor-tabbar">
+      <f7-link
+        @click="switchTab('tree', switchTabTree)"
+        :tab-link-active="currentTab === 'tree'"
+        :class="{ 'semantics-tab-active': currentTab === 'tree' }">
+        Design
+      </f7-link>
+      <f7-link
+        @click="switchTab('code', switchTabCode)"
+        :tab-link-active="currentTab === 'code'"
+        :class="{ 'semantics-tab-active': currentTab === 'code' }">
+        Code
+      </f7-link>
     </f7-toolbar>
     <f7-toolbar v-if="currentTab === 'tree'" bottom class="toolbar-details">
       <f7-link class="left" :class="{ disabled: selectedTag == null }" @click="selectTag(null)"> Clear </f7-link>
@@ -315,6 +325,12 @@
   .design
     --f7-grid-gap 0px
     overflow auto
+
+.semantics-editor-tabbar
+  .link
+    border-bottom 2px solid transparent
+  .link.semantics-tab-active
+    border-bottom-color var(--f7-tabbar-link-active-border-color)
 
 .semantics-tree-wrapper
   padding 0

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -10,8 +10,8 @@
         :f7router />
     </f7-navbar>
     <f7-toolbar tabbar position="top">
-      <f7-link @click="switchTab('tree')" :tab-link-active="currentTab === 'tree'" tab-link="#tree"> Design </f7-link>
-      <f7-link @click="switchTab('code')" :tab-link-active="currentTab === 'code'" tab-link="#code"> Code </f7-link>
+      <f7-link @click="switchTab('tree', switchTabTree)" :tab-link-active="currentTab === 'tree'"> Design </f7-link>
+      <f7-link @click="switchTab('code', switchTabCode)" :tab-link-active="currentTab === 'code'"> Code </f7-link>
     </f7-toolbar>
     <f7-toolbar v-if="currentTab === 'tree'" bottom class="toolbar-details">
       <f7-link class="left" :class="{ disabled: selectedTag == null }" @click="selectTag(null)"> Clear </f7-link>
@@ -38,7 +38,7 @@
       </div>
     </f7-toolbar>
     <f7-tabs class="semantics-editor-tabs">
-      <f7-tab class="design" id="tree" :tab-active="currentTab === 'tree'">
+      <f7-tab class="design" id="tree" :tab-active="currentTab === 'tree' ? true : null">
         <f7-block v-if="!ready" class="text-align-center">
           <f7-preloader />
           <div>Loading...</div>
@@ -139,7 +139,7 @@
                         :disabled="!selectedTag.editable"
                         :clear-button="selectedTag.editable"
                         placeholder="synonym"
-                        @change="updateSynonyms($event, index)" />
+                        @change="updateSynonym($event, index)" />
                       <f7-list-input
                         :value="newSynonym"
                         :disabled="!selectedTag.editable"
@@ -151,7 +151,7 @@
                   </f7-card-content>
                 </f7-card>
               </f7-block>
-              <f7-block v-if="selectedTag">
+              <f7-block v-if="selectedTag && (selectedTag.editable || selectedTag.defaultTag)">
                 <div><f7-block-title>Add Child Tag</f7-block-title></div>
                 <f7-card>
                   <f7-card-content>
@@ -168,14 +168,51 @@
           </f7-row>
         </f7-block>
       </f7-tab>
-      <f7-tab id="code" :tab-active="currentTab === 'code'">
-        <editor
+      <f7-tab id="code" :tab-active="currentTab === 'code' ? true : null">
+        <code-editor
           v-if="ready"
-          class="semantic-tag-code-editor"
-          mode="application/vnd.openhab.tag+yaml"
-          :value="editingTagsYaml"
-          @input="onEditorInput"
-          @save="save()" />
+          ref="codeEditor"
+          object-type="tags"
+          :read-only="editorReadOnly"
+          :read-only-msg="
+            showCodeTags === 'custom'
+              ? 'Showing non-editable tags, switch to editable to edit'
+              : showCodeTags === 'all'
+                ? 'Showing default tags, switch to editable to edit'
+                : ''
+          "
+          :object="codeEditorTags"
+          @parsed="update"
+          @changed="onCodeChanged">
+          <template #additional-panel-controls>
+            <f7-segmented>
+              <f7-button
+                outline
+                small
+                :active="showCodeTags === 'editable'"
+                tooltip="Show all editable tags"
+                @click="switchCodeTags('editable')">
+                Editable
+              </f7-button>
+              <f7-button
+                outline
+                small
+                :active="showCodeTags === 'custom'"
+                tooltip="Show all user defined tags"
+                @click="switchCodeTags('custom')">
+                Custom
+              </f7-button>
+              <f7-button
+                outline
+                small
+                :active="showCodeTags === 'all'"
+                tooltip="Show all tags, including default tags"
+                @click="switchCodeTags('all')">
+                All
+              </f7-button>
+            </f7-segmented>
+          </template>
+        </code-editor>
       </f7-tab>
     </f7-tabs>
 
@@ -245,7 +282,7 @@
               :disabled="!selectedTag.editable ? true : null"
               :clear-button="selectedTag.editable"
               placeholder="synonym"
-              @change="updateSynonyms($event, index)" />
+              @change="updateSynonym($event, index)" />
             <f7-list-input
               :value="newSynonym"
               :disabled="!selectedTag.editable ? true : null"
@@ -288,7 +325,6 @@
 
 .semantics-tree
   padding 0
-  border-right 1px solid var(--f7-block-strong-border-color)
   --f7-theme-color var(--f7-color-blue)
   --f7-theme-color-rgb var(--f7-color-blue-rgb)
   .treeview
@@ -317,6 +353,7 @@
         width 50% /* manually set column width because of https://github.com/openhab/openhab-webui/issues/2574 */
         height 100%
         overflow auto
+        border-right 1px solid var(--f7-block-strong-border-color)
         .semantics-tree
           margin 0
           height auto
@@ -350,15 +387,15 @@
 </style>
 
 <script>
-import { defineAsyncComponent } from 'vue'
+import { nextTick, defineAsyncComponent } from 'vue'
 import { f7, theme } from 'framework7-vue'
 import { mapStores } from 'pinia'
 
-import YAML from 'yaml'
 import fastDeepEqual from 'fast-deep-equal/es6'
 import SemanticsTreeview from '@/components/tags/semantics-treeview.vue'
 import TagMixin from '@/components/tags/tag-mixin'
 import { useDirty } from '@/pages/useDirty'
+import { useTabs } from '@/pages/useTabs'
 
 import { i18n } from '@/js/i18n'
 
@@ -369,26 +406,29 @@ export default {
   mixins: [TagMixin],
   components: {
     SemanticsTreeview,
-    editor: defineAsyncComponent(() => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue'))
+    CodeEditor: defineAsyncComponent(() => import(/* webpackChunkName: "code-editor" */ '@/components/config/controls/code-editor.vue'))
   },
   props: {
     f7router: Object
   },
   setup() {
-    const { dirty, dirtyIndicator } = useDirty('semantic-tags-edit-page')
+    const { currentTab, switchTab } = useTabs('tree')
+    const { dirty, dirtyIndicator, setupDirtyWatch } = useDirty('semantic-tags-edit-page')
     return {
       theme,
       dirty,
-      dirtyIndicator
+      dirtyIndicator,
+      setupDirtyWatch,
+      currentTab,
+      switchTab
     }
   },
   data() {
     return {
       semanticTags: [],
       selectedTag: null,
-      expandedTags: [],
+      expandedTags: {},
       newSynonym: '',
-      currentTab: 'tree',
       detailsTab: 'tag',
       detailsOpened: false,
       loading: false,
@@ -397,24 +437,44 @@ export default {
       expanded: false,
       filtering: false,
       expandedBeforeFiltering: false,
-      editableSemanticTagsYaml: null,
-      editingTagsYaml: null,
-      nonCodeDirty: false, // When editing code, keeps track if it was already dirty before switching to code tab
-      ready: false
+      ready: false,
+      codeDirty: false,
+      showCodeTags: 'editable'
     }
   },
   computed: {
-    ...mapStores(useSemanticsStore)
+    ...mapStores(useSemanticsStore),
+    editableTags() {
+      return this.semanticTags.filter((t) => t.editable).sort((a, b) => a.uid.localeCompare(b.uid))
+    },
+    customTags() {
+      return this.semanticTags.filter((t) => !t.defaultTag)
+    },
+    codeTagsToShow() {
+      if (this.showCodeTags === 'all') return this.semanticTags
+      if (this.showCodeTags === 'custom') return this.customTags
+      if (this.showCodeTags === 'editable') return this.editableTags
+      return []
+    },
+    codeEditorTags() {
+      return this.codeTagsToShow
+        .map((t) => {
+          const uid = (t.parent ? t.parent + '_' : '') + t.name
+          return {
+            uid: uid,
+            label: t.label,
+            description: t.description,
+            synonyms: [...t.synonyms]
+          }
+        })
+        .sort((a, b) => a.uid.localeCompare(b.uid))
+    },
+    editorReadOnly() {
+      if (this.showCodeTags === 'editable') return false
+      return this.codeTagsToShow.some((t) => !t.editable)
+    }
   },
   watch: {
-    semanticTags: {
-      handler: function () {
-        if (!this.loading) {
-          this.dirty = true
-        }
-      },
-      deep: true
-    },
     'semanticsStore.ready': {
       handler: function (newValue, oldValue) {
         if (newValue) {
@@ -422,6 +482,11 @@ export default {
         }
       },
       immediate: true
+    },
+    currentTab(newTab, oldTab) {
+      if (oldTab === 'tree') {
+        this.$refs.detailsSheet?.$el?.f7Modal?.close?.()
+      }
     }
   },
   methods: {
@@ -441,40 +506,49 @@ export default {
         useSemanticsStore().loadSemantics(i18n)
       }
     },
-    onEditorInput(value) {
-      if (value !== this.editableSemanticTagsYaml) {
-        this.dirty = this.nonCodeDirty || true
-      } else {
-        this.dirty = this.nonCodeDirty || false
-      }
-      this.editingTagsYaml = value
+    async switchTabTree() {
+      if (!this.codeDirty) return true
+
+      // Delay switching to the tree tab until parsing succeeds.
+      return new Promise((resolve) => {
+        this.$refs.codeEditor.parseCode(
+          () => {
+            resolve(true)
+          },
+          () => {
+            resolve(false)
+          },
+          true
+        )
+      })
     },
-    switchTab(tab) {
-      if (this.currentTab === tab) return
-      // avoid error with existing details sheet when switching tabs
-      const sheet = this.$refs['details-sheet']?.$el.f7Modal
-      if (sheet?.opened) {
-        sheet.close()
-      }
-      if (tab === 'code') {
-        this.currentTab = tab
-        this.nonCodeDirty = this.dirty
-        this.selectTag(null)
-        this.editableSemanticTagsYaml = this.toYaml()
-        this.editingTagsYaml = this.editableSemanticTagsYaml
-      } else {
-        if (!this.fromYaml()) {
-          f7.dialog.alert('Error parsing YAML')
-          return
-        }
-        this.currentTab = tab
-      }
+    switchTabCode() {
+      // Switching to code tab: set immediately, then generate
+      this.codeDirty = false
+      nextTick(() => {
+        this.$refs.codeEditor?.generateCode?.()
+      })
     },
-    keyDown(ev) {
-      if (ev.keyCode === 83 && (ev.ctrlKey || ev.metaKey) && !(ev.altKey || ev.shiftKey)) {
-        this.save()
-        ev.stopPropagation()
-        ev.preventDefault()
+    switchCodeTags(showCodeTags) {
+      if (this.showCodeTags === showCodeTags) return
+
+      if (!this.codeDirty) {
+        this.showCodeTags = showCodeTags
+        this.$nextTick(() => {
+          this.$refs.codeEditor?.generateCode?.()
+        })
+      } else {
+        this.codeDirty = false
+        this.$refs.codeEditor?.parseCode(
+          () => {
+            this.showCodeTags = showCodeTags
+            this.$nextTick(() => {
+              this.$refs.codeEditor?.generateCode?.()
+            })
+          },
+          undefined,
+          true
+        )
       }
     },
     load() {
@@ -487,14 +561,15 @@ export default {
           name: t.name,
           label: useSemanticsStore().Labels[t.name],
           description: t.description,
-          synonyms: useSemanticsStore().Synonyms[t.name],
+          synonyms: [...useSemanticsStore().Synonyms[t.name]],
           editable: t.editable,
+          defaultTag: !!t.defaultTag,
           parent: t.parent
         }
       })
       this.semanticTags = tags
       this.$nextTick(() => {
-        this.dirty = false
+        this.setupDirtyWatch(() => this.editableTags)
         this.loading = false
         this.ready = true
       })
@@ -508,9 +583,8 @@ export default {
         }
       }
 
-      const editableTags = this.semanticTags.filter((t) => t.editable)
-      const addedTags = editableTags.filter((t) => !useSemanticsStore().Tags.find((c) => c.uid === t.uid))
-      const modifiedTags = editableTags.filter((t) => useSemanticsStore().Tags.find((c) => c.uid === t.uid && !fastDeepEqual(c, t)))
+      const addedTags = this.editableTags.filter((t) => !useSemanticsStore().Tags.find((c) => c.uid === t.uid))
+      const modifiedTags = this.editableTags.filter((t) => useSemanticsStore().Tags.find((c) => c.uid === t.uid && !fastDeepEqual(c, t)))
       const removedTags = useSemanticsStore().Tags.filter((c) => !this.semanticTags.find((t) => t.uid === c.uid))
       console.debug('Added: ', addedTags, 'Removed: ', removedTags, 'Modified: ', modifiedTags)
 
@@ -556,7 +630,6 @@ export default {
           console.debug('Successfully modified tags')
           showToast((changeTasks.length === 1 ? 'Tag' : 'Tags') + ' modified')
         }
-        this.dirty = false
         useSemanticsStore()
           .loadSemantics(i18n)
           .then(() => {
@@ -655,7 +728,7 @@ export default {
       }
       this.newSynonym = ''
     },
-    updateSynonyms(event, index) {
+    updateSynonym(event, index) {
       const newValue = event.target.value.trim()
       if (newValue) {
         this.selectedTag.synonyms.splice(index, 1, newValue)
@@ -668,40 +741,29 @@ export default {
         this.selectTag(null)
       }
     },
-    toYaml() {
-      const tags = this.semanticTags
-        .filter((t) => t.editable)
-        .map((t) => {
-          return {
-            name: t.name,
-            label: t.label,
-            description: t.description,
-            synonyms: [...t.synonyms],
-            parent: t.parent
-          }
-        })
-      return YAML.stringify(tags)
-    },
-    fromYaml() {
+    update(value) {
+      if (this.editorReadOnly) return
+
+      const selectedTagUid = this.selectedTag?.uid
       const tags = [...this.semanticTags].filter((t) => !t.editable)
-      const editableTags = this.semanticTags.filter((t) => t.editable)
-      try {
-        const updatedTags = YAML.parse(this.editingTagsYaml).map((t) => {
-          const tag = t
-          tag.editable = true
-          tag.uid = t.parent + '_' + t.name
-          return tag
-        })
-        if (fastDeepEqual(updatedTags, editableTags)) {
-          return true
-        }
-        tags.push(...updatedTags)
-      } catch (error) {
-        console.warn('Error parsing YAML')
-        return false
-      }
+      const updatedTags = value.map((t) => {
+        const tag = t
+        tag.name = tag.uid.split('_').slice(-1)[0]
+        tag.parent = tag.uid.split('_').slice(0, -1).join('_')
+        tag.editable = true
+        tag.defaultTag = false
+        return tag
+      })
+      tags.push(...updatedTags)
       this.semanticTags = tags
-      return true
+      if (selectedTagUid) {
+        this.selectedTag = this.semanticTags.find((t) => t.uid === selectedTagUid) || null
+      }
+      this.codeDirty = false
+    },
+    onCodeChanged(codeDirty) {
+      this.dirty = this.dirty || codeDirty
+      this.codeDirty = codeDirty
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -12,14 +12,12 @@
     <f7-toolbar tabbar position="top" class="semantics-editor-tabbar">
       <f7-link
         @click="switchTab('tree', switchTabTree)"
-        :tab-link-active="currentTab === 'tree'"
-        :class="{ 'semantics-tab-active': currentTab === 'tree' }">
+        :tab-link-active="currentTab === 'tree'">
         Design
       </f7-link>
       <f7-link
         @click="switchTab('code', switchTabCode)"
-        :tab-link-active="currentTab === 'code'"
-        :class="{ 'semantics-tab-active': currentTab === 'code' }">
+        :tab-link-active="currentTab === 'code'">
         Code
       </f7-link>
     </f7-toolbar>
@@ -329,7 +327,7 @@
 .semantics-editor-tabbar
   .link
     border-bottom 2px solid transparent
-  .link.semantics-tab-active
+  .link.tab-link-active
     border-bottom-color var(--f7-tabbar-link-active-border-color)
 
 .semantics-tree-wrapper

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -38,7 +38,7 @@
       </div>
     </f7-toolbar>
     <f7-tabs class="semantics-editor-tabs">
-      <f7-tab class="design" id="tree" :tab-active="currentTab === 'tree' ? true : null">
+      <f7-tab class="design" id="tree" :tab-active="currentTab === 'tree'">
         <f7-block v-if="!ready" class="text-align-center">
           <f7-preloader />
           <div>Loading...</div>
@@ -168,7 +168,7 @@
           </f7-row>
         </f7-block>
       </f7-tab>
-      <f7-tab id="code" :tab-active="currentTab === 'code' ? true : null">
+      <f7-tab id="code" :tab-active="currentTab === 'code'">
         <code-editor
           v-if="ready"
           ref="codeEditor"
@@ -183,7 +183,8 @@
           "
           :object="codeEditorTags"
           @parsed="update"
-          @changed="onCodeChanged">
+          @changed="onCodeChanged"
+          @save="save">
           <template #additional-panel-controls>
             <f7-segmented>
               <f7-button
@@ -426,7 +427,7 @@ export default {
   data() {
     return {
       semanticTags: [],
-      selectedTag: null,
+      selectedTagUid: null,
       expandedTags: {},
       newSynonym: '',
       detailsTab: 'tag',
@@ -444,6 +445,9 @@ export default {
   },
   computed: {
     ...mapStores(useSemanticsStore),
+    selectedTag() {
+      return this.semanticTags.find((t) => t.uid === this.selectedTagUid) || null
+    },
     editableTags() {
       return this.semanticTags.filter((t) => t.editable).sort((a, b) => a.uid.localeCompare(b.uid))
     },
@@ -494,6 +498,7 @@ export default {
       if (window) {
         window.addEventListener('keydown', this.keyDown)
       }
+      this.setupDirtyWatch(() => this.editableTags)
     },
     onPageBeforeOut() {
       if (window) {
@@ -504,6 +509,13 @@ export default {
     onPageAfterOut() {
       if (this.dirty) {
         useSemanticsStore().loadSemantics(i18n)
+      }
+    },
+    keyDown(ev) {
+      if (ev.keyCode === 83 && (ev.ctrlKey || ev.metaKey) && !(ev.altKey || ev.shiftKey)) {
+        this.save()
+        ev.stopPropagation()
+        ev.preventDefault()
       }
     },
     async switchTabTree() {
@@ -569,19 +581,33 @@ export default {
       })
       this.semanticTags = tags
       this.$nextTick(() => {
-        this.setupDirtyWatch(() => this.editableTags)
+        this.dirty = false
         this.loading = false
         this.ready = true
       })
     },
     async save() {
-      if (!this.dirty) return
-      if (this.currentTab === 'code') {
-        if (!this.fromYaml()) {
-          f7.dialog.alert('Error parsing YAML, cannot save')
+      if (this.currentTab === 'code' && this.codeDirty) {
+        const parsedSuccessfully = await new Promise((resolve) => {
+          this.$refs.codeEditor.parseCode(
+            () => {
+              resolve(true)
+            },
+            () => {
+              f7.dialog.alert('Error parsing YAML, cannot save')
+              resolve(false)
+            },
+            true
+          )
+        })
+
+        if (!parsedSuccessfully) {
           return
         }
+
+        await this.$nextTick()
       }
+      if (!this.dirty) return
 
       const addedTags = this.editableTags.filter((t) => !useSemanticsStore().Tags.find((c) => c.uid === t.uid))
       const modifiedTags = this.editableTags.filter((t) => useSemanticsStore().Tags.find((c) => c.uid === t.uid && !fastDeepEqual(c, t)))
@@ -630,11 +656,8 @@ export default {
           console.debug('Successfully modified tags')
           showToast((changeTasks.length === 1 ? 'Tag' : 'Tags') + ' modified')
         }
-        useSemanticsStore()
-          .loadSemantics(i18n)
-          .then(() => {
-            this.load()
-          })
+        await useSemanticsStore().loadSemantics(i18n)
+        this.load()
       } catch (error) {
         console.error(error)
         f7.dialog.alert('Error saving: ' + error)
@@ -672,14 +695,14 @@ export default {
       }
     },
     selectTag(tag) {
-      if (this.selectedTag === tag) return
-      this.selectedTag = null
+      if (this.selectedTagUid === tag?.uid) return
       if (!tag) {
+        this.selectedTagUid = null
         this.detailsOpened = false
         return
       }
       this.$nextTick(() => {
-        this.selectedTag = tag
+        this.selectedTagUid = tag.uid
         this.detailsTab = 'tag'
         this.$nextTick(() => {
           const detailsLink = this.$refs.detailsLink
@@ -744,7 +767,6 @@ export default {
     update(value) {
       if (this.editorReadOnly) return
 
-      const selectedTagUid = this.selectedTag?.uid
       const tags = [...this.semanticTags].filter((t) => !t.editable)
       const updatedTags = value.map((t) => {
         const tag = t
@@ -756,9 +778,6 @@ export default {
       })
       tags.push(...updatedTags)
       this.semanticTags = tags
-      if (selectedTagUid) {
-        this.selectedTag = this.semanticTags.find((t) => t.uid === selectedTagUid) || null
-      }
       this.codeDirty = false
     },
     onCodeChanged(codeDirty) {

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -439,6 +439,7 @@ export default {
       filtering: false,
       expandedBeforeFiltering: false,
       ready: false,
+      tagsDirty: false,
       codeDirty: false,
       showCodeTags: 'editable'
     }
@@ -581,6 +582,7 @@ export default {
       })
       this.semanticTags = tags
       this.$nextTick(() => {
+        this.tagsDirty = this.codeDirty = false
         this.dirty = false
         this.loading = false
         this.ready = true
@@ -634,6 +636,7 @@ export default {
       const changeTasks = modifiedTags.map((t) => () => this.$oh.api.put('/rest/tags/' + t.uid, t))
       const removeTasks = removedTags.map((t) => () => this.$oh.api.delete('/rest/tags/' + t.uid))
       if (addTasks.length <= 0 && changeTasks.length <= 0 && removeTasks.length <= 0) {
+        this.tagsDirty = this.codeDirty = false
         this.dirty = false
         return
       }
@@ -778,10 +781,9 @@ export default {
       })
       tags.push(...updatedTags)
       this.semanticTags = tags
-      this.codeDirty = false
     },
     onCodeChanged(codeDirty) {
-      this.dirty = this.dirty || codeDirty
+      this.dirty = this.tagsDirty || codeDirty
       this.codeDirty = codeDirty
     }
   }

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -10,16 +10,8 @@
         :f7router />
     </f7-navbar>
     <f7-toolbar tabbar position="top" class="semantics-editor-tabbar">
-      <f7-link
-        @click="switchTab('tree', switchTabTree)"
-        :tab-link-active="currentTab === 'tree'">
-        Design
-      </f7-link>
-      <f7-link
-        @click="switchTab('code', switchTabCode)"
-        :tab-link-active="currentTab === 'code'">
-        Code
-      </f7-link>
+      <f7-link @click="switchTab('tree', switchTabTree)" :tab-link-active="currentTab === 'tree'"> Design </f7-link>
+      <f7-link @click="switchTab('code', switchTabCode)" :tab-link-active="currentTab === 'code'"> Code </f7-link>
     </f7-toolbar>
     <f7-toolbar v-if="currentTab === 'tree'" bottom class="toolbar-details">
       <f7-link class="left" :class="{ disabled: selectedTag == null }" @click="selectTag(null)"> Clear </f7-link>
@@ -415,7 +407,7 @@ import { useTabs } from '@/pages/useTabs'
 import { i18n } from '@/js/i18n'
 
 import { useSemanticsStore } from '@/js/stores/useSemanticsStore'
-import { showToast } from '@/js/dialog-promises'
+import { showToast, showAlertDialog } from '@/js/dialog-promises'
 
 export default {
   mixins: [TagMixin],
@@ -610,7 +602,7 @@ export default {
               resolve(true)
             },
             () => {
-              f7.dialog.alert('Error parsing YAML, cannot save')
+              showAlertDialog('Error parsing YAML, cannot save')
               resolve(false)
             },
             true
@@ -633,11 +625,11 @@ export default {
       if (
         addedTags.some((t) => {
           if (!t.name || !t.label || modifiedTags.some((t) => !t.name || !t.label)) {
-            f7.dialog.alert(`${t.name}: Tag name and label required`)
+            showAlertDialog(`${t.name}: Tag name and label required`)
             return true
           }
           if (useSemanticsStore().Tags.find((c) => c.name === t.name) && !removedTags.find((r) => r.name === t.name)) {
-            f7.dialog.alert(`${t.name}: Tag names must be unique`)
+            showAlertDialog(`${t.name}: Tag names must be unique`)
             return true
           }
           return false
@@ -677,7 +669,7 @@ export default {
         this.load()
       } catch (error) {
         console.error(error)
-        f7.dialog.alert('Error saving: ' + error)
+        showAlertDialog('Error saving: ' + error)
       }
     },
     toggleExpanded() {

--- a/bundles/org.openhab.ui/web/src/pages/useDirty.ts
+++ b/bundles/org.openhab.ui/web/src/pages/useDirty.ts
@@ -1,4 +1,4 @@
-import { ref, computed, type Ref, watch, onMounted, useTemplateRef } from 'vue'
+import { ref, computed, type Ref, type WatchSource, watch, onMounted, useTemplateRef } from 'vue'
 import type { Router } from 'framework7'
 import { showConfirmDialog } from '@/js/dialog-promises'
 import fastDeepEqual from 'fast-deep-equal/es6'
@@ -99,13 +99,14 @@ export function useDirty(pageRefOrName: string | Ref<PageRef> | null) {
    * @param value - The ref to watch for changes (typically your data model)
    * @param dirtyRef - Optional, currently unused (kept for API compatibility)
    */
-  function setupDirtyWatch(value: Ref<unknown>, dirtyRef?: Ref<boolean>) {
-    let pristineValue = cloneDeep(value.value)
+  function setupDirtyWatch(value: WatchSource<unknown>, dirtyRef?: Ref<boolean>) {
+    const getCurrentValue = () => (typeof value === 'function' ? value() : value.value)
+    let pristineValue = cloneDeep(getCurrentValue())
 
     watch(dirty, (newValue) => {
       if (!newValue) {
         // Update the pristine value when dirty is set to false, e.g. after saving
-        pristineValue = cloneDeep(value.value)
+        pristineValue = cloneDeep(getCurrentValue())
       }
     })
 

--- a/bundles/org.openhab.ui/web/src/pages/useTabs.ts
+++ b/bundles/org.openhab.ui/web/src/pages/useTabs.ts
@@ -3,13 +3,22 @@ import { ref } from 'vue'
 export function useTabs(initialTab: string = '') {
   const currentTab = ref(initialTab)
 
-  function switchTab(tab: string, onSuccessCallback?: () => void) {
-    if (currentTab.value !== tab) {
-      currentTab.value = tab
-      if (onSuccessCallback) {
-        onSuccessCallback()
-      }
+  function switchTab(tab: string, onSuccessCallback?: () => void | boolean | Promise<void | boolean>): boolean | Promise<boolean> {
+    if (currentTab.value === tab) return true
+
+    const callbackResult = onSuccessCallback?.()
+    if (callbackResult instanceof Promise) {
+      return callbackResult.then((resolvedValue) => {
+        if (resolvedValue === false) return false
+        currentTab.value = tab
+        return true
+      })
     }
+
+    if (callbackResult === false) return false
+
+    currentTab.value = tab
+    return true
   }
 
   return {


### PR DESCRIPTION
This enhances the semantic tag editor to use the new YAML conversion API introduced in: https://github.com/openhab/openhab-core/pull/5573

The logic in the treeview has been enhanced to only allow adding child tags inside a default tag or a managed tag to avoid issues of parent tags not being available when loading in core.

Not done in this PR, but a potential future enhancement: if tags are edited in the code editor, check the the parent-child relationships are still correct before accepting the change.

Here are some screenshots:

Show and edit editable (=managed) tags:

<img width="748" height="944" alt="image" src="https://github.com/user-attachments/assets/1b6052c8-6f25-4227-87be-f9d464f6abab" />

Show all custom tags (managed and unmanaged). If there are no unmanaged tags (nothing defined in files), this will be editable, if not this will be read-only:

<img width="752" height="942" alt="image" src="https://github.com/user-attachments/assets/bdbff550-3b5c-474d-bf88-b409093cd899" />

Show all tags, including the default tags. This will always be read-only:

<img width="750" height="938" alt="image" src="https://github.com/user-attachments/assets/52a84070-378f-4316-9a18-79681dba4c0f" />

