### PR TITLE
Add Items from Textual Definition: Work around hey-api bug with content-type in parse REST endpoint

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/parser/items-add-from-textual-definition.vue
@@ -246,7 +246,10 @@ const parseItems = () => {
         headers: {
           'Content-Type': serverMediaType,
           accept: 'application/json'
-        }
+        },
+        // Hey API bugs with all the different content types and tries to serialize the body as JSON
+        // This invalidates the content, and deserialization on the other end fails, causing the method to return 400
+        bodySerializer: (body) => body
       }
     )
     .then((data) => {


### PR DESCRIPTION
This fixes #4343.

It turns out that Hey API doesn't respect the content-type and tries to serialize the content to JSON despite the content-type not being JSON.

A "better" fix might be desirable long-term, but this makes the parsing of Items work again.