### PR TITLE
Log viewer: Fix log-viewer-card class style not applied

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/log-viewer/log-viewer-core.vue
@@ -188,8 +188,8 @@
     align-items center
     justify-content center
 
-/* Ensure the card takes full width and removes padding */
-.log-viewer-card
+  /* Ensure the card takes full width and removes padding */
+  .log-viewer-card
     margin 0
     padding 0
     width 100%


### PR DESCRIPTION
This happened due to incorrect indentation.