### PR TITLE
Update hard-coded `blue` elements to `theme-alt` style

### DIFF
--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -363,10 +363,10 @@
         :text="t('error.notReachable.msg') + '<br/><br/>Error: ' + communicationFailureMsg" />
       <f7-col>
         <f7-list>
-          <f7-list-button color="blue" @click="loadData">
+          <f7-list-button color="theme-alt" @click="loadData">
             {{ t('dialogs.retry') }}
           </f7-list-button>
-          <f7-list-button color="blue" @click="reload">
+          <f7-list-button color="theme-alt" @click="reload">
             {{ t('about.reload.reloadApp') }}
           </f7-list-button>
           <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches">
@@ -437,7 +437,7 @@
       .item-inner:before // chevron
         right var(--f7-list-item-padding-horizontal)
   .currentsection
-    background-color var(--f7-color-blue-tint)
+    background-color var(--oh-theme-alt-color-tint)
     color var(--f7-color-white)
     --f7-list-chevron-icon-color var(--f7-color-white)
     .icon
@@ -498,7 +498,7 @@
     .account
       background #232323 !important
     .currentsection
-      background-color var(--f7-color-blue-shade)
+      background-color var(--oh-theme-alt-color-shade)
   .openhab-logo
     .logo-inner
       background #111111 !important
@@ -510,7 +510,7 @@
   background-color red
   // --f7-list-item-media-margin 24px
   // --f7-list-item-padding-horizontal 32px
-  // --f7-list-chevron-icon-color var(--f7-color-blue-tint) !important
+  // --f7-list-chevron-icon-color var(--oh-theme-alt-color-tint) !important
 
 .section-toggle
   width 36px
@@ -547,7 +547,7 @@
   cursor ns-resize
   z-index 1
   &:hover
-    background var(--f7-color-blue)
+    background var(--oh-theme-alt-color)
     opacity 0.35
 
 .log-dock.fullscreen

--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -386,15 +386,6 @@
     .logo-inner
       background #111111 !important
 
-.menu-sublinks
-  color var(--f7-list-item-footer-text-color)
-  padding-left 0
-  margin-bottom var(--f7-list-margin-vertical)
-  background-color red
-  // --f7-list-item-media-margin 24px
-  // --f7-list-item-padding-horizontal 32px
-  // --f7-list-chevron-icon-color var(--oh-theme-alt-color-tint) !important
-
 .section-toggle
   width 36px
   color gray

--- a/bundles/org.openhab.ui/web/src/App.vue
+++ b/bundles/org.openhab.ui/web/src/App.vue
@@ -228,10 +228,10 @@
         :text="t('error.notReachable.msg') + '<br/><br/>Error: ' + communicationFailureMsg" />
       <f7-col>
         <f7-list>
-          <f7-list-button color="blue" @click="loadData">
+          <f7-list-button color="theme-alt" @click="loadData">
             {{ t('dialogs.retry') }}
           </f7-list-button>
-          <f7-list-button color="blue" @click="reload">
+          <f7-list-button color="theme-alt" @click="reload">
             {{ t('about.reload.reloadApp') }}
           </f7-list-button>
           <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches">
@@ -302,7 +302,7 @@
       .item-inner:before // chevron
         right var(--f7-list-item-padding-horizontal)
   .currentsection
-    background-color var(--f7-color-blue-tint)
+    background-color var(--oh-theme-alt-color-tint)
     color var(--f7-color-white)
     --f7-list-chevron-icon-color var(--f7-color-white)
     .icon
@@ -381,10 +381,19 @@
     .account
       background #232323 !important
     .currentsection
-      background-color var(--f7-color-blue-shade)
+      background-color var(--oh-theme-alt-color-shade)
   .openhab-logo
     .logo-inner
       background #111111 !important
+
+.menu-sublinks
+  color var(--f7-list-item-footer-text-color)
+  padding-left 0
+  margin-bottom var(--f7-list-margin-vertical)
+  background-color red
+  // --f7-list-item-media-margin 24px
+  // --f7-list-item-padding-horizontal 32px
+  // --f7-list-chevron-icon-color var(--oh-theme-alt-color-tint) !important
 
 .section-toggle
   width 36px
@@ -421,7 +430,7 @@
   cursor ns-resize
   z-index 1
   &:hover
-    background var(--f7-color-blue)
+    background var(--oh-theme-alt-color)
     opacity 0.35
 
 .log-dock.fullscreen

--- a/bundles/org.openhab.ui/web/src/assets/definitions/help/help-qstart-defs.json
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/help/help-qstart-defs.json
@@ -10,7 +10,7 @@
       },
       {
         "title": "Install",
-        "text": "Scroll to the Binding you need and click the <span style=\"background: var(--f7-list-item-border-color); border-radius: 20% / 100%; color: #2196f3; padding: 0 5px 0 5px\">INSTALL</span> button"
+        "text": "Scroll to the Binding you need and click the <span style=\"background: var(--f7-list-item-border-color); border-radius: 20% / 100%; color: var(--oh-theme-alt-color); padding: 0 5px 0 5px\">INSTALL</span> button"
       }
     ],
     "button": {
@@ -37,7 +37,7 @@
       },
       {
         "title": "Scan",
-        "text": "Click the <span style=\"background: #2196f3; border-radius: 3px; color: white; padding: 0 5px 0 5px\">Scan</span> button to automatically search for related devices"
+        "text": "Click the <span style=\"background: var(--oh-theme-alt-color); border-radius: 3px; color: white; padding: 0 5px 0 5px\">Scan</span> button to automatically search for related devices"
       },
       {
         "title": "Add Thing",
@@ -97,7 +97,7 @@
       },
       {
         "title": "Add Item",
-        "text": "Click the blue Link button at the bottom of the page"
+        "text": "Click the Link button at the bottom of the page"
       }
     ],
     "button": {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa/helpers.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/metadata/alexa/helpers.js
@@ -16,7 +16,7 @@ export const titleCase = (string) =>
 
 export const docLink = (title, anchor) => {
   const link = `%DOC_URL%#${anchor || title.replace(/[. ]/g, '-').toLowerCase()}`
-  return `<a class="external text-color-blue" target="_blank" href="${link}">${title}</a>`
+  return `<a class="external text-color-theme-alt" target="_blank" href="${link}">${title}</a>`
 }
 
 export const getGroupParameter = (parameter, groups = []) => {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.ts
@@ -127,7 +127,7 @@ export const actionParams = (paramPrefix?: string, groupName?: string) => {
     po(
       paramPrefix + 'actionPageTransition',
       'Transition Effect',
-      'Use a specific <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/view.html#custom-page-transitions">page transition animation</a>',
+      'Use a specific <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/view.html#custom-page-transitions">page transition animation</a>',
       [
         { value: 'f7-circle', label: 'Circle' },
         { value: 'f7-cover', label: 'Cover' },
@@ -158,14 +158,14 @@ export const actionParams = (paramPrefix?: string, groupName?: string) => {
     pt(
       paramPrefix + 'actionPhotos',
       'Images to show',
-      'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.'
+      'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.'
     ).v((_value, configuration) => {
       return actionSelected(configuration, 'photos')
     }),
     pt(
       paramPrefix + 'actionPhotoBrowserConfig',
       'Photo browser configuration',
-      'Configuration for the photo browser.<br />Edit in YAML or provide a JSON object, e.g.<br /><code>{ "exposition": false, "type": "popup", "theme": "dark" }</code><br /> See <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photo-browser-parameters">photo browser parameters</a> (not all are supported).'
+      'Configuration for the photo browser.<br />Edit in YAML or provide a JSON object, e.g.<br /><code>{ "exposition": false, "type": "popup", "theme": "dark" }</code><br /> See <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/photo-browser.html#photo-browser-parameters">photo browser parameters</a> (not all are supported).'
     ).v((_value, configuration) => {
       return actionSelected(configuration, 'photos')
     }),
@@ -222,7 +222,7 @@ export const actionParams = (paramPrefix?: string, groupName?: string) => {
     pt(
       paramPrefix + 'actionFeedback',
       'Action Feedback',
-      'Shows a toast popup when the action has been executed. Can either be a text to show or a JSON object including some of the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/toast.html#toast-parameters">supported parameters</a>'
+      'Shows a toast popup when the action has been executed. Can either be a text to show or a JSON object including some of the <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/toast.html#toast-parameters">supported parameters</a>'
     )
       .a()
       .v((_value, configuration) => {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.ts
@@ -127,7 +127,7 @@ export const actionParams = (groupName?: string, paramPrefix?: string) => {
     po(
       paramPrefix + 'actionPageTransition',
       'Transition Effect',
-      'Use a specific <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/view.html#custom-page-transitions">page transition animation</a>',
+      'Use a specific <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/view.html#custom-page-transitions">page transition animation</a>',
       [
         { value: 'f7-circle', label: 'Circle' },
         { value: 'f7-cover', label: 'Cover' },
@@ -158,14 +158,14 @@ export const actionParams = (groupName?: string, paramPrefix?: string) => {
     pt(
       paramPrefix + 'actionPhotos',
       'Images to show',
-      'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.'
+      'Array of URLs or objects representing the images. Auto-refresh is not supported.<br />Edit in YAML, e.g.<br /><code><pre>- item: ImageItem1<br />  caption: Camera</pre></code>or provide a JSON array, e.g.<br /><code>[ "url1", { "item": "ImageItem1", "caption": "Camera" } ]</code><br />Objects are in the <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/photo-browser.html#photos-array">photos array format</a> with an additional <code>item</code> property to specify an item to view.'
     ).v((_value, configuration) => {
       return actionSelected(configuration, 'photos')
     }),
     pt(
       paramPrefix + 'actionPhotoBrowserConfig',
       'Photo browser configuration',
-      'Configuration for the photo browser.<br />Edit in YAML or provide a JSON object, e.g.<br /><code>{ "exposition": false, "type": "popup", "theme": "dark" }</code><br /> See <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/photo-browser.html#photo-browser-parameters">photo browser parameters</a> (not all are supported).'
+      'Configuration for the photo browser.<br />Edit in YAML or provide a JSON object, e.g.<br /><code>{ "exposition": false, "type": "popup", "theme": "dark" }</code><br /> See <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/photo-browser.html#photo-browser-parameters">photo browser parameters</a> (not all are supported).'
     ).v((_value, configuration) => {
       return actionSelected(configuration, 'photos')
     }),
@@ -222,7 +222,7 @@ export const actionParams = (groupName?: string, paramPrefix?: string) => {
     pt(
       paramPrefix + 'actionFeedback',
       'Action Feedback',
-      'Shows a toast popup when the action has been executed. Can either be a text to show or a JSON object including some of the <a class="external text-color-blue" target="_blank" href="https://framework7.io/docs/toast.html#toast-parameters">supported parameters</a>'
+      'Shows a toast popup when the action has been executed. Can either be a text to show or a JSON object including some of the <a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/docs/toast.html#toast-parameters">supported parameters</a>'
     )
       .a()
       .v((_value, configuration) => {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/map/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/map/index.ts
@@ -23,18 +23,18 @@ export const OhMapPageDefinition = () =>
       'tileLayerProvider',
       'Provider for the background tiles',
       'The provider of tiles to use for the background of the map. ' +
-        'Use one from <a class="external text-color-blue" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>. ' +
+        'Use one from <a class="external text-color-theme-alt" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>. ' +
         'Some providers will not work until you set options, like access tokens, in the <code>tileLayerProviderOptions</code> parameter (in Code view). ' +
-        'See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. ' +
+        'See <a class="external text-color-theme-alt" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info. ' +
         'The default is CartoDB, the variant depending on the dark mode setting.'
     ),
     pt(
       'overlayTileLayerProvider',
       'Provider for the overlay tiles',
       'The provider of tiles to use for the overlay layer above the background of the map. ' +
-        'Use one from <a class="external text-color-blue" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>. ' +
+        'Use one from <a class="external text-color-theme-alt" target="_blank" href="https://leaflet-extras.github.io/leaflet-providers/preview/">Leaflet Providers</a>. ' +
         'Some providers will not work until you set options, like access tokens, in the <code>overlayTileLayerProviderOptions</code> parameter (in Code view). ' +
-        'See <a class="external text-color-blue" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info.'
+        'See <a class="external text-color-theme-alt" target="_blank" href="https://github.com/leaflet-extras/leaflet-providers#providers-requiring-registration">here</a> for more info.'
     )
   ])
 
@@ -45,7 +45,7 @@ export const OhMapMarkerDefinition = () =>
       pt(
         'icon',
         'Icon',
-        'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>)'
+        'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>)'
       )
     ])
     .paramGroup(pg('position', 'Position', 'Position'), [ItemParam(), LocationParam()])

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.ts
@@ -64,7 +64,7 @@ export const OhPlanMarkerDefinition = () =>
       pt(
         'visible',
         'Visibility',
-        'Enter an expression to dynamically show the marker, see <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/building-pages.html#widgets-definition-usage">Building Pages: <code>visible</code></a>'
+        'Enter an expression to dynamically show the marker, see <a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/docs/ui/building-pages.html#widgets-definition-usage">Building Pages: <code>visible</code></a>'
       )
     ])
     .paramGroup(
@@ -73,7 +73,7 @@ export const OhPlanMarkerDefinition = () =>
         pt(
           'icon',
           'Icon',
-          'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+          'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
         ),
         pb(
           'iconUseState',

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/plan/index.ts
@@ -80,7 +80,7 @@ export const OhPlanMarkerDefinition = () =>
       pt(
         'visible',
         'Visibility',
-        'Enter an expression to dynamically show the marker, see <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/building-pages.html#widgets-definition-usage">Building Pages: <code>visible</code></a>'
+        'Enter an expression to dynamically show the marker, see <a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/docs/ui/building-pages.html#widgets-definition-usage">Building Pages: <code>visible</code></a>'
       )
     ])
     .paramGroup(
@@ -89,7 +89,7 @@ export const OhPlanMarkerDefinition = () =>
         pt(
           'icon',
           'Icon',
-          'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+          'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
         ),
         pb(
           'iconUseState',

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.ts
@@ -51,7 +51,7 @@ export const OhLabelCardDefinition = () =>
       pt(
         'icon',
         'Icon',
-        'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+        'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
       ),
       pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons').a(),
       pn('iconSize', 'Icon Size', 'Size of the icon in px').a(),
@@ -120,7 +120,7 @@ export const OhGaugeCardDefinition = () =>
       pg(
         'gauge',
         'Gauge',
-        'Parameters are passed to the underlying <a target="_blank" class="external text-color-blue" href="https://framework7.io/vue/gauge.html#gauge-properties">gauge</a>'
+        'Parameters are passed to the underlying <a target="_blank" class="external text-color-theme-alt" href="https://framework7.io/vue/gauge.html#gauge-properties">gauge</a>'
       ),
       GaugeParameters()
     )
@@ -139,7 +139,7 @@ export const OhKnobCardDefinition = () =>
       pg(
         'knob',
         'Knob & Rounded Slider',
-        'Parameters are passed to the underlying <a target="_blank" class="external text-color-blue" href="https://github.com/Artem9989/vue-three-round-slider?tab=readme-ov-file#props">round-slider control</a>'
+        'Parameters are passed to the underlying <a target="_blank" class="external text-color-theme-alt" href="https://github.com/Artem9989/vue-three-round-slider?tab=readme-ov-file#props">round-slider control</a>'
       ),
       KnobParameters()
     )

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cells.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cells.ts
@@ -14,7 +14,7 @@ export const CellParameters = () => [
   pt(
     'icon',
     'Icon',
-    'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+    'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
   ),
   pt('color', 'Highlight Color', 'Color to use when highlighted'),
   pt(

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/listitems.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/listitems.ts
@@ -12,7 +12,7 @@ export const ListItemParameters = () => [
   pt(
     'icon',
     'Icon',
-    'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+    'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
   ),
   pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons').a(),
   pb(

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/button.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/button.ts
@@ -12,7 +12,7 @@ export default () => [
   pt(
     'iconF7',
     'Icon',
-    'Framework7 icon to display (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'
+    'Framework7 icon to display (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'
   ),
   pt('iconMaterial', 'Icon', 'Material design icon to display'),
   pt('iconColor', 'Icon Color', 'Not applicable to openHAB icons'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/clock.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/clock.ts
@@ -4,7 +4,7 @@ export default () => [
   pt(
     'timeFormat',
     'Time Format',
-    'Time format, see <a class="external text-color-blue" target="_blank" href="https://day.js.org/docs/en/display/format">dayjs docs</a>'
+    'Time format, see <a class="external text-color-theme-alt" target="_blank" href="https://day.js.org/docs/en/display/format">dayjs docs</a>'
   ).o(
     [
       { value: 'LTS', label: "Localized time including seconds ('LTS', e.g. '8:02:18 PM')" },
@@ -20,7 +20,7 @@ export default () => [
   pt(
     'dateFormat',
     'Date Format',
-    'Date format, see <a class="external text-color-blue" target="_blank" href="https://day.js.org/docs/en/display/format">dayjs docs</a>'
+    'Date format, see <a class="external text-color-theme-alt" target="_blank" href="https://day.js.org/docs/en/display/format">dayjs docs</a>'
   )
     .o(
       [

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/context.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/context.ts
@@ -14,6 +14,6 @@ export default () => [
   pt(
     'variables',
     'Widget Variables',
-    'Object with key:variable default value pairs. Variables are available to expressions in all child components via the <code>vars</code> object and take precedence over variables with the same name from higher contexts.<br />Variables are evaluated once before the widget is displayed the first time . Their values can only be changed by other component variable actions (e.g. <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/components/oh-button.html#action-variable">oh-button</a>)'
+    'Object with key:variable default value pairs. Variables are available to expressions in all child components via the <code>vars</code> object and take precedence over variables with the same name from higher contexts.<br />Variables are evaluated once before the widget is displayed the first time . Their values can only be changed by other component variable actions (e.g. <a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/docs/ui/components/oh-button.html#action-variable">oh-button</a>)'
   )
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/icon.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/icon.ts
@@ -4,14 +4,14 @@ export default () => [
   pt(
     'icon',
     'Icon',
-    '<code>oh:iconName</code> or <code>iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+    '<code>oh:iconName</code> or <code>iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
   ),
   pi('width', 'Width', 'Width of the icon in pixels'),
   pi('height', 'Height', 'Height of the icon in pixels'),
   pt(
     'color',
     'Color',
-    'Color of the icon (for F7/Material icons, a <a class="external text-color-blue" target="_blank" href="https://v5.framework7.io/docs/color-themes.html#colors">Framework7 color theme</a>, for Iconify icons, a CSS color). Not applicable to OH icons.'
+    'Color of the icon (for F7/Material icons, a <a class="external text-color-theme-alt" target="_blank" href="https://v5.framework7.io/docs/color-themes.html#colors">Framework7 color theme</a>, for Iconify icons, a CSS color). Not applicable to OH icons.'
   ),
   pb('inline', 'Inline', 'Display the icon inline (for Iconify icons only)'),
   pt('rotate', 'Rotate', 'Rotate the icon (for Iconify icons only; use a CSS value e.g. 90deg)'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/input.ts
@@ -37,7 +37,7 @@ export default () => [
   pt(
     'inputmode',
     'Input Mode',
-    'Type of data that might be entered (see <a class="external text-color-blue" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)'
+    'Type of data that might be entered (see <a class="external text-color-theme-alt" target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode">MDN docs</a>)'
   ),
   pt('placeholder', 'Placeholder', 'Placeholder text'),
   pb('sendButton', 'Send button', 'Display Send button to update the state with a command (needs a configured item)'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/link.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/link.ts
@@ -5,7 +5,7 @@ export default () => [
   pt(
     'iconF7',
     'Icon',
-    'Framework7 icon to display (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'
+    'Framework7 icon to display (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>)'
   ),
   pt('iconMaterial', 'Icon', 'Material design icon to display'),
   pt('iconColor', 'Icon Color', 'Color of the icon'),

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/trend.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/trend.ts
@@ -7,7 +7,7 @@ export default () => [
   pt(
     'trendGradient',
     'Trend Line Gradient',
-    'Colors of the trend line (see <a target="_blank" class="external text-color-blue" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)'
+    'Colors of the trend line (see <a target="_blank" class="external text-color-theme-alt" href="https://github.com/QingWei-Li/vue-trend#props">vue-trend</a>)'
   ).a(),
   po('trendGradientDirection', 'Trend Line Gradient Direction', 'Direction of the trend line gradient (default: top)', [
     { value: 'top', label: 'top' },

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/tabs/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/tabs/index.ts
@@ -8,7 +8,7 @@ export const OhTabDefinition = () =>
     pt(
       'icon',
       'Icon',
-      'Use <code>oh:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-blue" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
+      'Use <code>oh:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/link/icons">openHAB icon</a>), <code>f7:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://framework7.io/icons/">Framework7 icon</a>), <code>material:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://jossef.github.io/material-design-icons-iconfont/">Material icon</a>) or <code>iconify:iconSet:iconName</code> (<a class="external text-color-theme-alt" target="_blank" href="https://icon-sets.iconify.design">Iconify icon</a>, requires being online if not in cache)'
     ),
     pt('badge', 'Badge', 'Badge text to display').a(),
     pt('badgeColor', 'Badge Color', 'Color of the badge').a(),

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-card.vue
@@ -6,12 +6,12 @@
       </div>
       <div class="addon-card-title">
         <div v-if="showInstallActions" class="addon-card-title-after">
-          <f7-preloader v-if="'pending' in addon && addon.pending" color="blue" />
+          <f7-preloader v-if="'pending' in addon && addon.pending" color="theme-alt" />
           <f7-button
             v-else
             class="install-button prevent-active-state-propagation"
             :text="addon.installed ? 'Remove' : installActionText || 'Install'"
-            :color="addon.installed ? 'red' : 'blue'"
+            :color="addon.installed ? 'red' : 'theme-alt'"
             round
             small
             @click="buttonClicked" />
@@ -24,7 +24,7 @@
           <f7-icon
             v-if="addon.verifiedAuthor"
             size="15"
-            :color="uiOptionsStore.darkMode === 'dark' ? 'white' : 'blue'"
+            :color="uiOptionsStore.darkMode === 'dark' ? 'white' : 'theme-alt'"
             f7="checkmark_seal_fill"
             style="margin-top: -3px" />
         </div>

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-info-table.vue
@@ -19,7 +19,7 @@
 <style lang="stylus">
 .information-table
   --f7-list-bg-color transparent
-  --f7-theme-color var(--f7-color-blue)
+  --f7-theme-color var(--oh-theme-alt-color)
   .item-title
     --f7-list-item-title-text-color var(--f7-list-item-footer-text-color)
   .item-after

--- a/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addon-list-item.vue
@@ -6,7 +6,7 @@
         <f7-icon
           v-if="addon.verifiedAuthor"
           size="15"
-          :color="uiOptionsStore.darkMode === 'dark' ? 'white' : 'blue'"
+          :color="uiOptionsStore.darkMode === 'dark' ? 'white' : 'theme-alt'"
           f7="checkmark_seal_fill"
           style="margin-top: -3px" />
       </div>
@@ -19,12 +19,12 @@
     </template>
     <template #after>
       <div v-if="showInstallActions">
-        <f7-preloader v-if="'pending' in addon && addon.pending" color="blue" />
+        <f7-preloader v-if="'pending' in addon && addon.pending" color="theme-alt" />
         <f7-button
           v-else
           class="install-button prevent-active-state-propagation"
           :text="addon.installed ? 'Remove' : installActionText || 'Install'"
-          :color="addon.installed ? 'red' : 'blue'"
+          :color="addon.installed ? 'red' : 'theme-alt'"
           round
           small
           @click="buttonClicked" />

--- a/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
@@ -2,7 +2,7 @@
   <f7-block v-if="addons && addons.length > 0" class="addons-section" ref="addongroup">
     <f7-block-title v-if="title" medium>
       {{ title }}
-      <!-- <f7-link v-if="canExpand" color="blue" class="see-all-button margin-right" @click="expand">
+      <!-- <f7-link v-if="canExpand" color="theme-alt" class="see-all-button margin-right" @click="expand">
         Show All
       </f7-link> -->
     </f7-block-title>
@@ -70,7 +70,7 @@
         @addon-button-click="addonButtonClick" />
     </f7-list>
     <f7-block v-if="canExpand" class="display-flex justify-content-center">
-      <f7-button class="" outline color="blue" @click="expand" :text="`Show ${addons.length - addonCollapsedLimit} More`" />
+      <f7-button class="" outline color="theme-alt" @click="expand" :text="`Show ${addons.length - addonCollapsedLimit} More`" />
     </f7-block>
   </f7-block>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
+++ b/bundles/org.openhab.ui/web/src/components/addons/addons-section.vue
@@ -2,7 +2,7 @@
   <f7-block v-if="addons && addons.length > 0" class="addons-section" ref="addongroup">
     <f7-block-title v-if="title" medium>
       {{ title }}
-      <!-- <f7-link v-if="canExpand" color="blue" class="see-all-button margin-right" @click="expand">
+      <!-- <f7-link v-if="canExpand" color="theme-alt" class="see-all-button margin-right" @click="expand">
         Show All
       </f7-link> -->
     </f7-block-title>
@@ -81,7 +81,7 @@
         @addon-button-click="addonButtonClick" />
     </f7-list>
     <f7-block v-if="canExpand" class="display-flex justify-content-center">
-      <f7-button class="" outline color="blue" @click="expand" :text="`Show ${addons.length - addonCollapsedLimit} More`" />
+      <f7-button class="" outline color="theme-alt" @click="expand" :text="`Show ${addons.length - addonCollapsedLimit} More`" />
     </f7-block>
   </f7-block>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/config-sheet.vue
@@ -7,7 +7,7 @@
         <f7-badge
           v-if="advancedNonDefaultCount"
           style="margin-left: 2px"
-          color="blue"
+          color="theme-alt"
           class="count-badge"
           tooltip="Non-default advanced parameter">
           {{ advancedNonDefaultCount }}

--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -27,7 +27,7 @@
       @click="copy"
       icon-ios="f7:square_on_square"
       icon-aurora="f7:square_on_square"
-      color="blue"
+      color="theme-alt"
       class="copy display-flex flex-direction-row">
       &nbsp;Copy
     </f7-button>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -39,7 +39,7 @@
       icon-ios="f7:square_on_square"
       icon-aurora="f7:square_on_square"
       icon-md="material:content_copy"
-      color="blue"
+      color="theme-alt"
       tooltip="Copy code to clipboard"
       class="copy display-flex flex-direction-row">
       <span class="button-label">Copy</span>

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -53,7 +53,7 @@
         <f7-block v-if="!isAnythingPinned" class="no-margin no-padding">
           <p class="padding-horizontal">Use the search box above or the button below to temporarily pin objects here for quick access.</p>
           <p class="padding-horizontal">
-            <f7-button fill color="blue" @click="openModelPicker"> Pin Items from Model </f7-button>
+            <f7-button fill color="theme-alt" @click="openModelPicker"> Pin Items from Model </f7-button>
           </p>
         </f7-block>
         <!-- Pinned Items -->
@@ -93,7 +93,7 @@
                       :animate="false" />
                     <f7-link
                       class="itemlist-actions"
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="pin_fill"
                       icon-size="18"
                       tooltip="Unpin"
@@ -146,7 +146,7 @@
                       tooltip="Edit"
                       :href="'/settings/things/' + thing.UID"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('things', thing, 'UID')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('things', thing, 'UID')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -188,7 +188,7 @@
                       @click="toggleRuleDisabled(rule)" />
                     <f7-link
                       class="margin-right"
-                      :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                      :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="Run"
@@ -201,7 +201,7 @@
                       tooltip="Edit"
                       :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('rules', rule, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('rules', rule, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -243,7 +243,7 @@
                       @click="toggleRuleDisabled(rule, 'Scene')" />
                     <f7-link
                       class="margin-right"
-                      :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                      :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="Run"
@@ -256,7 +256,7 @@
                       tooltip="Edit"
                       :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scenes', rule, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scenes', rule, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -298,7 +298,7 @@
                       @click="toggleRuleDisabled(rule, 'Script')" />
                     <f7-link
                       class="margin-right"
-                      :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                      :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="Run"
@@ -311,7 +311,7 @@
                       tooltip="Edit"
                       :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scripts', rule, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scripts', rule, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -339,10 +339,10 @@
                     <f7-link color="gray" class="margin-right">
                       <clipboard-icon :value="page.uid" :size="18" tooltip="Copy Page UID" />
                     </f7-link>
-                    <!-- <f7-link class="margin-right" color="blue" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" /> -->
+                    <!-- <f7-link class="margin-right" color="theme-alt" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" /> -->
                     <f7-link
                       class="margin-right"
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="View"
@@ -356,7 +356,7 @@
                       tooltip="Edit"
                       :href="'/settings/pages/' + getPageType(page).type + '/' + page.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('pages', page, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('pages', page, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -387,7 +387,7 @@
                       tooltip="Edit"
                       :href="'/developer/widgets/' + widget.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('widgets', widget, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('widgets', widget, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -424,7 +424,7 @@
                       :href="'/settings/transformations/' + transformation.uid"
                       :animate="false" />
                     <f7-link
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="pin_fill"
                       icon-size="18"
                       tooltip="Unpin"
@@ -465,7 +465,7 @@
                       :href="'/settings/persistence/' + persistenceConfig.serviceId"
                       :animate="false" />
                     <f7-link
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="pin_fill"
                       icon-size="18"
                       tooltip="Unpin"
@@ -484,7 +484,7 @@
             <span>Event Monitor</span>
             <span style="margin-left: auto">
               <f7-link
-                :color="eventTopicFilter ? 'blue' : 'gray'"
+                :color="eventTopicFilter ? 'theme-alt' : 'gray'"
                 :icon-f7="eventTopicFilter ? 'line_horizontal_3_decrease_circle_fill' : 'line_horizontal_3_decrease_circle'"
                 icon-size="14"
                 tooltip="Filter topics"
@@ -493,7 +493,7 @@
           </f7-block-title>
           <f7-block>
             <p v-if="!sseClient">
-              <f7-button fill color="blue" @click="startSSE"> Stream Events </f7-button>
+              <f7-button fill color="theme-alt" @click="startSSE"> Stream Events </f7-button>
             </p>
             <p v-if="sseClient">
               <f7-button fill color="red" @click="stopSSE"> Stop Streaming </f7-button>
@@ -534,7 +534,7 @@
         <f7-block class="no-margin no-padding">
           <f7-block-title class="padding-horizontal"> Scripting Scratchpad </f7-block-title>
           <f7-list>
-            <f7-list-button @click="openScriptingScratchpad" color="blue"> Open Scratchpad </f7-list-button>
+            <f7-list-button @click="openScriptingScratchpad" color="theme-alt"> Open Scratchpad </f7-list-button>
           </f7-list>
         </f7-block>
       </div>
@@ -546,28 +546,28 @@
         <f7-block class="no-margin no-padding">
           <f7-list>
             <f7-list-item divider title="Things" />
-            <f7-list-button href="/settings/things/add" color="blue" :animate="false"> Add Thing </f7-list-button>
-            <f7-list-button @click="quickAddThing" color="blue"> Add Thing (quick) </f7-list-button>
-            <f7-list-button href="/settings/things/inbox" color="blue" :animate="false"> Inbox </f7-list-button>
+            <f7-list-button href="/settings/things/add" color="theme-alt" :animate="false"> Add Thing </f7-list-button>
+            <f7-list-button @click="quickAddThing" color="theme-alt"> Add Thing (quick) </f7-list-button>
+            <f7-list-button href="/settings/things/inbox" color="theme-alt" :animate="false"> Inbox </f7-list-button>
             <f7-list-item divider title="Items" />
-            <f7-list-button href="/settings/items/add" color="blue" :animate="false"> Create Item </f7-list-button>
-            <f7-list-button href="/settings/items/add-from-textual-definition" color="blue" :animate="false">
+            <f7-list-button href="/settings/items/add" color="theme-alt" :animate="false"> Create Item </f7-list-button>
+            <f7-list-button href="/settings/items/add-from-textual-definition" color="theme-alt" :animate="false">
               Add Items (textual)
             </f7-list-button>
             <f7-list-item divider title="Pages" />
-            <f7-list-button href="/settings/pages/layout/add" color="blue" :animate="false"> Create layout page </f7-list-button>
-            <f7-list-button href="/settings/pages/tabs/add" color="blue" :animate="false"> Create tabbed page </f7-list-button>
-            <f7-list-button href="/settings/pages/map/add" color="blue" :animate="false"> Create map view </f7-list-button>
-            <f7-list-button href="/settings/pages/plan/add" color="blue" :animate="false"> Create floor plan </f7-list-button>
-            <f7-list-button href="/settings/pages/chart/add" color="blue" :animate="false"> Create chart </f7-list-button>
-            <f7-list-button href="/settings/sitemaps/add" color="blue" :animate="false"> Create sitemap </f7-list-button>
+            <f7-list-button href="/settings/pages/layout/add" color="theme-alt" :animate="false"> Create layout page </f7-list-button>
+            <f7-list-button href="/settings/pages/tabs/add" color="theme-alt" :animate="false"> Create tabbed page </f7-list-button>
+            <f7-list-button href="/settings/pages/map/add" color="theme-alt" :animate="false"> Create map view </f7-list-button>
+            <f7-list-button href="/settings/pages/plan/add" color="theme-alt" :animate="false"> Create floor plan </f7-list-button>
+            <f7-list-button href="/settings/pages/chart/add" color="theme-alt" :animate="false"> Create chart </f7-list-button>
+            <f7-list-button href="/settings/sitemaps/add" color="theme-alt" :animate="false"> Create sitemap </f7-list-button>
             <f7-list-item divider title="Automation" />
-            <f7-list-button href="/settings/rules/add" color="blue" :animate="false"> Create rule </f7-list-button>
-            <f7-list-button href="/settings/scripts/add" color="blue" :animate="false"> Create script </f7-list-button>
-            <f7-list-button href="/settings/schedule/add" color="blue" :animate="false"> Create scheduled rule </f7-list-button>
+            <f7-list-button href="/settings/rules/add" color="theme-alt" :animate="false"> Create rule </f7-list-button>
+            <f7-list-button href="/settings/scripts/add" color="theme-alt" :animate="false"> Create script </f7-list-button>
+            <f7-list-button href="/settings/schedule/add" color="theme-alt" :animate="false"> Create scheduled rule </f7-list-button>
             <f7-list-item divider title="Advanced" />
-            <f7-list-button href="/developer/widgets/add" color="blue" :animate="false"> Create widget </f7-list-button>
-            <f7-list-button href="/developer/blocks/add" color="blue" :animate="false"> Create block library </f7-list-button>
+            <f7-list-button href="/developer/widgets/add" color="theme-alt" :animate="false"> Create widget </f7-list-button>
+            <f7-list-button href="/developer/blocks/add" color="theme-alt" :animate="false"> Create block library </f7-list-button>
           </f7-list>
         </f7-block>
       </div>
@@ -1075,7 +1075,7 @@ export default {
                     ...languages.map((l) => {
                       return {
                         text: l.label,
-                        color: 'blue',
+                        color: 'theme-alt',
                         onClick: () => {
                           const scratchpad = {
                             uid: 'scratchpad',

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -53,7 +53,7 @@
         <f7-block v-if="!isAnythingPinned" class="no-margin no-padding">
           <p class="padding-horizontal">Use the search box above or the button below to temporarily pin objects here for quick access.</p>
           <p class="padding-horizontal">
-            <f7-button fill color="blue" @click="openModelPicker"> Pin Items from Model </f7-button>
+            <f7-button fill color="theme-alt" @click="openModelPicker"> Pin Items from Model </f7-button>
           </p>
         </f7-block>
         <!-- Pinned Items -->
@@ -93,7 +93,7 @@
                       :animate="false" />
                     <f7-link
                       class="itemlist-actions"
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="pin_fill"
                       icon-size="18"
                       tooltip="Unpin"
@@ -146,7 +146,7 @@
                       tooltip="Edit"
                       :href="'/settings/things/' + thing.UID"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('things', thing, 'UID')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('things', thing, 'UID')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -188,7 +188,7 @@
                       @click="toggleRuleDisabled(rule)" />
                     <f7-link
                       class="margin-right"
-                      :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                      :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="Run"
@@ -201,7 +201,7 @@
                       tooltip="Edit"
                       :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('rules', rule, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('rules', rule, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -243,7 +243,7 @@
                       @click="toggleRuleDisabled(rule, 'Scene')" />
                     <f7-link
                       class="margin-right"
-                      :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                      :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="Run"
@@ -256,7 +256,7 @@
                       tooltip="Edit"
                       :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scenes', rule, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scenes', rule, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -298,7 +298,7 @@
                       @click="toggleRuleDisabled(rule, 'Script')" />
                     <f7-link
                       class="margin-right"
-                      :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                      :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="Run"
@@ -311,7 +311,7 @@
                       tooltip="Edit"
                       :href="'/settings/' + (rule.tags.indexOf('Script') >= 0 ? 'scripts' : 'rules') + '/' + rule.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scripts', rule, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('scripts', rule, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -339,10 +339,10 @@
                     <f7-link color="gray" class="margin-right">
                       <clipboard-icon :value="page.uid" :size="18" tooltip="Copy Page UID" />
                     </f7-link>
-                    <!-- <f7-link class="margin-right" color="blue" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" /> -->
+                    <!-- <f7-link class="margin-right" color="theme-alt" icon-f7="rectangle_on_rectangle" icon-size="18" tooltip="Open in Popup" /> -->
                     <f7-link
                       class="margin-right"
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="play"
                       icon-size="18"
                       tooltip="View"
@@ -356,7 +356,7 @@
                       tooltip="Edit"
                       :href="'/settings/pages/' + getPageType(page).type + '/' + page.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('pages', page, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('pages', page, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -387,7 +387,7 @@
                       tooltip="Edit"
                       :href="'/developer/widgets/' + widget.uid"
                       :animate="false" />
-                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('widgets', widget, 'uid')" />
+                    <f7-link color="theme-alt" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('widgets', widget, 'uid')" />
                   </div>
                 </template>
               </f7-list-item>
@@ -461,7 +461,7 @@
                       :href="'/settings/transformations/' + transformation.uid"
                       :animate="false" />
                     <f7-link
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="pin_fill"
                       icon-size="18"
                       tooltip="Unpin"
@@ -502,7 +502,7 @@
                       :href="'/settings/persistence/' + persistenceConfig.serviceId"
                       :animate="false" />
                     <f7-link
-                      color="blue"
+                      color="theme-alt"
                       icon-f7="pin_fill"
                       icon-size="18"
                       tooltip="Unpin"
@@ -521,7 +521,7 @@
             <span>Event Monitor</span>
             <span style="margin-left: auto">
               <f7-link
-                :color="eventTopicFilter ? 'blue' : 'gray'"
+                :color="eventTopicFilter ? 'theme-alt' : 'gray'"
                 :icon-f7="eventTopicFilter ? 'line_horizontal_3_decrease_circle_fill' : 'line_horizontal_3_decrease_circle'"
                 icon-size="14"
                 tooltip="Filter topics"
@@ -530,7 +530,7 @@
           </f7-block-title>
           <f7-block>
             <p v-if="!sseClient">
-              <f7-button fill color="blue" @click="startSSE"> Stream Events </f7-button>
+              <f7-button fill color="theme-alt" @click="startSSE"> Stream Events </f7-button>
             </p>
             <p v-if="sseClient">
               <f7-button fill color="red" @click="stopSSE"> Stop Streaming </f7-button>
@@ -571,7 +571,7 @@
         <f7-block class="no-margin no-padding">
           <f7-block-title class="padding-horizontal"> Scripting Scratchpad </f7-block-title>
           <f7-list>
-            <f7-list-button @click="openScriptingScratchpad" color="blue"> Open Scratchpad </f7-list-button>
+            <f7-list-button @click="openScriptingScratchpad" color="theme-alt"> Open Scratchpad </f7-list-button>
           </f7-list>
         </f7-block>
       </div>
@@ -583,29 +583,29 @@
         <f7-block class="no-margin no-padding">
           <f7-list>
             <f7-list-item divider title="Things" />
-            <f7-list-button href="/settings/things/add" color="blue" :animate="false"> Add Thing </f7-list-button>
-            <f7-list-button @click="quickAddThing" color="blue"> Add Thing (quick) </f7-list-button>
-            <f7-list-button href="/settings/things/inbox" color="blue" :animate="false"> Inbox </f7-list-button>
+            <f7-list-button href="/settings/things/add" color="theme-alt" :animate="false"> Add Thing </f7-list-button>
+            <f7-list-button @click="quickAddThing" color="theme-alt"> Add Thing (quick) </f7-list-button>
+            <f7-list-button href="/settings/things/inbox" color="theme-alt" :animate="false"> Inbox </f7-list-button>
             <f7-list-item divider title="Items" />
-            <f7-list-button href="/settings/items/add" color="blue" :animate="false"> Create Item </f7-list-button>
-            <f7-list-button href="/settings/items/add-from-textual-definition" color="blue" :animate="false">
+            <f7-list-button href="/settings/items/add" color="theme-alt" :animate="false"> Create Item </f7-list-button>
+            <f7-list-button href="/settings/items/add-from-textual-definition" color="theme-alt" :animate="false">
               Add Items (textual)
             </f7-list-button>
             <f7-list-item divider title="Pages" />
-            <f7-list-button href="/settings/pages/layout/add" color="blue" :animate="false"> Create layout page </f7-list-button>
-            <f7-list-button href="/settings/pages/tabs/add" color="blue" :animate="false"> Create tabbed page </f7-list-button>
-            <f7-list-button href="/settings/pages/map/add" color="blue" :animate="false"> Create map view </f7-list-button>
-            <f7-list-button href="/settings/pages/plan/add" color="blue" :animate="false"> Create floor plan </f7-list-button>
-            <f7-list-button href="/settings/pages/chart/add" color="blue" :animate="false"> Create chart </f7-list-button>
+            <f7-list-button href="/settings/pages/layout/add" color="theme-alt" :animate="false"> Create layout page </f7-list-button>
+            <f7-list-button href="/settings/pages/tabs/add" color="theme-alt" :animate="false"> Create tabbed page </f7-list-button>
+            <f7-list-button href="/settings/pages/map/add" color="theme-alt" :animate="false"> Create map view </f7-list-button>
+            <f7-list-button href="/settings/pages/plan/add" color="theme-alt" :animate="false"> Create floor plan </f7-list-button>
+            <f7-list-button href="/settings/pages/chart/add" color="theme-alt" :animate="false"> Create chart </f7-list-button>
             <f7-list-item divider title="Sitemaps" />
-            <f7-list-button href="/settings/sitemaps/add" color="blue" :animate="false"> Create sitemap </f7-list-button>
+            <f7-list-button href="/settings/sitemaps/add" color="theme-alt" :animate="false"> Create sitemap </f7-list-button>
             <f7-list-item divider title="Automation" />
-            <f7-list-button href="/settings/rules/add" color="blue" :animate="false"> Create rule </f7-list-button>
-            <f7-list-button href="/settings/scripts/add" color="blue" :animate="false"> Create script </f7-list-button>
-            <f7-list-button href="/settings/schedule/add" color="blue" :animate="false"> Create scheduled rule </f7-list-button>
+            <f7-list-button href="/settings/rules/add" color="theme-alt" :animate="false"> Create rule </f7-list-button>
+            <f7-list-button href="/settings/scripts/add" color="theme-alt" :animate="false"> Create script </f7-list-button>
+            <f7-list-button href="/settings/schedule/add" color="theme-alt" :animate="false"> Create scheduled rule </f7-list-button>
             <f7-list-item divider title="Advanced" />
-            <f7-list-button href="/developer/widgets/add" color="blue" :animate="false"> Create widget </f7-list-button>
-            <f7-list-button href="/developer/blocks/add" color="blue" :animate="false"> Create block library </f7-list-button>
+            <f7-list-button href="/developer/widgets/add" color="theme-alt" :animate="false"> Create widget </f7-list-button>
+            <f7-list-button href="/developer/blocks/add" color="theme-alt" :animate="false"> Create block library </f7-list-button>
           </f7-list>
         </f7-block>
       </div>
@@ -1127,7 +1127,7 @@ export default {
                     ...languages.map((l) => {
                       return {
                         text: l.label,
-                        color: 'blue',
+                        color: 'theme-alt',
                         onClick: () => {
                           const scratchpad = {
                             uid: 'scratchpad',

--- a/bundles/org.openhab.ui/web/src/components/developer/help-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help-sidebar.vue
@@ -138,13 +138,13 @@
       background #232323 !important
 
 .add-button-icon
-  color: #2196f3
+  color: var(--oh-theme-alt-color)
 
 .link-item-icon
   color: #4cd964
 
 .chevron-icon
-  color: #2196f3
+  color: var(--oh-theme-alt-color)
 
 .faq-title .item-title
   white-space: normal !important

--- a/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/help/context.vue
@@ -4,7 +4,7 @@
       <div v-show="ready" v-html="parsedDocs" />
     </f7-block>
     <f7-block>
-      <f7-link external :href="documentationLink" target="_blank" text="Open full documentation" color="blue" />
+      <f7-link external :href="documentationLink" target="_blank" text="Open full documentation" color="theme-alt" />
     </f7-block>
   </f7-block>
 </template>
@@ -111,7 +111,10 @@ export default {
 
                 // Allow embedding framework7 icons by using <!--F7(:blue|:green) ICON_NAME --> comments
                 body = body.replace(/<!--F7 ([A-z]*) -->/gm, '<i class="f7-icons size-22">$1</i>')
-                body = body.replace(/<!--F7:blue ([A-z]*) -->/gm, '<i class="f7-icons size-22" style="color: #2196f3">$1</i>')
+                body = body.replace(
+                  /<!--F7:blue ([A-z]*) -->/gm,
+                  '<i class="f7-icons size-22" style="color: var(--oh-theme-alt-color)">$1</i>'
+                )
                 body = body.replace(/<!--F7:green ([A-z]*) -->/gm, '<i class="f7-icons size-22" style="color: #4cd964">$1</i>')
 
                 body = body.replace(/<pre>/gm, '<div class="block block-strong no-padding"><pre class="padding-half">')

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -45,14 +45,14 @@
             <f7-link
               v-if="isPinned('items', item, 'name')"
               @click="$emit('unpin', 'items', item, 'name')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'items', item, 'name')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('items')" color="blue" @click="expandedTypes.items = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('items')" color="theme-alt" @click="expandedTypes.items = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Things -->
@@ -78,14 +78,14 @@
             <f7-link
               v-if="isPinned('things', thing, 'UID')"
               @click="$emit('unpin', 'things', thing, 'UID')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'things', thing, 'UID')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('things')" color="blue" @click="expandedTypes.things = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('things')" color="theme-alt" @click="expandedTypes.things = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Rules -->
@@ -117,14 +117,14 @@
             <f7-link
               v-if="isPinned('rules', rule, 'uid')"
               @click="$emit('unpin', 'rules', rule, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'rules', rule, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="expandedTypes.rules = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('rules')" color="theme-alt" @click="expandedTypes.rules = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Scenes -->
@@ -156,14 +156,14 @@
             <f7-link
               v-if="isPinned('scenes', rule, 'uid')"
               @click="$emit('unpin', 'scenes', rule, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'scenes', rule, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="expandedTypes.rules = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('rules')" color="theme-alt" @click="expandedTypes.rules = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Scripts -->
@@ -195,14 +195,14 @@
             <f7-link
               v-if="isPinned('scripts', rule, 'uid')"
               @click="$emit('unpin', 'scripts', rule, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'scripts', rule, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="expandedTypes.rules = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('rules')" color="theme-alt" @click="expandedTypes.rules = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Pages -->
@@ -234,14 +234,14 @@
             <f7-link
               v-if="isPinned('pages', page, 'uid')"
               @click="$emit('unpin', 'pages', page, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'pages', page, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('pages')" color="blue" @click="expandedTypes.pages = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('pages')" color="theme-alt" @click="expandedTypes.pages = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Widgets -->
@@ -272,14 +272,14 @@
             <f7-link
               v-if="isPinned('widgets', widget, 'uid')"
               @click="$emit('unpin', 'widgets', widget, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'widgets', widget, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('widgets')" color="blue" @click="expandedTypes.widgets = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('widgets')" color="theme-alt" @click="expandedTypes.widgets = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Transformations -->
@@ -311,7 +311,7 @@
             <f7-link
               v-if="isPinned('transformations', transformation, 'uid')"
               @click="$emit('unpin', 'transformations', transformation, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
@@ -324,7 +324,7 @@
               tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('transformations')" color="blue" @click="expandedTypes.transformations = true">
+        <f7-list-button v-if="!showingAll('transformations')" color="theme-alt" @click="expandedTypes.transformations = true">
           Show All
         </f7-list-button>
       </f7-list>
@@ -358,7 +358,7 @@
             <f7-link
               v-if="isPinned('persistenceConfigs', persistenceConfig, 'serviceId')"
               @click="$emit('unpin', 'persistenceConfigs', persistenceConfig, 'serviceId')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
@@ -371,7 +371,7 @@
               tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('persistenceConfigs')" color="blue" @click="expandedTypes.persistenceConfigs = true">
+        <f7-list-button v-if="!showingAll('persistenceConfigs')" color="theme-alt" @click="expandedTypes.persistenceConfigs = true">
           Show All
         </f7-list-button>
       </f7-list>

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -49,14 +49,14 @@
             <f7-link
               v-if="isPinned('items', item, 'name')"
               @click="$emit('unpin', 'items', item, 'name')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'items', item, 'name')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('items')" color="blue" @click="expandedTypes.items = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('items')" color="theme-alt" @click="expandedTypes.items = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Things -->
@@ -82,14 +82,14 @@
             <f7-link
               v-if="isPinned('things', thing, 'UID')"
               @click="$emit('unpin', 'things', thing, 'UID')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'things', thing, 'UID')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('things')" color="blue" @click="expandedTypes.things = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('things')" color="theme-alt" @click="expandedTypes.things = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Rules -->
@@ -121,14 +121,14 @@
             <f7-link
               v-if="isPinned('rules', rule, 'uid')"
               @click="$emit('unpin', 'rules', rule, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'rules', rule, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="expandedTypes.rules = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('rules')" color="theme-alt" @click="expandedTypes.rules = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Scenes -->
@@ -160,14 +160,14 @@
             <f7-link
               v-if="isPinned('scenes', rule, 'uid')"
               @click="$emit('unpin', 'scenes', rule, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'scenes', rule, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="expandedTypes.rules = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('rules')" color="theme-alt" @click="expandedTypes.rules = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Scripts -->
@@ -199,14 +199,14 @@
             <f7-link
               v-if="isPinned('scripts', rule, 'uid')"
               @click="$emit('unpin', 'scripts', rule, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'scripts', rule, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('rules')" color="blue" @click="expandedTypes.rules = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('rules')" color="theme-alt" @click="expandedTypes.rules = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Pages -->
@@ -238,14 +238,14 @@
             <f7-link
               v-if="isPinned('pages', page, 'uid')"
               @click="$emit('unpin', 'pages', page, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'pages', page, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('pages')" color="blue" @click="expandedTypes.pages = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('pages')" color="theme-alt" @click="expandedTypes.pages = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Widgets -->
@@ -276,14 +276,14 @@
             <f7-link
               v-if="isPinned('widgets', widget, 'uid')"
               @click="$emit('unpin', 'widgets', widget, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
             <f7-link v-else @click="$emit('pin', 'widgets', widget, 'uid')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('widgets')" color="blue" @click="expandedTypes.widgets = true"> Show All </f7-list-button>
+        <f7-list-button v-if="!showingAll('widgets')" color="theme-alt" @click="expandedTypes.widgets = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
     <!-- Sitemaps -->
@@ -354,7 +354,7 @@
             <f7-link
               v-if="isPinned('transformations', transformation, 'uid')"
               @click="$emit('unpin', 'transformations', transformation, 'uid')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
@@ -367,7 +367,7 @@
               tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('transformations')" color="blue" @click="expandedTypes.transformations = true">
+        <f7-list-button v-if="!showingAll('transformations')" color="theme-alt" @click="expandedTypes.transformations = true">
           Show All
         </f7-list-button>
       </f7-list>
@@ -401,7 +401,7 @@
             <f7-link
               v-if="isPinned('persistenceConfigs', persistenceConfig, 'serviceId')"
               @click="$emit('unpin', 'persistenceConfigs', persistenceConfig, 'serviceId')"
-              color="blue"
+              color="theme-alt"
               icon-f7="pin_fill"
               icon-size="18"
               tooltip="Unpin" />
@@ -414,7 +414,7 @@
               tooltip="Pin" />
           </template>
         </f7-list-item>
-        <f7-list-button v-if="!showingAll('persistenceConfigs')" color="blue" @click="expandedTypes.persistenceConfigs = true">
+        <f7-list-button v-if="!showingAll('persistenceConfigs')" color="theme-alt" @click="expandedTypes.persistenceConfigs = true">
           Show All
         </f7-list-button>
       </f7-list>

--- a/bundles/org.openhab.ui/web/src/components/home/habot.vue
+++ b/bundles/org.openhab.ui/web/src/components/home/habot.vue
@@ -37,7 +37,7 @@
       type="sent"
       class="habot-query margin-bottom"
       :text="query"
-      color="blue"
+      color="theme-alt"
       first
       tail />
     <f7-message
@@ -51,7 +51,7 @@
     <generic-widget-component v-if="cardContext && !focused && !interimSpeechResult" :context="cardContext" />
     <div v-if="query && !focused && answer && !busy && !interimSpeechResult" class="display-flex justify-content-space-between padding">
       <span />
-      <f7-button outline round color="blue" @click="endSession">
+      <f7-button outline round color="theme-alt" @click="endSession">
         {{ t('habot.dismiss') }}
       </f7-button>
     </div>

--- a/bundles/org.openhab.ui/web/src/components/item/group-members.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/group-members.vue
@@ -9,7 +9,7 @@
             :item="member"
             :link="'/settings/items/' + member.name"
             :context="context" />
-          <!-- <f7-list-button @click="enableEditMode" color="blue" title="Add or Remove Members" /> -->
+          <!-- <f7-list-button @click="enableEditMode" color="theme-alt" title="Add or Remove Members" /> -->
         </ul>
         <f7-list-group v-if="editMembers">
           <item-picker
@@ -25,9 +25,9 @@
       </f7-list>
     </f7-card-content>
     <f7-card-footer>
-      <f7-button v-if="!editMembers" color="blue" @click="enableEditMode"> Change </f7-button>
-      <f7-button v-if="editMembers" color="blue" fill raised @click="updateMembers"> Apply </f7-button>
-      <f7-button v-if="editMembers" color="blue" @click="cancelEditMode"> Cancel </f7-button>
+      <f7-button v-if="!editMembers" color="theme-alt" @click="enableEditMode"> Change </f7-button>
+      <f7-button v-if="editMembers" color="theme-alt" fill raised @click="updateMembers"> Apply </f7-button>
+      <f7-button v-if="editMembers" color="theme-alt" @click="cancelEditMode"> Cancel </f7-button>
     </f7-card-footer>
   </f7-card>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -141,7 +141,7 @@
               :text="group"
               :deleteable="editable"
               @delete="deleteGroup"
-              media-bg-color="blue"
+              media-bg-color="theme-alt"
               style="margin-right: 6px">
               <template #media>
                 <f7-icon ios="f7:folder_fill" md="material:folder" aurora="f7:folder_fill" />

--- a/bundles/org.openhab.ui/web/src/components/item/item.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item.vue
@@ -23,7 +23,7 @@
     <slot name="footer" />
     <template #subtitle>
       <div v-if="!noTags">
-        <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+        <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
           <template #media>
             <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
           </template>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-alexa.vue
@@ -65,7 +65,7 @@
       </f7-block-footer>
     </f7-block>
     <p class="padding">
-      <f7-link color="blue" external target="_blank" :href="docLink"> Alexa Integration Documentation </f7-link>
+      <f7-link color="theme-alt" external target="_blank" :href="docLink"> Alexa Integration Documentation </f7-link>
     </p>
   </div>
   <div v-else class="text-align-center">
@@ -163,7 +163,7 @@ export default {
     },
     groupLinks() {
       return this.item.groups
-        .map((g) => `<a class="text-color-blue" href="/settings/items/${g.name}/metadata/alexa">${g.label || g.name}</a>`)
+        .map((g) => `<a class="text-color-theme-alt" href="/settings/items/${g.name}/metadata/alexa">${g.label || g.name}</a>`)
         .join(', ')
     },
     isPartOfGroupEndpoint() {

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-ga.vue
@@ -40,7 +40,7 @@
       <config-sheet :parameterGroups="[]" :parameters="parameters" :configuration="metadata.config" :read-only="!editable" />
     </div>
     <p class="padding">
-      <f7-link color="blue" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/google-assistant`">
+      <f7-link color="theme-alt" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/google-assistant`">
         Google Assistant Integration Documentation
       </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-homekit.vue
@@ -65,11 +65,11 @@
         </f7-list>
       </f7-block>
       <f7-block-footer v-if="editable">
-        <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
+        <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
       </f7-block-footer>
     </f7-block>
     <p class="padding">
-      <f7-link color="blue" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/homekit`">
+      <f7-link color="theme-alt" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/homekit`">
         HomeKit integration documentation
       </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-itemdescription.vue
@@ -24,10 +24,10 @@
       </f7-block-footer>
     </f7-list>
     <p class="padding">
-      <f7-link v-if="namespace === 'stateDescription'" color="blue" external target="_blank" :href="docLink">
+      <f7-link v-if="namespace === 'stateDescription'" color="theme-alt" external target="_blank" :href="docLink">
         State Description Documentation
       </f7-link>
-      <f7-link v-if="namespace === 'commandDescription'" color="blue" external target="_blank" :href="docLink">
+      <f7-link v-if="namespace === 'commandDescription'" color="theme-alt" external target="_blank" :href="docLink">
         Command Description Documentation
       </f7-link>
     </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-linktomore.vue
@@ -14,7 +14,7 @@
           <small>
             Enter a valid URL, e.g. <code>https://www.openhab.org</code>, <code>/locations</code> or
             <code>/basicui/app?w=0004&sitemap=mysitemap</code>, to open when you long-press a tile in Android Device Control.
-            <f7-link external color="blue" target="_blank" :href="runtimeStore.websiteUrl + '/docs/apps/android.html#device-controls'"
+            <f7-link external color="theme-alt" target="_blank" :href="runtimeStore.websiteUrl + '/docs/apps/android.html#device-controls'"
               >Read the docs.</f7-link
             >
           </small>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-matter.vue
@@ -35,7 +35,7 @@
       <f7-block v-if="shouldShowAttributeMapping" class="padding-top no-padding no-margin">
         <f7-block-title class="padding-horizontal" medium> Matter Attributes Mapping </f7-block-title>
         <f7-block-footer v-if="dirtyItem.size">
-          <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
+          <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
         </f7-block-footer>
         <f7-block v-for="deviceType in classesAsArray" :key="deviceType" class="no-padding">
           <f7-block-title class="padding-left">
@@ -86,11 +86,11 @@
           <small class="text-color-gray">* indicates mandatory mapping</small>
         </f7-block-footer>
         <f7-block-footer v-if="dirtyItem.size">
-          <f7-button color="blue" @click="updatedLinkedItem"> Update group members </f7-button>
+          <f7-button color="theme-alt" @click="updatedLinkedItem"> Update group members </f7-button>
         </f7-block-footer>
       </f7-block>
       <p class="padding">
-        <f7-link color="blue" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/matter`">
+        <f7-link color="theme-alt" external target="_blank" :href="`${runtimeStore.websiteUrl}/link/matter`">
           Matter integration documentation
         </f7-link>
       </p>

--- a/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/metadata/item-metadata-menu.vue
@@ -30,7 +30,7 @@
       </f7-list>
     </f7-card-content>
     <f7-card-footer>
-      <f7-button color="blue" @click="addMetadata"> Add Metadata </f7-button>
+      <f7-button color="theme-alt" @click="addMetadata"> Add Metadata </f7-button>
     </f7-card-footer>
   </f7-card>
 </template>
@@ -108,7 +108,7 @@ export default {
               ...this.metadataNamespaces.map((n) => {
                 return {
                   text: n.label,
-                  color: 'blue',
+                  color: 'theme-alt',
                   onClick: () => {
                     this.f7router.navigate('/settings/items/' + this.item.name + '/metadata/' + n.name)
                   }
@@ -117,7 +117,7 @@ export default {
             ],
             [
               { label: true, text: 'Custom namespaces' },
-              { color: 'blue', text: 'Enter Custom Namespace...', onClick: this.editCustomMetadata }
+              { color: 'theme-alt', text: 'Enter Custom Namespace...', onClick: this.editCustomMetadata }
             ],
             [{ color: 'red', text: 'Cancel', close: true }]
           ]

--- a/bundles/org.openhab.ui/web/src/components/model/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/item-details.vue
@@ -4,7 +4,7 @@
       <f7-list media-list accordion-list>
         <ul>
           <item v-if="!createMode" :item="model.item" :link="'/settings/items/' + model.item.name" :context="context" :no-tags="editMode" />
-          <!-- <f7-list-button v-if="!editMode && !createMode" color="blue" title="Edit Item" @click="editMode = true">Edit Item</f7-list-button> -->
+          <!-- <f7-list-button v-if="!editMode && !createMode" color="theme-alt" title="Edit Item" @click="editMode = true">Edit Item</f7-list-button> -->
         </ul>
       </f7-list>
 
@@ -16,12 +16,12 @@
       </div>
     </f7-card-content>
     <f7-card-footer v-if="createMode || editMode" key="item-card-buttons">
-      <f7-button v-if="createMode" color="blue" fill raised @click="create"> Create </f7-button>
-      <f7-button v-else v-show="model.item.editable" color="blue" fill raised @click="save"> Save </f7-button>
-      <f7-button v-if="model.item.editable" color="blue" @click="cancel"> Cancel </f7-button>
+      <f7-button v-if="createMode" color="theme-alt" fill raised @click="create"> Create </f7-button>
+      <f7-button v-else v-show="model.item.editable" color="theme-alt" fill raised @click="save"> Save </f7-button>
+      <f7-button v-if="model.item.editable" color="theme-alt" @click="cancel"> Cancel </f7-button>
       <f7-button
         v-else
-        color="blue"
+        color="theme-alt"
         @click="cancel"
         icon-ios="material:expand_less"
         icon-md="material:expand_less"
@@ -32,7 +32,7 @@
     <f7-card-footer v-else key="item-card-buttons-edit-mode">
       <f7-button
         v-if="model.item.editable"
-        color="blue"
+        color="theme-alt"
         @click="edit"
         icon-ios="material:expand_more"
         icon-md="material:expand_more"
@@ -42,7 +42,7 @@
       <f7-button v-if="model.item.editable" color="red" @click="remove"> Remove </f7-button>
       <f7-button
         v-else
-        color="blue"
+        color="theme-alt"
         @click="edit"
         icon-ios="material:expand_more"
         icon-md="material:expand_more"

--- a/bundles/org.openhab.ui/web/src/components/model/link-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/link-details.vue
@@ -25,7 +25,7 @@
       </f7-list>
     </f7-card-content>
     <f7-card-footer>
-      <f7-button color="blue" @click="addLink"> Add Link </f7-button>
+      <f7-button color="theme-alt" @click="addLink"> Add Link </f7-button>
     </f7-card-footer>
   </f7-card>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/model/treeview-item.vue
@@ -6,7 +6,7 @@
     :icon-aurora="icon('aurora')"
     :icon-md="icon('md')"
     :textColor="iconColor"
-    :color="model.item.created !== false ? 'blue' : 'orange'"
+    :color="model.item.created !== false ? 'theme-alt' : 'orange'"
     :selected="itemSelected"
     :opened="model.opened"
     :toggle="canHaveChildren"
@@ -55,7 +55,7 @@
         {{ className }}
         <template v-if="includeItemTags">
           <div v-for="tag in getNonSemanticTags(model.item)" class="semantic-class chip" :key="tag" style="height: 16px; margin-left: 4px">
-            <div class="chip-media bg-color-blue" style="height: 16px; width: 16px">
+            <div class="chip-media bg-color-theme-alt" style="height: 16px; width: 16px">
               <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" style="font-size: 8px; height: 16px; line-height: 16px" />
             </div>
             <div class="chip-label" style="height: 16px; line-height: 16px">

--- a/bundles/org.openhab.ui/web/src/components/onboarding/onboarding-cards.vue
+++ b/bundles/org.openhab.ui/web/src/components/onboarding/onboarding-cards.vue
@@ -5,34 +5,34 @@
       title="Welcome to openHAB!"
       content="Congratulations, your server is up and running! However, it is not configured yet. Follow the setup wizard and let it guide you through the initial configuration. (Note: the wizard could also be started automatically on launch if no package is detected - services/org.openhab.addons > package).">
       <f7-card-footer>
-        <f7-link color="blue" @click="skipSetupWizard()"> No thanks </f7-link>
-        <!-- <f7-button color="blue" fill raised login-screen-open="#login-screen">Start Setup Wizard</f7-button> -->
-        <f7-button color="blue" fill raised href="/setup-wizard/"> Start Setup Wizard </f7-button>
+        <f7-link color="theme-alt" @click="skipSetupWizard()"> No thanks </f7-link>
+        <!-- <f7-button color="theme-alt" fill raised login-screen-open="#login-screen">Start Setup Wizard</f7-button> -->
+        <f7-button color="theme-alt" fill raised href="/setup-wizard/"> Start Setup Wizard </f7-button>
       </f7-card-footer>
     </f7-card>
     <f7-card v-show="showTasks" title="Suggested Tasks">
       <f7-card-content :padding="false">
         <ol>
           <li>
-            <f7-link no-link-class color="blue" href="#"> Install Bindings &amp; other add-ons </f7-link>
+            <f7-link no-link-class color="theme-alt" href="#"> Install Bindings &amp; other add-ons </f7-link>
           </li>
           <li>
-            <f7-link no-link-class color="blue" href="#"> Discover &amp; configure Things </f7-link>
+            <f7-link no-link-class color="theme-alt" href="#"> Discover &amp; configure Things </f7-link>
           </li>
           <li>
-            <f7-link no-link-class color="blue" href="#">
+            <f7-link no-link-class color="theme-alt" href="#">
               Design your home's conceptually with the semantic model builder and link the Things to Items
             </f7-link>
           </li>
           <li>
-            <f7-link no-link-class color="blue" href="#">
+            <f7-link no-link-class color="theme-alt" href="#">
               Connect to openHAB Cloud for remote access and integration with voice assistants
             </f7-link>
           </li>
         </ol>
       </f7-card-content>
       <f7-card-footer>
-        <f7-link color="blue" @click="dismissTasks"> Dismiss </f7-link>
+        <f7-link color="theme-alt" @click="dismissTasks"> Dismiss </f7-link>
       </f7-card-footer>
     </f7-card>
   </div>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -85,9 +85,11 @@
                   </div>
                 </template>
               </f7-list-item>
-              <f7-list-button color="theme-alt" @click="addSeries('oh-time-series', gridIdx)"> Add Time Series </f7-list-button>
-              <f7-list-button color="theme-alt" @click="addSeries('oh-aggregate-series', gridIdx)"> Add Aggregate Series </f7-list-button>
-              <f7-list-button color="theme-alt" @click="addSeries('oh-state-series', gridIdx)"> Add State Series </f7-list-button>
+              <template v-if="context.editmode?.isEditable">
+                <f7-list-button color="theme-alt" @click="addSeries('oh-time-series', gridIdx)"> Add Time Series </f7-list-button>
+                <f7-list-button color="theme-alt" @click="addSeries('oh-aggregate-series', gridIdx)"> Add Aggregate Series </f7-list-button>
+                <f7-list-button color="theme-alt" @click="addSeries('oh-state-series', gridIdx)"> Add State Series </f7-list-button>
+              </template>
             </f7-list>
           </f7-card>
         </div>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/chart/chart-designer.vue
@@ -4,13 +4,13 @@
       <f7-block-title>Coordinate Systems</f7-block-title>
       <f7-row class="margin-bottom">
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="addGrid">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="addGrid">
             <img src="./gridSimple.svg" width="80px" />
             Add<br />Grid
           </f7-link>
         </f7-col>
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="50">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="addCalendar">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="addCalendar">
             <img src="./calendar.svg" width="80px" />
             Add<br />Calendar
           </f7-link>
@@ -85,11 +85,9 @@
                   </div>
                 </template>
               </f7-list-item>
-              <template v-if="context.editmode?.isEditable">
-                <f7-list-button color="blue" @click="addSeries('oh-time-series', gridIdx)"> Add Time Series </f7-list-button>
-                <f7-list-button color="blue" @click="addSeries('oh-aggregate-series', gridIdx)"> Add Aggregate Series </f7-list-button>
-                <f7-list-button color="blue" @click="addSeries('oh-state-series', gridIdx)"> Add State Series </f7-list-button>
-              </template>
+              <f7-list-button color="theme-alt" @click="addSeries('oh-time-series', gridIdx)"> Add Time Series </f7-list-button>
+              <f7-list-button color="theme-alt" @click="addSeries('oh-aggregate-series', gridIdx)"> Add Aggregate Series </f7-list-button>
+              <f7-list-button color="theme-alt" @click="addSeries('oh-state-series', gridIdx)"> Add State Series </f7-list-button>
             </f7-list>
           </f7-card>
         </div>
@@ -180,7 +178,7 @@
               </f7-list-item>
               <f7-list-button
                 v-if="context.editmode?.isEditable"
-                color="blue"
+                color="theme-alt"
                 @click="addCalendarSeries('oh-calendar-series', calendarIdx)">
                 Add Calendar Series
               </f7-list-button>
@@ -196,8 +194,8 @@
       <f7-block-title>Other Components</f7-block-title>
       <f7-row class="margin-bottom">
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('tooltip')">
-            <f7-badge v-if="context.component.slots.tooltip" color="blue" class="count-badge">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('tooltip')">
+            <f7-badge v-if="context.component.slots.tooltip" color="theme-alt" class="count-badge">
               {{ context.component.slots.tooltip.length }}
             </f7-badge>
             <img src="./tooltip.svg" width="80px" />
@@ -205,8 +203,8 @@
           </f7-link>
         </f7-col>
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('visualMap')">
-            <f7-badge v-if="context.component.slots.visualMap" color="blue" class="count-badge">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('visualMap')">
+            <f7-badge v-if="context.component.slots.visualMap" color="theme-alt" class="count-badge">
               {{ context.component.slots.visualMap.length }}
             </f7-badge>
             <img src="./visualMap.svg" width="80px" />
@@ -214,8 +212,8 @@
           </f7-link>
         </f7-col>
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlot('dataZoom')">
-            <f7-badge v-if="context.component.slots.dataZoom" color="blue" class="count-badge">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlot('dataZoom')">
+            <f7-badge v-if="context.component.slots.dataZoom" color="theme-alt" class="count-badge">
               {{ context.component.slots.dataZoom.length }}
             </f7-badge>
             <img src="./dataZoom.svg" width="80px" />
@@ -225,8 +223,8 @@
       </f7-row>
       <f7-row class="margin-bottom">
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('legend')">
-            <f7-badge v-if="context.component.slots.legend" color="blue" class="count-badge">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('legend')">
+            <f7-badge v-if="context.component.slots.legend" color="theme-alt" class="count-badge">
               {{ context.component.slots.legend.length }}
             </f7-badge>
             <img src="./legend.svg" width="80px" />
@@ -234,8 +232,8 @@
           </f7-link>
         </f7-col>
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('title')">
-            <f7-badge v-if="context.component.slots.title" color="blue" class="count-badge">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('title')">
+            <f7-badge v-if="context.component.slots.title" color="theme-alt" class="count-badge">
               {{ context.component.slots.title.length }}
             </f7-badge>
             <img src="./title.svg" width="80px" />
@@ -243,8 +241,8 @@
           </f7-link>
         </f7-col>
         <f7-col class="elevation-2 elevation-hover-6 elevation-pressed-1 chartdesigner-big-button" width="33">
-          <f7-link color="blue" class="display-flex flex-direction-column padding" @click="configureSlotByName('toolbox')">
-            <f7-badge v-if="context.component.slots.toolbox" color="blue" class="count-badge">
+          <f7-link color="theme-alt" class="display-flex flex-direction-column padding" @click="configureSlotByName('toolbox')">
+            <f7-badge v-if="context.component.slots.toolbox" color="theme-alt" class="count-badge">
               {{ context.component.slots.toolbox.length }}
             </f7-badge>
             <img src="./toolbox.svg" width="80px" />

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/page-settings.vue
@@ -95,7 +95,7 @@
         </div>
       </f7-list>
       <f7-list v-if="!createMode" inline-labels no-hairline-md>
-        <f7-list-button color="blue" @click="duplicatePage"> Duplicate Page </f7-list-button>
+        <f7-list-button color="theme-alt" @click="duplicatePage"> Duplicate Page </f7-list-button>
         <f7-list-button v-if="!readOnly" color="red" @click="deletePage"> Remove Page </f7-list-button>
       </f7-list>
     </template>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/attribute-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/attribute-details.vue
@@ -90,7 +90,7 @@
       </f7-list>
     </f7-card-content>
     <f7-card-footer v-if="!disabled && widget.type !== 'Sitemap'" key="item-card-buttons-edit-mode">
-      <f7-button color="blue" @click="addAttribute"> Add </f7-button>
+      <f7-button color="theme-alt" @click="addAttribute"> Add </f7-button>
     </f7-card-footer>
   </f7-card>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/treeview-item.vue
@@ -5,7 +5,7 @@
     :label="widgetConfigLabel()"
     :icon-f7="widgetTypeIcon()"
     :textColor="iconColor"
-    :color="'blue'"
+    :color="'theme-alt'"
     :selected="selected && selected === widget ? true : null"
     :opened="!widget.closed"
     :toggle="canHaveChildren"

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/widget-details.vue
@@ -287,18 +287,18 @@
       </f7-list>
     </f7-card-content>
     <f7-card-footer v-if="editable || widget.type === 'Sitemap'" key="sitemap-widget-buttons-edit-mode" class="widget-details-footer">
-      <!-- <f7-button v-if="!editMode && !createMode" color="blue" @click="editMode = true" icon-ios="material:expand_more" icon-md="material:expand_more" icon-aurora="material:expand_more">Edit</f7-button> -->
+      <!-- <f7-button v-if="!editMode && !createMode" color="theme-alt" @click="editMode = true" icon-ios="material:expand_more" icon-md="material:expand_more" icon-aurora="material:expand_more">Edit</f7-button> -->
       <f7-segmented v-if="editable && widget.type !== 'Sitemap'">
         <f7-button
           v-if="widget.type === 'Button'"
-          color="blue"
+          color="theme-alt"
           @click="$emit('sortbuttons', widget.parent)"
           icon-f7="sort_down"
           tooltip="Sort Buttons" />
-        <f7-button color="blue" @click="$emit('moveup', widget)" icon-f7="chevron_up" tooltip="Move Up" />
-        <f7-button color="blue" @click="$emit('movedown', widget)" icon-f7="chevron_down" tooltip="Move Down" />
+        <f7-button color="theme-alt" @click="$emit('moveup', widget)" icon-f7="chevron_up" tooltip="Move Up" />
+        <f7-button color="theme-alt" @click="$emit('movedown', widget)" icon-f7="chevron_down" tooltip="Move Down" />
       </f7-segmented>
-      <f7-button v-if="editable || widget.type === 'Sitemap'" color="blue" @click="$emit('duplicate', widget)"> Duplicate </f7-button>
+      <f7-button v-if="editable || widget.type === 'Sitemap'" color="theme-alt" @click="$emit('duplicate', widget)"> Duplicate </f7-button>
       <f7-button v-if="editable && widget.type !== 'Sitemap'" color="red" @click="$emit('remove', widget)"> Remove </f7-button>
     </f7-card-footer>
   </f7-card>

--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-slot-config-popup.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/widget-slot-config-popup.vue
@@ -33,7 +33,7 @@
             @updated="dirty = true" />
           <f7-block v-else strong> This type of component cannot be configured: {{ slotComponent.component }}. </f7-block>
           <f7-list>
-            <f7-list-button v-if="!readOnly" color="blue" @click="editWidgetCode(slotComponent)"> Edit YAML </f7-list-button>
+            <f7-list-button v-if="!readOnly" color="theme-alt" @click="editWidgetCode(slotComponent)"> Edit YAML </f7-list-button>
             <!-- prettier-ignore  -->
             <f7-list-button
               v-if="!readOnly"

--- a/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/persistence/item-persistence-details.vue
@@ -22,7 +22,7 @@
       </f7-list>
     </f7-card-content>
     <f7-card-footer>
-      <f7-button color="blue" href="/settings/persistence/"> Configure Persistence Policies </f7-button>
+      <f7-button color="theme-alt" href="/settings/persistence/"> Configure Persistence Policies </f7-button>
     </f7-card-footer>
   </f7-card>
 </template>

--- a/bundles/org.openhab.ui/web/src/components/persistence/persistence-config-setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/persistence/persistence-config-setup-wizard.vue
@@ -75,7 +75,7 @@
               <f7-list-item>
                 {{ this.t('setupwizard.persistence-config.services.advancedConfig') }}
               </f7-list-item>
-              <f7-list-button color="blue" @click="resetConfiguration(service.id)">
+              <f7-list-button color="theme-alt" @click="resetConfiguration(service.id)">
                 {{ this.t('setupwizard.persistence-config.services.resetConfig') }}
               </f7-list-button>
             </f7-list>

--- a/bundles/org.openhab.ui/web/src/components/persistence/persistence-config-setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/persistence/persistence-config-setup-wizard.vue
@@ -78,7 +78,7 @@
               <f7-list-item>
                 {{ this.t('setupwizard.persistence-config.services.advancedConfig') }}
               </f7-list-item>
-              <f7-list-button color="blue" @click="resetConfiguration(service.id)">
+              <f7-list-button color="theme-alt" @click="resetConfiguration(service.id)">
                 {{ this.t('setupwizard.persistence-config.services.resetConfig') }}
               </f7-list-button>
             </f7-list>

--- a/bundles/org.openhab.ui/web/src/components/rule/action-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/action-module-wizard.vue
@@ -29,7 +29,7 @@
       </f7-col>
     </f7-row>
     <f7-list>
-      <f7-list-button title="Show All" color="blue" @click="$emit('show-advanced')" />
+      <f7-list-button title="Show All" color="theme-alt" @click="$emit('show-advanced')" />
     </f7-list>
   </f7-block>
   <f7-block v-else-if="category === 'item'" class="no-margin no-padding">

--- a/bundles/org.openhab.ui/web/src/components/rule/condition-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/condition-module-wizard.vue
@@ -29,7 +29,7 @@
       </f7-col>
     </f7-row>
     <f7-list>
-      <f7-list-button title="Show All" color="blue" @click="$emit('show-advanced')" />
+      <f7-list-button title="Show All" color="theme-alt" @click="$emit('show-advanced')" />
     </f7-list>
   </f7-block>
   <f7-block v-else-if="category === 'item'" class="no-margin no-padding">

--- a/bundles/org.openhab.ui/web/src/components/rule/trigger-module-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/trigger-module-wizard.vue
@@ -29,7 +29,7 @@
       </f7-col>
     </f7-row>
     <f7-list>
-      <f7-list-button title="Show All" color="blue" @click="$emit('show-advanced')" />
+      <f7-list-button title="Show All" color="theme-alt" @click="$emit('show-advanced')" />
     </f7-list>
   </f7-block>
   <f7-block v-else-if="category === 'item'" class="no-margin no-padding">

--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -5,7 +5,7 @@
       <f7-list-item v-if="tags.length > 0">
         <template #inner>
           <div>
-            <f7-chip v-for="tag in tags" :key="tag" :text="tag" :deleteable="!disabled" @delete="deleteTag" media-bg-color="blue">
+            <f7-chip v-for="tag in tags" :key="tag" :text="tag" :deleteable="!disabled" @delete="deleteTag" media-bg-color="theme-alt">
               <template #media>
                 <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
               </template>

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-group.vue
@@ -19,7 +19,7 @@
       class="channel-item"
       :subtitle="c.channel.id + ' (' + getItemType(c.channelType) + ')'"
       :badge="getLinkedItems(c.channel).length || ''"
-      badge-color="blue"
+      badge-color="theme-alt"
       @change="$emit('selected', c.channel, c.channelType)"
       @accordion:beforeopen="openedChannel = c.channelType.id"
       @accordion:close="openedChannel = ''"

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -45,17 +45,17 @@
         <template #after-title>
           <f7-icon v-if="!link.item.editable" f7="lock_fill" size="1rem" color="gray" />
         </template>
-        <!-- <f7-button color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
+        <!-- <f7-button color="theme-alt" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
       </f7-list-item>
     </f7-list-group>
-    <f7-list-item class="searchbar-ignore" link color="blue" subtitle="Add Link to Item..." @click="addLink()">
+    <f7-list-item class="searchbar-ignore" link color="theme-alt" subtitle="Add Link to Item..." @click="addLink()">
       <template #media>
         <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
       </template>
     </f7-list-item>
     <f7-list-button
       class="searchbar-ignore"
-      color="blue"
+      color="theme-alt"
       :title="
         thing.editable && (channelType.parameterGroups.length || channelType.parameters.length) ? 'Configure Channel' : 'Channel Details'
       "
@@ -63,7 +63,7 @@
     <f7-list-button
       v-if="extensible && thing.editable"
       class="searchbar-ignore"
-      color="blue"
+      color="theme-alt"
       title="Duplicate Channel"
       @click="duplicateChannel()" />
     <f7-list-button

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -69,7 +69,7 @@
                 <item-picker
                   v-if="isChecked(channel) && hasLinks(channel)"
                   :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
-                  textcolor="theme-alt"
+                  textColor="theme-alt"
                   :hideIcon="true"
                   :items="items.filter((i) => channel.linkedItems.includes(i.name))"
                   :multiple="false"

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-list.vue
@@ -69,7 +69,7 @@
                 <item-picker
                   v-if="isChecked(channel) && hasLinks(channel)"
                   :label="selectedItem(channel) ? 'Change Item Selection' : 'Pick Existing Linked Item'"
-                  textColor="blue"
+                  textcolor="theme-alt"
                   :hideIcon="true"
                   :items="items.filter((i) => channel.linkedItems.includes(i.name))"
                   :multiple="false"
@@ -91,10 +91,10 @@
           </f7-col>
         </f7-row>
         <f7-list v-if="multipleLinksMode">
-          <f7-list-button style="padding-left: 0; text-align: left" color="blue" @click="toggleAllChecks(true, $event)">
+          <f7-list-button style="padding-left: 0; text-align: left" color="theme-alt" @click="toggleAllChecks(true, $event)">
             Select All
           </f7-list-button>
-          <f7-list-button color="blue" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
+          <f7-list-button color="theme-alt" @click="toggleAllChecks(false, $event)"> Unselect All </f7-list-button>
         </f7-list>
       </f7-block>
     </f7-col>

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-status-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-status-mixin.js
@@ -25,7 +25,7 @@ export default {
           const { pretext, path, posttext } = result.groups
           if (!path) return description
           const root = location.protocol + '//' + location.host
-          return `${pretext}<a href="${root}/${path}" target="_blank" class="link color-blue external">${root}/${path}</a>${posttext}`
+          return `${pretext}<a href="${root}/${path}" target="_blank" class="link color-theme-alt external">${root}/${path}</a>${posttext}`
         }
       }
       return description

--- a/bundles/org.openhab.ui/web/src/components/util/list-filter.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/list-filter.vue
@@ -21,8 +21,8 @@
                   v-for="(label, value) in filter.options"
                   :key="value"
                   :text="label"
-                  :color="isFilteredBy(type, value) ? 'blue' : ''"
-                  media-bg-color="blue"
+                  :color="isFilteredBy(type, value) ? 'theme-alt' : ''"
+                  media-bg-color="theme-alt"
                   style="margin-right: 6px; cursor: pointer"
                   @click="toggleFilter(type, value)">
                   <template #media>

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-item.vue
@@ -19,7 +19,7 @@
           <f7-link
             v-if="defaultSlots.length > 0"
             href="#"
-            class="text-color-blue display-flex flex-direction-column margin-right"
+            class="text-color-theme-alt display-flex flex-direction-column margin-right"
             :popover-close="'.item-popover-' + uid"
             @click="context.editmode.configureWidget(defaultSlots[0], context)"
             icon-f7="square_pencil">
@@ -28,7 +28,7 @@
           <f7-link
             v-if="defaultSlots.length > 0"
             href="#"
-            class="text-color-blue display-flex flex-direction-column margin-right"
+            class="text-color-theme-alt display-flex flex-direction-column margin-right"
             :popover-close="'.item-popover-' + uid"
             @click="context.editmode.editWidgetCode(defaultSlots[0], context)"
             icon-f7="doc_text">

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-layout.vue
@@ -20,7 +20,7 @@
       <!-- fullscreen fab menu -->
       <template v-if="fullscreen">
         <f7-fab-backdrop />
-        <f7-fab v-if="context.editmode" position="right-bottom" color="blue">
+        <f7-fab v-if="context.editmode" position="right-bottom" color="theme-alt">
           <f7-icon f7="menu" />
           <f7-icon ios="f7:xmark" aurora="f7:xmark" md="material:close" />
           <f7-fab-buttons position="top">

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-row.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-row.vue
@@ -42,7 +42,7 @@
     </f7-row>
     <!-- <f7-row v-if="context.editmode">
       <f7-col class="display-flex justify-content-left">
-        <f7-button color="blue" text="Add column" icon-f7="rectangle_split_3x1" @click="$emit('add-widget', context.component, 'oh-grid-col')"></f7-button>
+        <f7-button color="theme-alt" text="Add column" icon-f7="rectangle_split_3x1" @click="$emit('add-widget', context.component, 'oh-grid-col')"></f7-button>
       </f7-col>
     </f7-row> -->
   </div>

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
@@ -4,7 +4,7 @@
       <oh-block v-for="(component, idx) in defaultSlots" v-bind="$attrs" :key="idx" :context="childContext(component)" />
       <f7-block v-if="context.editmode?.isEditable">
         <f7-list>
-          <f7-list-button color="blue" @click="$emit('add-block', context.component)"> Add Block </f7-list-button>
+          <f7-list-button color="theme-alt" @click="$emit('add-block', context.component)"> Add Block </f7-list-button>
         </f7-list>
       </f7-block>
 
@@ -15,7 +15,7 @@
       <template v-else-if="context.editmode?.isEditable">
         <f7-block>
           <f7-list>
-            <f7-list-button color="blue" @click="$emit('add-masonry', context.component)"> Add Masonry </f7-list-button>
+            <f7-list-button color="theme-alt" @click="$emit('add-masonry', context.component)"> Add Masonry </f7-list-button>
           </f7-list>
         </f7-block>
       </template>

--- a/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/plan/oh-plan-marker.vue
@@ -30,14 +30,14 @@
       <div class="display-flex">
         <f7-link
           href="#"
-          class="text-color-blue display-flex flex-direction-column margin-right"
+          class="text-color-theme-alt display-flex flex-direction-column margin-right"
           @click="context.editmode.configureWidget(context.component, context.parent)"
           icon-f7="square_pencil">
           Settings
         </f7-link>
         <f7-link
           href="#"
-          class="text-color-blue display-flex flex-direction-column margin-right"
+          class="text-color-theme-alt display-flex flex-direction-column margin-right"
           @click="context.editmode.editWidgetCode(context.component, context.parent)"
           icon-f7="doc_text">
           YAML
@@ -45,7 +45,7 @@
         <f7-link
           v-if="context.editmode.isEditable"
           href="#"
-          class="text-color-blue display-flex flex-direction-column margin-right"
+          class="text-color-theme-alt display-flex flex-direction-column margin-right"
           @click="context.editmode.copyWidget(context.component, context.parent)"
           icon-f7="scissors_alt">
           Copy

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/default-cell-item.js
@@ -31,7 +31,7 @@ export default function itemDefaultCellComponent(item, itemNameAsFooter) {
       component = {
         component: 'oh-cell',
         config: {
-          color: 'blue',
+          color: 'theme-alt',
           action: 'toggle',
           actionItem: item.name,
           actionCommand: 'ON',
@@ -44,7 +44,7 @@ export default function itemDefaultCellComponent(item, itemNameAsFooter) {
       component = {
         component: 'oh-slider-cell',
         config: {
-          color: 'blue',
+          color: 'theme-alt',
           action: 'toggle',
           actionItem: item.name,
           actionCommand: 'ON',
@@ -107,7 +107,7 @@ export default function itemDefaultCellComponent(item, itemNameAsFooter) {
         component = {
           component: 'oh-slider-cell',
           config: {
-            color: 'blue',
+            color: 'theme-alt',
             action: 'toggle',
             actionItem: item.name,
             actionCommand: 'ON',
@@ -125,7 +125,7 @@ export default function itemDefaultCellComponent(item, itemNameAsFooter) {
       component = {
         component: 'oh-cell',
         config: {
-          color: 'blue',
+          color: 'theme-alt',
           action: 'toggle',
           actionItem: item.name,
           actionCommand: 'ON',

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -2,7 +2,7 @@
   <f7-list-button
     v-if="config.listButton && !context.editmode"
     :title="config.title || 'Action'"
-    :color="config.color || 'blue'"
+    :color="config.color || 'theme-alt'"
     @click.stop="performAction" />
   <f7-list-item v-else-if="config.divider && !context.editmode" divider ref="divider" :title="config.title" />
   <f7-list-item

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-player-controls.vue
@@ -1,24 +1,31 @@
 <template>
   <f7-segmented v-bind="config" round outline strong class="player-controls" title="">
-    <f7-button color="blue" @click.stop="skipPrevious()" large icon-material="skip_previous" icon-size="24" icon-color="gray" />
+    <f7-button color="theme-alt" @click.stop="skipPrevious()" large icon-material="skip_previous" icon-size="24" icon-color="gray" />
     <f7-button
       v-if="this.config.showRewindFFward"
-      color="blue"
+      color="theme-alt"
       @click.stop="rewind()"
       large
       icon-material="fast_rewind"
       icon-size="24"
       icon-color="gray" />
-    <f7-button color="blue" @click.stop="playPause()" large round fill :icon-f7="isPlaying ? 'pause_fill' : 'play_fill'" icon-size="24" />
+    <f7-button
+      color="theme-alt"
+      @click.stop="playPause()"
+      large
+      round
+      fill
+      :icon-f7="isPlaying ? 'pause_fill' : 'play_fill'"
+      icon-size="24" />
     <f7-button
       v-if="this.config.showRewindFFward"
-      color="blue"
+      color="theme-alt"
       @click.stop="fastForward()"
       large
       icon-material="fast_forward"
       icon-size="24"
       icon-color="gray" />
-    <f7-button color="blue" @click.stop="skipNext()" large icon-material="skip_next" icon-size="24" icon-color="gray" />
+    <f7-button color="theme-alt" @click.stop="skipNext()" large icon-material="skip_next" icon-size="24" icon-color="gray" />
   </f7-segmented>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-sipclient.vue
@@ -438,7 +438,7 @@ export default {
                 .map((key) => {
                   return {
                     text: this.phonebook.get(key) || key,
-                    color: 'blue',
+                    color: 'theme-alt',
                     onClick: () => {
                       this.call(key)
                     }

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
@@ -81,7 +81,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
           f7.actions
             .create({
               buttons: [
-                [{ text: confirmConfig.text, color: confirmConfig.color || 'blue', onClick: () => resolve() }],
+                [{ text: confirmConfig.text, color: confirmConfig.color || 'theme-alt', onClick: () => resolve() }],
                 // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
                 [{ text: t('dialogs.cancel'), color: 'red', onClick: () => reject() }]
               ]
@@ -248,7 +248,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
                     }
                     return {
                       text: label || cmd,
-                      color: 'blue',
+                      color: 'theme-alt',
                       onClick: () => {
                         void statesStore.sendCommand(actionCommandOptionsItem, cmd).then(() => showActionFeedback(prefix, actionConfig))
                       }
@@ -262,7 +262,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
                     return item.commandDescription.commandOptions.map((cd) => {
                       return {
                         text: cd.label || cd.command,
-                        color: 'blue',
+                        color: 'theme-alt',
                         onClick: () => {
                           void statesStore
                             .sendCommand(actionCommandOptionsItem, cd.command)

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
@@ -85,7 +85,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
           f7.actions
             .create({
               buttons: [
-                [{ text: confirmConfig.text, color: confirmConfig.color || 'blue', onClick: () => resolve() }],
+                [{ text: confirmConfig.text, color: confirmConfig.color || 'theme-alt', onClick: () => resolve() }],
                 // eslint-disable-next-line @typescript-eslint/prefer-promise-reject-errors
                 [{ text: t('dialogs.cancel'), color: 'red', onClick: () => reject('action confirmation rejected') }]
               ]
@@ -250,7 +250,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
                     }
                     return {
                       text: label || cmd,
-                      color: 'blue',
+                      color: 'theme-alt',
                       onClick: () => {
                         void statesStore.sendCommand(actionCommandOptionsItem, cmd).then(() => showActionFeedback(prefix, actionConfig))
                       }
@@ -264,7 +264,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
                     return item.commandDescription.commandOptions.map((cd) => {
                       return {
                         text: cd.label || cd.command,
-                        color: 'blue',
+                        color: 'theme-alt',
                         onClick: () => {
                           void statesStore
                             .sendCommand(actionCommandOptionsItem, cd.command)

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -284,8 +284,8 @@ html
 
 .toolbar.toolbar-bottom, .tabbar.tabbar-bottom, .dock-toolbar
   --f7-theme-color var(--oh-theme-alt-color)
-  --f7-theme-color-rgb var(--f7-color-blue-rgb)
-  --f7-theme-color-tint var(--f7-color-blue-tint)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
+  --f7-theme-color-tint var(--oh-theme-alt-color-tint)
 
 .home-tabs
   --f7-theme-color var(--oh-theme-alt-color)

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -143,10 +143,54 @@ html
 
 /* Custom color theme properties */
 :root
-  --f7-theme-color #e64a19
-  --f7-theme-color-rgb 230, 74, 25
-  --f7-theme-color-shade #c13e15
-  --f7-theme-color-tint #ea673e
+  --oh-branding-color #e64a19     // do not change
+
+  --oh-theme-color var(--oh-branding-color)
+  --oh-theme-color-rgb 230, 74, 25
+  --oh-theme-color-shade #c13e15
+  --oh-theme-color-tint #ea673e
+
+  --oh-theme-alt-color #2196F3
+  --oh-theme-alt-color-rgb 33, 150, 243
+  --oh-theme-alt-color-shade #1b7fd0
+  --oh-theme-alt-color-tint #40a4f4
+
+  --f7-theme-color var(--oh-theme-color)
+  --f7-theme-color-rgb var(--oh-theme-color-rgb)
+  --f7-theme-color-shade var(--oh-theme-color-shade)
+  --f7-theme-color-tint var(--oh-theme-color-tint)
+
+// classes for theme and theme-alt so that colors can be used as the color property for f7 components
+.color-theme
+  --f7-theme-color var(--oh-theme-color)
+  --f7-theme-color-rgb var(--oh-theme-color-rgb)
+  --f7-theme-color-shade var(--oh-theme-color-shade)
+  --f7-theme-color-tint var(--oh-theme-color-tint)
+
+.text-color-theme
+  --f7-theme-color-text-color var(--oh-theme-color)
+  
+.bg-color-theme
+  --f7-theme-color-bg-color var(--oh-theme-color)
+
+.border-color-theme
+  --f7-theme-color-border-color var(--oh-theme-color)
+
+.color-theme-alt
+  --f7-theme-color var(--oh-theme-alt-color)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
+  --f7-theme-color-shade var(--oh-theme-alt-color-shade)
+  --f7-theme-color-tint var(--oh-theme-alt-color-tint)
+
+.text-color-theme-alt
+  --f7-theme-color-text-color var(--oh-theme-alt-color)
+  
+.bg-color-theme-alt
+  --f7-theme-color-bg-color var(--oh-theme-alt-color)
+
+.border-color-theme-alt
+  --f7-theme-color-border-color var(--oh-theme-alt-color)
+
 
 :root.theme-filled,
 :root .theme-filled
@@ -239,12 +283,12 @@ html
   transition opacity 0.3s ease
 
 .toolbar.toolbar-bottom, .tabbar.tabbar-bottom, .dock-toolbar
-  --f7-theme-color #2196f3
+  --f7-theme-color var(--oh-theme-alt-color)
   --f7-theme-color-rgb var(--f7-color-blue-rgb)
   --f7-theme-color-tint var(--f7-color-blue-tint)
 
 .home-tabs
-  --f7-theme-color #2196f3
+  --f7-theme-color var(--oh-theme-alt-color)
   --f7-bars-bg-color rgb(247, 247, 248)
   --f7-bars-text-color #000
   --f7-tabbar-link-inactive-color rgba(0, 0, 0, 0.54)

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -321,8 +321,8 @@ html
 
 .toolbar.toolbar-bottom, .tabbar.tabbar-bottom, .dock-toolbar
   --f7-theme-color var(--oh-theme-alt-color)
-  --f7-theme-color-rgb var(--f7-color-blue-rgb)
-  --f7-theme-color-tint var(--f7-color-blue-tint)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
+  --f7-theme-color-tint var(--oh-theme-alt-color-tint)
 
 .home-tabs
   --f7-theme-color var(--oh-theme-alt-color)

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -180,7 +180,7 @@ html
 
 /* Custom color theme properties */
 :root
-  --oh-branding-color #e64a19     // do not change
+  --oh-branding-color #e64a19 // do not change
 
   --oh-theme-color var(--oh-branding-color)
   --oh-theme-color-rgb 230, 74, 25

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -180,10 +180,54 @@ html
 
 /* Custom color theme properties */
 :root
-  --f7-theme-color #e64a19
-  --f7-theme-color-rgb 230, 74, 25
-  --f7-theme-color-shade #c13e15
-  --f7-theme-color-tint #ea673e
+  --oh-branding-color #e64a19     // do not change
+
+  --oh-theme-color var(--oh-branding-color)
+  --oh-theme-color-rgb 230, 74, 25
+  --oh-theme-color-shade #c13e15
+  --oh-theme-color-tint #ea673e
+
+  --oh-theme-alt-color #2196F3
+  --oh-theme-alt-color-rgb 33, 150, 243
+  --oh-theme-alt-color-shade #1b7fd0
+  --oh-theme-alt-color-tint #40a4f4
+
+  --f7-theme-color var(--oh-theme-color)
+  --f7-theme-color-rgb var(--oh-theme-color-rgb)
+  --f7-theme-color-shade var(--oh-theme-color-shade)
+  --f7-theme-color-tint var(--oh-theme-color-tint)
+
+// classes for theme and theme-alt so that colors can be used as the color property for f7 components
+.color-theme
+  --f7-theme-color var(--oh-theme-color)
+  --f7-theme-color-rgb var(--oh-theme-color-rgb)
+  --f7-theme-color-shade var(--oh-theme-color-shade)
+  --f7-theme-color-tint var(--oh-theme-color-tint)
+
+.text-color-theme
+  --f7-theme-color-text-color var(--oh-theme-color)
+  
+.bg-color-theme
+  --f7-theme-color-bg-color var(--oh-theme-color)
+
+.border-color-theme
+  --f7-theme-color-border-color var(--oh-theme-color)
+
+.color-theme-alt
+  --f7-theme-color var(--oh-theme-alt-color)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
+  --f7-theme-color-shade var(--oh-theme-alt-color-shade)
+  --f7-theme-color-tint var(--oh-theme-alt-color-tint)
+
+.text-color-theme-alt
+  --f7-theme-color-text-color var(--oh-theme-alt-color)
+  
+.bg-color-theme-alt
+  --f7-theme-color-bg-color var(--oh-theme-alt-color)
+
+.border-color-theme-alt
+  --f7-theme-color-border-color var(--oh-theme-alt-color)
+
 
 :root.theme-filled,
 :root .theme-filled
@@ -276,12 +320,12 @@ html
   transition opacity 0.3s ease
 
 .toolbar.toolbar-bottom, .tabbar.tabbar-bottom, .dock-toolbar
-  --f7-theme-color #2196f3
+  --f7-theme-color var(--oh-theme-alt-color)
   --f7-theme-color-rgb var(--f7-color-blue-rgb)
   --f7-theme-color-tint var(--f7-color-blue-tint)
 
 .home-tabs
-  --f7-theme-color #2196f3
+  --f7-theme-color var(--oh-theme-alt-color)
   --f7-bars-bg-color rgb(247, 247, 248)
   --f7-bars-text-color #000
   --f7-tabbar-link-inactive-color rgba(0, 0, 0, 0.54)

--- a/bundles/org.openhab.ui/web/src/js/clipboard.js
+++ b/bundles/org.openhab.ui/web/src/js/clipboard.js
@@ -41,7 +41,7 @@ function showManualCopyDialog(data, dialogTitle, dialogText, onSuccess, onError)
         },
         {
           text: 'OK',
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             copyText(data, undefined, (error, event) => {
               if (error) {

--- a/bundles/org.openhab.ui/web/src/pages/about.vue
+++ b/bundles/org.openhab.ui/web/src/pages/about.vue
@@ -52,7 +52,7 @@
                         <f7-progressbar
                           class="margin-top"
                           style="width: 90%"
-                          color="blue"
+                          color="theme-alt"
                           :progress="(systemInfo.freeMemory * 100) / systemInfo.totalMemory" />
                         <small class="margin-bottom text-color-gray">
                           {{
@@ -69,7 +69,7 @@
                       </div>
                     </template>
                   </f7-list-item>
-                  <f7-list-button color="blue" @click="textualSystemInfoOpened = true">
+                  <f7-list-button color="theme-alt" @click="textualSystemInfoOpened = true">
                     {{ t('about.technicalInformation.viewDetails') }}
                   </f7-list-button>
                 </f7-list>
@@ -102,10 +102,10 @@
           <f7-list-button v-if="showCachePurgeOption" color="red" @click="purgeServiceWorkerAndCaches()">
             {{ t('about.reload.purgeCachesAndRefresh') }}
           </f7-list-button>
-          <f7-list-button color="blue" @click="reload">
+          <f7-list-button color="theme-alt" @click="reload">
             {{ t('about.reload.reloadApp') }}
           </f7-list-button>
-          <f7-list-button color="blue" href="/setup-wizard/">
+          <f7-list-button color="theme-alt" href="/setup-wizard/">
             {{ t('about.reload.setupWizard') }}
           </f7-list-button>
         </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-config.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-config.vue
@@ -9,7 +9,7 @@
     </f7-navbar>
     <f7-block v-if="type === 'persistence'" class="block-narrow">
       <f7-col>
-        <f7-button large fill color="blue" :href="'/settings/persistence/' + name" class="persistence-button">
+        <f7-button large fill color="theme-alt" :href="'/settings/persistence/' + name" class="persistence-button">
           Configure Persistence Policies
         </f7-button>
       </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-details-sheet.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-details-sheet.vue
@@ -33,7 +33,7 @@
       <f7-block>
         <f7-row>
           <f7-col class="col-100 margin-top padding-horizontal">
-            <f7-button v-if="state === 'UNINSTALLED'" large fill color="blue" @click="install()">
+            <f7-button v-if="state === 'UNINSTALLED'" large fill color="theme-alt" @click="install()">
               {{ installableAddon ? 'Install' : 'Add' }}
             </f7-button>
             <f7-button v-if="state !== 'UNINSTALLED'" large fill color="red" @click="uninstall()">

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
@@ -16,14 +16,14 @@
               </div>
               <div v-if="addon.verifiedAuthor" class="addon-header-subtitle">
                 {{ addon.author }}
-                <f7-icon :color="uiOptionsStore.darkMode === 'dark' ? 'white' : 'blue'" f7="checkmark_seal_fill" />
+                <f7-icon :color="uiOptionsStore.darkMode === 'dark' ? 'white' : 'theme-alt'" f7="checkmark_seal_fill" />
               </div>
               <div v-else-if="addon.properties && addon.properties.views" class="addon-header-subtitle">
                 <addon-stats-line :addon="addon" :iconSize="15" />
               </div>
               <div class="addon-header-actions">
                 <div v-if="showInstallActions">
-                  <f7-preloader v-if="isPending(addon)" color="blue" />
+                  <f7-preloader v-if="isPending(addon)" color="theme-alt" />
                   <f7-button
                     v-else-if="addon.installed"
                     class="install-button"
@@ -37,7 +37,7 @@
                     v-else
                     class="install-button"
                     :text="installableAddon(addon) ? 'Install' : 'Add'"
-                    color="blue"
+                    color="theme-alt"
                     round
                     small
                     fill
@@ -47,7 +47,7 @@
                   v-if="showConfig"
                   icon-f7="gears"
                   tooltip="Configure add-on"
-                  color="blue"
+                  color="theme-alt"
                   :href="'/settings/addons/' + addonId"
                   round
                   small />
@@ -171,7 +171,7 @@
   .addon-description
     --f7-block-strong-bg-color transparent
     width calc(100%)
-    --f7-theme-color var(--f7-color-blue)
+    --f7-theme-color var(--oh-theme-alt-color)
   .addon-description-text
     overflow-x clip
     .emoji

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -73,7 +73,7 @@
       <f7-block v-if="searchResults.length === 0">
         '{{ this.$refs.storeSearchbar.$el.f7Searchbar.query }}' not found in {{ currentTab === 'main' ? 'any' : currentTab }} add-ons
         <div class="flex-shrink-0 if-aurora display-flex justify-content-center">
-          <f7-button color="blue" fill raised @click="clearSearch"> Clear Search </f7-button>
+          <f7-button color="theme-alt" fill raised @click="clearSearch"> Clear Search </f7-button>
         </div>
       </f7-block>
       <addons-section

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -15,7 +15,7 @@
       <f7-link class="right controls-link padding-right" ref="detailsLink" @click="openControls">
         {{ t('analyzer.controls') }}&nbsp;<f7-icon f7="chevron_up" />
       </f7-link>
-      <f7-link v-if="'orientation' in coordSettings" color="blue" icon-f7="crop_rotate" @click="toggleOrientation" />
+      <f7-link v-if="'orientation' in coordSettings" color="theme-alt" icon-f7="crop_rotate" @click="toggleOrientation" />
       <span v-else />
     </f7-toolbar>
 
@@ -355,9 +355,9 @@
 
 <style lang="stylus">
 .analyzer-controls
-  --f7-theme-color var(--f7-color-blue)
-  --f7-theme-color-rgb var(--f7-color-blue-rgb)
-  --f7-theme-color-tint var(--f7-color-blue-tint)
+  --f7-theme-color var(--oh-theme-alt-color)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
+  --f7-theme-color-tint var(--oh-theme-alt-color-tint)
   --f7-block-margin-vertical 16px
   z-index 11000
   .tabs .tab
@@ -632,7 +632,7 @@ export default {
       const actions = Object.values(Marker).map((m) => {
         return {
           text: m,
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             seriesOptions.marker = m
           }
@@ -651,7 +651,7 @@ export default {
       const actions = Object.values(AggregationFunction).map((a) => {
         return {
           text: this.t('analyzer.aggregations.' + a),
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             seriesOptions.aggregation = AggregationFunction[a as keyof typeof AggregationFunction]
           }
@@ -670,7 +670,7 @@ export default {
       const actions = Object.values(ValueAxisSplitOptions).map((value) => {
         return {
           text: value,
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             axis.split = value as ValueAxisSplitOptions
           }

--- a/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
+++ b/bundles/org.openhab.ui/web/src/pages/analyzer/analyzer.vue
@@ -15,7 +15,7 @@
       <f7-link class="right controls-link padding-right" ref="detailsLink" @click="openControls">
         {{ t('analyzer.controls') }}&nbsp;<f7-icon f7="chevron_up" />
       </f7-link>
-      <f7-link v-if="'orientation' in coordSettings" color="blue" icon-f7="crop_rotate" @click="toggleOrientation" />
+      <f7-link v-if="'orientation' in coordSettings" color="theme-alt" icon-f7="crop_rotate" @click="toggleOrientation" />
       <span v-else />
     </f7-toolbar>
 
@@ -355,9 +355,9 @@
 
 <style lang="stylus">
 .analyzer-controls
-  --f7-theme-color var(--f7-color-blue)
-  --f7-theme-color-rgb var(--f7-color-blue-rgb)
-  --f7-theme-color-tint var(--f7-color-blue-tint)
+  --f7-theme-color var(--oh-theme-alt-color)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
+  --f7-theme-color-tint var(--oh-theme-alt-color-tint)
   --f7-block-margin-vertical 16px
   z-index 11000
   .tabs .tab
@@ -632,7 +632,7 @@ export default {
       const actions = Object.values(Marker).map((m) => {
         return {
           text: m,
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             seriesOptions.marker = m
           }
@@ -651,7 +651,7 @@ export default {
       const actions = Object.values(AggregationFunction).map((a) => {
         return {
           text: this.t('analyzer.aggregations.' + a),
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             seriesOptions.aggregation = a
           }
@@ -670,7 +670,7 @@ export default {
       const actions = Object.values(ValueAxisSplitOptions).map((value) => {
         return {
           text: value,
-          color: 'blue',
+          color: 'theme-alt',
           onClick: () => {
             axis.split = value as ValueAxisSplitOptions
           }

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -74,10 +74,10 @@
           :value="previewGeneratedCode"
           :read-only="true" />
         <template #fixed>
-          <f7-fab v-show="previewMode === 'blockly'" position="right-bottom" color="blue" @click="togglePreviewMode('code')">
+          <f7-fab v-show="previewMode === 'blockly'" position="right-bottom" color="theme-alt" @click="togglePreviewMode('code')">
             <f7-icon f7="doc_text" />
           </f7-fab>
-          <f7-fab v-show="previewMode === 'code'" position="right-bottom" color="blue" @click="togglePreviewMode('blockly')">
+          <f7-fab v-show="previewMode === 'code'" position="right-bottom" color="theme-alt" @click="togglePreviewMode('blockly')">
             <f7-icon f7="ticket" />
           </f7-fab>
         </template>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -82,10 +82,10 @@
           :value="previewGeneratedCode"
           :read-only="true" />
         <template #fixed>
-          <f7-fab v-show="previewMode === 'blockly'" position="right-bottom" color="blue" @click="togglePreviewMode('code')">
+          <f7-fab v-show="previewMode === 'blockly'" position="right-bottom" color="theme-alt" @click="togglePreviewMode('code')">
             <f7-icon f7="doc_text" />
           </f7-fab>
-          <f7-fab v-show="previewMode === 'code'" position="right-bottom" color="blue" @click="togglePreviewMode('blockly')">
+          <f7-fab v-show="previewMode === 'code'" position="right-bottom" color="theme-alt" @click="togglePreviewMode('blockly')">
             <f7-icon f7="ticket" />
           </f7-fab>
         </template>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -75,7 +75,7 @@
             :title="b.uid">
             <template #subtitle>
               <div>
-                <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                   <template #media>
                     <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                   </template>
@@ -90,7 +90,7 @@
       </f7-col>
     </f7-block>
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -85,7 +85,7 @@
             :title="b.uid">
             <template #subtitle>
               <div>
-                <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                <f7-chip v-for="tag in b.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                   <template #media>
                     <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                   </template>
@@ -107,7 +107,7 @@
       </f7-col>
     </f7-block>
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -77,7 +77,7 @@
                   </template>
                   <template #header>
                     <div style="height: 100%; height: 32px" class="display-flex float-right flex-direction-column justify-content-center">
-                      <f7-toggle color="blue" :checked="runtimeStore.showDeveloperDock ? true : null" />
+                      <f7-toggle color="theme-alt" :checked="runtimeStore.showDeveloperDock ? true : null" />
                     </div>
                   </template>
                 </f7-list-item>
@@ -118,7 +118,7 @@
                   </template>
                   <template #header>
                     <div style="height: 100%; height: 32px" class="display-flex float-right flex-direction-column justify-content-center">
-                      <f7-toggle color="blue" v-model:checked="uiOptionsStore.codeMirrorSettings.vimMode" />
+                      <f7-toggle color="theme-alt" v-model:checked="uiOptionsStore.codeMirrorSettings.vimMode" />
                     </div>
                   </template>
                 </f7-list-item>

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -61,7 +61,7 @@
                           style="height: 100%; height: 32px"
                           class="display-flex float-right flex-direction-column justify-content-center">
                           <f7-toggle
-                            color="blue"
+                            color="theme-alt"
                             :checked="developerToggleValue(item.controlId) ? true : null"
                             @click.stop="toggleDeveloperMenuControl(item.controlId)" />
                         </div>

--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -11,7 +11,7 @@
         @scroll="handleScroll"
         @auto-size-column="autoSizeColumn" />
     </f7-card>
-    <button v-show="!autoScroll" class="button button-fill dock-scroll-button color-blue" @click="showLatestLogs()">
+    <button v-show="!autoScroll" class="button button-fill dock-scroll-button color-theme-alt" @click="showLatestLogs()">
       <f7-icon f7="arrow_down_to_line" />
     </button>
   </div>

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -157,7 +157,7 @@
                   <f7-card-content>
                     <f7-list>
                       <f7-list-button
-                        color="blue"
+                        color="theme-alt"
                         :title="`Insert ${semanticType(selectedTag.name)} Child Tag in ${selectedTag.name}`"
                         @click="addTag()" />
                     </f7-list>
@@ -180,7 +180,7 @@
     </f7-tabs>
 
     <template #fixed>
-      <f7-fab v-if="currentTab === 'tree'" class="add-to-semantics-fab" position="right-center" color="blue" @click="addTag()">
+      <f7-fab v-if="currentTab === 'tree'" class="add-to-semantics-fab" position="right-center" color="theme-alt" @click="addTag()">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
       </f7-fab>
@@ -289,8 +289,8 @@
 .semantics-tree
   padding 0
   border-right 1px solid var(--f7-block-strong-border-color)
-  --f7-theme-color var(--f7-color-blue)
-  --f7-theme-color-rgb var(--f7-color-blue-rgb)
+  --f7-theme-color var(--oh-theme-alt-color)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   .treeview
     --f7-treeview-item-height 40px
     .treeview-item-label
@@ -302,8 +302,8 @@
       color var(--f7-list-item-footer-text-color)
 .semantics-details-sheet
   .toolbar
-    --f7-theme-color var(--f7-color-blue)
-    --f7-theme-color-rgb var(--f7-color-blue-tint)
+    --f7-theme-color var(--oh-theme-alt-color)
+    --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   z-index 10900
 .md .semantics-details-sheet .toolbar .link
   width 35%

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -340,7 +340,6 @@
 
 .semantics-tree
   padding 0
-  border-right 1px solid var(--f7-block-strong-border-color)
   --f7-theme-color var(--oh-theme-alt-color)
   --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   .treeview

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -157,7 +157,7 @@
                   <f7-card-content>
                     <f7-list>
                       <f7-list-button
-                        color="blue"
+                        color="theme-alt"
                         :title="`Insert ${semanticType(selectedTag.name)} Child Tag in ${selectedTag.name}`"
                         @click="addTag()" />
                     </f7-list>
@@ -224,7 +224,7 @@
     </f7-tabs>
 
     <template #fixed>
-      <f7-fab v-if="currentTab === 'tree'" class="add-to-semantics-fab" position="right-center" color="blue" @click="addTag()">
+      <f7-fab v-if="currentTab === 'tree'" class="add-to-semantics-fab" position="right-center" color="theme-alt" @click="addTag()">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
       </f7-fab>
@@ -340,8 +340,9 @@
 
 .semantics-tree
   padding 0
-  --f7-theme-color var(--f7-color-blue)
-  --f7-theme-color-rgb var(--f7-color-blue-rgb)
+  border-right 1px solid var(--f7-block-strong-border-color)
+  --f7-theme-color var(--oh-theme-alt-color)
+  --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   .treeview
     --f7-treeview-item-height 40px
     .treeview-item-label
@@ -353,8 +354,8 @@
       color var(--f7-list-item-footer-text-color)
 .semantics-details-sheet
   .toolbar
-    --f7-theme-color var(--f7-color-blue)
-    --f7-theme-color-rgb var(--f7-color-blue-tint)
+    --f7-theme-color var(--oh-theme-alt-color)
+    --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   z-index 10900
 .md .semantics-details-sheet .toolbar .link
   width 35%

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -30,7 +30,7 @@
           Remove {{ selectedItems.length }}
         </f7-link>
         <f7-link
-          color="blue"
+          color="theme-alt"
           class="copy display-flex flex-direction-row"
           @click="copySelectedItemsToClipboard"
           icon-ios="f7:square_on_square"
@@ -85,7 +85,7 @@
             :title="widget.uid">
             <template #subtitle>
               <div>
-                <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                   <template #media>
                     <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                   </template>
@@ -107,7 +107,7 @@
       </f7-col>
     </f7-block>
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -30,7 +30,7 @@
           Remove {{ selectedItems.length }}
         </f7-link>
         <f7-link
-          color="blue"
+          color="theme-alt"
           class="copy display-flex flex-direction-row"
           @click="copySelectedItemsToClipboard"
           icon-ios="f7:square_on_square"
@@ -91,7 +91,7 @@
             :title="widget.uid">
             <template #subtitle>
               <div>
-                <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                <f7-chip v-for="tag in widget.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                   <template #media>
                     <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                   </template>
@@ -113,7 +113,7 @@
       </f7-col>
     </f7-block>
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -24,7 +24,7 @@
           <f7-button
             large
             fill
-            color="blue"
+            color="theme-alt"
             external
             :href="`${runtimeStore.websiteUrl}/link/docs`"
             target="_blank"
@@ -32,7 +32,7 @@
           <span style="width: 8px" />
           <f7-button
             large
-            color="blue"
+            color="theme-alt"
             external
             :href="`${runtimeStore.websiteUrl}/link/tutorial`"
             target="_blank"
@@ -42,7 +42,7 @@
           <f7-button
             large
             fill
-            color="blue"
+            color="theme-alt"
             @click="f7.emit('selectDeveloperDock', { dock: 'help', helpTab: 'quick' })"
             :text="$t('home.overview.button.quickstart')" />
         </f7-row>

--- a/bundles/org.openhab.ui/web/src/pages/panel-right.vue
+++ b/bundles/org.openhab.ui/web/src/pages/panel-right.vue
@@ -1,6 +1,6 @@
 <template>
   <f7-page class="other-apps">
-    <f7-navbar color="blue" :title="$t('home.otherApps')" />
+    <f7-navbar color="theme-alt" :title="$t('home.otherApps')" />
     <f7-link v-for="app in apps" class="app-link" :key="app.url" :href="app.url" external target="_blank">
       <f7-card class="app-card">
         <f7-card-content :padding="false">

--- a/bundles/org.openhab.ui/web/src/pages/profile.vue
+++ b/bundles/org.openhab.ui/web/src/pages/profile.vue
@@ -21,7 +21,7 @@
       <f7-row>
         <f7-col>
           <f7-list>
-            <f7-list-button color="blue" :external="true" href="/changePassword">
+            <f7-list-button color="theme-alt" :external="true" href="/changePassword">
               {{ t('profile.changePassword') }}
             </f7-list-button>
           </f7-list>
@@ -61,7 +61,10 @@
                   </f7-swipeout-button>
                 </f7-swipeout-actions>
               </f7-list-item>
-              <f7-list-button v-if="!expandedTypes.sessions && sessions.length > 10" color="blue" @click="expandedTypes.sessions = true">
+              <f7-list-button
+                v-if="!expandedTypes.sessions && sessions.length > 10"
+                color="theme-alt"
+                @click="expandedTypes.sessions = true">
                 {{ t('dialogs.showAll') }}
               </f7-list-button>
               <f7-list-button color="red" @click="logout()">
@@ -105,7 +108,7 @@
                   </f7-swipeout-button>
                 </f7-swipeout-actions>
               </f7-list-item>
-              <f7-list-button color="blue" :external="true" href="/createApiToken">
+              <f7-list-button color="theme-alt" :external="true" href="/createApiToken">
                 {{ t('profile.apiTokens.create') }}
               </f7-list-button>
             </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -90,7 +90,7 @@ export default {
             },
             {
               text: 'YAML',
-              color: 'blue',
+              color: 'theme-alt',
               onClick: () => {
                 copyOptions.format = 'YAML'
                 copyOptions.mediaType = 'application/yaml'

--- a/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/file-definition-mixin.js
@@ -136,7 +136,7 @@ export default {
             },
             {
               text: 'YAML',
-              color: 'blue',
+              color: 'theme-alt',
               onClick: () => {
                 copyOptions.format = 'YAML'
                 copyOptions.mediaType = 'application/yaml'

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-overview.vue
@@ -24,7 +24,7 @@
             title="Orphan Links"
             :badge="orphanLinksCount > 0 ? orphanLinksCount : undefined"
             :after="orphanLinksCount > 0 ? undefined : orphanLinksCount"
-            :badge-color="orphanLinksCount ? 'red' : 'blue'"
+            :badge-color="orphanLinksCount ? 'red' : 'theme-alt'"
             :footer="objectsSubtitles.orphanLinks">
             <template #media>
               <f7-icon f7="link" color="gray" />
@@ -37,7 +37,7 @@
             title="Semantic Model Conflicts"
             :badge="semanticsProblemCount > 0 ? semanticsProblemCount : undefined"
             :after="semanticsProblemCount > 0 ? undefined : semanticsProblemCount"
-            :badge-color="semanticsProblemCount ? 'red' : 'blue'"
+            :badge-color="semanticsProblemCount ? 'red' : 'theme-alt'"
             :footer="objectsSubtitles.semanticsProblems">
             <template #media>
               <f7-icon f7="list_bullet_indent" color="gray" />
@@ -55,7 +55,7 @@
             title="Persistence Problems"
             :badge="persistenceProblemsCount > 0 ? persistenceProblemsCount : undefined"
             :after="persistenceProblemsCount > 0 ? undefined : persistenceProblemsCount"
-            :badge-color="persistenceProblemsCount ? 'red' : 'blue'"
+            :badge-color="persistenceProblemsCount ? 'red' : 'theme-alt'"
             :footer="objectsSubtitles.persistenceProblems">
             <template #media>
               <f7-icon f7="link" color="gray" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-details.vue
@@ -43,7 +43,7 @@
         <f7-col>
           <f7-block-title>Non-Semantic Tags</f7-block-title>
           <f7-block strong class="tags-block">
-            <f7-chip v-for="tag in nonSemanticTags" :key="tag" :text="tag" media-bg-color="blue">
+            <f7-chip v-for="tag in nonSemanticTags" :key="tag" :text="tag" media-bg-color="theme-alt">
               <template #media>
                 <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
               </template>
@@ -104,8 +104,8 @@
       <f7-row>
         <f7-col>
           <f7-list>
-            <f7-list-button color="blue" @click="duplicateItem"> Duplicate Item </f7-list-button>
-            <f7-list-button color="blue" @click="copyFileDefinitionToClipboard(ObjectType.ITEM, [item.name])">
+            <f7-list-button color="theme-alt" @click="duplicateItem"> Duplicate Item </f7-list-button>
+            <f7-list-button color="theme-alt" @click="copyFileDefinitionToClipboard(ObjectType.ITEM, [item.name])">
               Copy File Definition
             </f7-list-button>
             <f7-list-button v-if="item.editable" color="red" @click="deleteItem"> Remove Item </f7-list-button>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/item-edit.vue
@@ -30,7 +30,7 @@
               text="Create"
               style="width: 150px"
               class="margin-horizontal"
-              color="blue"
+              color="theme-alt"
               raised
               fill
               @click="save" />
@@ -39,11 +39,11 @@
               text="Save"
               style="width: 150px"
               class="margin-horizontal"
-              color="blue"
+              color="theme-alt"
               raised
               fill
               @click="save" />
-            <f7-button :text="editable ? 'Cancel' : 'Back'" color="blue" @click="f7router.back()" />
+            <f7-button :text="editable ? 'Cancel' : 'Back'" color="theme-alt" @click="f7router.back()" />
           </div>
         </f7-block>
       </f7-tab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -32,7 +32,7 @@
         </f7-link>
         <f7-link
           v-show="selectedItems.length"
-          color="blue"
+          color="theme-alt"
           class="copy display-flex flex-direction-row"
           icon-ios="f7:square_on_square"
           icon-aurora="f7:square_on_square"
@@ -124,10 +124,15 @@
               <template #after-title>
                 <f7-icon v-if="!item.editable" f7="lock_fill" size="1rem" color="gray" />
               </template>
-              <!-- <f7-button color="blue" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
+              <!-- <f7-button color="theme-alt" icon-f7="compose" icon-size="24px" :link="`${item.name}/edit`"></f7-button> -->
               <template #subtitle>
                 <div>
-                  <f7-chip v-for="tag in getNonSemanticTags(item)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                  <f7-chip
+                    v-for="tag in getNonSemanticTags(item)"
+                    :key="tag"
+                    :text="tag"
+                    media-bg-color="theme-alt"
+                    style="margin-right: 6px">
                     <template #media>
                       <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                     </template>
@@ -146,7 +151,7 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${runtimeStore.websiteUrl}/link/items`"
           target="_blank"
@@ -155,10 +160,10 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="!showCheckboxes" position="center-bottom" text="Refresh" color="blue" @click="load()">
+      <f7-fab v-show="!showCheckboxes" position="center-bottom" text="Refresh" color="theme-alt" @click="load()">
         <f7-icon ios="f7:arrow_clockwise" md="material:refresh" aurora="f7:arrow_clockwise" />
       </f7-fab>
-      <f7-fab v-show="!showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="!showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
       </f7-fab>
     </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
@@ -64,7 +64,7 @@
                       {{ item.groupNames ? item.groupNames.join(', ') : '' }}
                     </td>
                     <td v-if="item.tags" class="label-cell">
-                      <f7-chip v-for="tag in item.tags" class="margin-right" :key="tag" :text="tag" media-bg-color="blue">
+                      <f7-chip v-for="tag in item.tags" class="margin-right" :key="tag" :text="tag" media-bg-color="theme-alt">
                         <template #media>
                           <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                         </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
@@ -1,9 +1,9 @@
 <template>
-  <div>
+  <div class="addon-section">
     <f7-block-title> Add-on Settings </f7-block-title>
     <f7-list class="search-list">
       <f7-list-item v-for="a in addonsSettings" v-show="!a.hidden" :key="a.uid" :link="'addons/' + a.uid" :title="a.label" />
-      <f7-list-button v-if="!expanded && addonsSettings.find((a) => a.hidden)" color="blue" @click="$emit('expand')">
+      <f7-list-button v-if="!expanded && addonsSettings.find((a) => a.hidden)" color="theme-alt" @click="$emit('expand')">
         {{ $t('dialogs.showAll') }}
       </f7-list-button>
     </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/addon-section.vue
@@ -1,9 +1,9 @@
 <template>
-  <div>
+  <div class="addon-section">
     <f7-block-title>{{ $t('settings.groups.addon-settings') }}</f7-block-title>
     <f7-list class="search-list">
       <f7-list-item v-for="a in addonsSettings" v-show="!a.hidden" :key="a.uid" :link="'addons/' + a.uid" :title="a.label" />
-      <f7-list-button v-if="!expanded && addonsSettings.find((a) => a.hidden)" color="blue" @click="$emit('expand')">
+      <f7-list-button v-if="!expanded && addonsSettings.find((a) => a.hidden)" color="theme-alt" @click="$emit('expand')">
         {{ $t('dialogs.showAll') }}
       </f7-list-button>
     </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -32,7 +32,7 @@
               title="Things"
               :badge="inboxCount > 0 ? inboxCount : undefined"
               :after="inboxCount > 0 ? thingsCount + '+' : thingsCount"
-              :badge-color="inboxCount ? 'red' : 'blue'"
+              :badge-color="inboxCount ? 'red' : 'theme-alt'"
               :footer="objectsSubtitles.things">
               <template #media>
                 <f7-icon f7="lightbulb" color="gray" />
@@ -43,7 +43,7 @@
               media-item
               link="model/"
               title="Model"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.model"
               @click="modelSelectedItem = null">
               <template #media>
@@ -56,7 +56,7 @@
               link="items/"
               title="Items"
               :after="itemsCount"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.items">
               <template #media>
                 <f7-icon f7="square_on_circle" color="gray" />
@@ -70,13 +70,13 @@
               link="transformations/"
               title="Transformations"
               :after="transformationsCount"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.transform">
               <template #media>
                 <f7-icon f7="function" color="gray" />
               </template>
             </f7-list-item>
-            <f7-list-item media-item link="persistence/" title="Persistence" badge-color="blue" :footer="objectsSubtitles.persistence">
+            <f7-list-item media-item link="persistence/" title="Persistence" badge-color="theme-alt" :footer="objectsSubtitles.persistence">
               <template #media>
                 <f7-icon f7="download_circle" color="gray" />
               </template>
@@ -89,7 +89,7 @@
               link="pages/"
               title="Pages"
               :after="componentsStore.pages().length"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.pages">
               <template #media>
                 <f7-icon f7="tv" color="gray" />
@@ -101,7 +101,7 @@
               link="sitemaps/"
               title="Sitemaps"
               :after="sitemapsCount"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.sitemaps">
               <template #media>
                 <f7-icon f7="menu" color="gray" />
@@ -110,7 +110,13 @@
           </f7-list>
           <f7-block-title v-if="runtimeStore.apiEndpoint('rules')"> Automation </f7-block-title>
           <f7-list media-list class="search-list">
-            <f7-list-item media-item link="rules/" title="Rules" :after="rulesCount" badge-color="blue" :footer="objectsSubtitles.rules">
+            <f7-list-item
+              media-item
+              link="rules/"
+              title="Rules"
+              :after="rulesCount"
+              badge-color="theme-alt"
+              :footer="objectsSubtitles.rules">
               <template #media>
                 <f7-icon f7="wand_stars" color="gray" />
               </template>
@@ -120,7 +126,7 @@
               link="scenes/"
               title="Scenes"
               :after="scenesCount"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.scenes">
               <template #media>
                 <f7-icon f7="film" color="gray" />
@@ -131,13 +137,13 @@
               link="scripts/"
               title="Scripts"
               :after="scriptsCount"
-              badge-color="blue"
+              badge-color="theme-alt"
               :footer="objectsSubtitles.scripts">
               <template #media>
                 <f7-icon f7="doc_plaintext" color="gray" />
               </template>
             </f7-list-item>
-            <f7-list-item media-item link="schedule/" title="Schedule" badge-color="blue" :footer="objectsSubtitles.schedule">
+            <f7-list-item media-item link="schedule/" title="Schedule" badge-color="theme-alt" :footer="objectsSubtitles.schedule">
               <template #media>
                 <f7-icon f7="calendar" color="gray" />
               </template>
@@ -154,7 +160,7 @@
                 :key="service.id"
                 :link="'services/' + service.id"
                 :title="service.label" />
-              <f7-list-button v-if="!expandedTypes.systemSettingsExpanded" color="blue" @click="expand('systemSettingsExpanded')">
+              <f7-list-button v-if="!expandedTypes.systemSettingsExpanded" color="theme-alt" @click="expand('systemSettingsExpanded')">
                 {{ $t('dialogs.showAll') }}
               </f7-list-button>
             </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -54,7 +54,7 @@
                 :key="service.id"
                 :link="'services/' + service.id"
                 :title="service.label" />
-              <f7-list-button v-if="!expandedTypes.systemSettingsExpanded" color="blue" @click="expand('systemSettingsExpanded')">
+              <f7-list-button v-if="!expandedTypes.systemSettingsExpanded" color="theme-alt" @click="expand('systemSettingsExpanded')">
                 {{ $t('dialogs.showAll') }}
               </f7-list-button>
             </f7-list>
@@ -381,7 +381,7 @@ export default {
     },
     settingsMenuBadgeColor(item) {
       if (item.id === 'things' && this.inboxCount > 0) return 'red'
-      return 'blue'
+      return 'theme-alt'
     },
     handleSettingsMenuItemClick(item) {
       if (item.id === 'model') this.modelSelectedItem = null
@@ -407,7 +407,7 @@ export default {
     .settings-col
       width 33%
 .settings-menu .icon
-  color var(--f7-color-blue)
+  color var(--oh-theme-alt-color)
 .theme-filled .settings-menu .icon
   color var(--f7-color-gray) !important
 .aurora .settings-menu .icon

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-template.vue
@@ -51,7 +51,7 @@
 
     <div v-if="selectedTemplate !== null && checkedItems.length > 0" class="if-aurora display-flex justify-content-center margin padding">
       <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="add">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="add">
           Add to Model
         </f7-button>
       </div>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -57,7 +57,7 @@
             <f7-list-group>
               <item-picker
                 :label="selectedGroup ? 'Change Selected Group' : 'Pick Existing Group'"
-                textColor="blue"
+                textcolor="theme-alt"
                 :hideIcon="true"
                 :items="selectableGroups"
                 :multiple="false"
@@ -80,7 +80,7 @@
             class and related property.<br /><br />
             The newly created Points will be linked to their respective channels with the default profile (you will be able to configure the
             links individually later if needed).
-            <f7-link class="display-block margin-top-half" @click="switchToExpertMode" color="blue"> Expert Mode </f7-link>
+            <f7-link class="display-block margin-top-half" @click="switchToExpertMode" color="theme-alt"> Expert Mode </f7-link>
           </f7-block-footer>
           <channel-list
             :thing="selectedThing"
@@ -97,7 +97,7 @@
 
     <div v-if="ready && selectedThing.UID" class="if-aurora display-flex justify-content-center margin padding">
       <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="add">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="add">
           Add to Model
         </f7-button>
       </div>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/add-from-thing.vue
@@ -57,7 +57,7 @@
             <f7-list-group>
               <item-picker
                 :label="selectedGroup ? 'Change Selected Group' : 'Pick Existing Group'"
-                textcolor="theme-alt"
+                textColor="theme-alt"
                 :hideIcon="true"
                 :items="selectableGroups"
                 :multiple="false"

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -76,7 +76,7 @@
           <f7-block v-if="empty">
             <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
             <f7-row class="display-flex justify-content-center">
-              <f7-button color="blue" large raised fill @click="addFromLocationTemplate()"> Add Locations from Template </f7-button>
+              <f7-button color="theme-alt" large raised fill @click="addFromLocationTemplate()"> Add Locations from Template </f7-button>
             </f7-row>
           </f7-block>
 
@@ -123,14 +123,14 @@
                 <f7-list>
                   <f7-list-button
                     v-show="!selectedItem || selectedItem.class.indexOf('Location') === 0"
-                    color="blue"
+                    color="theme-alt"
                     title="Add Location"
                     @click="addSemanticItem('Location')" />
-                  <f7-list-button color="blue" title="Create Equipment from Thing" @click="addFromThing(true)" />
-                  <f7-list-button color="blue" title="Create Points from Thing" @click="addFromThing(false)" />
-                  <f7-list-button color="blue" title="Add Equipment" @click="addSemanticItem('Equipment')" />
-                  <f7-list-button color="blue" title="Add Point" @click="addSemanticItem('Point')" />
-                  <f7-list-button v-if="includeNonSemantic" color="blue" title="Add Item" @click="addNonSemanticItem(false)" />
+                  <f7-list-button color="theme-alt" title="Create Equipment from Thing" @click="addFromThing(true)" />
+                  <f7-list-button color="theme-alt" title="Create Points from Thing" @click="addFromThing(false)" />
+                  <f7-list-button color="theme-alt" title="Add Equipment" @click="addSemanticItem('Equipment')" />
+                  <f7-list-button color="theme-alt" title="Add Point" @click="addSemanticItem('Point')" />
+                  <f7-list-button v-if="includeNonSemantic" color="theme-alt" title="Add Item" @click="addNonSemanticItem(false)" />
                 </f7-list>
               </f7-card-content>
             </f7-card>
@@ -147,7 +147,7 @@
         "
         class="add-to-model-fab"
         position="right-bottom"
-        color="blue">
+        color="theme-alt">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
         <f7-fab-buttons position="top">

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -243,8 +243,8 @@
   text-overflow ellipsis
 .model-details-sheet
   .toolbar
-    --f7-theme-color var(--f7-color-blue)
-    --f7-theme-color-rgb var(--f7-color-blue-rgb)
+    --f7-theme-color var(--oh-theme-alt-color)
+    --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   z-index 10900
 .md .model-details-sheet .toolbar .link
   width 17%

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -77,7 +77,7 @@
           <f7-block v-if="empty">
             <empty-state-placeholder icon="list_bullet_indent" title="model.title" text="model.text" />
             <f7-row class="display-flex justify-content-center">
-              <f7-button color="blue" large raised fill @click="addFromLocationTemplate()"> Add Locations from Template </f7-button>
+              <f7-button color="theme-alt" large raised fill @click="addFromLocationTemplate()"> Add Locations from Template </f7-button>
             </f7-row>
           </f7-block>
 
@@ -124,14 +124,14 @@
                 <f7-list>
                   <f7-list-button
                     v-show="!selectedItem || selectedItem.class.indexOf('Location') === 0"
-                    color="blue"
+                    color="theme-alt"
                     title="Add Location"
                     @click="addSemanticItem('Location')" />
-                  <f7-list-button color="blue" title="Create Equipment from Thing" @click="addFromThing(true)" />
-                  <f7-list-button color="blue" title="Create Points from Thing" @click="addFromThing(false)" />
-                  <f7-list-button color="blue" title="Add Equipment" @click="addSemanticItem('Equipment')" />
-                  <f7-list-button color="blue" title="Add Point" @click="addSemanticItem('Point')" />
-                  <f7-list-button v-if="includeNonSemantic" color="blue" title="Add Item" @click="addNonSemanticItem(false)" />
+                  <f7-list-button color="theme-alt" title="Create Equipment from Thing" @click="addFromThing(true)" />
+                  <f7-list-button color="theme-alt" title="Create Points from Thing" @click="addFromThing(false)" />
+                  <f7-list-button color="theme-alt" title="Add Equipment" @click="addSemanticItem('Equipment')" />
+                  <f7-list-button color="theme-alt" title="Add Point" @click="addSemanticItem('Point')" />
+                  <f7-list-button v-if="includeNonSemantic" color="theme-alt" title="Add Item" @click="addNonSemanticItem(false)" />
                 </f7-list>
               </f7-card-content>
             </f7-card>
@@ -148,7 +148,7 @@
         "
         class="add-to-model-fab"
         position="right-bottom"
-        color="blue">
+        color="theme-alt">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
         <f7-fab-buttons position="top">

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -245,8 +245,8 @@
   text-overflow ellipsis
 .model-details-sheet
   .toolbar
-    --f7-theme-color var(--f7-color-blue)
-    --f7-theme-color-rgb var(--f7-color-blue-rgb)
+    --f7-theme-color var(--oh-theme-alt-color)
+    --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
   z-index 10900
 .md .model-details-sheet .toolbar .link
   width 17%

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/layout/layout-edit.vue
@@ -18,7 +18,7 @@
         class="fullscreen-link"
         icon-f7="rectangle_arrow_up_right_arrow_down_left"
         text="Fullscreen"
-        color="blue"
+        color="theme-alt"
         @click="toggleFullscreen" />
       <div class="display-flex flex-direction-row align-items-center">
         <f7-toggle :checked="previewMode ? true : null" @toggle:change="(value) => togglePreviewMode(value)" />&nbsp;Run mode<span
@@ -40,7 +40,7 @@
           <f7-col>
             <f7-block-footer class="padding-horizontal margin-bottom">
               Note: After saving this page, you can view the page settings by clicking the chevron up icon (<f7-icon
-                color="blue"
+                color="theme-alt"
                 f7="chevron_up" />) at the bottom right corner of the screen, next to "Run mode"
             </f7-block-footer>
           </f7-col>
@@ -331,7 +331,7 @@ export default {
           .map((k) => {
             return {
               text: stdWidgets[k].widget().label,
-              color: 'blue',
+              color: 'theme-alt',
               onClick: () => doAddWidget(stdWidgets[k].widget().name)
             }
           })
@@ -340,7 +340,7 @@ export default {
           .map((w) => {
             return {
               text: w.uid,
-              color: 'blue',
+              color: 'theme-alt',
               onClick: () => doAddWidget('widget:' + w.uid)
             }
           })
@@ -357,7 +357,7 @@ export default {
             [{ label: true, text: 'Personal Widgets' }, ...customWidgetOptions],
             [
               {
-                color: 'blue',
+                color: 'theme-alt',
                 text: 'Add from Model...',
                 onClick: addFromModel
               }

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/map/map-edit.vue
@@ -86,8 +86,12 @@
                   </f7-menu>
                 </template>
               </f7-list-item>
-              <f7-list-button v-if="isEditable" color="blue" title="Add marker" @click="addWidget(page, 'oh-map-marker')" />
-              <f7-list-button v-if="isEditable" color="blue" title="Add circle marker" @click="addWidget(page, 'oh-map-circle-marker')" />
+              <f7-list-button v-if="isEditable" color="theme-alt" title="Add marker" @click="addWidget(page, 'oh-map-marker')" />
+              <f7-list-button
+                v-if="isEditable"
+                color="theme-alt"
+                title="Add circle marker"
+                @click="addWidget(page, 'oh-map-circle-marker')" />
             </f7-list>
           </f7-col>
         </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -30,7 +30,7 @@
           Remove
         </f7-link>
         <f7-link
-          color="blue"
+          color="theme-alt"
           class="copy display-flex flex-direction-row"
           @click="copySelectedItemsToClipboard"
           icon-ios="f7:square_on_square"
@@ -123,7 +123,7 @@
               :badge="page.config?.order">
               <template #subtitle>
                 <div>
-                  <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                  <f7-chip v-for="tag in page.tags" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                     <template #media>
                       <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                     </template>
@@ -158,7 +158,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
         <f7-fab-buttons position="top">

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/plan/plan-edit.vue
@@ -83,7 +83,7 @@
                   </f7-menu>
                 </template>
               </f7-list-item>
-              <f7-list-button v-if="isEditable" color="blue" title="Add marker" @click="addWidget(page, 'oh-plan-marker')" />
+              <f7-list-button v-if="isEditable" color="theme-alt" title="Add marker" @click="addWidget(page, 'oh-plan-marker')" />
             </f7-list>
             <f7-block-footer v-if="isEditable" class="param-description">
               You can also

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -119,7 +119,7 @@
                   <f7-card-content>
                     <f7-list>
                       <f7-list-button
-                        color="blue"
+                        color="theme-alt"
                         :title="`Insert Widget Inside ${selectedWidget.type}`"
                         actions-open="#widget-type-selection" />
                     </f7-list>
@@ -131,7 +131,9 @@
                 <f7-card>
                   <f7-card-content>
                     <f7-list>
-                      <f7-list-button color="blue" @click="addWidget('Button')"> Insert Button Widget Inside Buttongrid </f7-list-button>
+                      <f7-list-button color="theme-alt" @click="addWidget('Button')">
+                        Insert Button Widget Inside Buttongrid
+                      </f7-list-button>
                     </f7-list>
                   </f7-card-content>
                 </f7-card>
@@ -173,7 +175,7 @@
         v-if="canAddChildren(selectedWidget) && selectedWidget.type !== 'Buttongrid'"
         class="add-to-sitemap-fab"
         position="right-center"
-        color="blue"
+        color="theme-alt"
         @click="selectWidgetType">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
@@ -182,7 +184,7 @@
         v-if="canAddChildren(selectedWidget) && selectedWidget.type === 'Buttongrid'"
         class="add-to-sitemap-fab"
         position="right-center"
-        color="blue"
+        color="theme-alt"
         @click="addWidget('Button')">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
@@ -334,8 +336,8 @@
       color var(--f7-list-item-footer-text-color)
 .sitemap-details-sheet
   .toolbar
-    --f7-theme-color var(--f7-color-blue)
-    --f7-theme-color-rgb var(--f7-color-blue-rgb)
+    --f7-theme-color var(--oh-theme-alt-color)
+    --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
     .toolbar-inner
       display flex
       overflow-x auto

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -119,7 +119,7 @@
                   <f7-card-content>
                     <f7-list>
                       <f7-list-button
-                        color="blue"
+                        color="theme-alt"
                         :title="`Insert Widget Inside ${selectedWidget.type}`"
                         actions-open="#widget-type-selection" />
                     </f7-list>
@@ -131,7 +131,9 @@
                 <f7-card>
                   <f7-card-content>
                     <f7-list>
-                      <f7-list-button color="blue" @click="addWidget('Button')"> Insert Button Widget Inside Buttongrid </f7-list-button>
+                      <f7-list-button color="theme-alt" @click="addWidget('Button')">
+                        Insert Button Widget Inside Buttongrid
+                      </f7-list-button>
                     </f7-list>
                   </f7-card-content>
                 </f7-card>
@@ -174,7 +176,7 @@
         v-if="canAddChildren(selectedWidget) && selectedWidget.type !== 'Buttongrid'"
         class="add-to-sitemap-fab"
         position="right-center"
-        color="blue"
+        color="theme-alt"
         @click="selectWidgetType">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
@@ -183,7 +185,7 @@
         v-if="canAddChildren(selectedWidget) && selectedWidget.type === 'Buttongrid'"
         class="add-to-sitemap-fab"
         position="right-center"
-        color="blue"
+        color="theme-alt"
         @click="addWidget('Button')">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:multiply" md="material:close" aurora="f7:multiply" />
@@ -335,8 +337,8 @@
       color var(--f7-list-item-footer-text-color)
 .sitemap-details-sheet
   .toolbar
-    --f7-theme-color var(--f7-color-blue)
-    --f7-theme-color-rgb var(--f7-color-blue-rgb)
+    --f7-theme-color var(--oh-theme-alt-color)
+    --f7-theme-color-rgb var(--oh-theme-alt-color-rgb)
     .toolbar-inner
       display flex
       overflow-x auto

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemaps-list.vue
@@ -33,7 +33,7 @@
         </f7-link>
         <f7-link
           v-show="selection.length"
-          color="blue"
+          color="theme-alt"
           class="copy display-flex flex-direction-row"
           icon-ios="f7:square_on_square"
           icon-aurora="f7:square_on_square"
@@ -108,7 +108,7 @@
             <f7-button
               large
               fill
-              color="blue"
+              color="theme-alt"
               external
               :href="`${runtimeStore.websiteUrl}/docs/ui/sitemaps`"
               target="_blank"
@@ -119,7 +119,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
       </f7-fab>
     </template>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/tabs/tabs-edit.vue
@@ -65,7 +65,7 @@
                   </f7-menu>
                 </template>
               </f7-list-item>
-              <f7-list-button v-if="isEditable" color="blue" title="Add tab" @click="addWidget(page, 'oh-tab')" />
+              <f7-list-button v-if="isEditable" color="theme-alt" title="Add tab" @click="addWidget(page, 'oh-tab')" />
             </f7-list>
           </f7-col>
         </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -17,7 +17,7 @@
               <f7-block-footer style="padding-left: 16px; padding-right: 16px">
                 Persistence stores data over time, which can be retrieved at a later time, e.g. to restore Item states after startup, or to
                 display graphs in the UI.
-                <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/persistence`">
+                <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/persistence`">
                   Learn more about persistence.
                 </f7-link>
               </f7-block-footer>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -23,7 +23,7 @@
               <f7-block-footer style="padding-left: 16px; padding-right: 16px">
                 Persistence stores data over time, which can be retrieved at a later time, e.g. to restore Item states after startup, or to
                 display graphs in the UI.
-                <f7-link external color="blue" target="_blank" :href="`${websiteUrl}/link/persistence`">
+                <f7-link external color="theme-alt" target="_blank" :href="`${websiteUrl}/link/persistence`">
                   Learn more about persistence.
                 </f7-link>
               </f7-block-footer>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -51,13 +51,13 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${runtimeStore.websiteUrl}/link/persistence`"
           target="_blank"
           :text="$t('home.overview.button.documentation')" />
         <span style="width: 8px" />
-        <f7-button large fill color="blue" href="/addons/persistence/"> Install a persistence add-on </f7-button>
+        <f7-button large fill color="theme-alt" href="/addons/persistence/"> Install a persistence add-on </f7-button>
       </f7-row>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-settings.vue
@@ -46,13 +46,13 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${websiteUrl}/link/persistence`"
           target="_blank"
           :text="$t('home.overview.button.documentation')" />
         <span style="width: 8px" />
-        <f7-button large fill color="blue" href="/addons/persistence/"> Install a persistence add-on </f7-button>
+        <f7-button large fill color="theme-alt" href="/addons/persistence/"> Install a persistence add-on </f7-button>
       </f7-row>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -57,7 +57,7 @@
                 icon-md="f7:play_round"
                 icon-aurora="f7:play_round"
                 icon-size="32"
-                :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                 @click="runNow" />
             </div>
             Status:
@@ -258,13 +258,15 @@
                     <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
                   </template>
                 </f7-list-item>
-                <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'blue'" :title="sectionLabels[section][1]"></f7-list-button> -->
+                <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'theme-alt'" :title="sectionLabels[section][1]"></f7-list-button> -->
               </f7-list>
             </div>
           </f7-col>
           <f7-col v-if="!createMode && !stubMode">
             <f7-list>
-              <f7-list-button v-if="isEditable || !hasOpaqueModule" color="blue" @click="duplicateRule"> Duplicate Rule </f7-list-button>
+              <f7-list-button v-if="isEditable || !hasOpaqueModule" color="theme-alt" @click="duplicateRule">
+                Duplicate Rule
+              </f7-list-button>
               <f7-list-button v-if="isEditable" color="red" @click="deleteRule"> Delete Rule </f7-list-button>
             </f7-list>
           </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -54,7 +54,7 @@
                 icon-md="f7:play_round"
                 icon-aurora="f7:play_round"
                 icon-size="32"
-                :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                 @click="runNow" />
             </div>
             Status:
@@ -255,18 +255,18 @@
                     <f7-icon color="green" aurora="f7:plus_circle_fill" ios="f7:plus_circle_fill" md="material:control_point" />
                   </template>
                 </f7-list-item>
-                <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'blue'" :title="sectionLabels[section][1]"></f7-list-button> -->
+                <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'theme-alt'" :title="sectionLabels[section][1]"></f7-list-button> -->
               </f7-list>
             </div>
           </f7-col>
           <f7-col v-if="!createMode && !stubMode">
             <f7-list>
-              <f7-list-button v-if="isEditable || (!hasOpaqueModule && !hasSharedContextModule)" color="blue" @click="duplicateRule">
+              <f7-list-button v-if="isEditable || (!hasOpaqueModule && !hasSharedContextModule)" color="theme-alt" @click="duplicateRule">
                 Duplicate Rule
               </f7-list-button>
               <f7-list-button
                 v-if="!hasOpaqueModule"
-                color="blue"
+                color="theme-alt"
                 title="Copy File Definition"
                 @click="copyPopupOpened = !copyPopupOpened" />
               <f7-list-button v-if="isEditable" color="red" @click="deleteRule"> Delete Rule </f7-list-button>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-module-popup.vue
@@ -131,7 +131,7 @@
             :readOnly="readOnly"
             @updated="onUpdated" />
           <f7-block v-else>
-            <f7-button @click="editBlockly" color="blue" outline fill> Edit Blockly </f7-button>
+            <f7-button @click="editBlockly" color="theme-alt" outline fill> Edit Blockly </f7-button>
           </f7-block>
         </f7-col>
       </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -141,7 +141,7 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${runtimeStore.websiteUrl}/link/${type.toLowerCase()}`"
           target="_blank"
@@ -197,7 +197,7 @@
                       <f7-icon ios="f7:doc_on_doc_fill" md="material:file_copy" aurora="f7:doc_on_doc_fill" />
                     </template>
                   </f7-chip>
-                  <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                  <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                     <template #media>
                       <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                     </template>
@@ -215,7 +215,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -158,7 +158,7 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${runtimeStore.websiteUrl}/link/${type.toLowerCase()}`"
           target="_blank"
@@ -214,7 +214,7 @@
                       <f7-icon ios="f7:doc_on_doc_fill" md="material:file_copy" aurora="f7:doc_on_doc_fill" />
                     </template>
                   </f7-chip>
-                  <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="blue" style="margin-right: 6px">
+                  <f7-chip v-for="tag in displayedTags(rule)" :key="tag" :text="tag" media-bg-color="theme-alt" style="margin-right: 6px">
                     <template #media>
                       <f7-icon ios="f7:tag_fill" md="material:label" aurora="f7:tag_fill" />
                     </template>
@@ -232,7 +232,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -33,7 +33,7 @@
                 icon-md="f7:play_round"
                 icon-aurora="f7:play_round"
                 icon-size="32"
-                :color="rule.status.status === 'IDLE' ? 'blue' : 'gray'"
+                :color="rule.status.status === 'IDLE' ? 'theme-alt' : 'gray'"
                 @click="runNow" />
             </div>
             Status:
@@ -120,13 +120,13 @@
                       <f7-link
                         icon-f7="arrow_uturn_left_circle"
                         class="margin-left-half"
-                        color="blue"
+                        color="theme-alt"
                         tooltip="Set to current state"
                         @click="(ev) => updateCommandFromCurrentState(ev, mod)" />
                       <f7-link
                         icon-f7="arrowtriangle_right_circle"
                         class="margin-left-half"
-                        color="blue"
+                        color="theme-alt"
                         tooltip="Test command"
                         @click="(ev) => testCommand(ev, mod)" />
                     </span>
@@ -157,14 +157,14 @@
                     @input="selectItems"
                     :no-after="true"
                     class="scene-items-picker" />
-                  <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'blue'" :title="sectionLabels[section][1]"></f7-list-button> -->
+                  <!-- <f7-list-button :color="(showModuleControls) ? 'gray' : 'theme-alt'" :title="sectionLabels[section][1]"></f7-list-button> -->
                 </f7-list-group>
               </f7-list>
             </div>
           </f7-col>
           <f7-col v-if="isEditable && !createMode">
             <f7-list>
-              <f7-list-button color="blue" @click="duplicateRule"> Duplicate Scene </f7-list-button>
+              <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Scene </f7-list-button>
               <f7-list-button color="red" @click="deleteRule"> Remove Scene </f7-list-button>
             </f7-list>
           </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -33,7 +33,7 @@
           icon-ios="f7:play_round"
           icon-md="f7:play_round"
           icon-aurora="f7:play_round"
-          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'blue' : 'gray'"
+          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'theme-alt' : 'gray'"
           @click="runNow" />
         <f7-link
           v-else
@@ -50,7 +50,7 @@
           icon-ios="f7:play_round"
           icon-md="f7:play_round"
           icon-aurora="f7:play_round"
-          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'blue' : 'gray'"
+          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'theme-alt' : 'gray'"
           @click="runNow" />
         <f7-chip
           v-if="currentModule && currentModule.configuration.script"
@@ -69,7 +69,7 @@
                 :key="renderer"
                 :title="renderer"
                 style="text-transform: capitalize"
-                color="blue"
+                color="theme-alt"
                 radio
                 :checked="renderer === blocklyRenderer"
                 @click="setBlocklyRenderer(renderer)" />
@@ -77,14 +77,14 @@
               <f7-list-item
                 v-if="!$device.desktop"
                 title="As Labels"
-                color="blue"
+                color="theme-alt"
                 radio
                 :checked="blocklyShowLabels"
                 @click="setBlocklyShowLabels(true)" />
               <f7-list-item
                 v-if="!$device.desktop"
                 title="As Item IDs"
-                color="blue"
+                color="theme-alt"
                 radio
                 :checked="!blocklyShowLabels"
                 @click="setBlocklyShowLabels(false)" />
@@ -146,13 +146,13 @@
         </template>
         <f7-link
           v-if="documentationLink(mode) && !isBlockly"
-          icon-color="blue"
+          icon-color="theme-alt"
           :text="$device.desktop ? 'Open Documentation' : 'Docs'"
           tooltip="Open documentation"
           icon-ios="f7:question_circle"
           icon-md="f7:question_circle"
           icon-aurora="f7:question_circle"
-          color="blue"
+          color="theme-alt"
           :href="runtimeStore.websiteUrl + documentationLink(mode)"
           target="_blank"
           external />
@@ -221,7 +221,7 @@
       </f7-block>
       <div v-if="createMode" class="if-aurora display-flex justify-content-center margin padding">
         <div class="flex-shrink-0">
-          <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="createScript">
+          <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="createScript">
             Create Script
           </f7-button>
         </div>
@@ -230,7 +230,7 @@
       <f7-fab
         v-show="!createMode && !script && mode === 'application/javascript' && !isBlockly"
         position="center-bottom"
-        color="blue"
+        color="theme-alt"
         @click="convertToBlockly"
         text="Design with Blockly">
         <f7-icon f7="ticket_fill" />
@@ -265,7 +265,7 @@
           <f7-block v-if="editable && isScriptRule" class="block-narrow">
             <f7-col>
               <f7-list>
-                <f7-list-button color="blue" @click="duplicateRule"> Duplicate Script </f7-list-button>
+                <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Script </f7-list-button>
                 <f7-list-button color="red" @click="deleteRule"> Remove Script </f7-list-button>
               </f7-list>
             </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/script/script-edit.vue
@@ -33,7 +33,7 @@
           icon-ios="f7:play_round"
           icon-md="f7:play_round"
           icon-aurora="f7:play_round"
-          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'blue' : 'gray'"
+          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'theme-alt' : 'gray'"
           @click="runNow" />
         <f7-link
           v-else
@@ -50,7 +50,7 @@
           icon-ios="f7:play_round"
           icon-md="f7:play_round"
           icon-aurora="f7:play_round"
-          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'blue' : 'gray'"
+          :color="rule.status.status === 'IDLE' && isMimeTypeAvailable(mode) ? 'theme-alt' : 'gray'"
           @click="runNow" />
         <f7-chip
           v-if="currentModule && currentModule.configuration.script"
@@ -69,7 +69,7 @@
                 :key="renderer"
                 :title="renderer"
                 style="text-transform: capitalize"
-                color="blue"
+                color="theme-alt"
                 radio
                 :checked="renderer === blocklyRenderer"
                 @click="setBlocklyRenderer(renderer)" />
@@ -77,14 +77,14 @@
               <f7-list-item
                 v-if="!$device.desktop"
                 title="As Labels"
-                color="blue"
+                color="theme-alt"
                 radio
                 :checked="blocklyShowLabels"
                 @click="setBlocklyShowLabels(true)" />
               <f7-list-item
                 v-if="!$device.desktop"
                 title="As Item IDs"
-                color="blue"
+                color="theme-alt"
                 radio
                 :checked="!blocklyShowLabels"
                 @click="setBlocklyShowLabels(false)" />
@@ -146,13 +146,13 @@
         </template>
         <f7-link
           v-if="documentationLink(mode) && !isBlockly"
-          icon-color="blue"
+          icon-color="theme-alt"
           :text="$device.desktop ? 'Open Documentation' : 'Docs'"
           tooltip="Open documentation"
           icon-ios="f7:question_circle"
           icon-md="f7:question_circle"
           icon-aurora="f7:question_circle"
-          color="blue"
+          color="theme-alt"
           :href="runtimeStore.websiteUrl + documentationLink(mode)"
           target="_blank"
           external />
@@ -231,7 +231,7 @@
       </f7-block>
       <div v-if="createMode" class="if-aurora display-flex justify-content-center margin padding">
         <div class="flex-shrink-0">
-          <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="createScript">
+          <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="createScript">
             Create Script
           </f7-button>
         </div>
@@ -240,7 +240,7 @@
       <f7-fab
         v-show="!createMode && !script && mode === 'application/javascript' && !isBlockly"
         position="center-bottom"
-        color="blue"
+        color="theme-alt"
         @click="convertToBlockly"
         text="Design with Blockly">
         <f7-icon f7="ticket_fill" />
@@ -275,7 +275,7 @@
           <f7-block v-if="editable && isScriptRule" class="block-narrow">
             <f7-col>
               <f7-list>
-                <f7-list-button color="blue" @click="duplicateRule"> Duplicate Script </f7-list-button>
+                <f7-list-button color="theme-alt" @click="duplicateRule"> Duplicate Script </f7-list-button>
                 <f7-list-button color="red" @click="deleteRule"> Remove Script </f7-list-button>
               </f7-list>
             </f7-col>

--- a/bundles/org.openhab.ui/web/src/pages/settings/schedule/schedule.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/schedule/schedule.vue
@@ -72,7 +72,7 @@
       </div>
     </div>
     <template #fixed>
-      <f7-fab v-if="ready" position="right-bottom" color="blue" href="add">
+      <f7-fab v-if="ready" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -53,11 +53,11 @@
     <f7-block v-if="runtimeStore.apiEndpoint('addons')" class="block-narrow">
       <f7-col v-if="bindings.length">
         <f7-list>
-          <f7-list-button color="blue" title="Install More Bindings" @click="installBindings" />
+          <f7-list-button color="theme-alt" title="Install More Bindings" @click="installBindings" />
         </f7-list>
       </f7-col>
       <f7-row v-else-if="ready" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" @click="installBindings"> Install Bindings </f7-button>
+        <f7-button large fill color="theme-alt" @click="installBindings"> Install Bindings </f7-button>
       </f7-row>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -59,11 +59,11 @@
     <f7-block v-if="runtimeStore.apiEndpoint('addons')" class="block-narrow">
       <f7-col v-if="bindings.length">
         <f7-list>
-          <f7-list-button color="blue" title="Install More Bindings" @click="installBindings" />
+          <f7-list-button color="theme-alt" title="Install More Bindings" @click="installBindings" />
         </f7-list>
       </f7-col>
       <f7-row v-else-if="ready" class="display-flex justify-content-center">
-        <f7-button large fill color="blue" @click="installBindings"> Install Bindings </f7-button>
+        <f7-button large fill color="theme-alt" @click="installBindings"> Install Bindings </f7-button>
       </f7-row>
     </f7-block>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -21,7 +21,7 @@
             <f7-button
               class="padding-left padding-right"
               style="width: 150px"
-              :color="scanning ? 'red' : 'blue'"
+              :color="scanning ? 'red' : 'theme-alt'"
               large
               raised
               fill
@@ -49,7 +49,7 @@
             :title="entry.label"
             :subtitle="entry.representationProperty ? entry.properties[entry.representationProperty] : ''"
             :footer="entry.thingUID" />
-          <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="blue" />
+          <f7-list-button v-show="scanResults.length > 1" title="Add All" @click="approveAll" color="theme-alt" />
         </f7-list>
 
         <f7-block-title>Add Manually</f7-block-title>
@@ -73,7 +73,7 @@
               :footer="getHeading(thingType.description)"
               :header="thingType.UID"
               :badge="thingType.bridge ? 'Bridge' : ''"
-              badge-color="blue"
+              badge-color="theme-alt"
               media-item />
           </ul>
         </f7-list>
@@ -188,7 +188,7 @@ export default {
         try {
           this.scanTimeout = parseInt(data)
           this.scanProgress = 0
-          let progressBarEl = f7.progressbar.show('#scan-progress', 0, 'blue')
+          let progressBarEl = f7.progressbar.show('#scan-progress', 0, 'theme-alt')
           this.intervalId = setInterval(() => {
             this.scanProgress += 1
             f7.progressbar.set(progressBarEl, (this.scanProgress * 100) / this.scanTimeout)

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -32,7 +32,7 @@
 
     <div v-if="ready" class="if-aurora display-flex justify-content-center margin">
       <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save">
+        <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="save">
           Create Thing
         </f7-button>
       </div>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-add.vue
@@ -37,7 +37,9 @@
 
     <div v-if="ready && currentChannelType" class="if-aurora display-flex justify-content-center margin padding">
       <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save"> Create </f7-button>
+        <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="save">
+          Create
+        </f7-button>
       </div>
     </div>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -58,7 +58,7 @@
         <template v-if="$f7dim.width >= 500">
           <f7-button
             @click="copyFileDefinitionToClipboard(ObjectType.THING, selectedItems)"
-            color="blue"
+            color="theme-alt"
             class="copy wider-screen display-flex flex-direction-row"
             icon-ios="f7:square_on_square"
             icon-aurora="f7:square_on_square">
@@ -67,7 +67,7 @@
         </template>
         <!-- buttons for narrower screen -->
         <template v-else>
-          <f7-button color="blue" class="popover-button narrower-screen" popover-open=".item-popover"> ... </f7-button>
+          <f7-button color="theme-alt" class="popover-button narrower-screen" popover-open=".item-popover"> ... </f7-button>
           <f7-popover
             class="item-popover"
             ref="popover"
@@ -78,7 +78,7 @@
             <div class="margin-vertical display-flex justify-content-center" style="width: 100%">
               <f7-link
                 @click="performActionOnSelection('copy')"
-                color="blue"
+                color="theme-alt"
                 class="copy display-flex flex-direction-column margin-right"
                 icon-ios="f7:square_on_square"
                 icon-aurora="f7:square_on_square"
@@ -197,7 +197,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="!showCheckboxes" position="right-bottom" color="blue" href="/settings/things/add/">
+      <f7-fab v-show="!showCheckboxes" position="right-bottom" color="theme-alt" href="/settings/things/add/">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
         <f7-icon ios="f7:close" md="material:close" aurora="f7:close" />
       </f7-fab>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-add.vue
@@ -108,7 +108,7 @@
         <f7-block-title>Profile</f7-block-title>
         <f7-block-footer class="padding-left padding-right">
           Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
+          <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
             Learn more about profiles.
           </f7-link>
         </f7-block-footer>
@@ -144,7 +144,9 @@
 
     <div v-if="ready && profileTypes.length" class="if-aurora display-flex justify-content-center padding margin">
       <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="save"> Link </f7-button>
+        <f7-button class="padding-left padding-right" style="width: 150px" color="theme-alt" large raised fill @click="save">
+          Link
+        </f7-button>
       </div>
     </div>
   </f7-page>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/link/link-edit.vue
@@ -56,7 +56,7 @@
         <f7-block-title>Profile</f7-block-title>
         <f7-block-footer class="padding-left padding-right">
           Profiles define how Channels and Items work together. Install transformation add-ons to get additional profiles.
-          <f7-link external color="blue" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
+          <f7-link external color="theme-alt" target="_blank" :href="`${runtimeStore.websiteUrl}/link/profiles`">
             Learn more about profiles.
           </f7-link>
         </f7-block-footer>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-action-popup.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-action-popup.vue
@@ -38,7 +38,7 @@
         <!-- Execute Button -->
         <f7-col v-if="!executing">
           <f7-list>
-            <f7-list-button color="blue" title="Execute Action" @click="execute" />
+            <f7-list-button color="theme-alt" title="Execute Action" @click="execute" />
           </f7-list>
         </f7-col>
         <!-- Action Outputs -->

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -187,7 +187,7 @@
                     <f7-badge
                       v-if="advancedThingActionsCount"
                       style="margin-left: 2px"
-                      color="blue"
+                      color="theme-alt"
                       class="count-badge"
                       tooltip="Advanced/Expert Thing actions">
                       {{ advancedThingActionsCount }}
@@ -239,7 +239,7 @@
               <f7-list>
                 <f7-list-button
                   v-for="action in actionGroup.actions"
-                  :color="action.verify ? 'yellow' : 'blue'"
+                  :color="action.verify ? 'yellow' : 'theme-alt'"
                   :key="action.name"
                   :title="action.label"
                   @click="action.execute()" />
@@ -253,13 +253,13 @@
             <f7-list>
               <f7-list-button
                 v-if="thing?.statusInfo?.statusDetail === 'HANDLER_MISSING_ERROR'"
-                color="blue"
+                color="theme-alt"
                 title="Install Binding"
                 @click="installBinding" />
-              <f7-list-button v-if="!error" color="blue" title="Duplicate Thing" @click="duplicateThing" />
+              <f7-list-button v-if="!error" color="theme-alt" title="Duplicate Thing" @click="duplicateThing" />
               <f7-list-button
                 v-if="!error"
-                color="blue"
+                color="theme-alt"
                 title="Copy File Definition"
                 @click="copyFileDefinitionToClipboard(ObjectType.THING, [thingId])" />
               <f7-list-button v-if="editable" color="red" title="Remove Thing" @click="deleteThing" />
@@ -282,11 +282,11 @@
               <f7-list-button
                 v-if="isExtensible && editable"
                 class="searchbar-ignore"
-                color="blue"
+                color="theme-alt"
                 title="Add Channel"
                 @click="addChannel()" />
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Equipment to Model" @click="addToModel(true)" />
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Points to Model" @click="addToModel(false)" />
+              <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Equipment to Model" @click="addToModel(true)" />
+              <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Points to Model" @click="addToModel(false)" />
               <f7-list-button
                 v-if="hasLinkedItems"
                 class="searchbar-ignore"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -190,7 +190,7 @@
                     <f7-badge
                       v-if="advancedThingActionsCount"
                       style="margin-left: 2px"
-                      color="blue"
+                      color="theme-alt"
                       class="count-badge"
                       tooltip="Advanced/Expert Thing actions">
                       {{ advancedThingActionsCount }}
@@ -242,7 +242,7 @@
               <f7-list>
                 <f7-list-button
                   v-for="action in actionGroup.actions"
-                  :color="action.verify ? 'yellow' : 'blue'"
+                  :color="action.verify ? 'yellow' : 'theme-alt'"
                   :key="action.name"
                   :title="action.label"
                   @click="action.execute()" />
@@ -254,11 +254,11 @@
         <f7-block v-if="ready" class="block-narrow no-margin-top">
           <f7-col>
             <f7-list>
-              <f7-list-button v-if="offerInstallBinding" color="blue" title="Install Binding" @click="installBinding" />
-              <f7-list-button v-if="!error" color="blue" title="Duplicate Thing" @click="duplicateThing" />
+              <f7-list-button v-if="offerInstallBinding" color="theme-alt" title="Install Binding" @click="installBinding" />
+              <f7-list-button v-if="!error" color="theme-alt" title="Duplicate Thing" @click="duplicateThing" />
               <f7-list-button
                 v-if="!error"
-                color="blue"
+                color="theme-alt"
                 title="Copy File Definition"
                 @click="copyFileDefinitionToClipboard(ObjectType.THING, [thingId])" />
               <f7-list-button v-if="editable" color="red" title="Remove Thing" @click="deleteThing" />
@@ -281,11 +281,11 @@
               <f7-list-button
                 v-if="isExtensible && editable"
                 class="searchbar-ignore"
-                color="blue"
+                color="theme-alt"
                 title="Add Channel"
                 @click="addChannel()" />
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Equipment to Model" @click="addToModel(true)" />
-              <f7-list-button class="searchbar-ignore" color="blue" title="Add Points to Model" @click="addToModel(false)" />
+              <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Equipment to Model" @click="addToModel(true)" />
+              <f7-list-button class="searchbar-ignore" color="theme-alt" title="Add Points to Model" @click="addToModel(false)" />
               <f7-list-button
                 v-if="hasLinkedItems"
                 class="searchbar-ignore"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-inbox-mixin.js
@@ -160,7 +160,7 @@ export default {
     entryActionsCopyThingDefinitionButton(entry) {
       return {
         text: 'Copy Thing File Definition',
-        color: 'blue',
+        color: 'theme-alt',
         bold: true,
         onClick: () => this.copyFileDefinitionToClipboard(this.ObjectType.THING, [entry.thingUID])
       }
@@ -168,7 +168,7 @@ export default {
     entryActionsIgnoreButton(entry, loadFn, ignored) {
       return {
         text: !ignored ? 'Ignore' : 'Unignore',
-        color: !ignored ? 'orange' : 'blue',
+        color: !ignored ? 'orange' : 'theme-alt',
         onClick: () => {
           if (ignored) {
             this.unignoreEntry(entry, loadFn)

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -50,7 +50,7 @@
         </f7-link>
         <f7-link
           v-show="selectedItems.length"
-          color="blue"
+          color="theme-alt"
           class="copy display-flex flex-direction-row"
           @click="copyFileDefinitionToClipboard(ObjectType.THING, selectedItems)"
           icon-ios="f7:square_on_square"
@@ -199,7 +199,7 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${runtimeStore.websiteUrl}/link/thing`"
           target="_blank"
@@ -208,7 +208,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab position="right-bottom" color="blue" href="add/">
+      <f7-fab position="right-bottom" color="theme-alt" href="add/">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
       </f7-fab>
       <f7-fab position="center-bottom" :text="`Inbox (${inboxCount})`" :color="inboxCount > 0 ? 'red' : 'gray'" href="inbox">
@@ -230,7 +230,7 @@
     right -4px
     width 10px
     height 10px
-    background-color var(--f7-color-blue)
+    background-color var(--oh-theme-alt-color)
     border 1px solid var(--f7-list-bg-color)
     border-radius 50%
     pointer-events none

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-edit.vue
@@ -22,7 +22,14 @@
       @new-language="language = $event" />
     <div v-if="ready && createMode" class="if-aurora display-flex justify-content-center margin padding">
       <div class="flex-shrink-0">
-        <f7-button class="padding-left padding-right" style="width: 150px" color="blue" large raised fill @click="createTransformation">
+        <f7-button
+          class="padding-left padding-right"
+          style="width: 150px"
+          color="theme-alt"
+          large
+          raised
+          fill
+          @click="createTransformation">
           Create
         </f7-button>
       </div>
@@ -51,13 +58,13 @@
         </f7-segmented>
         <f7-link
           v-if="DocumentationLinks[transformation.type]"
-          icon-color="blue"
+          icon-color="theme-alt"
           :text="$device.desktop ? 'Open Documentation' : 'Docs'"
           tooltip="Open documentation"
           icon-ios="f7:question_circle"
           icon-md="f7:question_circle"
           icon-aurora="f7:question_circle"
-          color="blue"
+          color="theme-alt"
           :href="runtimeStore.websiteUrl + DocumentationLinks[transformation.type]"
           target="_blank"
           external />
@@ -80,7 +87,7 @@
       @save="createMode ? createTransformation() : save()" />
     <blockly-editor v-else-if="isBlockly" ref="blocklyEditor" :blocks="transformation.configuration.blockSource" @change="dirty = true" />
     <!-- TODO: Enable Blockly after blocks have been adjusted
-    <f7-fab v-show="transformation.configuration && !transformation.configuration.function && transformation.configuration.mode === 'application/javascript' && !isBlockly" position="center-bottom" color="blue" @click="convertToBlockly" text="Design with Blockly">
+    <f7-fab v-show="transformation.configuration && !transformation.configuration.function && transformation.configuration.mode === 'application/javascript' && !isBlockly" position="center-bottom" color="theme-alt" @click="convertToBlockly" text="Design with Blockly">
       <f7-icon f7="ticket_fill" />
     </f7-fab>
     -->

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -115,7 +115,7 @@
         <f7-button
           large
           fill
-          color="blue"
+          color="theme-alt"
           external
           :href="`${runtimeStore.websiteUrl}/link/transformations`"
           target="_blank"
@@ -124,7 +124,7 @@
     </f7-block>
 
     <template #fixed>
-      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="blue" href="add">
+      <f7-fab v-show="ready && !showCheckboxes" position="right-bottom" color="theme-alt" href="add">
         <f7-icon ios="f7:plus" md="material:add" aurora="f7:plus" />
       </f7-fab>
     </template>

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard-info.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard-info.vue
@@ -8,7 +8,7 @@
   <f7-block>
     {{ body }}
     <br /><br />
-    <a class="text-color-blue external" target="_blank" :href="link"> {{ t('setupwizard.documentationLink') }}</a>
+    <a class="text-color-theme-alt external" target="_blank" :href="link"> {{ t('setupwizard.documentationLink') }}</a>
     <br />
   </f7-block>
 </template>

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard-tab-header.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard-tab-header.vue
@@ -5,7 +5,7 @@
         <img class="intro-logo" :src="image" type="image/svg+xml" />
       </div>
       <div v-else-if="icon" class="compact-padding">
-        <f7-icon size="48" color="blue" :f7="icon" />
+        <f7-icon size="48" color="theme-alt" :f7="icon" />
       </div>
       {{ title }}
     </f7-login-screen-title>
@@ -13,7 +13,7 @@
   <f7-block v-if="header || link" strong>
     <span class="text" v-html="header" />
     <br v-if="link" />
-    <a v-if="link" class="text-color-blue external" target="_blank" :href="link"> {{ t('setupwizard.' + step + '.link') }}</a>
+    <a v-if="link" class="text-color-theme-alt external" target="_blank" :href="link"> {{ t('setupwizard.' + step + '.link') }}</a>
   </f7-block>
 </template>
 

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -15,7 +15,7 @@
           icon-ios="f7:arrow_left"
           icon-aurora="f7:arrow_left"
           icon-md="material:arrow_back"
-          color="blue"
+          color="theme-alt"
           @click="handler(prev)" />
       </f7-nav-left>
       <f7-nav-title v-if="currentStep !== 'welcome'" class="wizard-progress-title">
@@ -25,7 +25,7 @@
         </f7-link>
       </f7-nav-title>
       <f7-nav-right>
-        <f7-link icon-ios="f7:xmark" icon-aurora="f7:xmark" icon-md="material:close" color="blue" @click="skipSetup" />
+        <f7-link icon-ios="f7:xmark" icon-aurora="f7:xmark" icon-md="material:close" color="theme-alt" @click="skipSetup" />
       </f7-nav-right>
     </f7-navbar>
 
@@ -103,7 +103,7 @@
             v-if="next && firstStepNotDone && firstStepNotDone !== 'intro'"
             large
             fill
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.skipToNext')"
             class="margin-bottom"
             @click="toStep(firstStepNotDone)" />
@@ -111,10 +111,10 @@
             v-if="next"
             large
             :fill="!firstStepNotDone || firstStepNotDone === 'intro'"
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.beginSetup')"
             @click="handler(next)" />
-          <f7-button large color="blue" :text="t('setupwizard.skipSetup')" @click="skipSetup" />
+          <f7-button large color="theme-alt" :text="t('setupwizard.skipSetup')" @click="skipSetup" />
         </f7-block>
         <f7-list>
           <f7-list-item :title="t('setupwizard.short')">
@@ -162,10 +162,10 @@
             v-if="updatedLocation && next"
             large
             fill
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.' + currentStep + '.next')"
             @click="handler(next)" />
-          <f7-button v-if="skip" large color="blue" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
+          <f7-button v-if="skip" large color="theme-alt" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
         </f7-block>
       </f7-tab>
 
@@ -191,10 +191,10 @@
             v-if="network && next"
             large
             fill
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.' + currentStep + '.next')"
             @click="handler(next)" />
-          <f7-button v-if="skip" large color="blue" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
+          <f7-button v-if="skip" large color="theme-alt" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
         </f7-block>
       </f7-tab>
 
@@ -206,7 +206,7 @@
           :image="wizardSteps[currentStep].image"
           :link="wizardSteps[currentStep].link" />
         <f7-block class="display-flex flex-direction-column padding">
-          <f7-button v-if="next" large fill color="blue" :text="t('setupwizard.next')" @click="handler(next)" />
+          <f7-button v-if="next" large fill color="theme-alt" :text="t('setupwizard.next')" @click="handler(next)" />
         </f7-block>
       </f7-tab>
 
@@ -261,13 +261,13 @@
               v-if="!installingAddons && addonSuggestionsReady && toInstallAddons.length > 0 && next"
               large
               fill
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.' + currentStep + '.next', toInstallAddons.length)"
               @click="handler(next)" />
             <f7-button
               v-if="!installingAddons && skip"
               large
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.' + currentStep + '.skip')"
               class="margin-top"
               @click="handler(skip)" />
@@ -275,7 +275,7 @@
               v-if="installingAddons"
               large
               fill
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.addons.cancelInstall')"
               class="margin-top"
               @click="cancelInstall" />
@@ -296,11 +296,17 @@
         </f7-block-footer>
         <f7-block class="padding">
           <div>
-            <f7-button v-if="next" large fill color="blue" :text="t('setupwizard.' + currentStep + '.config')" @click="handler(next)" />
+            <f7-button
+              v-if="next"
+              large
+              fill
+              color="theme-alt"
+              :text="t('setupwizard.' + currentStep + '.config')"
+              @click="handler(next)" />
             <f7-button
               v-if="skip"
               large
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.' + currentStep + '.configLater')"
               class="margin-top"
               @click="handler(skip)" />
@@ -332,7 +338,7 @@
               v-if="next"
               large
               :fill="!setupWizardStepsDone.modelLinkClicked"
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.welcome.modelLink')"
               :class="{ 'margin-bottom': !setupWizardStepsDone.modelLinkClicked }"
               @click="handler({ ...next, link: '/settings/model/' })" />
@@ -340,14 +346,14 @@
               v-if="next && bindingsInstalled"
               large
               :fill="setupWizardStepsDone.modelLinkClicked && !setupWizardStepsDone.inboxLinkClicked"
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.welcome.inboxLink')"
               :class="{ 'margin-bottom': setupWizardStepsDone.modelLinkClicked && !setupWizardStepsDone.inboxLinkClicked }"
               @click="handler({ ...next, link: '/settings/things/inbox' })" />
             <f7-button
               v-if="next"
               large
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.welcome.getStarted')"
               @click="handler({ ...next, link: '/' })" />
           </div>

--- a/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
+++ b/bundles/org.openhab.ui/web/src/pages/wizards/setup-wizard.vue
@@ -15,7 +15,7 @@
           icon-ios="f7:arrow_left"
           icon-aurora="f7:arrow_left"
           icon-md="material:arrow_back"
-          color="blue"
+          color="theme-alt"
           @click="handler(prev)" />
       </f7-nav-left>
       <f7-nav-title v-if="currentStep !== 'welcome'" class="wizard-progress-title">
@@ -25,7 +25,7 @@
         </f7-link>
       </f7-nav-title>
       <f7-nav-right>
-        <f7-link icon-ios="f7:xmark" icon-aurora="f7:xmark" icon-md="material:close" color="blue" @click="skipSetup" />
+        <f7-link icon-ios="f7:xmark" icon-aurora="f7:xmark" icon-md="material:close" color="theme-alt" @click="skipSetup" />
       </f7-nav-right>
     </f7-navbar>
 
@@ -103,7 +103,7 @@
             v-if="next"
             large
             :fill="!firstStepNotDone || firstStepNotDone === 'intro'"
-            color="blue"
+            color="theme-alt"
             :text="firstStepNotDone && firstStepNotDone !== 'intro' ? t('setupwizard.restartSetup') : t('setupwizard.beginSetup')"
             class="margin-bottom"
             @click="handler(next)" />
@@ -111,11 +111,11 @@
             v-if="next && firstStepNotDone && firstStepNotDone !== 'intro'"
             large
             fill
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.resumeSetup')"
             class="margin-bottom"
             @click="toStep(firstStepNotDone)" />
-          <f7-button large color="blue" :text="t('setupwizard.skipSetup')" @click="skipSetup" />
+          <f7-button large color="theme-alt" :text="t('setupwizard.skipSetup')" @click="skipSetup" />
         </f7-block>
         <f7-list>
           <f7-list-item :title="t('setupwizard.short')">
@@ -163,10 +163,10 @@
             v-if="updatedLocation && next"
             large
             fill
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.' + currentStep + '.next')"
             @click="handler(next)" />
-          <f7-button v-if="skip" large color="blue" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
+          <f7-button v-if="skip" large color="theme-alt" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
         </f7-block>
       </f7-tab>
 
@@ -192,10 +192,10 @@
             v-if="network && next"
             large
             fill
-            color="blue"
+            color="theme-alt"
             :text="t('setupwizard.' + currentStep + '.next')"
             @click="handler(next)" />
-          <f7-button v-if="skip" large color="blue" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
+          <f7-button v-if="skip" large color="theme-alt" :text="t('setupwizard.skip')" class="margin-top" @click="handler(skip)" />
         </f7-block>
       </f7-tab>
 
@@ -207,7 +207,7 @@
           :image="wizardSteps[currentStep].image"
           :link="wizardSteps[currentStep].link" />
         <f7-block class="display-flex flex-direction-column padding">
-          <f7-button v-if="next" large fill color="blue" :text="t('setupwizard.next')" @click="handler(next)" />
+          <f7-button v-if="next" large fill color="theme-alt" :text="t('setupwizard.next')" @click="handler(next)" />
         </f7-block>
       </f7-tab>
 
@@ -262,13 +262,13 @@
               v-if="!installingAddons && addonSuggestionsReady && toInstallAddons.length > 0 && next"
               large
               fill
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.' + currentStep + '.next', toInstallAddons.length)"
               @click="handler(next)" />
             <f7-button
               v-if="!installingAddons && skip"
               large
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.' + currentStep + '.skip')"
               class="margin-top"
               @click="handler(skip)" />
@@ -276,7 +276,7 @@
               v-if="installingAddons"
               large
               fill
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.addons.cancelInstall')"
               class="margin-top"
               @click="cancelInstall" />
@@ -297,11 +297,17 @@
         </f7-block-footer>
         <f7-block class="padding">
           <div>
-            <f7-button v-if="next" large fill color="blue" :text="t('setupwizard.' + currentStep + '.config')" @click="handler(next)" />
+            <f7-button
+              v-if="next"
+              large
+              fill
+              color="theme-alt"
+              :text="t('setupwizard.' + currentStep + '.config')"
+              @click="handler(next)" />
             <f7-button
               v-if="skip"
               large
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.' + currentStep + '.configLater')"
               class="margin-top"
               @click="handler(skip)" />
@@ -333,7 +339,7 @@
               v-if="next"
               large
               :fill="!setupWizardStepsDone.modelLinkClicked"
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.welcome.modelLink')"
               :class="{ 'margin-bottom': !setupWizardStepsDone.modelLinkClicked }"
               @click="handler({ ...next, link: '/settings/model/' })" />
@@ -341,14 +347,14 @@
               v-if="next && bindingsInstalled"
               large
               :fill="setupWizardStepsDone.modelLinkClicked && !setupWizardStepsDone.inboxLinkClicked"
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.welcome.inboxLink')"
               :class="{ 'margin-bottom': setupWizardStepsDone.modelLinkClicked && !setupWizardStepsDone.inboxLinkClicked }"
               @click="handler({ ...next, link: '/settings/things/inbox' })" />
             <f7-button
               v-if="next"
               large
-              color="blue"
+              color="theme-alt"
               :text="t('setupwizard.welcome.getStarted')"
               @click="handler({ ...next, link: '/' })" />
           </div>


### PR DESCRIPTION
This is precursor PR as a step to support themes in the future.  This PR updates the codebase from using hardcoded "blue" as the alternative UI to a css style called theme-alt.

This PR does not make any visual changes to the UI, it only updates references to the "blue" color to the newly defined css variables and styles.

- creates the various supporting css variables --oh-theme-color (red branding color) and --oh-theme-alt-color (blue ui color use predominantly in the ui)
- creates appropriate f7 color classes (i.e. color-blue ==> color-theme-alt) so that you can specify color="theme-alt" as a property on f7 components
- updates codebase to either refer to --oh-theme-alt-color variable, changes color="blue" to color="theme-alt"