### PR TITLE
Fixes for navbar on mobile

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-dock-icon.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-dock-icon.vue
@@ -53,9 +53,9 @@ const isOnLogViewerPage = computed(() => {
 })
 </script>
 
-<style scoped>
-.dev-dock-icons {
-  display: inline-flex;
-  margin-right: 8px;
-}
+<style scoped lang="stylus">
+.dev-dock-icons
+  display inline-flex
+  &:not(:last-child)
+    margin-right 8px
 </style>

--- a/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
+++ b/bundles/org.openhab.ui/web/src/components/navigation/oh-nav-content.vue
@@ -2,7 +2,7 @@
   <f7-nav-left class="oh-nav-content">
     <f7-link v-if="menuIcon" class="menu-icon" icon-ios="f7:menu" icon-aurora="f7:menu" icon-md="material:menu" panel-open="left" />
     <f7-link v-if="!theme.md && backLink" icon-f7="chevron_left" :href="backLinkUrl" @click="back">
-      {{ backLink }}
+      {{ $f7dim.width > 500 ? backLink : null }}
     </f7-link>
     <f7-link v-else icon-f7="arrow_left_md" :href="backLinkUrl" @click="back" />
   </f7-nav-left>

--- a/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/persistence/persistence-edit.vue
@@ -4,7 +4,7 @@
       <oh-nav-content
         :title="pageTitle + dirtyIndicator"
         :editable
-        :save-link="editable ? 'Save (Ctrl-S)' : null"
+        :save-link="editable ? `Save${$device.desktop ? ' (Ctrl-S)' : ''}` : null"
         back-link-url="/settings/persistence/"
         @save="save()"
         :f7router />

--- a/bundles/org.openhab.ui/web/src/types/globals.d.ts
+++ b/bundles/org.openhab.ui/web/src/types/globals.d.ts
@@ -6,6 +6,10 @@ declare module '@vue/runtime-core' {
     $device: Device
     $t: Composer['t']
     $fullscreen: typeof import('vue-fullscreen').api
+    $f7dim: {
+      width: number
+      height: number
+    }
   }
 }
 


### PR DESCRIPTION
- Hide navbar save link text on mobile.
- Developer dock icons: Only add right margin if not last element.
- persistence-edit: Hide `(Ctrl-S)` hint from save link if not on desktop.