### PR TITLE
Fix OpenAPI spec missing optional slot field for `UiComponent`

### DIFF
--- a/bundles/org.openhab.ui/web/build/RootUIComponent.json
+++ b/bundles/org.openhab.ui/web/build/RootUIComponent.json
@@ -1,0 +1,39 @@
+{
+  "required": ["component", "config", "uid", "tags", "props", "timestamp"],
+  "type": "object",
+  "properties": {
+    "component": {
+      "type": "string"
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "slots": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/UIComponent"
+        }
+      }
+    },
+    "uid": {
+      "type": "string"
+    },
+    "tags": {
+      "uniqueItems": true,
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "props": {
+      "$ref": "#/components/schemas/ConfigDescription"
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time"
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/build/UIComponent.json
+++ b/bundles/org.openhab.ui/web/build/UIComponent.json
@@ -1,0 +1,22 @@
+{
+  "required": ["component", "config"],
+  "type": "object",
+  "properties": {
+    "component": {
+      "type": "string"
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "slots": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/UIComponent"
+        }
+      }
+    }
+  }
+}

--- a/bundles/org.openhab.ui/web/build/generate-rest-client.mjs
+++ b/bundles/org.openhab.ui/web/build/generate-rest-client.mjs
@@ -36,7 +36,7 @@ if (url) {
   process.stdout.write('DONE\n')
 
   try {
-    // temporary fix for UIComponent schema in OpenAPI spec - see https://github.com/openhab/openhab-core/issues/5686
+    // TODO: temporary fix for UIComponent schema in OpenAPI spec - see https://github.com/openhab/openhab-core/issues/5686
     process.stdout.write(`Updating UIComponent in ${file} ... `)
     execSync(`jq '.components.schemas.UIComponent = input' ${file} ./build/UIComponent.json > tmp.json &&  mv tmp.json ${file}`, {
       stdio: 'ignore'
@@ -47,7 +47,7 @@ if (url) {
   }
 
   try {
-    // temporary fix for RootUIComponent schema in OpenAPI spec
+    // TODO: temporary fix for RootUIComponent schema in OpenAPI spec
     process.stdout.write(`Updating RootUIComponent in ${file} ... `)
     execSync(`jq '.components.schemas.RootUIComponent = input' ${file} ./build/RootUIComponent.json > tmp.json &&  mv tmp.json ${file}`, {
       stdio: 'ignore'

--- a/bundles/org.openhab.ui/web/build/generate-rest-client.mjs
+++ b/bundles/org.openhab.ui/web/build/generate-rest-client.mjs
@@ -36,6 +36,28 @@ if (url) {
   process.stdout.write('DONE\n')
 
   try {
+    // temporary fix for UIComponent schema in OpenAPI spec - see https://github.com/openhab/openhab-core/issues/5686
+    process.stdout.write(`Updating UIComponent in ${file} ... `)
+    execSync(`jq '.components.schemas.UIComponent = input' ${file} ./build/UIComponent.json > tmp.json &&  mv tmp.json ${file}`, {
+      stdio: 'ignore'
+    })
+    process.stdout.write('DONE\n')
+  } catch (updateError) {
+    process.stderr.write('ERROR updating UIComponent:', updateError)
+  }
+
+  try {
+    // temporary fix for RootUIComponent schema in OpenAPI spec
+    process.stdout.write(`Updating RootUIComponent in ${file} ... `)
+    execSync(`jq '.components.schemas.RootUIComponent = input' ${file} ./build/RootUIComponent.json > tmp.json &&  mv tmp.json ${file}`, {
+      stdio: 'ignore'
+    })
+    process.stdout.write('DONE\n')
+  } catch (updateError) {
+    process.stderr.write('ERROR updating RootUIComponent:', updateError)
+  }
+
+  try {
     process.stdout.write(`Applying oxfmt to ${file} ... `)
     execSync(`oxfmt ${file}`, { stdio: 'ignore' })
     process.stdout.write('DONE\n')
@@ -44,17 +66,15 @@ if (url) {
   }
 }
 
-if (file && !openApi) {
-  process.stdout.write(`Reading OpenAPI spec from file ${file} ... `)
-  try {
-    const data = fs.readFileSync(file, 'utf8')
-    openApi = JSON.parse(data)
-  } catch (error) {
-    process.stderr.write('ERROR reading OpenAPI spec from file:', error)
-    process.exit(1)
-  }
-  process.stdout.write('DONE\n')
+process.stdout.write(`Reading OpenAPI spec from file ${file} ... `)
+try {
+  const data = fs.readFileSync(file, 'utf8')
+  openApi = JSON.parse(data)
+} catch (error) {
+  process.stderr.write('ERROR reading OpenAPI spec from file:', error)
+  process.exit(1)
 }
+process.stdout.write('DONE\n')
 
 try {
   await createClient({

--- a/bundles/org.openhab.ui/web/build/openhab-api-spec.json
+++ b/bundles/org.openhab.ui/web/build/openhab-api-spec.json
@@ -8305,17 +8305,17 @@
           "typeUID": {
             "type": "string"
           },
+          "configuration": {
+            "$ref": "#/components/schemas/Configuration"
+          },
+          "id": {
+            "type": "string"
+          },
           "label": {
             "type": "string"
           },
           "description": {
             "type": "string"
-          },
-          "id": {
-            "type": "string"
-          },
-          "configuration": {
-            "$ref": "#/components/schemas/Configuration"
           }
         }
       },
@@ -9015,24 +9015,21 @@
           "asCharacter": {
             "type": "string"
           },
+          "asShort": {
+            "type": "integer",
+            "format": "int32"
+          },
           "asBigDecimal": {
             "type": "number"
           },
           "asBigInteger": {
             "type": "integer"
           },
-          "asShort": {
-            "type": "integer",
-            "format": "int32"
+          "empty": {
+            "type": "boolean"
           },
           "asString": {
             "type": "string"
-          },
-          "asBoolean": {
-            "type": "boolean"
-          },
-          "empty": {
-            "type": "boolean"
           },
           "asDouble": {
             "type": "number",
@@ -9046,11 +9043,8 @@
             "type": "integer",
             "format": "int64"
           },
-          "jsonNull": {
+          "asBoolean": {
             "type": "boolean"
-          },
-          "asJsonObject": {
-            "$ref": "#/components/schemas/JsonObject"
           },
           "jsonObject": {
             "type": "boolean"
@@ -9058,49 +9052,46 @@
           "jsonArray": {
             "type": "boolean"
           },
-          "jsonPrimitive": {
+          "jsonNull": {
             "type": "boolean"
           },
-          "asJsonPrimitive": {
-            "$ref": "#/components/schemas/JsonPrimitive"
+          "asJsonArray": {
+            "$ref": "#/components/schemas/JsonArray"
           },
           "asJsonNull": {
             "$ref": "#/components/schemas/JsonNull"
           },
-          "asJsonArray": {
-            "$ref": "#/components/schemas/JsonArray"
+          "jsonPrimitive": {
+            "type": "boolean"
+          },
+          "asJsonObject": {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          "asJsonPrimitive": {
+            "$ref": "#/components/schemas/JsonPrimitive"
           }
         }
       },
       "JsonElement": {
         "type": "object",
         "properties": {
-          "jsonNull": {
-            "type": "boolean"
-          },
-          "asJsonObject": {
-            "$ref": "#/components/schemas/JsonObject"
-          },
           "jsonObject": {
             "type": "boolean"
           },
           "jsonArray": {
             "type": "boolean"
           },
-          "jsonPrimitive": {
+          "jsonNull": {
             "type": "boolean"
           },
-          "asJsonPrimitive": {
-            "$ref": "#/components/schemas/JsonPrimitive"
+          "asJsonArray": {
+            "$ref": "#/components/schemas/JsonArray"
           },
           "asJsonNull": {
             "$ref": "#/components/schemas/JsonNull"
           },
           "asNumber": {
             "type": "number"
-          },
-          "asJsonArray": {
-            "$ref": "#/components/schemas/JsonArray"
           },
           "asFloat": {
             "type": "number",
@@ -9113,21 +9104,27 @@
           "asCharacter": {
             "type": "string"
           },
+          "asShort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "jsonPrimitive": {
+            "type": "boolean"
+          },
+          "asJsonObject": {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          "asJsonPrimitive": {
+            "$ref": "#/components/schemas/JsonPrimitive"
+          },
           "asBigDecimal": {
             "type": "number"
           },
           "asBigInteger": {
             "type": "integer"
           },
-          "asShort": {
-            "type": "integer",
-            "format": "int32"
-          },
           "asString": {
             "type": "string"
-          },
-          "asBoolean": {
-            "type": "boolean"
           },
           "asDouble": {
             "type": "number",
@@ -9140,38 +9137,32 @@
           "asLong": {
             "type": "integer",
             "format": "int64"
+          },
+          "asBoolean": {
+            "type": "boolean"
           }
         }
       },
       "JsonNull": {
         "type": "object",
         "properties": {
-          "jsonNull": {
-            "type": "boolean"
-          },
-          "asJsonObject": {
-            "$ref": "#/components/schemas/JsonObject"
-          },
           "jsonObject": {
             "type": "boolean"
           },
           "jsonArray": {
             "type": "boolean"
           },
-          "jsonPrimitive": {
+          "jsonNull": {
             "type": "boolean"
           },
-          "asJsonPrimitive": {
-            "$ref": "#/components/schemas/JsonPrimitive"
+          "asJsonArray": {
+            "$ref": "#/components/schemas/JsonArray"
           },
           "asJsonNull": {
             "$ref": "#/components/schemas/JsonNull"
           },
           "asNumber": {
             "type": "number"
-          },
-          "asJsonArray": {
-            "$ref": "#/components/schemas/JsonArray"
           },
           "asFloat": {
             "type": "number",
@@ -9184,21 +9175,27 @@
           "asCharacter": {
             "type": "string"
           },
+          "asShort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "jsonPrimitive": {
+            "type": "boolean"
+          },
+          "asJsonObject": {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          "asJsonPrimitive": {
+            "$ref": "#/components/schemas/JsonPrimitive"
+          },
           "asBigDecimal": {
             "type": "number"
           },
           "asBigInteger": {
             "type": "integer"
           },
-          "asShort": {
-            "type": "integer",
-            "format": "int32"
-          },
           "asString": {
             "type": "string"
-          },
-          "asBoolean": {
-            "type": "boolean"
           },
           "asDouble": {
             "type": "number",
@@ -9211,6 +9208,9 @@
           "asLong": {
             "type": "integer",
             "format": "int64"
+          },
+          "asBoolean": {
+            "type": "boolean"
           }
         }
       },
@@ -9220,32 +9220,23 @@
           "empty": {
             "type": "boolean"
           },
-          "jsonNull": {
-            "type": "boolean"
-          },
-          "asJsonObject": {
-            "$ref": "#/components/schemas/JsonObject"
-          },
           "jsonObject": {
             "type": "boolean"
           },
           "jsonArray": {
             "type": "boolean"
           },
-          "jsonPrimitive": {
+          "jsonNull": {
             "type": "boolean"
           },
-          "asJsonPrimitive": {
-            "$ref": "#/components/schemas/JsonPrimitive"
+          "asJsonArray": {
+            "$ref": "#/components/schemas/JsonArray"
           },
           "asJsonNull": {
             "$ref": "#/components/schemas/JsonNull"
           },
           "asNumber": {
             "type": "number"
-          },
-          "asJsonArray": {
-            "$ref": "#/components/schemas/JsonArray"
           },
           "asFloat": {
             "type": "number",
@@ -9258,21 +9249,27 @@
           "asCharacter": {
             "type": "string"
           },
+          "asShort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "jsonPrimitive": {
+            "type": "boolean"
+          },
+          "asJsonObject": {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          "asJsonPrimitive": {
+            "$ref": "#/components/schemas/JsonPrimitive"
+          },
           "asBigDecimal": {
             "type": "number"
           },
           "asBigInteger": {
             "type": "integer"
           },
-          "asShort": {
-            "type": "integer",
-            "format": "int32"
-          },
           "asString": {
             "type": "string"
-          },
-          "asBoolean": {
-            "type": "boolean"
           },
           "asDouble": {
             "type": "number",
@@ -9285,6 +9282,9 @@
           "asLong": {
             "type": "integer",
             "format": "int64"
+          },
+          "asBoolean": {
+            "type": "boolean"
           }
         }
       },
@@ -9305,12 +9305,6 @@
           "asCharacter": {
             "type": "string"
           },
-          "asBigDecimal": {
-            "type": "number"
-          },
-          "asBigInteger": {
-            "type": "integer"
-          },
           "asShort": {
             "type": "integer",
             "format": "int32"
@@ -9324,11 +9318,14 @@
           "boolean": {
             "type": "boolean"
           },
+          "asBigDecimal": {
+            "type": "number"
+          },
+          "asBigInteger": {
+            "type": "integer"
+          },
           "asString": {
             "type": "string"
-          },
-          "asBoolean": {
-            "type": "boolean"
           },
           "asDouble": {
             "type": "number",
@@ -9342,11 +9339,8 @@
             "type": "integer",
             "format": "int64"
           },
-          "jsonNull": {
+          "asBoolean": {
             "type": "boolean"
-          },
-          "asJsonObject": {
-            "$ref": "#/components/schemas/JsonObject"
           },
           "jsonObject": {
             "type": "boolean"
@@ -9354,17 +9348,23 @@
           "jsonArray": {
             "type": "boolean"
           },
-          "jsonPrimitive": {
+          "jsonNull": {
             "type": "boolean"
           },
-          "asJsonPrimitive": {
-            "$ref": "#/components/schemas/JsonPrimitive"
+          "asJsonArray": {
+            "$ref": "#/components/schemas/JsonArray"
           },
           "asJsonNull": {
             "$ref": "#/components/schemas/JsonNull"
           },
-          "asJsonArray": {
-            "$ref": "#/components/schemas/JsonArray"
+          "jsonPrimitive": {
+            "type": "boolean"
+          },
+          "asJsonObject": {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          "asJsonPrimitive": {
+            "$ref": "#/components/schemas/JsonPrimitive"
           }
         }
       },
@@ -11236,6 +11236,7 @@
         }
       },
       "UIComponent": {
+        "required": ["component", "config"],
         "type": "object",
         "properties": {
           "component": {
@@ -11244,10 +11245,20 @@
           "config": {
             "type": "object",
             "additionalProperties": true
+          },
+          "slots": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/UIComponent"
+              }
+            }
           }
         }
       },
       "RootUIComponent": {
+        "required": ["component", "config", "uid", "tags", "props", "timestamp"],
         "type": "object",
         "properties": {
           "component": {

--- a/bundles/org.openhab.ui/web/src/api/types.gen.ts
+++ b/bundles/org.openhab.ui/web/src/api/types.gen.ts
@@ -138,10 +138,10 @@ export type RuleStatusInfo = {
 
 export type Module = {
     typeUID: string;
+    configuration: Configuration;
+    id: string;
     label: string;
     description: string;
-    id: string;
-    configuration: Configuration;
 };
 
 export type Configuration = {
@@ -387,93 +387,93 @@ export type JsonArray = {
     asFloat: number;
     asByte: string;
     asCharacter: string;
+    asShort: number;
     asBigDecimal: number;
     asBigInteger: number;
-    asShort: number;
-    asString: string;
-    asBoolean: boolean;
     empty: boolean;
+    asString: string;
     asDouble: number;
     asInt: number;
     asLong: number;
-    jsonNull: boolean;
-    asJsonObject: JsonObject;
+    asBoolean: boolean;
     jsonObject: boolean;
     jsonArray: boolean;
-    jsonPrimitive: boolean;
-    asJsonPrimitive: JsonPrimitive;
-    asJsonNull: JsonNull;
+    jsonNull: boolean;
     asJsonArray: JsonArray;
+    asJsonNull: JsonNull;
+    jsonPrimitive: boolean;
+    asJsonObject: JsonObject;
+    asJsonPrimitive: JsonPrimitive;
 };
 
 export type JsonElement = {
-    jsonNull: boolean;
-    asJsonObject: JsonObject;
     jsonObject: boolean;
     jsonArray: boolean;
-    jsonPrimitive: boolean;
-    asJsonPrimitive: JsonPrimitive;
+    jsonNull: boolean;
+    asJsonArray: JsonArray;
     asJsonNull: JsonNull;
     asNumber: number;
-    asJsonArray: JsonArray;
     asFloat: number;
     asByte: string;
     asCharacter: string;
+    asShort: number;
+    jsonPrimitive: boolean;
+    asJsonObject: JsonObject;
+    asJsonPrimitive: JsonPrimitive;
     asBigDecimal: number;
     asBigInteger: number;
-    asShort: number;
     asString: string;
-    asBoolean: boolean;
     asDouble: number;
     asInt: number;
     asLong: number;
+    asBoolean: boolean;
 };
 
 export type JsonNull = {
-    jsonNull: boolean;
-    asJsonObject: JsonObject;
     jsonObject: boolean;
     jsonArray: boolean;
-    jsonPrimitive: boolean;
-    asJsonPrimitive: JsonPrimitive;
+    jsonNull: boolean;
+    asJsonArray: JsonArray;
     asJsonNull: JsonNull;
     asNumber: number;
-    asJsonArray: JsonArray;
     asFloat: number;
     asByte: string;
     asCharacter: string;
+    asShort: number;
+    jsonPrimitive: boolean;
+    asJsonObject: JsonObject;
+    asJsonPrimitive: JsonPrimitive;
     asBigDecimal: number;
     asBigInteger: number;
-    asShort: number;
     asString: string;
-    asBoolean: boolean;
     asDouble: number;
     asInt: number;
     asLong: number;
+    asBoolean: boolean;
 };
 
 export type JsonObject = {
     empty: boolean;
-    jsonNull: boolean;
-    asJsonObject: JsonObject;
     jsonObject: boolean;
     jsonArray: boolean;
-    jsonPrimitive: boolean;
-    asJsonPrimitive: JsonPrimitive;
+    jsonNull: boolean;
+    asJsonArray: JsonArray;
     asJsonNull: JsonNull;
     asNumber: number;
-    asJsonArray: JsonArray;
     asFloat: number;
     asByte: string;
     asCharacter: string;
+    asShort: number;
+    jsonPrimitive: boolean;
+    asJsonObject: JsonObject;
+    asJsonPrimitive: JsonPrimitive;
     asBigDecimal: number;
     asBigInteger: number;
-    asShort: number;
     asString: string;
-    asBoolean: boolean;
     asDouble: number;
     asInt: number;
     asLong: number;
+    asBoolean: boolean;
 };
 
 export type JsonPrimitive = {
@@ -481,25 +481,25 @@ export type JsonPrimitive = {
     asFloat: number;
     asByte: string;
     asCharacter: string;
-    asBigDecimal: number;
-    asBigInteger: number;
     asShort: number;
     string: boolean;
     number: boolean;
     boolean: boolean;
+    asBigDecimal: number;
+    asBigInteger: number;
     asString: string;
-    asBoolean: boolean;
     asDouble: number;
     asInt: number;
     asLong: number;
-    jsonNull: boolean;
-    asJsonObject: JsonObject;
+    asBoolean: boolean;
     jsonObject: boolean;
     jsonArray: boolean;
-    jsonPrimitive: boolean;
-    asJsonPrimitive: JsonPrimitive;
-    asJsonNull: JsonNull;
+    jsonNull: boolean;
     asJsonArray: JsonArray;
+    asJsonNull: JsonNull;
+    jsonPrimitive: boolean;
+    asJsonObject: JsonObject;
+    asJsonPrimitive: JsonPrimitive;
 };
 
 export type StringList = Array<string>;
@@ -1152,6 +1152,9 @@ export type UiComponent = {
     config: {
         [key: string]: unknown;
     };
+    slots?: {
+        [key: string]: Array<UiComponent>;
+    };
 };
 
 export type RootUiComponent = {
@@ -1159,7 +1162,7 @@ export type RootUiComponent = {
     config: {
         [key: string]: unknown;
     };
-    slots: {
+    slots?: {
         [key: string]: Array<UiComponent>;
     };
     uid: string;

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/series/oh-time-series.ts
@@ -10,8 +10,8 @@ import { OhTimeSeriesDefinition } from '@/assets/definitions/widgets/chart'
 const timeSeries: SeriesComponent = {
   neededItems(context, component) {
     let markAreaItems: string[] = []
-    if ('slots' in component && Array.isArray((component as api.RootUiComponent).slots.markArea)) {
-      markAreaItems = (component as api.RootUiComponent).slots.markArea
+    if (Array.isArray(component.slots?.markArea)) {
+      markAreaItems = component.slots.markArea
         .map((a, i) =>
           context.evaluateExpression<string | undefined>(
             ComponentId.get(component)! + '.mitem' + i,
@@ -40,8 +40,8 @@ const timeSeries: SeriesComponent = {
     }
 
     // other things
-    if ('slots' in component && Array.isArray((component as api.RootUiComponent).slots.markArea)) {
-      const markAreaComponent = (component as api.RootUiComponent).slots.markArea[0]
+    if (Array.isArray(component.slots?.markArea)) {
+      const markAreaComponent = component.slots.markArea[0]
       if (markAreaComponent) {
         series.markArea = MarkArea.get(context, markAreaComponent, points, startTime, endTime)
         series.id += '#mark-area'

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-block.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-block.vue
@@ -73,10 +73,7 @@ const props = defineProps<{
   context: WidgetContext
 }>()
 
-const parentDefaultSlots =
-  props.context.parent?.component && 'slots' in props.context.parent.component && props.context.parent.component.slots.default
-    ? props.context.parent.component.slots?.default
-    : []
+const parentDefaultSlots = props.context.parent?.component?.slots?.default ?? []
 
 const { config, childContext, scopedCssUid, visible, defaultSlots } = useWidgetContext(computed(() => props.context))
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-layout-page.vue
@@ -56,5 +56,5 @@ const context = computed(() => props.context)
 const { config, childContext, scopedCssUid, defaultSlots, evaluateExpression } = useWidgetContext(context)
 const { performAction } = useWidgetAction(context, config, evaluateExpression)
 
-const masonrySlots = computed(() => ('slots' in props.context.component && props.context.component.slots.masonry) || [])
+const masonrySlots = computed(() => props.context.component.slots?.masonry ?? [])
 </script>

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
@@ -368,7 +368,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
                       return el
                     }
                   }
-                  throw new Error('Invalid actionPhotos parameter format in ' + ctx.component.component)
+                  throw new Error('Invalid actionPhotos parameter format in ' + (ctx.component as api.RootUiComponent).component)
                 })
 
                 const resolvedPhotos = await Promise.all(promises)

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetAction.ts
@@ -368,7 +368,7 @@ export function useWidgetAction(context: Ref<WidgetContext>, config: Ref<WidgetA
                       return el
                     }
                   }
-                  throw new Error('Invalid actionPhotos parameter format in ' + (ctx.component as api.RootUiComponent).component)
+                  throw new Error('Invalid actionPhotos parameter format in ' + ctx.component.component)
                 })
 
                 const resolvedPhotos = await Promise.all(promises)

--- a/bundles/org.openhab.ui/web/src/components/widgets/useWidgetContext.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/useWidgetContext.ts
@@ -7,7 +7,7 @@ import { useComponentsStore } from '@/js/stores/useComponentsStore'
 import { useWidgetExpression } from '@/components/widgets/useWidgetExpression.ts'
 
 import type { ContextVarObj, VariableObject, VariableScopeName, VariableValue, WidgetContext } from './types'
-import { computed, onBeforeUnmount, onMounted, type Ref, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, readonly, type Ref, ref } from 'vue'
 import * as api from '@/api'
 import { applyParameterDefaults } from '@/components/widgets/helpers.ts'
 
@@ -37,8 +37,9 @@ export function useWidgetContext(context: Ref<WidgetContext>) {
 
   // computed
   const componentType = computed<string | null>(() => {
-    if (!context.value.component?.component) return null
-    return (evaluateExpression('type', context.value.component.component) as string) || null
+    const component = context.value.component.component
+    if (!component) return null
+    return (evaluateExpression('type', component) as string) || null
   })
 
   const childWidgetComponentType = computed<string | null>(() => {
@@ -123,7 +124,7 @@ export function useWidgetContext(context: Ref<WidgetContext>) {
         ? { ...widget, slots: { ...widget.slots, ...context.value.component.slots } }
         : widget
     return {
-      component: extendedWidget,
+      component: extendedWidget as api.RootUiComponent | api.UiComponent,
       props: config.value,
       fn: context.value.fn,
       const: context.value.const,
@@ -176,7 +177,7 @@ export function useWidgetContext(context: Ref<WidgetContext>) {
 
   // lifecycle
   onMounted(() => {
-    const stylesheet = context.value.component?.config?.stylesheet as string | undefined
+    const stylesheet = context.value.component.config?.stylesheet as string | undefined
     if (stylesheet) {
       scopedCssUid.value = 'scoped-' + f7.utils.id()
       let style = document.createElement('style')

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -38,7 +38,7 @@
     <!-- Tabbed Pages -->
     <f7-toolbar v-if="page && pageType === 'tabs' && visibleToCurrentUser" tabbar labels bottom>
       <f7-link
-        v-for="(tab, idx) in page.slots.default"
+        v-for="(tab, idx) in page.slots?.default"
         :key="idx"
         :tab-link="'#tab-' + idx"
         @click="onTabChange(idx)"
@@ -53,7 +53,7 @@
       </f7-link>
     </f7-toolbar>
     <f7-tabs v-if="page && pageType === 'tabs' && visibleToCurrentUser">
-      <f7-tab v-for="(tab, idx) in page.slots.default" :id="'tab-' + idx" :key="idx" :tab-active="currentTab === idx">
+      <f7-tab v-for="(tab, idx) in page.slots?.default" :id="'tab-' + idx" :key="idx" :tab-active="currentTab === idx">
         <component :is="tabComponent(tab)" v-if="currentTab === idx" :context="tabContext(tab)" :f7router />
       </f7-tab>
     </f7-tabs>
@@ -145,7 +145,7 @@ const pageStyle = computed(() => {
   if (!context.value) return null
   const pageComponent: DeepReadonly<api.RootUiComponent> | string | null =
     pageType.value === 'tabs'
-      ? context.value.component?.slots.default?.[currentTab.value]
+      ? context.value.component?.slots?.default?.[currentTab.value]
         ? // the tabbed page component can be null if this.currentTab is out of bounds
           tabContext(context.value.component!.slots.default![currentTab.value]!).component
         : null
@@ -223,7 +223,7 @@ const onTabChange = (idx: number) => {
   // @ts-expect-error - url is not typed as part of the router
   props.f7router.url = url
 }
-const tabContext = (tab: api.UiComponent) => {
+const tabContext = (tab: DeepReadonly<api.UiComponent>) => {
   const tabPage: DeepReadonly<api.RootUiComponent> | string = tab.config.page
     ? componentStore.page((tab.config.page as string).replace('page:', ''))!
     : tab.component
@@ -259,7 +259,7 @@ const pageComponent = (page: api.RootUiComponent | DeepReadonly<api.RootUiCompon
   }
   return null
 }
-const tabComponent = (tab: string | api.UiComponent) => {
+const tabComponent = (tab: string | DeepReadonly<api.UiComponent>) => {
   switch (tab) {
     case 'oh-locations-tab':
       return OhLocationsTab
@@ -277,7 +277,7 @@ const tabComponent = (tab: string | api.UiComponent) => {
   if (!page) return null
   return pageComponent(page)
 }
-const tabEvaluateExpression = (tab: api.UiComponent, idx: number, key: string) => {
+const tabEvaluateExpression = (tab: DeepReadonly<api.UiComponent>, idx: number, key: string) => {
   const ctx = tabContext(tab)
   return evaluateExpression('tab-' + idx + '-' + key, tab.config[key], ctx as unknown as WidgetContext, ctx.props)
 }
@@ -295,7 +295,7 @@ const editPage = () => {
         {
           text: 'Edit Current Tab',
           onClick: () => {
-            const tabPageUid = (page.value!.slots.default![currentTab.value]!.config.page as string).replace('page:', '')
+            const tabPageUid = (page.value!.slots?.default![currentTab.value]!.config.page as string).replace('page:', '')
             const tabPage = componentStore.page(tabPageUid)!
             const tabPageType = getPageType(tabPage).type
             props.f7router.navigate('/settings/pages/' + tabPageType + '/' + tabPageUid)


### PR DESCRIPTION
- Updates the openapi spec to the latest from RC1
- applies fixes to the spec to address missing optional slots in the UIComponent (https://github.com/openhab/openhab-core/issues/5686)
- Also makes the slots optional in the RootUIComponent (since it is inherited from UIComponent)
- fixed several typescript errors due to the change

@florian-h05, I'd like to get swagger to generate the slots correctly, but per the above issue, it is confused due to the recursive nature. Hopefully we can address that and then we can remove the tweaking of the openapi spec.