### PR TITLE
Thing Details: Improve binding installation link logic

### DIFF
--- a/bundles/org.openhab.ui/web/src/js/stores/useThingEditStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useThingEditStore.ts
@@ -25,6 +25,8 @@ export const useThingEditStore = defineStore('thingEditStore', () => {
   const thingActions = ref<api.ThingAction[] | null>(null)
   const configStatusInfo = ref<api.ConfigStatusMessage[] | null>(null)
   const firmwares = ref<api.Firmware[] | null>(null)
+  const offerInstallBinding = ref<boolean | null>(null)
+  const bindingHasErrors = ref<boolean | null>(null)
 
   // watch
   watch(
@@ -47,6 +49,18 @@ export const useThingEditStore = defineStore('thingEditStore', () => {
         delete savedThingClone.statusInfo
         delete savedThingClone.configuration
         thingDirty.value = !fastDeepEqual(thingClone, savedThingClone)
+
+        offerInstallBinding.value = false
+        bindingHasErrors.value = false
+        if (thing.value?.statusInfo?.statusDetail === 'HANDLER_MISSING_ERROR') {
+          const bindingId = thing.value.UID.split(':')[0]
+          if (bindingId) {
+            void api.getAddonById({ addonId: 'binding-' + bindingId }).then((binding) => {
+              offerInstallBinding.value = !binding || !binding.installed
+              bindingHasErrors.value = !offerInstallBinding.value
+            })
+          }
+        }
       }
     },
     { deep: true }
@@ -231,6 +245,8 @@ export const useThingEditStore = defineStore('thingEditStore', () => {
     editable,
     isExtensible,
     hasLinkedItems,
+    offerInstallBinding,
+    bindingHasErrors,
 
     load,
     save

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -47,7 +47,10 @@
                 -
                 <f7-link :href="'/settings/things/' + thing.bridgeUID"> View Bridge </f7-link>
               </template>
-              <br />
+              <template v-else-if="offerInstallBinding">
+                - Binding is not installed. <f7-link @click="installBinding"> Install Binding </f7-link>
+              </template>
+              <template v-else-if="bindingHasErrors"> - Binding is installed but failed to load. Check the logs for errors. </template>
               <div v-if="thingStatusDescription(thing.statusInfo)" v-html="thingStatusDescription(thing.statusInfo)" />
             </div>
           </f7-col>
@@ -251,11 +254,7 @@
         <f7-block v-if="ready" class="block-narrow no-margin-top">
           <f7-col>
             <f7-list>
-              <f7-list-button
-                v-if="thing?.statusInfo?.statusDetail === 'HANDLER_MISSING_ERROR'"
-                color="blue"
-                title="Install Binding"
-                @click="installBinding" />
+              <f7-list-button v-if="offerInstallBinding" color="blue" title="Install Binding" @click="installBinding" />
               <f7-list-button v-if="!error" color="blue" title="Duplicate Thing" @click="duplicateThing" />
               <f7-list-button
                 v-if="!error"
@@ -569,7 +568,9 @@ export default {
       'firmwares',
       'editable',
       'isExtensible',
-      'hasLinkedItems'
+      'hasLinkedItems',
+      'offerInstallBinding',
+      'bindingHasErrors'
     ])
   },
   watch: {


### PR DESCRIPTION
When the Thing status is HANDLER_MISSING_ERROR
- Offer to install the binding only if the binding is truly not installed.
- If it's installed, suggest to check the logs instead.

Please consider backporting to 5.2. Currently the "Install binding" can appear even when the binding is already installed but failed to start. It causes confusion when user clicks install binding but the binding is already installed.