### PR TITLE
Sitemap editor: Minor fixes

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/attribute-details.vue
+++ b/bundles/org.openhab.ui/web/src/components/pagedesigner/sitemap/attribute-details.vue
@@ -19,7 +19,7 @@
             :value="attr.value"
             :disabled="disabled"
             @change="updateAttribute($event, idx, attr)" />
-          <div v-else-if="hasArrayFields" style="flex: 1">
+          <div v-else-if="hasArrayFields" style="flex: 1; min-width: 0">
             <div
               v-if="disabled || !isArrayEditing(idx)"
               style="display: flex; align-items: center; width: 100%; min-height: 32px; cursor: pointer"
@@ -69,7 +69,7 @@
               </div>
             </div>
           </div>
-          <div v-else style="flex: 1">
+          <div v-else style="flex: 1; min-width: 0">
             <div
               v-if="disabled || !isArrayEditing(idx)"
               style="display: flex; align-items: center; width: 100%; min-height: 32px; cursor: pointer"

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/sitemap/sitemap-edit.vue
@@ -164,7 +164,8 @@
           :object-id="sitemap.name"
           :read-only="!isEditable"
           @parsed="update"
-          @changed="onCodeChanged" />
+          @changed="onCodeChanged"
+          @save="save()" />
       </f7-tab>
     </f7-tabs>
 
@@ -725,7 +726,7 @@ export default {
           () => {
             this.codeDirty = false
             this.dirty = this.sitemapDirty
-            this.save(stay, true)
+            this.save(stay)
           },
           () => {
             this.currentTab = 'code'
@@ -768,6 +769,11 @@ export default {
           } else {
             showToast('Sitemap updated')
             this.lastCleanSitemap = this.stripClosed(this.sitemap)
+            if (this.currentTab === 'code') {
+              nextTick(() => {
+                this.$refs.codeEditor?.generateCode?.()
+              })
+            }
           }
           f7.emit('sidebarRefresh', null)
         })


### PR DESCRIPTION
Fixes:

- Text overflow of collapsed conditions
- Code editor save not properly resetting original code state