### PR TITLE
fix: include sitemaps in developer sidebar search and pinned objects [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -394,6 +394,42 @@
             </ul>
           </f7-list>
         </f7-block>
+        <!-- Pinned Sitemaps -->
+        <f7-block v-if="developerStore.pinnedObjects.sitemaps.length" class="no-margin no-padding">
+          <f7-block-title class="padding-horizontal display-flex">
+            <span>Pinned Sitemaps</span>
+            <span style="margin-left: auto">
+              <f7-link color="gray" icon-f7="multiply" icon-size="14" @click="unpinAll('sitemaps')" />
+            </span>
+          </f7-block-title>
+          <f7-list media-list>
+            <ul>
+              <f7-list-item
+                v-for="sitemap in developerStore.pinnedObjects.sitemaps"
+                :key="sitemap.id"
+                media-item
+                :title="sitemap.label"
+                :footer="sitemap.id">
+                <template #footer>
+                  <div class="display-flex align-items-flex-end justify-content-flex-end" style="margin-top: 3px">
+                    <f7-link color="gray" class="margin-right">
+                      <clipboard-icon :value="sitemap.id" :size="18" tooltip="Copy Sitemap ID" />
+                    </f7-link>
+                    <f7-link
+                      class="margin-right"
+                      color="gray"
+                      icon-f7="pencil"
+                      icon-size="18"
+                      tooltip="Edit"
+                      :href="'/settings/sitemaps/' + sitemap.id"
+                      :animate="false" />
+                    <f7-link color="blue" icon-f7="pin_fill" icon-size="18" tooltip="Unpin" @click="unpin('sitemaps', sitemap, 'id')" />
+                  </div>
+                </template>
+              </f7-list-item>
+            </ul>
+          </f7-list>
+        </f7-block>
         <!-- Pinned Transformations -->
         <f7-block v-if="developerStore.pinnedObjects.transformations.length" class="no-margin no-padding">
           <f7-block-title class="padding-horizontal display-flex">
@@ -682,6 +718,7 @@ export default {
         scripts: [],
         pages: [],
         widgets: [],
+        sitemaps: [],
         transformations: [],
         persistenceConfigs: []
       },
@@ -751,6 +788,9 @@ export default {
       },
       widgets: {
         keys: ['uid', props, slots]
+      },
+      sitemaps: {
+        keys: ['id', 'label']
       },
       transformations: {
         keys: ['uid', 'label', 'configuration.function']
@@ -866,8 +906,9 @@ export default {
             Promise.resolve(useComponentsStore().pages()), // 3
             this.$oh.api.get('/rest/ui/components/system:sitemap'), // 4
             Promise.resolve(useComponentsStore().widgets()), // 5
-            this.$oh.api.get('/rest/transformations'), // 6
-            this.loadPersistenceConfigs() // 7
+            this.$oh.api.get('/rest/sitemaps'), // 6
+            this.$oh.api.get('/rest/transformations'), // 7
+            this.loadPersistenceConfigs() // 8
           ]
 
       this.searchResultsLoading = true
@@ -881,8 +922,9 @@ export default {
             rules: new Fuse(data[2], this.SEARCH.rules),
             pages: new Fuse([...data[3], ...data[4]], this.SEARCH.pages),
             widgets: new Fuse(data[5], this.SEARCH.widgets),
-            transformations: new Fuse(data[6], this.SEARCH.transformations),
-            persistence: new Fuse(data[7], this.SEARCH.persistence)
+            sitemaps: new Fuse(data[6], this.SEARCH.sitemaps),
+            transformations: new Fuse(data[7], this.SEARCH.transformations),
+            persistence: new Fuse(data[8], this.SEARCH.persistence)
           }
         }
 
@@ -906,6 +948,7 @@ export default {
 
         const pages = this.searchData(this.cachedFuseObjects.pages, query)
         const widgets = this.searchData(this.cachedFuseObjects.widgets, query)
+        const sitemaps = this.searchData(this.cachedFuseObjects.sitemaps, query)
         const transformations = this.searchData(this.cachedFuseObjects.transformations, query)
         const persistenceConfigs = this.searchData(this.cachedFuseObjects.persistence, query)
 
@@ -917,6 +960,7 @@ export default {
           scripts,
           pages,
           widgets,
+          sitemaps,
           transformations,
           persistenceConfigs
         }
@@ -949,6 +993,7 @@ export default {
         scripts: [],
         pages: [],
         widgets: [],
+        sitemaps: [],
         transformations: [],
         persistenceConfigs: []
       }

--- a/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/search-results.vue
@@ -11,7 +11,8 @@
         !searchResults.rules.length &&
         !searchResults.pages.length &&
         !searchResults.scenes.length &&
-        !searchResults.scripts.length
+        !searchResults.scripts.length &&
+        !searchResults.sitemaps.length
       "
       class="text-align-center">
       <div>Nothing found</div>
@@ -282,6 +283,45 @@
         <f7-list-button v-if="!showingAll('widgets')" color="blue" @click="expandedTypes.widgets = true"> Show All </f7-list-button>
       </f7-list>
     </f7-block>
+    <!-- Sitemaps -->
+    <f7-block v-if="searchResults.sitemaps.length" class="no-margin no-padding">
+      <f7-block-title class="padding-left">
+        <f7-icon class="margin-right" f7="square_list" />Sitemaps ({{ searchResults.sitemaps.length }})
+      </f7-block-title>
+      <f7-list media-list>
+        <f7-list-item
+          v-for="sitemap in filteredSearchResults.sitemaps"
+          media-item
+          :key="sitemap.id"
+          :title="sitemap.label"
+          :footer="sitemap.id"
+          link=""
+          no-chevron
+          @click="(evt) => togglePin(evt, 'sitemaps', sitemap, 'id')">
+          <template #after>
+            <f7-link color="gray">
+              <clipboard-icon :value="sitemap.id" tooltip="Copy Sitemap ID" />
+            </f7-link>
+            <f7-link
+              color="gray"
+              icon-f7="pencil"
+              icon-size="18"
+              tooltip="Edit"
+              :href="'/settings/sitemaps/' + sitemap.id"
+              :animate="false" />
+            <f7-link
+              v-if="isPinned('sitemaps', sitemap, 'id')"
+              @click="$emit('unpin', 'sitemaps', sitemap, 'id')"
+              color="blue"
+              icon-f7="pin_fill"
+              icon-size="18"
+              tooltip="Unpin" />
+            <f7-link v-else @click="$emit('pin', 'sitemaps', sitemap, 'id')" color="gray" icon-f7="unpin" icon-size="18" tooltip="Pin" />
+          </template>
+        </f7-list-item>
+        <f7-list-button v-if="!showingAll('sitemaps')" color="blue" @click="expandedTypes.sitemaps = true"> Show All </f7-list-button>
+      </f7-list>
+    </f7-block>
     <!-- Transformations -->
     <f7-block v-if="searchResults.transformations.length" class="no-margin no-padding">
       <f7-block-title class="padding-left">
@@ -449,6 +489,11 @@ export default {
         : this.searchResults.widgets
           ? this.searchResults.widgets.slice(0, 5)
           : []
+      const sitemaps = this.expandedTypes.sitemaps
+        ? this.searchResults.sitemaps
+        : this.searchResults.sitemaps
+          ? this.searchResults.sitemaps.slice(0, 5)
+          : []
       const transformations = this.expandedTypes.transformations
         ? this.searchResults.transformations
         : this.searchResults.transformations
@@ -459,7 +504,7 @@ export default {
         : this.searchResults.persistenceConfigs
           ? this.searchResults.persistenceConfigs.slice(0, 5)
           : []
-      return { items, things, rules, scenes, scripts, pages, widgets, transformations, persistenceConfigs }
+      return { items, things, rules, scenes, scripts, pages, widgets, sitemaps, transformations, persistenceConfigs }
     }
   },
   watch: {

--- a/bundles/org.openhab.ui/web/src/js/stores/useDeveloperStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useDeveloperStore.ts
@@ -9,6 +9,7 @@ interface PinnedObjects {
   scripts: Array<string>
   pages: Array<string>
   widgets: Array<string>
+  sitemaps: Array<string>
   transformations: Array<string>
   persistenceConfigs: Array<string>
 }
@@ -22,6 +23,7 @@ export const useDeveloperStore = defineStore('developer', () => {
     scripts: [],
     pages: [],
     widgets: [],
+    sitemaps: [],
     transformations: [],
     persistenceConfigs: []
   })


### PR DESCRIPTION
Closes #5732

## Problem
File-based sitemaps (DSL/YAML, loaded from the `sitemaps/` folder) are missing from the developer sidebar in two ways:

1. **Search** — the developer sidebar only queries `GET /rest/ui/components/system:sitemap` (sitemap *components*) and `useComponentsStore().pages()` (UI-based pages). File-based sitemaps are not represented in either, so they never appear in search results.
2. **Edit link** — when a sitemap does appear via the `system:sitemap` component, `getPageType(page).type` returns `unknown` (no component match), routing the Edit button to `/settings/pages/unknown/{id}`, which shows "Unknown page type. Check the component of your page definition."

## Changes
- **developer-sidebar.vue**: fetch `/rest/sitemaps` (REST endpoint for all registered sitemaps) and add it as a Fuse index keyed on `id` + `label`; expose `sitemaps` in the search results object.
- **search-results.vue**: new **Sitemaps** results block with a proper `/settings/sitemaps/{id}` edit link (correct URL, no more "unknown page type").
- **developer-sidebar.vue**: new **Pinned Sitemaps** section in the sidebar with copy / edit / unpin actions.
- **useDeveloperStore.ts**: extend `PinnedObjects` with a `sitemaps` array so sitemaps can be pinned like Items / Pages / Widgets.

## Testing
- `/rest/sitemaps` is already used server-side in `SitemapResource` and returns every registered sitemap (file-based + component-based).
- New Fuse keys (`id`, `label`) follow the same pattern as other search categories (e.g. Items uses `name`, `label`).
- New edit link targets `/settings/sitemaps/{id}` which is the existing sitemap editor route.
