### PR TITLE
Unhide "scripts"/triggerless rules from "Rules" view

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
+++ b/bundles/org.openhab.ui/web/src/components/tags/tag-input.vue
@@ -72,7 +72,7 @@ export default {
       this.pendingTag = ''
       // Block adding of Scene or Script tags in the wrong editor
       // Adding them would otherwise lead to a situation where the rule/scene/script is not visible in the UI
-      if ((!this.inScriptEditor && newTag === 'Script') || (!this.inSceneEditor && newTag === 'Scene')) {
+      if ((this.inSceneEditor && newTag === 'Script') || (!this.inSceneEditor && newTag === 'Scene')) {
         return
       }
       if (newTag && this.item.tags.indexOf(newTag) === -1) {

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -441,7 +441,7 @@ export default {
         if (ruleData.status === 'fulfilled') {
           this.rules = ruleData.value
             .filter((r) => {
-              if (!this.showScripts && r.tags?.includes('Script')) return false
+              if (this.showScenes && r.tags?.includes('Script')) return false
               if (!this.showScenes && r.tags?.includes('Scene')) return false
               return true
             })
@@ -452,7 +452,7 @@ export default {
             this.ruleStatuses[rule.uid] = rule.status
 
             rule.tags.forEach((t) => {
-              if (t === 'Scene' || t === 'Script') return
+              if (t === 'Scene' || (this.showScripts && t === 'Script')) return
               if (t.startsWith('marketplace:')) return
               uniqueTags.add(t)
             })
@@ -671,7 +671,7 @@ export default {
       }
     },
     displayedTags(rule) {
-      return rule.tags.filter((t) => t !== 'Script' && t !== 'Scene')
+      return rule.tags.filter((t) => t !== 'Scene' && (!this.showScripts || t !== 'Script'))
     },
     updateFilteredItems() {
       const filters = this.$refs.filters


### PR DESCRIPTION
As was discussed here: https://github.com/openhab/openhab-core/pull/5462#issuecomment-4187804231, there seem to be some agreement that we should move away from the "script" concept, even though the exact road to get there isn't clear.

There is no technical difference between a triggerless rule and a "script", except that a "script" has the `Script` tag applied to it. This tag triggers specific functionality in MainUI that hides the rule under "Rules" in `rules-list.vue` and makes it show up under "Scripts" instead. However, "Scripts" doesn't allow the user to access the rule itself, it opens the script editor for the first `Action` directly.

 DSL rules that have the `.script` extension automatically gets the `Script` tag applied. For other scripting languages, you must specifically create it under "Scripts" to have the tag applied - but it also prevents you from seeing the YAML view, modifying various details, and adding triggers or conditions. If you create it under "Rules" instead, you don't have all these restrictions, and the only thing you can't do with such a rule is to add the `Script` tag, because that tag is "banned" and is ignored if you try.

This PR simply removes the hiding of rules with the `Script` tag from the "Rules" view and unbans the `Script` tag so that it's possible to add manually. Apart from that, nothing else is changed, "Scripts" behave as before.

I see this as a "soft" first step towards removing the artificial difference in treatment between rules with and without the `Script` tag. 