### PR TITLE
Code Editor: Show checkbox focus outline in codemirror search panel

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -90,10 +90,11 @@
     .cm-panel.cm-search
       label:has(input[type="checkbox"])
         position relative
-        top 2px
+        vertical-align middle
         display inline-flex
-        input[type=checkbox]:focus-visible
-          outline 2px solid black
+        input[type="checkbox"]:focus-visible
+          outline 2px solid -webkit-focus-ring-color
+          outline-offset 2px
 </style>
 
 <script setup lang="ts">

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -93,7 +93,7 @@
         vertical-align middle
         display inline-flex
         input[type="checkbox"]:focus-visible
-          outline 2px auto Highlight 
+          outline 2px auto Highlight
           outline 2px solid -webkit-focus-ring-color
           outline-offset 2px
 </style>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -93,6 +93,7 @@
         vertical-align middle
         display inline-flex
         input[type="checkbox"]:focus-visible
+          outline 2px auto Highlight 
           outline 2px solid -webkit-focus-ring-color
           outline-offset 2px
 </style>

--- a/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/script-editor.vue
@@ -86,6 +86,14 @@
     // Display the close button in the search form in upper right corner, not full width
     .cm-panel.cm-search [name=close]
       width unset
+
+    .cm-panel.cm-search
+      label:has(input[type="checkbox"])
+        position relative
+        top 2px
+        display inline-flex
+        input[type=checkbox]:focus-visible
+          outline 2px solid black
 </style>
 
 <script setup lang="ts">


### PR DESCRIPTION
Resolves #4433

Also made the checkbox and label to align vertically

<img width="516" height="68" alt="codemirror-search-focus" src="https://github.com/user-attachments/assets/1f603125-542c-488b-9c54-5532163580c8" />

This should be backported
