### PR TITLE
 Re-evaluate `oh-context` values after item-state hydration

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/context.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/context.ts
@@ -9,11 +9,11 @@ export default () => [
   pt(
     'constants',
     'Widget Constants',
-    'Object with key:constant pairs. Constants are available to expressions in all child components via the <code>const</code> object.<br />Constants are evaluated once before the widget is displayed the first time and cannot be changed.'
+    'Object with key:constant pairs. Constants are available to expressions in all child components via the <code>const</code> object.<br />Constants are evaluated before the widget is displayed and cannot be changed. If an initial item state dependency is not available yet, constants are re-evaluated once when the missing item state arrives.'
   ),
   pt(
     'variables',
     'Widget Variables',
-    'Object with key:variable default value pairs. Variables are available to expressions in all child components via the <code>vars</code> object and take precedence over variables with the same name from higher contexts.<br />Variables are evaluated once before the widget is displayed the first time . Their values can only be changed by other component variable actions (e.g. <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/components/oh-button.html#action-variable">oh-button</a>)'
+    'Object with key:variable default value pairs. Variables are available to expressions in all child components via the <code>vars</code> object and take precedence over variables with the same name from higher contexts.<br />Variables are evaluated before the widget is displayed. If an initial item state dependency is not available yet, variable defaults are re-evaluated once when the missing item state arrives. Their values can later be changed by component variable actions (e.g. <a class="external text-color-blue" target="_blank" href="https://www.openhab.org/docs/ui/components/oh-button.html#action-variable">oh-button</a>).'
   )
 ]

--- a/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/context.ts
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/widgets/system/context.ts
@@ -9,11 +9,11 @@ export default () => [
   pt(
     'constants',
     'Widget Constants',
-    'Object with key:constant pairs. Constants are available to expressions in all child components via the <code>const</code> object.<br />Constants are evaluated once before the widget is displayed the first time and cannot be changed.'
+    'Object with key:constant pairs. Constants are available to expressions in all child components via the <code>const</code> object.<br />Constants are evaluated once before the widget is displayed the first time and cannot be changed. If an initial item state dependency is not available yet, constants are re-evaluated once when the missing item state arrives.'
   ),
   pt(
     'variables',
     'Widget Variables',
-    'Object with key:variable default value pairs. Variables are available to expressions in all child components via the <code>vars</code> object and take precedence over variables with the same name from higher contexts.<br />Variables are evaluated once before the widget is displayed the first time . Their values can only be changed by other component variable actions (e.g. <a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/docs/ui/components/oh-button.html#action-variable">oh-button</a>)'
+    'Object with key:variable default value pairs. Variables are available to expressions in all child components via the <code>vars</code> object and take precedence over variables with the same name from higher contexts.<br />Variables are evaluated once before the widget is displayed the first time. If an initial item state dependency is not available yet, variable defaults are re-evaluated once when the missing item state arrives. Their values can only be changed by other component variable actions (e.g. <a class="external text-color-theme-alt" target="_blank" href="https://www.openhab.org/docs/ui/components/oh-button.html#action-variable">oh-button</a>).'
   )
 ]

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-context.vue
@@ -9,9 +9,16 @@
 <script>
 import { f7 } from 'framework7-vue'
 
-import { computed } from 'vue'
+import { computed, nextTick, watch } from 'vue'
 import { useWidgetContext } from '@/components/widgets/useWidgetContext'
 import { OhContextDefinition } from '@/assets/definitions/widgets/system'
+import { useStatesStore } from '@/js/stores/useStatesStore'
+
+const INVALID_ITEM_STORE_PROPS = new Set(['_keys', '__ob__', 'toString', 'undefined', 'constructor', 'getters', 'effect', '_vm', 'toJSON'])
+
+function isTrackableItemStoreProp(prop) {
+  return typeof prop === 'string' && !INVALID_ITEM_STORE_PROPS.has(prop) && !prop.startsWith('__v_')
+}
 
 export default {
   inheritAttrs: false,
@@ -22,7 +29,14 @@ export default {
   setup(props) {
     const { varScope, childContext, evaluateExpression, defaultSlots } = useWidgetContext(computed(() => props.context))
     varScope.value = (props.context.varScope || 'varScope') + '-' + f7.utils.id()
-    return { varScope, childContext, evaluateExpression, defaultSlots }
+    const statesStore = useStatesStore()
+    return { varScope, childContext, evaluateExpression, defaultSlots, statesStore }
+  },
+  data() {
+    return {
+      const: {},
+      localCtxVars: {}
+    }
   },
   computed: {
     fn() {
@@ -51,22 +65,31 @@ export default {
       }
       ctx.fn = ctxFunctions
 
-      const ctxConstants = this.const
-      if (this.context.const) {
-        for (const constKey in this.context.const) {
-          if (!ctxConstants[constKey]) ctxConstants[constKey] = this.context.const[constKey]
-        }
+      ctx.const = {
+        ...(this.context.const || {}),
+        ...this.const
       }
-      ctx.const = ctxConstants
 
       if (typeof ctx.ctxVars !== 'object') ctx.ctxVars = {}
       ctx.ctxVars[this.varScope] = this.localCtxVars
 
       return ctx
+    },
+    collectMissingItems(evaluateDefaults) {
+      const accessedItems = new Set()
+      const trackingStore = new Proxy(this.context.store, {
+        get(target, prop) {
+          if (isTrackableItemStoreProp(prop)) accessedItems.add(prop)
+          return target[prop]
+        }
+      })
+      evaluateDefaults({ ...this.context, store: trackingStore })
+
+      return Array.from(accessedItems).filter((itemName) => !this.statesStore.itemStates.has(itemName))
     }
   },
   beforeMount() {
-    const evaluateDefaults = () => {
+    const evaluateDefaults = (evaluationContext = this.context) => {
       if (!this.context?.component?.config) return
 
       this.const = {}
@@ -74,7 +97,7 @@ export default {
       if (sourceConst) {
         if (typeof sourceConst !== 'object') return
         for (const key in sourceConst) {
-          this.const[key] = this.evaluateExpression(key, sourceConst[key])
+          this.const[key] = this.evaluateExpression(key, sourceConst[key], evaluationContext)
         }
       }
 
@@ -83,11 +106,26 @@ export default {
       if (sourceCtxVars) {
         if (typeof sourceCtxVars !== 'object') return
         for (const key in sourceCtxVars) {
-          this.localCtxVars[key] = this.evaluateExpression(key, sourceCtxVars[key])
+          this.localCtxVars[key] = this.evaluateExpression(key, sourceCtxVars[key], evaluationContext)
         }
       }
     }
-    evaluateDefaults()
+
+    const missingItems = this.collectMissingItems(evaluateDefaults)
+    if (missingItems.length === 0) return
+
+    let stop = null
+    stop = watch(
+      () => missingItems.every((itemName) => this.statesStore.itemStates.has(itemName)),
+      (ready) => {
+        if (!ready) return
+        evaluateDefaults()
+        void nextTick(() => {
+          if (stop) stop()
+        })
+      },
+      { immediate: true }
+    )
   }
 }
 </script>


### PR DESCRIPTION

## Fixes

Fixes #2842.

## Problem

`oh-context` constants and variable defaults are evaluated before the child widgets are displayed.

If the UI has just been opened or hard-refreshed, item states might not yet be available in the item state store when these expressions are evaluated. In that case, `const.*` and `vars.*` values can be initialized with missing, stale, or incomplete values.

Example from #2842:

```yaml
component: oh-context
config:
  constants:
    testItemConst: =`testNumber state is ${items.testNumber.state}`
  variables:
    testItemVar: =`testNumber state is ${items.testNumber.state}`
slots:
  default:
    - component: f7-card
      config:
        title: =`testNumber state is ${items.testNumber.state}`
        content: =const.testItemConst
        footer: =vars.testItemVar
```

Expected result:

```text
title   -> current testNumber state
content -> current testNumber state
footer  -> current testNumber state
```

Actual result after a hard refresh:

```text
title   -> correct item state
content -> missing or stale value from const.testItemConst
footer  -> missing or stale value from vars.testItemVar
```

The direct child expression:

```yaml
title: =`testNumber state is ${items.testNumber.state}`
```

can update once the item state becomes available, because it is evaluated inside the normal widget expression flow.

However, the `oh-context` values:

```yaml
constants:
  testItemConst: =`testNumber state is ${items.testNumber.state}`

variables:
  testItemVar: =`testNumber state is ${items.testNumber.state}`
```

were already evaluated once before the item state was available. They then kept that initial incorrect value.

## Why this happens

Before this change, `oh-context` evaluated constants and variable defaults once during initialization:

```javascript
this.const[key] = this.evaluateExpression(key, sourceConst[key])
this.localCtxVars[key] = this.evaluateExpression(key, sourceCtxVars[key])
```

At that point, the expression can access `items.testNumber.state`, but if `testNumber` is not yet present in the item state store, the expression result is based on the missing state.

Later, when the item state arrives, the child widget can update its own direct `items.*` expressions, but the already initialized `const.*` and `vars.*` values are not recalculated.

## Solution

This PR tracks which item states are accessed while evaluating `oh-context` constants and variable defaults.

During the initial evaluation, `oh-context` uses a small tracking wrapper around the item state store. This allows it to detect expressions such as `items.testNumber.state`.

If one of the accessed item states is not available yet, `oh-context` waits until all missing item states are present, then evaluates the constants and variable defaults once again.

Simplified behavior:

```text
initial evaluation
-> track accessed item states
-> detect missing item states
-> wait until missing states arrive
-> evaluate constants and variable defaults once again
-> pass corrected values to child widgets
```

## Reactivity note

This PR does **not** make `oh-context` constants or variable defaults fully reactive. That is intentional.

`oh-context` constants are meant to be stable values inside the child context. Variable defaults are also initial values; after initialization, variables can be changed by widget variable actions.

This PR only fixes the initial missing-state hydration problem. The new behavior is:

```text
initial evaluation
-> item state missing
-> wait until the missing state arrives
-> evaluate once again
-> keep that value
```

It does not mean:

```text
item state changes every time
-> const / variable default recalculates every time
```

Making these values fully reactive would change the existing semantics of `oh-context`. It could also break widgets that rely on constants being stable or overwrite variables that were changed later by widget actions.

## Result

After this change, `oh-context` constants and variable defaults that depend on item states are correctly initialized after a hard refresh or first page load, even when the item state was not available during the first evaluation.

Direct child expressions and `const.*` / `vars.*` values now start from the same item state once the initial item state has arrived, while preserving the existing non-reactive semantics of constants and variable defaults.
