### PR TITLE
Properly support read-only block libraries

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1181,11 +1181,7 @@ Blockly.ContextMenuItems.registerCommentOptions()
 export default {
   props: {
     blocks: String,
-    libraryDefinitions: Array,
-    readOnly: {
-      type: Boolean,
-      default: false
-    }
+    libraryDefinitions: Array
   },
   emits: ['mounted', 'ready', 'change'],
   data() {
@@ -1285,7 +1281,7 @@ export default {
       this.addLibraryToToolbox(libraryDefinitions || [])
 
       const options = {
-        toolbox: this.readOnly ? null : this.$refs.toolbox,
+        toolbox: this.$refs.toolbox,
         horizontalLayout: !this.$device.desktop,
         theme: useUIOptionsStore().darkMode === 'dark' ? DarkTheme : undefined,
         zoom: {
@@ -1303,7 +1299,6 @@ export default {
         },
         trashcan: false,
         showLabels: false,
-        readOnly: this.readOnly,
 
         // Multi-select-options
         multiselectCopyPaste: {
@@ -1319,50 +1314,7 @@ export default {
       }
 
       workspace = Blockly.inject(this.$refs.blocklyEditor, options)
-      if (this.readOnly && libraryDefinitions) {
-        try {
-          const blocksRoot = libraryDefinitions.blocks || libraryDefinitions
-          let blockTypesToRender = []
-
-          if (blocksRoot && typeof blocksRoot === 'object') {
-            Object.keys(blocksRoot).forEach((libraryKey) => {
-              const libraryItem = blocksRoot[libraryKey]
-              if (libraryItem.slots && Array.isArray(libraryItem.slots.blocks)) {
-                libraryItem.slots.blocks.forEach((blockComponent) => {
-                  if (blockComponent.config && blockComponent.config.type) {
-                    blockTypesToRender.push(blockComponent.config.type)
-                  }
-                })
-              } else if (libraryItem.config && libraryItem.config.type) {
-                blockTypesToRender.push(libraryItem.config.type)
-              }
-            })
-          }
-
-          blockTypesToRender.forEach((blockType, index) => {
-            if (Blockly.Blocks[blockType]) {
-              const newBlock = workspace.newBlock(blockType)
-
-              // Move and stagger the blocks vertically so they don't overlap
-              newBlock.initSvg()
-              newBlock.render()
-              newBlock.moveBy(50, 50 + index * 160)
-            } else {
-              console.warn(`Block type "${blockType}" was defined in blocklibrary but not registered in Blockly.Blocks`)
-            }
-          })
-
-          setTimeout(() => {
-            if (workspace) {
-              workspace.zoomToFit()
-            }
-          }, 50)
-        } catch (e) {
-          console.error('Failed to render block library definitions in read-only layout:', e)
-        }
-      } else {
-        workspace.addChangeListener(shadowBlockConversionChangeListener)
-      }
+      workspace.addChangeListener(shadowBlockConversionChangeListener)
       const workspaceSearch = new WorkspaceSearch(workspace)
       workspaceSearch.init()
 

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1181,7 +1181,11 @@ Blockly.ContextMenuItems.registerCommentOptions()
 export default {
   props: {
     blocks: String,
-    libraryDefinitions: Array
+    libraryDefinitions: Array,
+    readOnly: {
+      type: Boolean,
+      default: false
+    }
   },
   emits: ['mounted', 'ready', 'change'],
   data() {
@@ -1281,7 +1285,7 @@ export default {
       this.addLibraryToToolbox(libraryDefinitions || [])
 
       const options = {
-        toolbox: this.$refs.toolbox,
+        toolbox: this.readOnly ? null : this.$refs.toolbox,
         horizontalLayout: !this.$device.desktop,
         theme: useUIOptionsStore().darkMode === 'dark' ? DarkTheme : undefined,
         zoom: {
@@ -1299,6 +1303,7 @@ export default {
         },
         trashcan: false,
         showLabels: false,
+        readOnly: this.readOnly,
 
         // Multi-select-options
         multiselectCopyPaste: {
@@ -1314,7 +1319,50 @@ export default {
       }
 
       workspace = Blockly.inject(this.$refs.blocklyEditor, options)
-      workspace.addChangeListener(shadowBlockConversionChangeListener)
+      if (this.readOnly && libraryDefinitions) {
+        try {
+          const blocksRoot = libraryDefinitions.blocks || libraryDefinitions
+          let blockTypesToRender = []
+
+          if (blocksRoot && typeof blocksRoot === 'object') {
+            Object.keys(blocksRoot).forEach((libraryKey) => {
+              const libraryItem = blocksRoot[libraryKey]
+              if (libraryItem.slots && Array.isArray(libraryItem.slots.blocks)) {
+                libraryItem.slots.blocks.forEach((blockComponent) => {
+                  if (blockComponent.config && blockComponent.config.type) {
+                    blockTypesToRender.push(blockComponent.config.type)
+                  }
+                })
+              } else if (libraryItem.config && libraryItem.config.type) {
+                blockTypesToRender.push(libraryItem.config.type)
+              }
+            })
+          }
+
+          blockTypesToRender.forEach((blockType, index) => {
+            if (Blockly.Blocks[blockType]) {
+              const newBlock = workspace.newBlock(blockType)
+
+              // Move and stagger the blocks vertically so they don't overlap
+              newBlock.initSvg()
+              newBlock.render()
+              newBlock.moveBy(50, 50 + index * 160)
+            } else {
+              console.warn(`Block type "${blockType}" was defined in blocklibrary but not registered in Blockly.Blocks`)
+            }
+          })
+
+          setTimeout(() => {
+            if (workspace) {
+              workspace.zoomToFit()
+            }
+          }, 50)
+        } catch (e) {
+          console.error('Failed to render block library definitions in read-only layout:', e)
+        }
+      } else {
+        workspace.addChangeListener(shadowBlockConversionChangeListener)
+      }
       const workspaceSearch = new WorkspaceSearch(workspace)
       workspaceSearch.init()
 

--- a/bundles/org.openhab.ui/web/src/components/util/not-editable-notice.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/not-editable-notice.vue
@@ -1,8 +1,7 @@
 <template>
   <f7-block>
     <f7-block-footer class="no-margin">
-      <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: This {{ subject }} is not editable because it has been provisioned from a
-      file.
+      <f7-icon f7="lock_fill" size="12" color="gray" />&nbsp;Note: This {{ subject }} is not editable.
     </f7-block-footer>
   </f7-block>
 </template>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/block-preview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/block-preview.vue
@@ -56,7 +56,11 @@ import { useUIOptionsStore } from '@/js/stores/useUIOptionsStore'
 
 export default {
   props: {
-    blocksDefinition: Object
+    blocksDefinition: Object,
+    readOnly: {
+      type: Boolean,
+      default: false
+    }
   },
   data() {
     return {
@@ -82,7 +86,7 @@ export default {
       this.workspace = Blockly.inject(this.$refs.blockPreview, {
         theme: useUIOptionsStore().darkMode === 'dark' ? 'dark' : undefined,
         trashcan: false,
-        readOnly: false
+        readOnly: this.readOnly
       })
     },
     defineBlocks() {

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/block-preview.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/block-preview.vue
@@ -47,6 +47,7 @@
 </style>
 
 <script>
+import { markRaw } from 'vue'
 import { mapStores } from 'pinia'
 import * as Blockly from 'blockly'
 
@@ -83,11 +84,12 @@ export default {
   },
   methods: {
     initWorkspace() {
-      this.workspace = Blockly.inject(this.$refs.blockPreview, {
+      const injectedWorkspace = Blockly.inject(this.$refs.blockPreview, {
         theme: useUIOptionsStore().darkMode === 'dark' ? 'dark' : undefined,
         trashcan: false,
         readOnly: this.readOnly
       })
+      this.workspace = markRaw(injectedWorkspace)
     },
     defineBlocks() {
       try {

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -3,6 +3,7 @@
     <f7-navbar>
       <oh-nav-content
         :title="(createMode ? 'Create Block Library' : 'Block Library: ' + blocks.uid) + dirtyIndicator"
+        :editable="isEditable"
         :save-link="`Save${$device.desktop ? ' (Ctrl-S)' : ''}`"
         @save="save()"
         :f7router />
@@ -16,35 +17,39 @@
       <f7-link @click="refreshBlocks"> Refresh<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span> </f7-link>
     </f7-toolbar>
     <f7-block v-if="split === 'horizontal'" :key="blockKey + '-h'" class="blocks-editor horizontal">
+      <not-editable-notice v-if="ready && !isEditable" subject="block library" />
       <f7-row resizable>
         <f7-col style="min-width: 20px" class="blocks-code">
           <editor
             class="blocks-component-editor"
             mode="application/vnd.openhab.uicomponent+yaml;type=blocks"
             :value="blocksDefinition"
+            :readOnly="!isEditable"
             @input="onEditorInput"
             @save="save()" />
         </f7-col>
       </f7-row>
       <f7-row v-if="ready" resizable>
         <f7-col style="min-width: 20px" class="block-preview-pane margin-horizontal margin-bottom">
-          <block-preview :blocks-definition="blocks" :key="previewKey" />
+          <block-preview :blocks-definition="blocks" :read-only="!isEditable" :key="previewKey" />
           <!-- <generic-widget-component :key="widgetKey" :context="context" /> -->
         </f7-col>
       </f7-row>
     </f7-block>
     <f7-block v-else :key="blockKey + 'b'" class="blocks-editor vertical">
+      <not-editable-notice v-if="ready && !isEditable" subject="block library" />
       <f7-row resizable>
         <f7-col resizable style="min-width: 20px" class="blocks-code">
           <editor
             class="blocks-component-editor"
             mode="application/vnd.openhab.uicomponent+yaml;type=blocks"
             :value="blocksDefinition"
+            :readOnly="!isEditable"
             @input="onEditorInput"
             @save="save()" />
         </f7-col>
         <f7-col v-if="ready" resizable style="min-width: 20px" class="block-preview-pane padding-right margin-bottom">
-          <block-preview :blocks-definition="blocks" :key="previewKey" />
+          <block-preview :blocks-definition="blocks" :read-only="!isEditable" :key="previewKey" />
           <!-- <generic-widget-component :key="widgetKey" :context="context" /> -->
         </f7-col>
       </f7-row>
@@ -66,6 +71,7 @@
           ref="blocklyPreviewEditor"
           :blocks="previewBlockSource"
           :library-definitions="[blocks]"
+          :read-only="!isEditable"
           @change="dirty = true" />
         <editor
           v-else-if="previewMode === 'code'"
@@ -103,6 +109,10 @@
       overflow auto
     .blocks-code
       height 100%
+      position relative
+      .v-codemirror
+        position absolute
+        inset 0
   &.vertical
     .block-preview-pane
       z-index auto !important
@@ -119,12 +129,12 @@
 import { f7 } from 'framework7-vue'
 import { nextTick, defineAsyncComponent } from 'vue'
 
-import YAML from 'yaml'
-
 import BlocklyEditor from '@/components/config/controls/blockly-editor.vue'
 import BlockPreview from './block-preview.vue'
+import NotEditableNotice from '@/components/util/not-editable-notice.vue'
 import { showToast } from '@/js/dialog-promises'
 import { useDirty } from '@/pages/useDirty'
+import { toFileYAMLSyntax, fromFileYAMLSyntax } from '@/pages/yaml-file-format'
 
 const toStringOptions = { toStringDefaults: { lineWidth: 0 } }
 
@@ -132,7 +142,8 @@ export default {
   components: {
     editor: defineAsyncComponent(() => import(/* webpackChunkName: "script-editor" */ '@/components/config/controls/script-editor.vue')),
     BlocklyEditor, // 'blockly-editor': () => import(/* webpackChunkName: "blockly-editor" */ '@/components/config/controls/blockly-editor.vue'),
-    BlockPreview // 'block-preview': () => import(/* webpackChunkName: "blockly-editor" */ './block-preview.vue')
+    BlockPreview, // 'block-preview': () => import(/* webpackChunkName: "blockly-editor" */ './block-preview.vue')
+    NotEditableNotice
   },
   props: {
     uid: String,
@@ -147,6 +158,7 @@ export default {
   data() {
     return {
       blocksDefinition: null,
+      blocksEditable: true,
       items: [],
       ready: false,
       split: 'vertical',
@@ -165,10 +177,14 @@ export default {
     blocks() {
       try {
         if (!this.blocksDefinition) return {}
-        return YAML.parse(this.blocksDefinition, { prettyErrors: true, toStringOptions })
+        const uid = this.createMode ? null : this.uid
+        return fromFileYAMLSyntax('blocks', this.blocksDefinition, uid)
       } catch (e) {
         return { component: 'Error', config: { error: e.message } }
       }
+    },
+    isEditable() {
+      return this.createMode || this.blocksEditable
     }
   },
   methods: {
@@ -243,76 +259,75 @@ export default {
       this.loading = true
       if (this.createMode) {
         const uid = f7.utils.id()
-        this.blocksDefinition = YAML.stringify(
-          {
-            uid: 'blocklibrary_' + uid,
-            tags: [],
-            component: 'BlockLibrary',
-            config: {
-              name: 'Block Library ' + uid
-            },
-            slots: {
-              blocks: [
-                {
-                  component: 'BlockType',
-                  config: {
-                    type: 'block1',
-                    message0: 'Do %1 with %2 and %3 then %4',
-                    args0: [
-                      {
-                        type: 'field_dropdown',
-                        name: 'OPTION1',
-                        options: [
-                          ['something', 'option1'],
-                          ['something else', 'option2']
-                        ]
-                      },
-                      {
-                        type: 'field_input',
-                        name: 'TEXT1',
-                        text: 'some text'
-                      },
-                      {
-                        type: 'input_value',
-                        name: 'NAME'
-                      },
-                      {
-                        type: 'input_statement',
-                        name: 'NAME'
-                      }
-                    ],
-                    previousStatement: null,
-                    nextStatement: null,
-                    colour: 90,
-                    tooltip: '',
-                    helpUrl: ''
-                  },
-                  slots: {
-                    code: [
-                      {
-                        component: 'BlockCodeTemplate',
-                        config: {
-                          template:
-                            '/* Incomplete example skeleton, check out\n' +
-                            '   https://openhab.org/link/blocklib-tutorial\n' +
-                            '   to learn how to build block libraries */\n'
-                        }
-                      }
-                    ]
-                  }
-                }
-              ]
-            }
+        this.blocksDefinition = toFileYAMLSyntax('blocks', {
+          uid: 'blocklibrary_' + uid,
+          tags: [],
+          component: 'BlockLibrary',
+          config: {
+            name: 'Block Library ' + uid
           },
-          { toStringOptions }
-        )
+          slots: {
+            blocks: [
+              {
+                component: 'BlockType',
+                config: {
+                  type: 'block1',
+                  message0: 'Do %1 with %2 and %3 then %4',
+                  args0: [
+                    {
+                      type: 'field_dropdown',
+                      name: 'OPTION1',
+                      options: [
+                        ['something', 'option1'],
+                        ['something else', 'option2']
+                      ]
+                    },
+                    {
+                      type: 'field_input',
+                      name: 'TEXT1',
+                      text: 'some text'
+                    },
+                    {
+                      type: 'input_value',
+                      name: 'NAME'
+                    },
+                    {
+                      type: 'input_statement',
+                      name: 'NAME'
+                    }
+                  ],
+                  previousStatement: null,
+                  nextStatement: null,
+                  colour: 90,
+                  tooltip: '',
+                  helpUrl: ''
+                },
+                slots: {
+                  code: [
+                    {
+                      component: 'BlockCodeTemplate',
+                      config: {
+                        template:
+                          '/* Incomplete example skeleton, check out\n' +
+                          '   https://openhab.org/link/blocklib-tutorial\n' +
+                          '   to learn how to build block libraries */\n'
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        })
         nextTick(() => {
           this.loading = false
           this.ready = true
         })
       } else {
         this.$oh.api.get('/rest/ui/components/ui:blocks/' + this.uid).then((data) => {
-          this.blocksDefinition = YAML.stringify(data, { toStringOptions })
+          this.blocksEditable = data.editable ?? true
+          delete data.editable
+          this.blocksDefinition = toFileYAMLSyntax('blocks', data)
           nextTick(() => {
             this.loading = false
             this.ready = true
@@ -321,6 +336,7 @@ export default {
       }
     },
     save(stay) {
+      if (!this.isEditable) return
       if (!this.blocks.uid) {
         f7.dialog.alert('Please give an ID to the block library')
         return

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -16,7 +16,7 @@
         @click="split = split === 'horizontal' ? 'vertical' : 'horizontal'; blockKey = f7.utils.id()" />
       <f7-link @click="refreshBlocks"> Refresh<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span> </f7-link>
     </f7-toolbar>
-    <f7-block v-if="split === 'horizontal'" :key="blockKey + '-h'" class="blocks-editor horizontal">
+    <f7-block v-if="split === 'horizontal'" :key="blockKey + '-h'" class="blocks-editor horizontal" :class="{ 'not-editable': !isEditable }">
       <not-editable-notice v-if="ready && !isEditable" subject="block library" />
       <f7-row resizable>
         <f7-col style="min-width: 20px" class="blocks-code">
@@ -36,7 +36,7 @@
         </f7-col>
       </f7-row>
     </f7-block>
-    <f7-block v-else :key="blockKey + 'b'" class="blocks-editor vertical">
+    <f7-block v-else :key="blockKey + 'b'" class="blocks-editor vertical" :class="{ 'not-editable': !isEditable }">
       <not-editable-notice v-if="ready && !isEditable" subject="block library" />
       <f7-row resizable>
         <f7-col resizable style="min-width: 20px" class="blocks-code">
@@ -98,19 +98,18 @@
   z-index auto !important
   top 0
   height calc(100%)
+  &.not-editable
+    height calc(100% - 2 * var(--f7-block-margin-vertical))
   .code-editor-fit
     height 100%
   .row
     height 100%
     .block-preview-pane
-      height 100%
+      height calc(100% - var(--f7-grid-gap))
       overflow auto
     .blocks-code
       height 100%
       position relative
-      .v-codemirror
-        position absolute
-        inset 0
   &.vertical
     .block-preview-pane
       z-index auto !important

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -16,7 +16,11 @@
         @click="split = split === 'horizontal' ? 'vertical' : 'horizontal'; blockKey = f7.utils.id()" />
       <f7-link @click="refreshBlocks"> Refresh<span v-if="$device.desktop">&nbsp;(Ctrl-R)</span> </f7-link>
     </f7-toolbar>
-    <f7-block v-if="split === 'horizontal'" :key="blockKey + '-h'" class="blocks-editor horizontal" :class="{ 'not-editable': !isEditable }">
+    <f7-block
+      v-if="split === 'horizontal'"
+      :key="blockKey + '-h'"
+      class="blocks-editor horizontal"
+      :class="{ 'not-editable': !isEditable }">
       <not-editable-notice v-if="ready && !isEditable" subject="block library" />
       <f7-row resizable>
         <f7-col style="min-width: 20px" class="blocks-code">

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-edit.vue
@@ -70,9 +70,7 @@
           v-if="previewMode === 'blockly'"
           ref="blocklyPreviewEditor"
           :blocks="previewBlockSource"
-          :library-definitions="[blocks]"
-          :read-only="!isEditable"
-          @change="dirty = true" />
+          :library-definitions="[blocks]" />
         <editor
           v-else-if="previewMode === 'code'"
           class="blocks-preview-code"

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -20,20 +20,30 @@
     </f7-navbar>
 
     <f7-toolbar v-if="showCheckboxes" class="contextual-toolbar" :class="{ navbar: theme.md }" bottom-ios bottom-aurora>
-      <f7-link
-        v-if="!theme.md"
-        v-show="selectedItems.length"
-        color="red"
-        class="delete"
-        icon-ios="f7:trash"
-        icon-aurora="f7:trash"
-        @click="removeSelected">
-        Remove {{ selectedItems.length }}
-      </f7-link>
+      <div v-if="!theme.md && selectedItems.length > 0" class="display-flex justify-content-center" style="width: 100%">
+        <f7-link
+          v-if="!theme.md && deletableSelectedItems.length"
+          color="red"
+          class="delete display-flex flex-direction-row margin-right"
+          icon-ios="f7:trash"
+          icon-aurora="f7:trash"
+          @click="removeSelected">
+          Remove {{ deletableSelectedItems.length }}
+        </f7-link>
+        <f7-link
+          color="blue"
+          class="copy display-flex flex-direction-row"
+          icon-ios="f7:square_on_square"
+          icon-aurora="f7:square_on_square"
+          @click="copySelectedItemsToClipboard">
+          &nbsp;Copy {{ selectedItems.length }}
+        </f7-link>
+      </div>
       <f7-link v-if="theme.md" icon-md="material:close" icon-color="white" @click="showCheckboxes = false" />
       <div v-if="theme.md" class="title">{{ selectedItems.length }} selected</div>
-      <div v-if="theme.md" class="right">
-        <f7-link v-show="selectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected" />
+      <div v-if="theme.md && selectedItems.length" class="right">
+        <f7-link v-show="deletableSelectedItems.length" icon-md="material:delete" icon-color="white" @click="removeSelected" />
+        <f7-link tooltip="Copy selected" icon-md="material:content_copy" icon-color="white" @click="copySelectedItemsToClipboard" />
       </div>
     </f7-toolbar>
 
@@ -41,8 +51,8 @@
       <f7-list-item title="Nothing found" />
     </f7-list>
 
-    <!-- skeleton for not ready -->
     <f7-block v-show="!nowidgetEngine" class="block-narrow">
+      <!-- skeleton for not ready -->
       <f7-col v-show="!ready">
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list media-list class="col wide">
@@ -52,7 +62,7 @@
               media-item
               :key="n"
               :class="`skeleton-text skeleton-effect-blink`"
-              title="Title of the widget"
+              title="Title of the block library"
               subtitle="Tag1, Tag2, Tag3..." />
           </f7-list-group>
         </f7-list>
@@ -85,6 +95,13 @@
             <template #media>
               <span class="item-initial">{{ b.uid[0].toUpperCase() }}</span>
             </template>
+            <template #after>
+              <!-- This is here to push the after-title icon so it would appear immediately after the title
+                    for consistency with Things, Items, and other lists that have the lock icon for non-editable entries -->
+            </template>
+            <template #after-title>
+              <f7-icon v-if="b.editable === false" f7="lock_fill" color="gray" />
+            </template>
           </f7-list-item>
         </f7-list>
       </f7-col>
@@ -103,6 +120,9 @@ import { nextTick } from 'vue'
 import { f7, theme } from 'framework7-vue'
 import { showToast } from '@/js/dialog-promises'
 
+import copyToClipboard from '@/js/clipboard'
+import { toFileYAMLSyntax } from '@/pages/yaml-file-format'
+
 export default {
   props: {
     f7router: Object
@@ -120,6 +140,11 @@ export default {
       selectedItems: [],
       showCheckboxes: false,
       eventSource: null
+    }
+  },
+  computed: {
+    deletableSelectedItems() {
+      return this.selectedItems.filter((i) => this.blocks.find((b) => b.uid === i)?.editable !== false)
     }
   },
   methods: {
@@ -173,14 +198,18 @@ export default {
     removeSelected() {
       const vm = this
 
-      f7.dialog.confirm(`Remove ${this.selectedItems.length} selected block libraries?`, 'Remove block libraries', () => {
-        vm.doRemoveSelected()
-      })
+      f7.dialog.confirm(
+        `Remove ${this.deletableSelectedItems.length} selected block librar${this.deletableSelectedItems.length === 1 ? 'y' : 'ies'}?`,
+        'Remove block libraries',
+        () => {
+          vm.doRemoveSelected()
+        }
+      )
     },
     doRemoveSelected() {
       let dialog = f7.dialog.progress('Deleting block libraries...')
 
-      const promises = this.selectedItems.map((i) => this.$oh.api.delete('/rest/ui/components/ui:blocks/' + i))
+      const promises = this.deletableSelectedItems.map((i) => this.$oh.api.delete('/rest/ui/components/ui:blocks/' + i))
       Promise.all(promises)
         .then((data) => {
           showToast('Block library removed')
@@ -196,6 +225,14 @@ export default {
           f7.dialog.alert('An error occurred while deleting: ' + err)
           f7.emit('sidebarRefresh', null)
         })
+    },
+    copySelectedItemsToClipboard() {
+      const itemsToCopy = this.blocks.filter((block) => this.selectedItems.includes(block.uid))
+      const yaml = toFileYAMLSyntax('blocks', itemsToCopy)
+      copyToClipboard(yaml, {
+        onSuccess: () => showToast(`${itemsToCopy.length} block library definitions copied to clipboard`),
+        onError: () => showToast('Failed to copy block library definitions to clipboard')
+      })
     }
   }
 }


### PR DESCRIPTION
This PR depends on https://github.com/openhab/openhab-core/pull/5590.

Support for providing widgets and pages through YAML have been implemented previously, but block libraries were left out. Since these are almost identical from core's point of view, I decided to add block libraries as well in https://github.com/openhab/openhab-core/pull/5590 when implementing support for hosting these in "the new YAML format" on the marketplace.

This would leave the UI with one "inconsistency", because the UI doesn't know that a block library might not be editable, and it won't know to "wrap" the YAML in `version:` etc.

This PR aims to address these shortcomings, but there's a problem: I don't know Blockly, I have no idea what a block library is or how you use or view it. Since Blockly is used to render these blocks in the UI, and I have no idea about any of it, there were some challenges in making the UI work for "read-only entries". I've tried my best, I haven't found a way to edit the read-only entries, but ultimately, I can't "verify" that the result makes sense. Somebody that knows/understands Blockly should verify the functionality for read-only libraries. The behavior for editable libraries shouldn't have changed.

Here are a couple of screenshots of a read-only library:

<img width="895" height="882" alt="image" src="https://github.com/user-attachments/assets/a2b1f826-a731-4019-ba3c-23255ddcb8ef" />

<img width="1011" height="869" alt="image" src="https://github.com/user-attachments/assets/da4851b5-efb4-4a25-9643-67bb8cfdca71" />
