### PR TITLE
oh-cell: Only intercept taphold/contextmenu events if cell is expandable

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/cell/oh-cell.vue
@@ -260,9 +260,8 @@ export default {
       return false
     },
     openCell(evt) {
+      if (this.context.editmode || !this.hasExpandedControls) return
       if (evt && evt.preventDefault) evt.preventDefault()
-      if (this.context.editmode) return false
-      if (!this.hasExpandedControls) return false
       f7.card.open(this.$refs.card.$el)
       history.pushState(
         { cardId: this.cardId },


### PR DESCRIPTION
Not being able to right click and debug the DOM when working on oh-cell based widgets drives me crazy ...