### PR TITLE
[blockly] Add blocks to javaify and jsify data

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -68,6 +68,66 @@ export default function defineOHBlocks_Scripts(f7, transformationServices) {
   }
 
   /*
+   * Runs the rule with the specified UID, synchronously or asynchronously.
+   * Parameters can be provided with the special parameter block oh_scriptparam
+   * Blockly part
+   */
+  Blockly.Blocks['oh_runrule_v2'] = {
+    init: function () {
+      const dropdown = new Blockly.FieldDropdown(
+        [
+          ['asynchronously', 'ASYNC'],
+          ['synchronously', 'SYNC']
+        ],
+        this.validate.bind(this)
+      )
+
+      this.appendValueInput('ruleUID').setCheck('String').appendField('run rule or script').appendField(dropdown, 'MODE')
+      this.appendValueInput('parameters').appendField('with context').setCheck('Dictionary')
+      this.setInputsInline(false)
+
+      // Set the default
+      this.setPreviousStatement(true, null)
+      this.setNextStatement(true, null)
+
+      this.setColour(0)
+      this.setTooltip('Run a rule or script with a certain UID, and optional parameters. To retrive the result, use synchronous mode.')
+      this.setHelpUrl(
+        'https://www.openhab.org/docs/configuration/blockly/rules-blockly-run-and-process.html#run-rule-or-script-created-in-ui'
+      )
+    },
+
+    validate: function (newValue) {
+      if (newValue === 'SYNC') {
+        this.setPreviousStatement(false)
+        this.setNextStatement(false)
+        this.setOutput(true, 'Dictionary')
+      } else {
+        this.setOutput(false)
+        this.setPreviousStatement(true, null)
+        this.setNextStatement(true, null)
+      }
+    }
+  }
+
+  /*
+   * Runs the rule with the specified UID, synchronously or asynchronously.
+   * Parameters can be provided with the special parameter block oh_scriptparam
+   * Code part
+   */
+  javascriptGenerator.forBlock['oh_runrule_v2'] = function (block) {
+    const ruleUID = javascriptGenerator.valueToCode(block, 'ruleUID', javascriptGenerator.ORDER_ATOMIC)
+    const scriptParameters = javascriptGenerator.valueToCode(block, 'parameters', javascriptGenerator.ORDER_ATOMIC) || 'null'
+
+    if (block.getFieldValue('MODE') === 'SYNC') {
+      const code = `rules.runRule(${ruleUID}, ${scriptParameters})`
+      return [code, javascriptGenerator.ORDER_NONE]
+    } else {
+      return `rules.runAsync(${ruleUID}, ${scriptParameters});\n`
+    }
+  }
+
+  /*
    * Recursively convert any value, array or object to use Java types. Functions are not supported.
    * Blockly part
    */

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-scripts.js
@@ -68,6 +68,52 @@ export default function defineOHBlocks_Scripts(f7, transformationServices) {
   }
 
   /*
+   * Recursively convert any value, array or object to use Java types. Functions are not supported.
+   * Blockly part
+   */
+  Blockly.Blocks['oh_javaify'] = {
+    init: function () {
+      this.appendValueInput('INPUT_VALUE').appendField('javaify')
+      this.setOutput(true, null)
+      this.setColour(280)
+      this.setTooltip('Recursively convert any value, array or object to use Java types. Functions are not supported.')
+    }
+  }
+
+  /*
+   * Recursively convert any value, array or object to use Java types. Functions are not supported.
+   * Code part
+   */
+  javascriptGenerator.forBlock['oh_javaify'] = function (block) {
+    const inputValue = javascriptGenerator.valueToCode(block, 'INPUT_VALUE', javascriptGenerator.ORDER_NONE) || 'null'
+    const code = `javaify(${inputValue})`
+    return [code, javascriptGenerator.ORDER_NONE]
+  }
+
+  /*
+   * Recursively convert Java Lists, Sets, and Maps and their entries/values to their JS counterparts.
+   * Blockly part
+   */
+  Blockly.Blocks['oh_jsify'] = {
+    init: function () {
+      this.appendValueInput('INPUT_VALUE').appendField('jsify')
+      this.setOutput(true, null)
+      this.setColour(300)
+      this.setTooltip('Recursively convert Java Lists, Sets, and Maps and their entries/values to their JS counterparts.')
+    }
+  }
+
+  /*
+   * Recursively convert Java Lists, Sets, and Maps and their entries/values to their JS counterparts.
+   * Code part
+   */
+  javascriptGenerator.forBlock['oh_jsify'] = function (block) {
+    const inputValue = javascriptGenerator.valueToCode(block, 'INPUT_VALUE', javascriptGenerator.ORDER_NONE) || 'null'
+    const code = `jsify(${inputValue})`
+    return [code, javascriptGenerator.ORDER_NONE]
+  }
+
+  /*
    * Allow transformations via different methods
    * inputs
    *   - value to be transformed

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
@@ -30,7 +30,7 @@ export default function defineOHBlocks_Variables(f7) {
       this.setNextStatement(true, null)
       this.setColour(0)
       this.setTooltip(
-        'stores a value with a variable name that can be retrieved on subsequent runs of this rule/script to the private rule or shared global cache'
+        'stores a value with a variable name that can be retrieved on subsequent runs of this rule/script to the private rule or shared global cache. Vales stored in the shared cache will automatically have `javaify()` applied.'
       )
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html#store-value')
     }
@@ -47,30 +47,73 @@ export default function defineOHBlocks_Variables(f7) {
     init: function () {
       this.appendDummyInput().appendField('stored value')
       this.appendValueInput('key')
-      this.appendDummyInput()
-        .appendField('from ')
-        .appendField(
-          new Blockly.FieldDropdown([
-            ['private', '.private'],
-            ['shared', '.shared']
-          ]),
-          'cacheType'
-        )
-        .appendField('cache')
+
+      const cacheDropdown = new Blockly.FieldDropdown(
+        [
+          ['private', '.private'],
+          ['shared', '.shared']
+        ],
+        this.validate.bind(this)
+      )
+
+      this.appendDummyInput('cacheInput').appendField('from ').appendField(cacheDropdown, 'cacheType').appendField('cache')
+
       this.setInputsInline(true)
       this.setOutput(true, null)
       this.setColour(0)
       this.setTooltip(
-        'retrieves the value that was previously stored for that particular script/rule from the private rule or shared global cache'
+        'Retrieves the value that was previously stored for that particular script/rule from the private rule or shared global cache.'
       )
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html#get-stored-value')
+    },
+    validate: function (newValue) {
+      const cacheInput = this.getInput('cacheInput')
+      if (!cacheInput) return
+
+      const hasJsify = this.getField('jsifyOpt')
+
+      if (newValue === '.shared') {
+        if (!hasJsify) {
+          cacheInput.appendField(' ', 'jsifySpace')
+
+          const jsifyTooltip =
+            'Automatically converts retrieved Java objects from the shared cache back into standard JavaScript objects for ease of use.'
+          const checkbox = new Blockly.FieldCheckbox('TRUE')
+          checkbox.setTooltip(jsifyTooltip)
+          cacheInput.appendField(checkbox, 'jsifyOpt')
+
+          const label = new Blockly.FieldLabel('jsify value')
+          label.setTooltip(jsifyTooltip)
+          cacheInput.appendField(label, 'jsifyLabel')
+        }
+      } else {
+        if (hasJsify) {
+          cacheInput.removeField('jsifySpace')
+          cacheInput.removeField('jsifyOpt')
+          cacheInput.removeField('jsifyLabel')
+        }
+      }
     }
   }
 
+  /*
+   * Retrieves the value from private or shared cache.
+   * Code part
+   */
   javascriptGenerator.forBlock['oh_get_value'] = function (block) {
     const key = valueToCode(block, 'key', javascriptGenerator.ORDER_ATOMIC)
     const cacheType = block.getFieldValue('cacheType')
-    return [`cache${cacheType}.get(${key})`, javascriptGenerator.ORDER_NONE]
+    const jsifyOpt = block.getField('jsifyOpt') ? block.getFieldValue('jsifyOpt') === 'TRUE' : true
+
+    let code
+    // To maintain backwards compatibility, we only specify the extra argument if it's different from the default
+    if (cacheType === '.shared' && !jsifyOpt) {
+      code = `cache.shared.get(${key}, null, false)`
+    } else {
+      code = `cache${cacheType}.get(${key})`
+    }
+
+    return [code, javascriptGenerator.ORDER_NONE]
   }
 
   Blockly.Blocks['oh_check_undefined_value'] = {

--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-valuestorage.js
@@ -15,16 +15,16 @@ export default function defineOHBlocks_Variables(f7) {
       this.appendValueInput('value').setCheck(['Number', 'Boolean', 'String'])
       this.appendDummyInput().appendField('into')
       this.appendValueInput('key')
-      this.appendDummyInput()
-        .appendField('to ')
-        .appendField(
-          new Blockly.FieldDropdown([
-            ['private', '.private'],
-            ['shared', '.shared']
-          ]),
-          'cacheType'
-        )
-        .appendField('cache')
+
+      const cacheDropdown = new Blockly.FieldDropdown(
+        [
+          ['private', '.private'],
+          ['shared', '.shared']
+        ],
+        this.validate.bind(this)
+      )
+
+      this.appendDummyInput('cacheInput').appendField('to ').appendField(cacheDropdown, 'cacheType').appendField('cache')
       this.setInputsInline(true)
       this.setPreviousStatement(true, null)
       this.setNextStatement(true, null)
@@ -33,6 +33,33 @@ export default function defineOHBlocks_Variables(f7) {
         'stores a value with a variable name that can be retrieved on subsequent runs of this rule/script to the private rule or shared global cache. Vales stored in the shared cache will automatically have `javaify()` applied.'
       )
       this.setHelpUrl('https://www.openhab.org/docs/configuration/blockly/rules-blockly-value-storage.html#store-value')
+    },
+    validate: function (newValue) {
+      const cacheInput = this.getInput('cacheInput')
+      if (!cacheInput) return
+
+      const hasJavaify = this.getField('javaifyOpt')
+
+      if (newValue === '.shared') {
+        if (!hasJavaify) {
+          cacheInput.appendField(' ', 'javaifySpace')
+
+          const javaifyTooltip = 'Automatically convert JS objects to Java objects for storage in the shared cache.'
+          const checkbox = new Blockly.FieldCheckbox('TRUE')
+          checkbox.setTooltip(javaifyTooltip)
+          cacheInput.appendField(checkbox, 'javaifyOpt')
+
+          const label = new Blockly.FieldLabel('javaify value')
+          label.setTooltip(javaifyTooltip)
+          cacheInput.appendField(label, 'javaifyLabel')
+        }
+      } else {
+        if (hasJavaify) {
+          cacheInput.removeField('javaifySpace')
+          cacheInput.removeField('javaifyOpt')
+          cacheInput.removeField('javaifyLabel')
+        }
+      }
     }
   }
 
@@ -40,6 +67,12 @@ export default function defineOHBlocks_Variables(f7) {
     const key = valueToCode(block, 'key', javascriptGenerator.ORDER_ATOMIC)
     const value = valueToCode(block, 'value', javascriptGenerator.ORDER_ATOMIC)
     const cacheType = block.getFieldValue('cacheType')
+    const javaifyOpt = block.getField('javaifyOpt') ? block.getFieldValue('javaifyOpt') === 'TRUE' : true
+
+    // To maintain backwards compatibility, we only specify the extra argument if it's different from the default
+    if (cacheType === '.shared' && !javaifyOpt) {
+      return `cache.shared.put(${key}, ${value}, false);\n`
+    }
     return `cache${cacheType}.put(${key}, ${value});\n`
   }
 
@@ -77,7 +110,7 @@ export default function defineOHBlocks_Variables(f7) {
           cacheInput.appendField(' ', 'jsifySpace')
 
           const jsifyTooltip =
-            'Automatically converts retrieved Java objects from the shared cache back into standard JavaScript objects for ease of use.'
+            'Automatically convert retrieved Java objects from the shared cache back into standard JavaScript objects for ease of use.'
           const checkbox = new Blockly.FieldCheckbox('TRUE')
           checkbox.setTooltip(jsifyTooltip)
           cacheInput.appendField(checkbox, 'jsifyOpt')

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1054,6 +1054,8 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_javaify"></block>
+          <block type="oh_jsify"></block>
           <sep gap="48" />
           <block type="oh_context_info" />
           <block type="oh_context_attribute">

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1042,7 +1042,7 @@
               </shadow>
             </value>
           </block>
-          <block type="oh_runrule">
+          <block type="oh_runrule_v2">
             <value name="ruleUID">
               <shadow type="text">
                 <field name="TEXT">ruleUID</field>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/blockly-editor.vue
@@ -1042,6 +1042,18 @@
               </shadow>
             </value>
           </block>
+          <block type="oh_runrule">
+            <value name="ruleUID">
+              <shadow type="text">
+                <field name="TEXT">ruleUID</field>
+              </shadow>
+            </value>
+            <value name="parameters">
+              <shadow type="dicts_create_with">
+                <mutation items="0" />
+              </shadow>
+            </value>
+          </block>
           <block type="oh_runrule_v2">
             <value name="ruleUID">
               <shadow type="text">


### PR DESCRIPTION
This PR does two things: It adds two new blocks for `javaify()` and `jsify()`. It also replaces the "run rule" block with one that can call either `runRule()` or `runAsync()`, and that returns a result if `runRule()` is used. The old block is unchanged to avoid breaking existing scripts, but it has been removed from the toolbar so that it can't be added to new scripts. 

This was done to avoid confusion by having two almost identical blocks. If you don't care about the result/output from the other rule, it can just fire of the other rule asynchronously and continue immediately. If you do want the result/output, you will have to wait for the execution of the other rule to finish. The one situation this doesn't "cover" is if you don't care about the result, but want to wait for the other rule to finish before progressing in the current rule. This can be achieved by "dumping" the result in some dummy block that you don't use.

There are a number of things I'm unsure of here, like the texts/name to show and where to put the new blocks in the toolbar. I've put them directly below `runRule` for now, but it doesn't really fit there. It doesn't really fit in any of the other categories either, so it might be better to create a new category..?

Also, I haven't been able to link to any documentation for `javaify()` and `jsify()`, because I'm pretty sure that doesn't exist. The question is if we should make that documentation first, and then link to it from the blocks, or if that isn't important enough to hold this back.

@florian-h05 @rkoshak I don't know to what degree any you have the answer to any of these questions, or if there is somebody else that should be asked - but you two are the only I can think of at the moment.

