### PR TITLE
`navigate` widget action: Fix actionPageDefineVars not applied anymore

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -186,12 +186,20 @@ const fullscreenIcon = computed(() => {
 })
 
 // watchers
-watch(page, (newPage) => {
-  if (newPage?.config?.defineVars) vars.value = Object.assign(vars.value, newPage.config.defineVars)
-})
-watch(props, (newProps) => {
-  if (newProps.defineVars) vars.value = Object.assign(vars.value, newProps.defineVars)
-})
+watch(
+  page,
+  (newPage) => {
+    if (newPage?.config?.defineVars) vars.value = Object.assign(vars.value, newPage.config.defineVars)
+  },
+  { immediate: true }
+)
+watch(
+  props,
+  (newProps) => {
+    if (newProps.defineVars) vars.value = Object.assign(vars.value, newProps.defineVars)
+  },
+  { immediate: true }
+)
 
 // methods
 const onPageAfterIn = () => {


### PR DESCRIPTION
Fixes #4323.
Regression from #4257.