### PR TITLE
Fix tabbed page navigation issues

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -129,8 +129,13 @@ const theme = f7.theme
 useViewArea()
 const { evaluateExpression } = useWidgetExpression()
 
+function normalizeTabIndex(value: unknown): number {
+  const idx = Math.trunc(Number(value))
+  return Number.isFinite(idx) && idx >= 0 ? idx : 0
+}
+
 // data (state)
-const currentTab = ref(props.initialTab ? Number(props.initialTab) : 0)
+const currentTab = ref(normalizeTabIndex(props.initialTab))
 const isFullscreen = ref(fullscreen.isFullscreen)
 const vars = ref({})
 const root = useTemplateRef<{ $el: HTMLElement }>('root')
@@ -184,9 +189,12 @@ const fullscreenIcon = computed(() => {
 // methods
 const onPageAfterIn = () => {
   statesStore.startTrackingStates()
-  // make sure to set the current tab
-  // fixes an issue where a tabbed subpage was opened and navigated around, when returning back to original page, tab was rendered empty
-  onTabChange(currentTab.value)
+  // Reactivate the current tab from state (F7 can lose the `tab-active` class across transitions, rendering the tab empty)
+  if (pageType.value === 'tabs') {
+    vars.value = {}
+    const tabEl = root.value?.$el.querySelector<HTMLElement>('#tab-' + currentTab.value)
+    if (tabEl) f7.tab.show(tabEl, false)
+  }
 }
 const onPageBeforeOut = () => {
   statesStore.stopTrackingStates()


### PR DESCRIPTION
For the past ~2 months i have noticed that on tabbed pages, selecting a tab and then navigating into an element and back (quickly) would sometimes land on /page/myPage/NaN instead of the correct tab index (like 0 or 1) , rendering a blank page, which is super annoying. This now guards against 'NaN' values and uses the previous tab state for tab index selection when returning. Have been running this for a couple days on my production system. 