### PR TITLE
[mainui] Interactive SVG support in widgets

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/standard/cards.ts
@@ -167,10 +167,12 @@ export const OhToggleCardDefinition = () =>
 
 // OhImageCard
 import ImageParameters from '../system/image.ts'
+import SvgEmbeddingParameters from '../system/svg.ts'
 export const OhImageCardDefinition = () =>
   new WidgetDefinition('oh-image-card', 'Image Card', 'Display an image (URL or Image item ) in a card')
     .paramGroup(CardParameterGroup(), CardParameters())
     .paramGroup(pg('image', 'Image'), ImageParameters())
+    .paramGroup(pg('svgEmbedding', 'SVG Embedding'), SvgEmbeddingParameters())
     .paramGroup(actionGroup(undefined, undefined, 'Action to perform when the image is clicked'), actionParams())
 
 // OhVideoCard

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/index.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/index.ts
@@ -1,4 +1,4 @@
-import { WidgetDefinition, pt, pb } from '../helpers.ts'
+import { WidgetDefinition, pg, pt, pb } from '../helpers.ts'
 import { actionGroup, actionParams } from '../actions.ts'
 
 const VariableParameter = pt('variable', 'Variable', 'Name of the variable to set on input change')
@@ -53,9 +53,11 @@ export const OhIconDefinition = () =>
   new WidgetDefinition('oh-icon', 'Icon', 'Display an openHAB icon').paramGroup(actionGroup(), actionParams()).params(IconParameters())
 
 import ImageParameters from './image.ts'
+import SvgEmbeddingParameters from './svg.ts'
 export const OhImageDefinition = () =>
-  new WidgetDefinition('oh-image', 'Image', 'Displays an image from a URL or an item')
+  new WidgetDefinition('oh-image', 'Image', 'Displays an image from a URL or an item, optionally as an embedded interactive SVG')
     .paramGroup(actionGroup(), actionParams())
+    .paramGroup(pg('svgEmbedding', 'SVG Embedding'), SvgEmbeddingParameters())
     .params(ImageParameters())
 
 import VideoParameters from './video.ts'

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/svg.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/svg.ts
@@ -1,0 +1,16 @@
+import { pb } from '../helpers.ts'
+
+export default () => [
+  pb(
+    'embedSvg',
+    'Embed SVG',
+    'Embed the SVG image directly into the page instead of displaying it as a regular image (default false). ' +
+      'Elements marked with an <code>openhab</code> attribute become interactive: they can visualize Item states and perform actions, ' +
+      'configured per element id in the <code>embeddedSvgActions</code> config object (YAML only). Requires the URL to point to an SVG file.'
+  ),
+  pb(
+    'embedSvgFlashing',
+    'SVG Flashing in Run-Mode',
+    'Flashes SVG elements marked with an <code>openhab</code> attribute on hovering in run-mode (default false)'
+  ).a()
+]

--- a/bundles/org.openhab.ui/web/src/components/widgets/svg/oh-embedded-svg-mixin.js
+++ b/bundles/org.openhab.ui/web/src/components/widgets/svg/oh-embedded-svg-mixin.js
@@ -30,12 +30,22 @@ export default {
       return this.$refs.canvasBackground?.querySelector('svg') || null
     },
     /**
+     * Returns the URL of the SVG image to embed. Override when the hosting component configures
+     * the image under a different key (e.g. `url` for oh-image).
+     *
+     * @returns {string|undefined}
+     */
+    embeddedSvgUrl() {
+      return this.config.imageUrl
+    },
+    /**
      * Fetches and validates the SVG markup from the configured Image URL.
      *
      * @returns {Promise<string>}
      */
     async fetchEmbeddedSvgText() {
-      let imageUrl = this.config.imageUrl
+      const configuredUrl = this.embeddedSvgUrl()
+      let imageUrl = configuredUrl
       // in editmode we add a random number to the URL to always load the latest SVG (avoid caching)
       if (this.context.editmode) {
         imageUrl += (imageUrl.includes('?') ? '&' : '?') + `rnd=${Math.random()}`
@@ -43,13 +53,11 @@ export default {
       const svgUrl = await this.$oh.media.getImage(imageUrl)
       return fetch(svgUrl).then((response) => {
         if (!response.ok) {
-          return Promise.reject(
-            new Error(`Failed to load from ${this.config.imageUrl}. Status: ${response.status} (${response.statusText})`)
-          )
+          return Promise.reject(new Error(`Failed to load from ${configuredUrl}. Status: ${response.status} (${response.statusText})`))
         }
         const contentType = (response.headers.get('Content-Type') || '').toLowerCase()
         if (!contentType.includes('image/svg+xml')) {
-          return Promise.reject(new Error(`${this.config.imageUrl} is not an SVG file`))
+          return Promise.reject(new Error(`${configuredUrl} is not an SVG file`))
         }
         return response.text()
       })
@@ -474,13 +482,17 @@ export default {
      * @param {Element} svgElement the source element (used for warnings only)
      */
     applyStyleClasses(svgElementConfig, isOn, svgElement) {
+      // resolve ids within this component's own SVG first, so several instances of the same SVG
+      // on one page (e.g. a personal widget used twice) don't target another instance's elements
+      const svgRoot = this.embeddedSvgRoot()
       const setClasses = (spec, add) => {
         if (!spec) return
         for (const entry of spec.split(',')) {
           const [idPart, classPart] = entry.split(':')
           if (!idPart || !classPart) continue
           const targetId = idPart.trim()
-          const targetElement = document.getElementById(targetId)
+          const idSelector = `[id="${targetId.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`
+          const targetElement = svgRoot?.querySelector(idSelector) || document.getElementById(targetId)
           if (!targetElement) {
             console.warn(`Target element ${targetId} not found for style class expression of ${svgElement.id}`)
             continue

--- a/bundles/org.openhab.ui/web/src/components/widgets/svg/oh-embedded-svg-mixin.test.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/svg/oh-embedded-svg-mixin.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import embeddedSvgMixin from './oh-embedded-svg-mixin'
+
+const mixinMethods = (embeddedSvgMixin as any).methods
+
+describe('oh-embedded-svg-mixin applyStyleClasses', () => {
+  it('resolves style class targets within its own SVG root before the document', () => {
+    document.body.innerHTML = '<svg id="instance1"><rect id="indicator" /></svg>' + '<svg id="instance2"><rect id="indicator" /></svg>'
+    const ownRoot = document.getElementById('instance2')
+    const ctx = { embeddedSvgRoot: () => ownRoot }
+
+    mixinMethods.applyStyleClasses.call(ctx, { stateOnAsStyleClass: 'indicator:active' }, true, { id: 'source' })
+
+    expect(ownRoot!.querySelector('#indicator')!.classList.contains('active')).toBe(true)
+    expect(document.querySelector('#instance1 #indicator')!.classList.contains('active')).toBe(false)
+  })
+
+  it('falls back to a document-wide lookup when the id is not inside the SVG root', () => {
+    document.body.innerHTML = '<svg id="instance1"></svg><div id="outside"></div>'
+    const ctx = { embeddedSvgRoot: () => document.getElementById('instance1') }
+
+    mixinMethods.applyStyleClasses.call(ctx, { stateOnAsStyleClass: 'outside:active' }, true, { id: 'source' })
+
+    expect(document.getElementById('outside')!.classList.contains('active')).toBe(true)
+  })
+})

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.test.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import ohImage from './oh-image.vue'
+
+const methods = (ohImage as any).methods
+
+function embedContext(overrides: Record<string, unknown> = {}) {
+  const container = document.createElement('div')
+  return {
+    config: { url: '/static/floorplan.svg', embedSvg: true },
+    context: {},
+    embeddedSvgToken: 0,
+    embeddedSvgReady: false,
+    $refs: { svgContainer: container },
+    fetchEmbeddedSvgText: vi.fn(),
+    removeWidgetSvg: methods.removeWidgetSvg,
+    subscribeEmbeddedSvgListeners: vi.fn(),
+    setupEmbeddedSvgStateTracking: vi.fn(),
+    unsubscribeEmbeddedSvgListeners: vi.fn(),
+    unsubscribeEmbeddedSvgStateTracking: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('oh-image.vue SVG embedding', () => {
+  it('reads the SVG URL from the url config', () => {
+    const ctx = { config: { url: '/static/remote.svg' } }
+    expect(methods.embeddedSvgUrl.call(ctx)).toBe('/static/remote.svg')
+  })
+
+  it('embeds the SVG, derives a viewBox from fixed dimensions and subscribes', async () => {
+    const ctx = embedContext()
+    ctx.fetchEmbeddedSvgText.mockResolvedValue(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="50"><rect id="lamp" openhab="true" /></svg>'
+    )
+
+    await methods.embedWidgetSvg.call(ctx)
+
+    const svg = (ctx.$refs.svgContainer as HTMLElement).querySelector('svg')
+    expect(svg).not.toBeNull()
+    expect(svg!.getAttribute('viewBox')).toBe('0 0 100 50')
+    expect(svg!.hasAttribute('width')).toBe(false)
+    expect(svg!.hasAttribute('height')).toBe(false)
+    expect(ctx.embeddedSvgReady).toBe(true)
+    expect(ctx.subscribeEmbeddedSvgListeners).toHaveBeenCalled()
+    expect(ctx.setupEmbeddedSvgStateTracking).toHaveBeenCalled()
+  })
+
+  it('keeps an existing viewBox untouched', async () => {
+    const ctx = embedContext()
+    ctx.fetchEmbeddedSvgText.mockResolvedValue('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 20" width="100" height="50"></svg>')
+
+    await methods.embedWidgetSvg.call(ctx)
+
+    const svg = (ctx.$refs.svgContainer as HTMLElement).querySelector('svg')
+    expect(svg!.getAttribute('viewBox')).toBe('0 0 10 20')
+  })
+
+  it('discards a stale in-flight embed after the token was invalidated', async () => {
+    const ctx = embedContext()
+    let resolveFetch: (svg: string) => void
+    ctx.fetchEmbeddedSvgText.mockReturnValue(new Promise((resolve) => (resolveFetch = resolve)))
+
+    const embedding = methods.embedWidgetSvg.call(ctx)
+    ctx.embeddedSvgToken++ // simulates an unmount or re-embed while the fetch is in flight
+    resolveFetch!('<svg xmlns="http://www.w3.org/2000/svg"></svg>')
+    await embedding
+
+    expect((ctx.$refs.svgContainer as HTMLElement).querySelector('svg')).toBeNull()
+    expect(ctx.embeddedSvgReady).toBe(false)
+    expect(ctx.subscribeEmbeddedSvgListeners).not.toHaveBeenCalled()
+  })
+
+  it('performs the configured action on click in run mode', () => {
+    const actionConfig = { action: 'toggle', actionItem: 'Lamp' }
+    const ctx = {
+      context: {},
+      config: { embeddedSvgActions: { lamp: actionConfig } },
+      performAction: vi.fn()
+    }
+
+    methods.svgOnClick.call(ctx, { id: 'lamp' })
+
+    expect(ctx.performAction).toHaveBeenCalledWith(null, null, actionConfig, ctx.context)
+  })
+
+  it('does not perform actions in edit mode or for unconfigured elements', () => {
+    const ctx = {
+      context: { editmode: {} },
+      config: { embeddedSvgActions: { lamp: { action: 'toggle' } } },
+      performAction: vi.fn()
+    }
+    methods.svgOnClick.call(ctx, { id: 'lamp' })
+
+    const runCtx = {
+      context: {},
+      config: {},
+      performAction: vi.fn()
+    }
+    methods.svgOnClick.call(runCtx, { id: 'unconfigured' })
+
+    expect(ctx.performAction).not.toHaveBeenCalled()
+    expect(runCtx.performAction).not.toHaveBeenCalled()
+  })
+})

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-image.vue
@@ -1,6 +1,7 @@
 <template>
+  <div v-if="config.embedSvg" ref="svgContainer" class="oh-image oh-image-svg" />
   <img
-    v-if="config.lazy"
+    v-else-if="config.lazy"
     ref="lazyImage"
     v-bind="config"
     :data-src="computedSrc"
@@ -10,17 +11,27 @@
   <img v-else ref="image" v-bind="config" :src="computedSrc" class="oh-image" @click="clicked" />
 </template>
 
+<style lang="stylus">
+.oh-image-svg
+  svg
+    display block
+    width 100%
+    height auto
+</style>
+
 <script>
 import { nextTick, computed } from 'vue'
 import { f7 } from 'framework7-vue'
 
 import { useWidgetContext } from '@/components/widgets/useWidgetContext'
 import { OhImageDefinition } from '@/assets/definitions/widgets/system'
+import embeddedSvgMixin from '@/components/widgets/svg/oh-embedded-svg-mixin'
 import foregroundService from '../widget-foreground-service'
 import { useWidgetAction } from '@/components/widgets/useWidgetAction.ts'
+import { showToast } from '@/js/dialog-promises'
 
 export default {
-  mixins: [foregroundService],
+  mixins: [foregroundService, embeddedSvgMixin],
   props: {
     context: Object
   },
@@ -28,21 +39,45 @@ export default {
   setup(props) {
     const context = computed(() => props.context)
     const { config, hasAction, evaluateExpression } = useWidgetContext(context)
-    const { performAction } = useWidgetAction(context, config, evaluateExpression)
-    return { config, hasAction, performAction }
+    // aliased so it doesn't clobber the performAction() method below, which the SVG mixin calls
+    const { performAction: runWidgetAction } = useWidgetAction(context, config, evaluateExpression)
+    return { config, hasAction, runWidgetAction }
   },
   data() {
     return {
       t: f7.utils.id(),
       src: null,
-      ts: 0
+      ts: 0,
+      embeddedSvgToken: 0
     }
   },
   watch: {
     url(val) {
+      if (this.config.embedSvg) {
+        this.embedWidgetSvg()
+        return
+      }
       this.$oh.media.getImage(val).then((url) => {
         this.src = url
       })
+    },
+    'config.embedSvg'(val) {
+      if (val) {
+        this.embedWidgetSvg()
+      } else {
+        this.removeWidgetSvg()
+        this.startForegroundActivity()
+      }
+    },
+    // re-setup state tracking when the actions config changes (e.g. while live-editing the widget YAML);
+    // click handlers read the config at click time and don't need to be reattached
+    'config.embeddedSvgActions': {
+      deep: true,
+      handler() {
+        if (!this.embeddedSvgReady) return
+        this.unsubscribeEmbeddedSvgStateTracking()
+        this.setupEmbeddedSvgStateTracking()
+      }
     },
     src(val) {
       if (this.config.lazy)
@@ -81,10 +116,16 @@ export default {
     clicked() {
       if (this.context.component.component !== 'oh-image') return // don't interfere if we're in the context of a oh-image-card for example
       if (this.hasAction) {
-        this.performAction()
+        this.runWidgetAction()
       }
     },
     startForegroundActivity() {
+      if (this.config.embedSvg) {
+        // interactive SVGs are (re)embedded when the page enters the foreground so Item state
+        // subscriptions are released while the page is out of view
+        this.embedWidgetSvg()
+        return
+      }
       if (this.config.item) {
         this.loadItemImage()
       } else {
@@ -100,6 +141,66 @@ export default {
     },
     stopForegroundActivity() {
       if (this.refreshInterval) clearInterval(this.refreshInterval)
+      this.removeWidgetSvg()
+    },
+    // Mixin overrides: the image widget configures the image under `url`, hosts the SVG in its own
+    // container, and runs SVG actions itself instead of emitting them to a parent page.
+    embeddedSvgUrl() {
+      return this.config.url
+    },
+    embeddedSvgRoot() {
+      return this.$refs.svgContainer?.querySelector('svg') || null
+    },
+    performAction(evt, prefix, config, context) {
+      this.runWidgetAction(evt, prefix || '', context, config)
+    },
+    // There is no popup-based configuration for embedded SVGs in widgets - the embeddedSvgActions
+    // are part of the widget YAML - so clicks only act in run mode.
+    svgOnClick(el) {
+      if (this.context.editmode) return
+      const actionConfig = this.config.embeddedSvgActions?.[el.id]
+      if (actionConfig) this.performAction(null, null, actionConfig, this.context)
+    },
+    embedWidgetSvg() {
+      this.removeWidgetSvg()
+      if (!this.config.url) return
+      // invalidation token: an unmount or re-embed bumps it so a stale in-flight fetch is discarded
+      const token = ++this.embeddedSvgToken
+      return this.fetchEmbeddedSvgText()
+        .then((svgCode) => {
+          if (token !== this.embeddedSvgToken || !this.$refs.svgContainer) return
+          const svgEl = new DOMParser().parseFromString(svgCode, 'image/svg+xml').documentElement
+          if (!svgEl || svgEl.tagName.toLowerCase() !== 'svg') {
+            return Promise.reject(new Error(`${this.config.url} did not parse to a valid SVG element`))
+          }
+          // scale with the widget width: derive a viewBox from fixed dimensions, then drop them
+          if (!svgEl.getAttribute('viewBox')) {
+            const width = parseFloat(svgEl.getAttribute('width'))
+            const height = parseFloat(svgEl.getAttribute('height'))
+            if (!isNaN(width) && !isNaN(height)) svgEl.setAttribute('viewBox', `0 0 ${width} ${height}`)
+          }
+          svgEl.removeAttribute('width')
+          svgEl.removeAttribute('height')
+          svgEl.classList.add('disable-user-drag')
+          this.$refs.svgContainer.replaceChildren(svgEl)
+          this.subscribeEmbeddedSvgListeners()
+          this.setupEmbeddedSvgStateTracking()
+          this.embeddedSvgReady = true
+        })
+        .catch((err) => {
+          nextTick(() => {
+            showToast('Failed to embed SVG: ' + err)
+          })
+        })
+    },
+    removeWidgetSvg() {
+      // invalidate any in-flight embed even when nothing is mounted yet
+      this.embeddedSvgToken++
+      if (!this.embeddedSvgReady) return
+      this.unsubscribeEmbeddedSvgListeners()
+      this.unsubscribeEmbeddedSvgStateTracking()
+      this.$refs.svgContainer?.replaceChildren()
+      this.embeddedSvgReady = false
     }
   }
 }

--- a/bundles/org.openhab.ui/web/src/types/components/widgets/standard/oh-image-card.gen.ts
+++ b/bundles/org.openhab.ui/web/src/types/components/widgets/standard/oh-image-card.gen.ts
@@ -20,6 +20,8 @@ export interface Config {
   lazy?: boolean
   lazyFadeIn?: boolean
   refreshInterval?: number
+  embedSvg?: boolean
+  embedSvgFlashing?: boolean
   action?: Action | Action[]
   actionUrl?: string
   actionUrlSameWindow?: boolean

--- a/bundles/org.openhab.ui/web/src/types/components/widgets/system/oh-image.gen.ts
+++ b/bundles/org.openhab.ui/web/src/types/components/widgets/system/oh-image.gen.ts
@@ -38,6 +38,8 @@ export interface Config {
   actionVariable?: string
   actionVariableValue?: string
   actionVariableKey?: string
+  embedSvg?: boolean
+  embedSvgFlashing?: boolean
   item?: string
   url?: string
   lazy?: boolean


### PR DESCRIPTION
I have a new found love for using SVGs in openHAB  ;-) .  

This extends our enhanced SVG support to image widgets.  Our 5.2 release actually did the majority of the work by moving SVG support to a shared mixin, this PR uses that to support interactive SVGs in wdigets.

I originally created a new SVG component and card type, but quickly realized this duplicated much of the existing  image versions, so i instead decided to extend our  `oh-image`  and `oh-image-card` to support the SVG interactive features.

example SVG

```xml
  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 120">
    <rect width="200" height="120" rx="10" fill="#e5e7eb"/>
    <!-- clickable, state-colored lamp: the openhab attribute marks it interactive -->
    <circle id="lamp" openhab="true" cx="60" cy="60" r="30" fill="#9ca3af" stroke="#4b5563" stroke-width="3"/>
    <!-- text label fed with the Item's (display) state -->
    <text x="138" y="66" font-size="16" font-family="sans-serif" text-anchor="middle" fill="#111827">
      <tspan id="lampState" openhab="true">--</tspan>
    </text>
  </svg>
```

Use in a image card

```yaml
component: oh-image-card
config:
  title: Kitchen
  url: /static/demo-lamp.svg
  embedSvg: true
  embeddedSvgActions:
    lamp:
      action: toggle
      actionItem: KitchenLight
      stateItems: [KitchenLight]
      stateOnColor: "#ffb700"
```

Custom widget

```yaml
 uid: svg-lamp-demo
props:
  parameters:
    - name: item
      label: Lamp Item
      type: TEXT
      context: item
      description: Switch Item to control
component: oh-image
config:
  url: /static/demo-lamp.svg
  embedSvg: true
  embeddedSvgActions:
    lamp:                       # id of the clickable element
      action: toggle
      actionItem: =props.item
      actionCommand: ON
      actionCommandAlt: OFF
      stateItems:
        - =props.item
      stateOnColor: "#ffb700"   # fill while ON
    lampState:                  # id of the <tspan>, tracks the Item state
      stateItems:
        - =props.item
      useDisplayState: true        
```

I would definitely want to add some docs about this as creating a GUI to configure this is a future issue. 