### PR TITLE
Rules list: Resurrect RUNNING status

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -689,8 +689,6 @@ export default {
           case 'state':
             const uid = topicParts[2]
             const newStatus = JSON.parse(event.payload)
-            // skip status updates for RUNNING for performance reasons (can be easily skipped as it was never really shown due to the short execution time of rules)
-            if (newStatus.status === 'RUNNING') return
 
             if (!this.ruleStatuses[uid]) this.ruleStatuses[uid] = {}
             this.ruleStatuses[uid].status = newStatus.status


### PR DESCRIPTION
`RUNNING` status for rules in `rules-list.vue` was disabled in #2623 for performance reasons. I question the idea, the sending and receiving of the events are still there, the only thing that is "saved" is the actual rendering. I certainly can't notice any difference in performance when I re-enable the status badge. There's a limit to how many rules can be shown on the screen at the same time, and I assume that Vue or the browser is smart enough to not render changes to elements that aren't visible. There's no animation or other "heavy processing", it's just a simple update of what's shown on the screen.

It's true that it's often so quick that it's not noticeable, but that depends entirely on what the rule does. And, perhaps especially, in those cases where the rules run for longer, it might be important that the user can see that. It might or might not be "by design". The fact that a rule says `IDLE` when it's running is also somewhat of a "lie". I don't think that's a good thing, when information is presented, it should be correct.

So, I'm hereby suggesting to re-enable `RUNNING` status for rules in `rules-list.vue`.

<img width="1225" height="882" alt="RulesListRunning" src="https://github.com/user-attachments/assets/b613fbaa-2892-47f6-a3c8-743ac5f54ded" />
