### PR TITLE
Thing Add: speed up the loading of installed binding list

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -97,7 +97,7 @@ export default {
   methods: {
     onPageAfterIn() {
       this.loading = true
-      this.$oh.api.get('/rest/addons?serviceId=all').then((data) => {
+      this.$oh.api.get('/rest/addons?serviceId=all&installedOnly=true').then((data) => {
         let installedBindings = data.filter((addon) => addon.type === 'binding' && addon.installed === true)
         this.bindings = installedBindings.sort((a, b) => a.label.localeCompare(b.label))
         this.loading = false


### PR DESCRIPTION
Fixes #2337

Depends on: openhab/openhab-core#5692

