### PR TITLE
Add local setting to disable hiding tabs when scrolling

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/i18n/theme-switcher/en.json
+++ b/bundles/org.openhab.ui/web/src/assets/i18n/theme-switcher/en.json
@@ -18,6 +18,7 @@
   "about.miscellaneous.home.hideChatInput": "Hide chat input box on home page",
   "about.miscellaneous.home.disableCardExpansionAnimation": "Disable card expansion animations",
   "about.miscellaneous.theme.disablePageTransition": "Disable page transition animations",
+  "about.miscellaneous.theme.disableHideBarsOnScroll": "Disable hide tabs when scrolling",
   "about.miscellaneous.webaudio.enable": "Enable Web Audio sink support",
   "about.miscellaneous.commandItem.title": "Listen for UI commands to ",
   "about.miscellaneous.commandItem.selectItem": "Item",

--- a/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
+++ b/bundles/org.openhab.ui/web/src/components/theme-switcher.vue
@@ -91,6 +91,10 @@
             <f7-toggle v-model:checked="disablePageTransitionAnimation" />
           </f7-list-item>
           <f7-list-item>
+            <span>{{ t('about.miscellaneous.theme.disableHideBarsOnScroll') }}</span>
+            <f7-toggle v-model:checked="disableHideBarsOnScroll" />
+          </f7-list-item>
+          <f7-list-item>
             <span>{{ t('about.miscellaneous.webaudio.enable') }}</span>
             <f7-toggle v-model:checked="webAudio" />
           </f7-list-item>
@@ -212,6 +216,7 @@ export default {
     ...mapStores(useRuntimeStore, useUIOptionsStore),
     ...mapWritableState(useUIOptionsStore, [
       'disablePageTransitionAnimation',
+      'disableHideBarsOnScroll',
       'bars',
       'homeNavBar',
       'homeBackground',

--- a/bundles/org.openhab.ui/web/src/js/stores/useUIOptionsStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useUIOptionsStore.ts
@@ -44,6 +44,8 @@ export const useUIOptionsStore = defineStore('uiOptions', () => {
 
   const hideChatInput = ref<boolean>(localStorage.getItem('openhab.ui:theme.home.hidechatinput') === 'true')
 
+  const disableHideBarsOnScroll = ref<boolean>(localStorage.getItem('openhab.ui:theme.disablehidebarsonscroll') === 'true')
+
   // shared with Basic UI
   const webAudio = ref<boolean>(localStorage.getItem('openhab.ui:webaudio.enable') === 'true')
 
@@ -175,6 +177,10 @@ export const useUIOptionsStore = defineStore('uiOptions', () => {
 
   watch(hideChatInput, (newValue) => {
     localStorage.setItem('openhab.ui:theme.home.hidechatinput', newValue.toString())
+  })
+
+  watch(disableHideBarsOnScroll, (newValue) => {
+    localStorage.setItem('openhab.ui:theme.disablehidebarsonscroll', newValue.toString())
   })
 
   watch(webAudio, (newValue) => {
@@ -325,6 +331,7 @@ export const useUIOptionsStore = defineStore('uiOptions', () => {
       blocklyRenderer: blocklyRenderer.value,
       disablePageTransitionAnimation: disablePageTransitionAnimation.value,
       hideChatInput: hideChatInput.value,
+      disableHideBarsOnScroll: disableHideBarsOnScroll.value,
       webAudio: webAudio.value,
       visibleBreakpointDisabled: visibleBreakpointDisabled.value
     }
@@ -341,6 +348,7 @@ export const useUIOptionsStore = defineStore('uiOptions', () => {
     blocklyRenderer,
     disablePageTransitionAnimation,
     hideChatInput,
+    disableHideBarsOnScroll,
     webAudio,
     visibleBreakpointDisabled,
     codeEditorType,

--- a/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
+++ b/bundles/org.openhab.ui/web/src/pages/page/page-view.vue
@@ -3,7 +3,7 @@
     ref="root"
     @page:afterin="onPageAfterIn"
     @page:beforeout="onPageBeforeOut"
-    hide-bars-on-scroll
+    :hide-bars-on-scroll="!uiOptionsStore.disableHideBarsOnScroll"
     :style="pageStyle"
     class="disable-user-select">
     <f7-navbar
@@ -122,6 +122,7 @@ const props = defineProps<{
 const componentStore = useComponentsStore()
 const statesStore = useStatesStore()
 const userStore = useUserStore()
+const uiOptionsStore = useUIOptionsStore()
 
 const theme = f7.theme
 


### PR DESCRIPTION
I didn't go very in-depth with this, I just mimicked what I found was already there. The name of the option, the description string, the placement, these things should all be evaluated - since I just "picked something that seemed reasonable".

Except for that, it does what the title says, it allows disabling the hiding of "bars" (I suspect that's more than just the tab bar) when scrolling, for those that find that annoying/impractical. Unfortunately, it's only a local storage setting, so one must do it over and over again on every browser/device, but that problem is shared with all the other "UI options".

Partially addressed #4135.