### PR TITLE
`oh-list-item`: Enable `accordionItem` configuration property

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -182,7 +182,8 @@ export default {
       return this.context.parent.component.config.accordionEquipment && this.accordionSlots.length > 0
     },
     isRegularAccordion() {
-      return this.context.parent.component.config.accordionList && this.accordionSlots.length > 0
+      if (this.config?.accordionItem === false) return false
+      return (this.config?.accordionItem === true || this.context.parent.component.config.accordionList) && this.accordionSlots.length > 0
     },
     accordionSlots() {
       if (!this.context.component.slots?.accordion?.length) return []


### PR DESCRIPTION
As discussed [here](https://community.openhab.org/t/location-badge-counts-semantic-property-brightness-as-light/169479), the current practice of controlling whether a list item should be accordion or not via its parent, is problematic at times. In particular, it is problematic when the parent isn't a list, but for example an `oh-repeater`. It is also problematic when the parent is provided, like for e.g. location cards etc.

This PR does the following:

* If `accordionItem` isn’t specified, it behaves as today, according to the parent.
* If `accordionItem` is set to `true` and it has at least one accordion slot, it will be an accordion.
* If `accordionItem` is set to `false`, it won’t be an accordion regardless of what the parent says.

`accordionItem` is already a property that can be set for `f7-list-item`, but not for `oh-list-item`. It's therefore the natural choice for the name of the "new" property.

This PR should thus only change the behavior in situations where this property is explicitly set for `oh-list-item`, which shouldn't be that widespread, given that it has no effect today.