### PR TITLE
Add-ons Store: Add a refresh button for explicit add-on list reload

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -298,6 +298,8 @@ import { AddonIcons, AddonTitles, AddonSuggestionLabels, AddonConnectionTypes, A
 
 import { useRuntimeStore } from '@/js/stores/useRuntimeStore'
 
+let handledReloadInCurrentDocument = false
+
 export default {
   mixins: [AddonStoreMixin],
   props: {
@@ -381,8 +383,39 @@ export default {
     updateLeftPanelVisibility() {
       this.leftPanelOpened = f7.panel.get('left').opened
     },
+    isBrowserReloadOnAddonStore() {
+      // Detect browser reloads (Cmd+R, F5, etc.) on the /addons page using the PerformanceNavigationTiming API
+      const navigationEntry = performance.getEntriesByType?.('navigation')?.[0]
+      const isReload = navigationEntry?.type === 'reload'
+      if (!isReload) return false
+
+      // Compare against the original document URL to distinguish browser reloads
+      // on /addons from reloads elsewhere followed by in-app navigation.
+      let initialPathname = ''
+      if (navigationEntry?.name) {
+        try {
+          initialPathname = new URL(navigationEntry.name).pathname
+        } catch {
+          initialPathname = ''
+        }
+      }
+
+      if (!initialPathname && typeof window !== 'undefined') {
+        initialPathname = window.location.pathname
+      }
+
+      return initialPathname.startsWith('/addons')
+    },
     load(refresh = false) {
       this.ready = false
+
+      if (!refresh && !handledReloadInCurrentDocument && this.isBrowserReloadOnAddonStore()) {
+        refresh = true
+        // Prevent multiple refreshes on the same document load,
+        // e.g. when the user reloads, then navigates to another page and back to /addons.
+        handledReloadInCurrentDocument = true
+      }
+
       if (this.searchFor) {
         // Show this in the searchbar while the page is loading
         this.$refs.storeSearchbar.$el.f7Searchbar.$inputEl.val(this.searchFor)

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -3,7 +3,7 @@
     <f7-navbar large class="store-nav">
       <oh-nav-content :title="AddonTitles[currentTab] || 'Add-on Store'" :large="true" :back-link-url="backLinkUrl" :f7router />
     </f7-navbar>
-    <f7-toolbar v-show="$f7dim.width < 1024 || !leftPanelOpened" tabbar bottom>
+    <f7-toolbar v-if="$f7dim.width < 1024 || !leftPanelOpened" tabbar bottom>
       <f7-link
         tab-link="#main"
         :tab-link-active="runtimeStore.pagePath === '/addons/'"
@@ -272,6 +272,12 @@
       @closed="addonPopupOpened = false"
       @install="installAddon"
       @uninstall="uninstallAddon" />
+
+    <template #fixed>
+      <f7-fab v-show="ready" position="right-bottom" color="blue" @click="load(true)">
+        <f7-icon ios="f7:arrow_clockwise" md="material:refresh" aurora="f7:arrow_clockwise" />
+      </f7-fab>
+    </template>
   </f7-page>
 </template>
 
@@ -375,7 +381,8 @@ export default {
     updateLeftPanelVisibility() {
       this.leftPanelOpened = f7.panel.get('left').opened
     },
-    load() {
+    load(refresh = false) {
+      this.ready = false
       if (this.searchFor) {
         // Show this in the searchbar while the page is loading
         this.$refs.storeSearchbar.$el.f7Searchbar.$inputEl.val(this.searchFor)
@@ -394,7 +401,8 @@ export default {
       })
       this.$oh.api.get('/rest/addons/services').then((data) => {
         this.services = data
-        Promise.all(this.services.map((s) => this.$oh.api.get('/rest/addons?serviceId=' + s.id))).then((data2) => {
+        const refreshParam = refresh ? '&refresh=true' : ''
+        Promise.all(this.services.map((s) => this.$oh.api.get('/rest/addons?serviceId=' + s.id + refreshParam))).then((data2) => {
           data2.forEach((addons, idx) => {
             this.addons[data[idx].id] = data2[idx]
           })


### PR DESCRIPTION
Allow users to manually trigger an immediate reload of the add-on list, so that core will re-fetch the list of remote add-ons (e.g. marketplace add-ons) and return a fresh result.

The reload can be done through either of these two mechanisms:
- A refresh FAB in the bottom right corner
- Browser refresh (typically F5, Cmd+R, or the refresh icon on the browser)

Previously the add-on list was reloaded in core based on a 15-minute expiring cache. This resulted in random stutterings when loading the add-ons store page. Additionally, the user must wait for this cache to expire before they see the updated list of remote addons, and they don't know exactly when this happens.

Depends on https://github.com/openhab/openhab-core/pull/5710 

The core PR removes the expiring cache mechanism and provides a way for the UI to request a refresh on demand.

This improves responsiveness and gives users predictable control over when the data is refreshed. This would be very handy if you're posting or updating a marketplace addon and want to test it - you can instantly refresh the listing without waiting for the "15 minute" cache to expire or resorting to restarting the addon.marketplace bundle to force a refresh.

<img width="783" height="1018" alt="image" src="https://github.com/user-attachments/assets/2623cae7-b2e7-4b7f-ab77-b946bdc0e7ab" />