### PR TITLE
Developer sidebar: Fix duplicate keys in events list v-for

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -502,7 +502,7 @@
           <f7-list media-list>
             <f7-list-item
               v-for="event in sseEvents"
-              :key="event.time.getTime()"
+              :key="event.sequenceId"
               :title="event.topic"
               :subtitle="event.type"
               :footer="event.payload" />
@@ -1184,6 +1184,7 @@ export default {
         '',
         (event) => {
           event.time = new Date()
+          event.sequenceId = this.sseEvents.length > 0 ? this.sseEvents[0].sequenceId + 1 : 1
           this.sseEvents.unshift(...[event])
           this.sseEvents.splice(20)
         }

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -142,7 +142,7 @@
                 <f7-list media-list>
                   <f7-list-item
                     v-for="event in sseEvents"
-                    :key="event.time.getTime() + '#' + f7.utils.id()"
+                    :key="event.sequenceId"
                     :title="event.topic"
                     :subtitle="event.payload"
                     :after="event.type" />
@@ -162,7 +162,7 @@
                 <f7-list media-list>
                   <f7-list-item
                     v-for="event in wsEvents"
-                    :key="event.time.getTime() + '#' + f7.utils.id()"
+                    :key="event.sequenceId"
                     :title="event.topic"
                     :subtitle="event.payload"
                     :after="event.type" />
@@ -247,6 +247,7 @@ export default {
     startSSE() {
       this.sseClient = this.$oh.sse.connect('/rest/events', '', (event) => {
         event.time = new Date()
+        event.sequenceId = this.sseEvents.length > 0 ? this.sseEvents[0].sequenceId + 1 : 1
         this.sseEvents.unshift(...[event])
         this.sseEvents.splice(5)
       })
@@ -259,6 +260,7 @@ export default {
     startWS() {
       this.wsClient = this.$oh.ws.events([], (event) => {
         event.time = new Date()
+        event.sequenceId = this.wsEvents.length > 0 ? this.wsEvents[0].sequenceId + 1 : 1
         this.wsEvents.unshift(...[event])
         this.wsEvents.splice(5)
       })


### PR DESCRIPTION
As described in #4295, the developer toolbar fills my browser console with warnings. I also think it means that many events aren't shown. When looking at it, the reason seems pretty obvious: The "current time" in with milliseconds precision is used as an index. Since a millisecond is a long time for a computer, it can and will happen that multiple events are created within the same millisecond, and when that happens, Vue's "index" fails because of duplicated. For me, it happened at an alarming rate, the browser console grew "like crazy".

I simply introduced a counter instead. Simple, but I think, effective. It will have to run for many thousands of years to reach the maximum value, so I think we're safe there.

Fixes #4295.