### PR TITLE
Semantic tag editor: Fix missing copy & revert buttons on narrow screens

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/code-editor.vue
@@ -28,6 +28,7 @@
       @click="copy"
       icon-ios="f7:square_on_square"
       icon-aurora="f7:square_on_square"
+      icon-md="material:content_copy"
       color="blue"
       tooltip="Copy code to clipboard"
       class="copy display-flex flex-direction-row">
@@ -39,6 +40,7 @@
       :disabled="!dirty"
       icon-ios="f7:arrow_2_circlepath"
       icon-aurora="f7:arrow_2_circlepath"
+      icon-md="material:undo"
       color="red"
       tooltip="Revert local changes to the code"
       class="reset display-flex flex-direction-row">

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -186,30 +186,33 @@
           @changed="onCodeChanged"
           @save="save">
           <template #additional-panel-controls>
-            <f7-segmented>
+            <f7-segmented class="code-editor-tag-filter">
               <f7-button
                 outline
                 small
                 :active="showCodeTags === 'editable'"
                 tooltip="Show all editable tags"
+                icon-f7="pencil"
                 @click="switchCodeTags('editable')">
-                Editable
+                <span class="button-label">Editable</span>
               </f7-button>
               <f7-button
                 outline
                 small
                 :active="showCodeTags === 'custom'"
                 tooltip="Show all user defined tags"
+                icon-f7="ellipsis"
                 @click="switchCodeTags('custom')">
-                Custom
+                <span class="button-label">Custom</span>
               </f7-button>
               <f7-button
                 outline
                 small
                 :active="showCodeTags === 'all'"
                 tooltip="Show all tags, including default tags"
+                icon-f7="arrow_left_right"
                 @click="switchCodeTags('all')">
-                All
+                <span class="button-label">All</span>
               </f7-button>
             </f7-segmented>
           </template>
@@ -383,6 +386,15 @@
     margin-bottom var(--f7-sheet-height)
   .semantics-details-sheet
     height calc(0.8*var(--f7-sheet-height))
+
+@media (min-width: 476px)
+  .code-editor-toolbar .code-editor-tag-filter
+    .button .icon
+      display none
+@media (min-width: 768px)
+  .code-editor-toolbar .code-editor-tag-filter
+    .button .icon
+      display inherit
 
 .expand-button
   height unset

--- a/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/semantics/semantic-tags-edit.vue
@@ -193,6 +193,7 @@
                 :active="showCodeTags === 'editable'"
                 tooltip="Show all editable tags"
                 icon-f7="pencil"
+                icon-md="material:edit"
                 @click="switchCodeTags('editable')">
                 <span class="button-label">Editable</span>
               </f7-button>
@@ -202,6 +203,7 @@
                 :active="showCodeTags === 'custom'"
                 tooltip="Show all user defined tags"
                 icon-f7="ellipsis"
+                icon-md="material:more_horiz"
                 @click="switchCodeTags('custom')">
                 <span class="button-label">Custom</span>
               </f7-button>
@@ -211,6 +213,7 @@
                 :active="showCodeTags === 'all'"
                 tooltip="Show all tags, including default tags"
                 icon-f7="arrow_left_right"
+                icon-md="f7:arrow_left_right"
                 @click="switchCodeTags('all')">
                 <span class="button-label">All</span>
               </f7-button>


### PR DESCRIPTION
Identified here: https://github.com/openhab/openhab-core/issues/5538#issuecomment-4641526232

On narrow screens, the tag filter buttons make the copy and revert buttons disappear.

This PR replaces the button text with icons on narrow screens.

<img width="335" height="67" alt="image" src="https://github.com/user-attachments/assets/bc63c88f-dc75-4fe6-83fa-ba9b40e72947" />

Tooltips still convey the meaning.

