### PR TITLE
Charts: Fix oh-category-axis values expression not evaluated

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.test.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import dayjs from 'dayjs'
 import { ChartType, OhCategoryAxis } from '@/types/components/widgets'
-import { getCategoryAxisData } from './oh-category-axis'
+import categoryAxis, { getCategoryAxisData } from './oh-category-axis'
 
 describe('oh-category-axis', () => {
   describe('getCategoryAxisData', () => {
@@ -130,6 +130,101 @@ describe('oh-category-axis', () => {
       } as any
       const result = getCategoryAxisData(config, startTime, endTime)
       expect(result.name).toBeUndefined()
+    })
+  })
+
+  describe('categoryAxis.get', () => {
+    const startTime = dayjs('2026-01-01T00:00:00')
+    const endTime = dayjs('2026-01-02T00:00:00')
+
+    it('should preserve evaluated dynamic data when categoryType is values', () => {
+      const dynamicData = ['2026-07-22T00:00', '2026-07-22T01:00', '2026-07-22T02:00']
+      const context = {
+        chart: { config: {} },
+        evaluateExpression: (_id: string, config: any) => ({
+          ...config,
+          data: dynamicData
+        })
+      } as any
+      const component = {
+        config: {
+          categoryType: OhCategoryAxis.CategoryType.values,
+          data: "=JSON.parse(items['open_meteo_forecast'].state).hourly.time"
+        }
+      } as any
+
+      const result = categoryAxis.get(context, component, startTime, endTime)
+      expect(result.type).toBe('category')
+      expect(result.data).toEqual(dynamicData)
+    })
+
+    it('should preserve static array data when categoryType is values', () => {
+      const staticData = ['Cat A', 'Cat B', 'Cat C']
+      const context = {
+        chart: { config: {} },
+        evaluateExpression: (_id: string, config: any) => ({ ...config })
+      } as any
+      const component = {
+        config: {
+          categoryType: OhCategoryAxis.CategoryType.values,
+          data: staticData
+        }
+      } as any
+
+      const result = categoryAxis.get(context, component, startTime, endTime)
+      expect(result.type).toBe('category')
+      expect(result.data).toEqual(staticData)
+    })
+
+    it('should preserve custom name from config and not overwrite it with default name', () => {
+      const context = {
+        chart: { config: {} },
+        evaluateExpression: (_id: string, config: any) => ({ ...config })
+      } as any
+      const component = {
+        config: {
+          categoryType: OhCategoryAxis.CategoryType.day,
+          name: 'Custom Day Axis'
+        }
+      } as any
+
+      const result = categoryAxis.get(context, component, startTime, endTime)
+      expect(result.name).toBe('Custom Day Axis')
+    })
+
+    it('should set default axis name when no custom name is provided', () => {
+      const context = {
+        chart: { config: {} },
+        evaluateExpression: (_id: string, config: any) => ({ ...config })
+      } as any
+      const component = {
+        config: {
+          categoryType: OhCategoryAxis.CategoryType.day
+        }
+      } as any
+
+      const result = categoryAxis.get(context, component, startTime, endTime)
+      expect(result.name).toBe('h')
+    })
+
+    it('should reverse axis data when inverse is true', () => {
+      const dynamicData = ['A', 'B', 'C']
+      const context = {
+        chart: { config: {} },
+        evaluateExpression: (_id: string, config: any) => ({
+          ...config,
+          data: [...dynamicData]
+        })
+      } as any
+      const component = {
+        config: {
+          categoryType: OhCategoryAxis.CategoryType.values,
+          data: dynamicData
+        }
+      } as any
+
+      const result = categoryAxis.get(context, component, startTime, endTime, true)
+      expect(result.data).toEqual(['C', 'B', 'A'])
     })
   })
 })

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/axis/oh-category-axis.ts
@@ -85,8 +85,8 @@ export function getCategoryAxisData(config: OhCategoryAxis.Config, startTime: Da
       }
       break
     case OhCategoryAxis.CategoryType.values:
-      data.push(...(config.data || []))
-      break
+      // pass through
+      return { data: config.data ?? [], name: undefined }
     default:
       const exhaustiveCheck: never = config.categoryType
       console.warn('oh-category-axis: Unknown categoryType', exhaustiveCheck)
@@ -97,17 +97,17 @@ export function getCategoryAxisData(config: OhCategoryAxis.Config, startTime: Da
 
 const categoryAxis: AxisComponent = {
   get(context, component, startTime, endTime, inverse) {
-    const config = component.config as any as OhCategoryAxis.Config
     // @ts-expect-error component config's type doesn't include the required properties
     const axis = context.evaluateExpression<OhCategoryAxisOption>(ComponentId.get(component)!, component.config, OhCategoryAxisDefinition)
     axis.type = 'category'
     const chartType = context.chart.config.chartType
 
-    const { name, data } = getCategoryAxisData(config, startTime, endTime, chartType)
-    axis.name = name
+    const { name, data } = getCategoryAxisData(axis, startTime, endTime, chartType)
+    if (name && !axis.name) axis.name = name
+
     axis.data = data
 
-    if (inverse) axis.data = axis.data.reverse()
+    if (inverse && Array.isArray(axis.data)) axis.data = axis.data.reverse()
 
     return axis
   }


### PR DESCRIPTION
Fixes #4388.
Regression from some of the charting change in openHAB 5.2.0.