### PR TITLE
i18n: Don't throw exception if a language cannot be found

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/i18n.ts
+++ b/bundles/org.openhab.ui/web/src/js/i18n.ts
@@ -38,11 +38,7 @@ export async function loadLocaleMessages(dir: string, mergeLocaleMessage: (local
     localeFilesArray.map(async (locale): Promise<unknown> => {
       const path = `../assets/i18n/${dir}/${locale}.json`
       const loader = localeFilesGlob[path]
-      if (loader) {
-        return loader()
-      } else {
-        throw new Error(`Locale file not found: ${path}`)
-      }
+      return loader ? loader() : Promise.resolve({}) // return empty object if no loader is found for the locale
     })
   )
 


### PR DESCRIPTION
importing the lanuage ../assets/i18n/about/en-US.json was causing an exception since that file does not exist.

Regression from #4164 