### PR TITLE
Rule edit: Update rule code when the source changes

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -636,6 +636,16 @@ export default {
           this.loading = false
           if (!this.createMode && !this.stubMode && this.hasOpaqueModule && this.hasSource) {
             this.switchTab('source')
+          } else if (this.currentTab === 'code') {
+            this.resolveEditorTypes().then(() => {
+              if (!this.hasCode) {
+                showToast('This rule cannot be shown in code form because it contains elements that cannot be serialized to YAML or DSL.')
+                this.currentTab = 'design'
+                f7.tab.show('#design')
+              } else {
+                this.$refs.codeEditor.generateCode()
+              }
+            })
           }
         })
       }

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -641,7 +641,6 @@ export default {
               if (!this.hasCode) {
                 showToast('This rule cannot be shown in code form because it contains elements that cannot be serialized to YAML or DSL.')
                 this.currentTab = 'design'
-                f7.tab.show('#design')
               } else {
                 this.$refs.codeEditor.generateCode()
               }
@@ -828,7 +827,6 @@ export default {
           if (!this.hasCode) {
             showToast('This rule cannot be shown in code form because it contains elements that cannot be serialized to YAML or DSL.')
             this.currentTab = 'design'
-            f7.tab.show('#design')
           } else {
             this.$refs.codeEditor.generateCode()
           }
@@ -840,7 +838,6 @@ export default {
           },
           () => {
             this.currentTab = 'code'
-            f7.tab.show('#code')
           },
           { editorType: this.uiOptionsStore.codeEditorType, showAll: editor.isShowAll }
         )
@@ -918,7 +915,6 @@ export default {
           this.$refs.codeEditor.generateCode()
         } catch (e) {
           this.currentTab = 'code'
-          f7.tab.show('#code')
           throw e
         }
       }


### PR DESCRIPTION
This is a small fix for something that was forgotten. Under normal circumstances, there are no reasons to update the code in `load()` because the "Code tab" is never the "start tab". But, with a file-based rule, if you already have the "Code tab" open and the source file is updated, there is a need to regenerate the code to make sure that it reflects the changes made to the source file.
