### PR TITLE
Fix widget action regression from #3959

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/actions.ts
@@ -28,7 +28,7 @@ export const actionGroup = (groupPrefix?: string, label?: string, description?: 
   }
 }
 
-export const actionParams = (paramPrefix?: string, groupName?: string) => {
+export const actionParams = (groupName?: string, paramPrefix?: string) => {
   paramPrefix = paramPrefix ? (paramPrefix += '_') : ''
   if (!groupName) groupName = 'actions'
   const actionKey = paramPrefix + 'action'


### PR DESCRIPTION
During refactoring in #3959, the order of two method parameters were swapped, but callers weren't updated. The result is not surprising that things don't work as expected.

(One of) the bug(s) is discussed here: https://community.openhab.org/t/action-context-parameter-groups-are-not-properly-displayed-on-configuration-dialogs/169608