### PR TITLE
Fix several memory leak causes

### DIFF
--- a/bundles/org.openhab.ui/AGENTS.md
+++ b/bundles/org.openhab.ui/AGENTS.md
@@ -126,6 +126,8 @@ All web development happens in the `web/` directory.
 - **Composable argument reactivity:** If reactivity needs to be preserved when passing arguments to composables, `Ref`s or `ComputedRef`s must be passed instead of raw values.
 - **Reactivity export reactivity:** Composables must not export raw values. Instead, they should export `Ref`s or `ComputedRef`s to ensure reactivity is preserved for the caller.
 - **CSS leaking:** Wrap styles in `<style>` with a unique class matching the component name to prevent styles from affecting other components.
+- **Unclosed SSE Streams/WebSockets & Retainers:** Connecting an SSE stream (`$oh.sse.connect(...)`) or WebSocket (`this.$oh.ws.connect(...)`) binds callback closures to `this` (the component instance). If `this.$oh.sse.close(...)`/`this.$oh.ws.close(...)` is not called in `beforeUnmount()` / `onUnmounted()`, the component, its reactive state, child components, and DOM subtree will be permanently pinned in memory.
+- **Global Event Listener Cleanup:** Window or document event listeners (`resize`, `keydown`, `mousedown`, `mousemove`, `popstate`) attached in `mounted()` / `onMounted()` must be unconditionally removed in `beforeUnmount()` / `onUnmounted()`. Safely guard any `$refs` dereferences with optional chaining (`this.$refs.card?.$el`) so teardown runtime exceptions do not bypass listener removal.
 
 ## Reference Documentation
 

--- a/bundles/org.openhab.ui/web/patches/framework7+7.1.5.patch
+++ b/bundles/org.openhab.ui/web/patches/framework7+7.1.5.patch
@@ -1,44 +1,39 @@
-diff --git a/node_modules/framework7/package.json b/node_modules/framework7/package.json
-index f607800..24e6369 100644
---- a/node_modules/framework7/package.json
-+++ b/node_modules/framework7/package.json
-@@ -4,12 +4,30 @@
-   "description": "Full featured mobile HTML framework for building iOS & Android apps",
-   "type": "module",
-   "exports": {
--    ".": "./framework7.esm.js",
--    "./core": "./framework7.esm.js",
--    "./bundle": "./framework7-bundle.esm.js",
--    "./lite": "./framework7-lite.esm.js",
--    "./lite/bundle": "./framework7-lite-bundle.esm.js",
--    "./lite-bundle": "./framework7-lite-bundle.esm.js",
-+    ".": {
-+      "default": "./framework7.esm.js",
-+      "types": "./framework7-types.d.ts"
-+    },
-+    "./core":  {
-+      "default": "./framework7.esm.js",
-+      "types": "./framework7-types.d.ts"
-+    },
-+    "./bundle": {
-+      "default": "./framework7-bundle.esm.js",
-+      "types": "./framework7-types.d.ts"
-+    },
-+    "./lite": {
-+      "default": "./framework7-lite.esm.js",
-+      "types": "./framework7-types.d.ts"
-+    },
-+    "./lite/bundle": {
-+      "default": "./framework7-lite-bundle.esm.js",
-+      "types": "./framework7-types.d.ts"
-+    },
-+    "./lite-bundle": {
-+      "default": "./framework7-lite-bundle.esm.js",
-+      "types": "./framework7-types.d.ts"
-+    },
-     "./less": "./framework7.less",
-     "./less/bundle": "./framework7-bundle.less",
-     "./css": "./framework7.css",
+diff --git a/node_modules/framework7/components/tooltip/tooltip.js b/node_modules/framework7/components/tooltip/tooltip.js
+index c4ffd27..533b1cc 100644
+--- a/node_modules/framework7/components/tooltip/tooltip.js
++++ b/node_modules/framework7/components/tooltip/tooltip.js
+@@ -99,13 +99,12 @@ export default {
+     },
+ 
+     pageBeforeRemove(page) {
+-      const app = this;
+-      page.$el.find('.tooltip-init').each(el => {
++      page.$el.find('*').each(el => {
+         if (el.f7Tooltip) el.f7Tooltip.destroy();
+       });
+ 
+-      if (app.theme === 'ios' && page.view && page.view.router.dynamicNavbar && page.$navbarEl && page.$navbarEl.length > 0) {
+-        page.$navbarEl.find('.tooltip-init').each(el => {
++      if (page.$navbarEl && page.$navbarEl.length > 0) {
++        page.$navbarEl.find('*').each(el => {
+           if (el.f7Tooltip) el.f7Tooltip.destroy();
+         });
+       }
+diff --git a/node_modules/framework7/modules/router/router-class.js b/node_modules/framework7/modules/router/router-class.js
+index 01963aa..c35bb06 100644
+--- a/node_modules/framework7/modules/router/router-class.js
++++ b/node_modules/framework7/modules/router/router-class.js
+@@ -1072,6 +1072,10 @@ class Router extends Framework7Class {
+     $pageEl.trigger(colonName, page);
+     router.emit(camelName, page);
+ 
++    if (callback === 'afterIn' && page.pageFrom) {
++      page.pageFrom = null;
++    }
++
+     if (callback === 'beforeRemove' || callback === 'beforeUnmount') {
+       detachEvents();
+ 
 diff --git a/node_modules/framework7/shared/utils.d.ts b/node_modules/framework7/shared/utils.d.ts
 index c88ac4c..e29088b 100644
 --- a/node_modules/framework7/shared/utils.d.ts

--- a/bundles/org.openhab.ui/web/patches/framework7+7.1.5.patch
+++ b/bundles/org.openhab.ui/web/patches/framework7+7.1.5.patch
@@ -34,6 +34,47 @@ index 01963aa..c35bb06 100644
      if (callback === 'beforeRemove' || callback === 'beforeUnmount') {
        detachEvents();
  
+diff --git a/node_modules/framework7/package.json b/node_modules/framework7/package.json
+index f607800..24e6369 100644
+--- a/node_modules/framework7/package.json
++++ b/node_modules/framework7/package.json
+@@ -4,12 +4,30 @@
+   "description": "Full featured mobile HTML framework for building iOS & Android apps",
+   "type": "module",
+   "exports": {
+-    ".": "./framework7.esm.js",
+-    "./core": "./framework7.esm.js",
+-    "./bundle": "./framework7-bundle.esm.js",
+-    "./lite": "./framework7-lite.esm.js",
+-    "./lite/bundle": "./framework7-lite-bundle.esm.js",
+-    "./lite-bundle": "./framework7-lite-bundle.esm.js",
++    ".": {
++      "default": "./framework7.esm.js",
++      "types": "./framework7-types.d.ts"
++    },
++    "./core":  {
++      "default": "./framework7.esm.js",
++      "types": "./framework7-types.d.ts"
++    },
++    "./bundle": {
++      "default": "./framework7-bundle.esm.js",
++      "types": "./framework7-types.d.ts"
++    },
++    "./lite": {
++      "default": "./framework7-lite.esm.js",
++      "types": "./framework7-types.d.ts"
++    },
++    "./lite/bundle": {
++      "default": "./framework7-lite-bundle.esm.js",
++      "types": "./framework7-types.d.ts"
++    },
++    "./lite-bundle": {
++      "default": "./framework7-lite-bundle.esm.js",
++      "types": "./framework7-types.d.ts"
++    },
+     "./less": "./framework7.less",
+     "./less/bundle": "./framework7-bundle.less",
+     "./css": "./framework7.css",
 diff --git a/node_modules/framework7/shared/utils.d.ts b/node_modules/framework7/shared/utils.d.ts
 index c88ac4c..e29088b 100644
 --- a/node_modules/framework7/shared/utils.d.ts

--- a/bundles/org.openhab.ui/web/patches/framework7-vue+7.1.5.patch
+++ b/bundles/org.openhab.ui/web/patches/framework7-vue+7.1.5.patch
@@ -1,8 +1,41 @@
+diff --git a/node_modules/framework7-vue/components/searchbar.js b/node_modules/framework7-vue/components/searchbar.js
+index a0ece30..dee1698 100644
+--- a/node_modules/framework7-vue/components/searchbar.js
++++ b/node_modules/framework7-vue/components/searchbar.js
+@@ -221,9 +221,11 @@ export default {
+       emit('click:disable', event);
+     };
+ 
++    let isMounted = true;
+     onMounted(() => {
+       if (!props.init) return;
+       f7ready(() => {
++        if (!isMounted) return;
+         const params = noUndefinedProps({
+           el: elRef.value,
+           inputEvents: props.inputEvents,
+@@ -274,7 +276,11 @@ export default {
+       });
+     });
+     onBeforeUnmount(() => {
++      isMounted = false;
+       if (f7Searchbar && f7Searchbar.destroy) f7Searchbar.destroy();
++      else if (elRef.value && elRef.value.f7Searchbar && elRef.value.f7Searchbar.destroy) {
++        elRef.value.f7Searchbar.destroy();
++      }
+       f7Searchbar = null;
+     });
+     const classes = computed(() => classNames('searchbar', {
 diff --git a/node_modules/framework7-vue/framework7-vue.d.ts b/node_modules/framework7-vue/framework7-vue.d.ts
-index c3bbb28..460b6fc 100644
+index c3bbb28..0fad65a 100644
 --- a/node_modules/framework7-vue/framework7-vue.d.ts
 +++ b/node_modules/framework7-vue/framework7-vue.d.ts
-@@ -126,6 +126,8 @@ interface useStore {
+@@ -1,3 +1,4 @@
++import type { App } from 'vue';
+ import Framework7, { Framework7Plugin } from 'framework7/types';
+ import { Store } from 'framework7/types';
+ 
+@@ -126,6 +127,8 @@ interface useStore {
  
  declare const useStore: useStore;
  
@@ -12,24 +45,99 @@ index c3bbb28..460b6fc 100644
 -export { f7, f7ready, theme, useStore };
 +export { f7, f7ready, theme, useStore, registerComponents };
  export default Framework7Vue;
-diff --git a/node_modules/framework7-vue/package.json b/node_modules/framework7-vue/package.json
-index 836e093..ba6e4bd 100644
---- a/node_modules/framework7-vue/package.json
-+++ b/node_modules/framework7-vue/package.json
-@@ -4,8 +4,14 @@
-   "description": "Build full featured iOS & Android apps using Framework7 & Vue",
-   "type": "module",
-   "exports": {
--    ".": "./framework7-vue.js",
--    "./bundle": "./framework7-vue-bundle.js",
-+    ".": {
-+      "default": "./framework7-vue.js",
-+      "types": "./framework7-vue.d.ts"
-+    },
-+    "./bundle": {
-+      "default": "./framework7-vue-bundle.js",
-+      "types": "./framework7-vue.d.ts"
-+    },
-     "./components/*": "./components/*",
-     "./shared/*": "./shared/*"
-   },
+diff --git a/node_modules/framework7-vue/shared/components-router.js b/node_modules/framework7-vue/shared/components-router.js
+index 6859856..865c9e0 100644
+--- a/node_modules/framework7-vue/shared/components-router.js
++++ b/node_modules/framework7-vue/shared/components-router.js
+@@ -108,6 +108,9 @@ export default {
+       viewRouter.pages.forEach((page, index) => {
+         if (page.el === pageEl) {
+           pageComponentFound = true;
++          page.component = null;
++          page.props = null;
++          page.el = null;
+           viewRouter.pages.splice(index, 1);
+           viewRouter.setPages(viewRouter.pages);
+         }
+diff --git a/node_modules/framework7-vue/shared/use-smart-select.js b/node_modules/framework7-vue/shared/use-smart-select.js
+index 4dbfd58..c7504b7 100644
+--- a/node_modules/framework7-vue/shared/use-smart-select.js
++++ b/node_modules/framework7-vue/shared/use-smart-select.js
+@@ -3,8 +3,10 @@ import { f7ready, f7 } from './f7.js';
+ import { extend } from './utils.js';
+ export const useSmartSelect = (props, setInstance, getEl) => {
+   let f7SmartSelect;
++  let isMounted = true;
+   onMounted(() => {
+     f7ready(() => {
++      if (!isMounted) return;
+       if (props.smartSelect) {
+         const ssParams = extend({
+           el: getEl()
+@@ -15,6 +17,7 @@ export const useSmartSelect = (props, setInstance, getEl) => {
+     });
+   });
+   onBeforeUnmount(() => {
++    isMounted = false;
+     if (f7SmartSelect && f7SmartSelect.destroy) {
+       f7SmartSelect.destroy();
+     }
+diff --git a/node_modules/framework7-vue/shared/use-tab.js b/node_modules/framework7-vue/shared/use-tab.js
+index 3758618..5882d83 100644
+--- a/node_modules/framework7-vue/shared/use-tab.js
++++ b/node_modules/framework7-vue/shared/use-tab.js
+@@ -1,6 +1,7 @@
+ import { onMounted, onBeforeUnmount } from 'vue';
+ import { f7, f7ready } from './f7.js';
+ export const useTab = (elRef, emit) => {
++  let isMounted = true;
+   const onTabShow = el => {
+     if (elRef.value !== el) return;
+     emit('tab:show', el);
+@@ -14,11 +15,13 @@ export const useTab = (elRef, emit) => {
+   onMounted(() => {
+     if (!elRef.value) return;
+     f7ready(() => {
++      if (!isMounted) return;
+       f7.on('tabShow', onTabShow);
+       f7.on('tabHide', onTabHide);
+     });
+   });
+   onBeforeUnmount(() => {
++    isMounted = false;
+     if (!f7) return;
+     f7.off('tabShow', onTabShow);
+     f7.off('tabHide', onTabHide);
+diff --git a/node_modules/framework7-vue/shared/use-tooltip.js b/node_modules/framework7-vue/shared/use-tooltip.js
+index 57e5b19..a137bbf 100644
+--- a/node_modules/framework7-vue/shared/use-tooltip.js
++++ b/node_modules/framework7-vue/shared/use-tooltip.js
+@@ -2,6 +2,7 @@ import { watch, onMounted, onBeforeUnmount } from 'vue';
+ import { f7, f7ready } from './f7.js';
+ export const useTooltip = (elRef, props) => {
+   let f7Tooltip = null;
++  let isMounted = true;
+   const {
+     tooltip,
+     tooltipTrigger
+@@ -10,6 +11,7 @@ export const useTooltip = (elRef, props) => {
+     if (!elRef.value) return;
+     if (!tooltip) return;
+     f7ready(() => {
++      if (!isMounted) return;
+       f7Tooltip = f7.tooltip.create({
+         targetEl: elRef.value,
+         text: tooltip,
+@@ -18,9 +20,12 @@ export const useTooltip = (elRef, props) => {
+     });
+   });
+   onBeforeUnmount(() => {
++    isMounted = false;
+     if (f7Tooltip && f7Tooltip.destroy) {
+       f7Tooltip.destroy();
+       f7Tooltip = null;
++    } else if (elRef.value && elRef.value.f7Tooltip && elRef.value.f7Tooltip.destroy) {
++      elRef.value.f7Tooltip.destroy();
+     }
+   });
+   watch(() => props.tooltip, value => {

--- a/bundles/org.openhab.ui/web/patches/framework7-vue+7.1.5.patch
+++ b/bundles/org.openhab.ui/web/patches/framework7-vue+7.1.5.patch
@@ -45,6 +45,27 @@ index c3bbb28..0fad65a 100644
 -export { f7, f7ready, theme, useStore };
 +export { f7, f7ready, theme, useStore, registerComponents };
  export default Framework7Vue;
+diff --git a/node_modules/framework7-vue/package.json b/node_modules/framework7-vue/package.json
+index 836e093..ba6e4bd 100644
+--- a/node_modules/framework7-vue/package.json
++++ b/node_modules/framework7-vue/package.json
+@@ -4,8 +4,14 @@
+   "description": "Build full featured iOS & Android apps using Framework7 & Vue",
+   "type": "module",
+   "exports": {
+-    ".": "./framework7-vue.js",
+-    "./bundle": "./framework7-vue-bundle.js",
++    ".": {
++      "default": "./framework7-vue.js",
++      "types": "./framework7-vue.d.ts"
++    },
++    "./bundle": {
++      "default": "./framework7-vue-bundle.js",
++      "types": "./framework7-vue.d.ts"
++    },
+     "./components/*": "./components/*",
+     "./shared/*": "./shared/*"
+   },
 diff --git a/node_modules/framework7-vue/shared/components-router.js b/node_modules/framework7-vue/shared/components-router.js
 index 6859856..865c9e0 100644
 --- a/node_modules/framework7-vue/shared/components-router.js

--- a/bundles/org.openhab.ui/web/patches/framework7-vue+7.1.5.patch
+++ b/bundles/org.openhab.ui/web/patches/framework7-vue+7.1.5.patch
@@ -162,3 +162,16 @@ index 57e5b19..a137bbf 100644
      }
    });
    watch(() => props.tooltip, value => {
+diff --git a/node_modules/framework7-vue/components/menu-item.js b/node_modules/framework7-vue/components/menu-item.js
+index 7a1a2b3..b82c3d4 100644
+--- a/node_modules/framework7-vue/components/menu-item.js
++++ b/node_modules/framework7-vue/components/menu-item.js
+@@ -84,7 +84,7 @@ export default {
+ 
+     const detachEvents = () => {
+       f7.off('menuOpened', onOpened);
+-      f7.off('menuClosed', onOpened);
++      f7.off('menuClosed', onClosed);
+     };
+ 
+     onMounted(() => attachEvents());

--- a/bundles/org.openhab.ui/web/src/components/chat/chat-core.vue
+++ b/bundles/org.openhab.ui/web/src/components/chat/chat-core.vue
@@ -237,7 +237,7 @@ import { storeToRefs } from 'pinia'
 
 import * as api from '@/api'
 import { ApiError } from '@/js/hey-api.ts'
-import sse, { type KeepaliveEventSource } from '@/js/openhab/sse'
+import sse, { type SSEConnection } from '@/js/openhab/sse'
 import { useUIOptionsStore } from '@/js/stores/useUIOptionsStore.ts'
 import { useStatesStore } from '@/js/stores/useStatesStore.ts'
 
@@ -269,7 +269,7 @@ const settingsOpened = ref(false)
 const llmTools = ref<api.LlmTool[]>([])
 const { assistSelectedLlmTools, assistShowGenericToolVisualisation } = storeToRefs(uiOptionsStore)
 
-let sseConnection: KeepaliveEventSource | null = null
+let sseConnection: SSEConnection | null = null
 
 // Computed
 const suggestions = computed(() => [

--- a/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
+++ b/bundles/org.openhab.ui/web/src/components/developer/developer-sidebar.vue
@@ -832,6 +832,7 @@ export default {
   },
   beforeUnmount() {
     this.stopEventSource()
+    this.stopSSE()
     if (this.addThingAutocomplete) this.addThingAutocomplete.destroy()
   },
   methods: {
@@ -1242,6 +1243,8 @@ export default {
       )
     },
     stopSSE() {
+      if (!this.sseClient) return
+
       this.$oh.sse.close(this.sseClient)
       this.sseClient = null
     },

--- a/bundles/org.openhab.ui/web/src/components/widgets/chart/oh-chart-page.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/chart/oh-chart-page.vue
@@ -4,7 +4,7 @@
     class="oh-chart-page-chart"
     :class="{ 'with-tabbar': context.tab, 'with-toolbar': context.analyzer }"
     :style="uiOptionsStore.darkMode === 'dark' ? 'background-color: black;' : 'background-color: white;'"
-    :context="this.context" />
+    :context="context" />
 </template>
 
 <style lang="stylus">

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -234,9 +234,7 @@ export default {
     }
   },
   beforeUnmount() {
-    if (!this.context.editmode) {
-      window.removeEventListener('resize', this.setDimensions)
-    }
+    window.removeEventListener('resize', this.setDimensions)
     if (this.config.embedSvg && this.embeddedSvgReady) {
       this.embeddedSvgReady = false
       this.unsubscribeEmbeddedSvgListeners()

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-canvas-layout.vue
@@ -206,10 +206,6 @@ export default {
       this.grid.pitch = this.config.grid || 20
       this.grid.enable = this.config.gridEnable || false
       this.actLyrIdx = this.config.activeIdx || 0
-
-      if (!this.context.editmode) {
-        window.addEventListener('resize', this.setDimensions)
-      }
     }
     this.$fullscreen.isEnabled = true
     this.canvasLayoutStyle()
@@ -234,7 +230,6 @@ export default {
     }
   },
   beforeUnmount() {
-    window.removeEventListener('resize', this.setDimensions)
     if (this.config.embedSvg && this.embeddedSvgReady) {
       this.embeddedSvgReady = false
       this.unsubscribeEmbeddedSvgListeners()

--- a/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-layout.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/layout/oh-grid-layout.vue
@@ -166,9 +166,7 @@ export default {
     this.windowHeight = window.screen.height
   },
   beforeUnmount() {
-    if (!this.context.editmode) {
-      window.removeEventListener('resize', this.setDimensions)
-    }
+    window.removeEventListener('resize', this.setDimensions)
   },
   methods: {
     isRetina() {

--- a/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/standard/list/oh-list-item.vue
@@ -190,11 +190,6 @@ export default {
       return this.context.component.slots.accordion
     }
   },
-  created() {
-    if (this.config.divider && !this.context.editmode) {
-      window.addEventListener('resize', this.duringResize)
-    }
-  },
   methods: {
     openAccordionOrPerformAction() {
       if (this.isEquipmentAccordion) {

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-chart.vue
@@ -1,5 +1,5 @@
 <template>
-  <oh-chart-component ref="chart" :context="this.context" />
+  <oh-chart-component ref="chart" :context="context" />
 </template>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/js/composables/useViewArea.ts
+++ b/bundles/org.openhab.ui/web/src/js/composables/useViewArea.ts
@@ -44,9 +44,8 @@ export function useViewArea() {
         // ignore
       }
       resizeObserver = null
-    } else {
-      window.removeEventListener('resize', updateViewAreaDimensions)
     }
+    window.removeEventListener('resize', updateViewAreaDimensions)
     observedElement = null
   })
 

--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.test.ts
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import sse from './sse'
+
+vi.mock('event-source-polyfill', () => {
+  class MockEventSource {
+    url: string
+    options: any
+    readyState: number = 0 // CONNECTING
+    listeners: Record<string, ((...args: any[]) => void)[]> = {}
+    onmessage: ((ev: MessageEvent) => void) | null = null
+    onopen: ((ev: Event) => void) | null = null
+    onerror: ((ev: Event) => void) | null = null
+
+    constructor(url: string, options?: any) {
+      this.url = url
+      this.options = options
+      if (!(global as any).mockEventSourceInstances) {
+        ;(global as any).mockEventSourceInstances = []
+      }
+      ;(global as any).mockEventSourceInstances.push(this)
+    }
+
+    addEventListener(type: string, listener: any) {
+      if (!this.listeners[type]) this.listeners[type] = []
+      this.listeners[type].push(listener)
+    }
+
+    removeEventListener(type: string, listener: any) {
+      if (!this.listeners[type]) return
+      this.listeners[type] = this.listeners[type].filter((l) => l !== listener)
+    }
+
+    close() {
+      this.readyState = 2 // CLOSED
+    }
+  }
+
+  return {
+    EventSourcePolyfill: MockEventSource,
+    NativeEventSource: MockEventSource
+  }
+})
+
+vi.mock('./auth', () => ({
+  getAccessToken: () => 'mock-token',
+  getTokenInCustomHeader: () => false,
+  getBasicCredentials: () => null
+}))
+
+describe('SSE Connection and Reconnect', () => {
+  beforeEach(() => {
+    ;(global as any).mockEventSourceInstances = []
+    vi.useFakeTimers()
+    global.fetch = vi.fn().mockResolvedValue({ status: 200 })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function getInstances(): any[] {
+    return (global as any).mockEventSourceInstances || []
+  }
+
+  it('should track logical connection separately and close all underlying connections', async () => {
+    // 1. Establish SSE connection
+    const conn = sse.connect(
+      '/rest/events',
+      [],
+      () => {},
+      () => {}
+    )
+    const instances = getInstances()
+    expect(instances.length).toBe(1)
+    const es1 = instances[0]
+    expect(conn.currentEventSource).toBe(es1)
+
+    // Simulate connection failure (readyState = 2, triggers onerror)
+    es1.readyState = 2
+    if (es1.onerror) {
+      es1.onerror({} as Event)
+    }
+
+    // Wait for the fetch and verify reconnect schedules a timeout
+    await Promise.resolve() // let fetch promise resolve
+    expect(global.fetch).toHaveBeenCalledWith('/rest/events', expect.any(Object))
+
+    // 2. Reconnection timer should be set for 1 second
+    // Advance timers by 1 second to trigger the reconnect
+    await vi.advanceTimersByTimeAsync(1000)
+
+    // A new EventSource should have been instantiated on reconnect
+    expect(instances.length).toBe(2)
+    const es2 = instances[1]
+    expect(conn.currentEventSource).toBe(es2)
+
+    // 3. Call close on the logical handle
+    sse.close(conn)
+
+    // Both underlying EventSources should end up closed (readyState === 2)
+    expect(es1.readyState).toBe(2)
+    expect(es2.readyState).toBe(2)
+    expect(conn.closed).toBe(true)
+    expect(conn.currentEventSource).toBeNull()
+  })
+
+  it('should cancel pending reconnect and not spawn new connection if closed', async () => {
+    // 1. Establish SSE connection
+    const conn = sse.connect(
+      '/rest/events',
+      [],
+      () => {},
+      () => {}
+    )
+    const instances = getInstances()
+    expect(instances.length).toBe(1)
+    const es1 = instances[0]
+
+    // Simulate connection failure
+    es1.readyState = 2
+    if (es1.onerror) {
+      es1.onerror({} as Event)
+    }
+
+    await Promise.resolve()
+
+    // 2. Close the logical connection before the reconnect timer fires
+    sse.close(conn)
+    expect(conn.closed).toBe(true)
+
+    // 3. Advance timers past the 1 second reconnect delay
+    await vi.advanceTimersByTimeAsync(1000)
+
+    // No new event source should be instantiated
+    expect(instances.length).toBe(1)
+  })
+})

--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.ts
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.ts
@@ -141,8 +141,15 @@ function newSSEConnection(
             // Close the current broken connection
             es.close()
             es.clearKeepalive()
-            // Reinitialize the connection
+            // Reinitialize the connection and update openSSEClients so that
+            // SSEService.close() can reach the new live EventSource.
+            const oldIndex = openSSEClients.indexOf(es)
             eventSource = initEventSource() // Reassign the outer scope's eventSource
+            if (oldIndex >= 0) {
+              openSSEClients.splice(oldIndex, 1, eventSource)
+            } else {
+              openSSEClients.push(eventSource)
+            }
           }
         }, reconnectSeconds * 1000)
       }

--- a/bundles/org.openhab.ui/web/src/js/openhab/sse.ts
+++ b/bundles/org.openhab.ui/web/src/js/openhab/sse.ts
@@ -3,15 +3,49 @@ import { getAccessToken, getTokenInCustomHeader, getBasicCredentials } from './a
 import type { ItemState } from '../stores/useStatesStore'
 
 /**
- * An EventSource that is extended with a keepalive/heartbeat mechanism.
+ * A logical Server-Sent Events (SSE) connection handle that tracks the underlying EventSource instance and reconnection/keepalive states.
  */
-export interface KeepaliveEventSource extends EventSource {
-  keepaliveTimer?: number
+export interface SSEConnection {
+  /**
+   * The fully resolved absolute URL of the connection endpoint.
+   */
+  readonly url: string
+  /**
+   * The current underlying EventSource instance used by this logical connection.
+   * Updated automatically when a reconnection occurs.
+   */
+  currentEventSource: EventSource | null
+  /**
+   * A flag indicating whether this connection has been explicitly closed.
+   * If true, it prevents further reconnection attempts and ignores any pending timer callbacks or stream events.
+   */
+  closed: boolean
+  /**
+   * The timeout job ID for the schedules reconnection attempt.
+   * Used to cancel pending reconnects when the connection is explicitly closed.
+   * Only present if the underlying EventSource connection has been lost.
+   */
+  reconnectTimeout: number | null
+  /**
+   * The timeout job ID for the active keepalive/heartbeat timer.
+   * Used to track if the server stops sending heartbeat signals.
+   * Only present if the server sent a {@code alive} heartbeat message.
+   */
+  keepaliveTimer: number | null
+  /**
+   * Establishes or resets the keepalive/heartbeat timer.
+   * Starts a timer for <code>seconds + 2</code> seconds, triggering the heartbeat callback with `false` if no heartbeat is received before the timer expires.
+   *
+   * @param seconds the heartbeat interval in seconds
+   */
   setKeepalive: (seconds?: number) => void
+  /**
+   * Clears the active keepalive/heartbeat timer and clear the timeout job ID.
+   */
   clearKeepalive: () => void
 }
 
-let openSSEClients: KeepaliveEventSource[] = []
+let openSSEClients: SSEConnection[] = []
 
 type ReadyCallback = (data: string) => void
 type MessageCallback = (data: any) => void
@@ -28,12 +62,38 @@ function newSSEConnection(
   messageCallback: MessageCallback,
   errorCallback: ErrorCallback,
   heartbeatCallback: HeartbeatCallback | undefined
-): KeepaliveEventSource {
-  let eventSource: KeepaliveEventSource
+): SSEConnection {
   let reconnectSeconds = 1
 
+  const connection: SSEConnection = {
+    url: '',
+    currentEventSource: null,
+    closed: false,
+    reconnectTimeout: null,
+    keepaliveTimer: null,
+    setKeepalive(seconds: number = 10) {
+      console.debug('Setting keepalive interval seconds', seconds)
+      this.clearKeepalive()
+      this.keepaliveTimer = setTimeout(
+        () => {
+          console.warn('SSE timeout error')
+          if (heartbeatCallback) {
+            heartbeatCallback(false)
+          }
+        },
+        (seconds + 2) * 1000
+      )
+    },
+    clearKeepalive() {
+      if (this.keepaliveTimer) {
+        clearTimeout(this.keepaliveTimer)
+      }
+      this.keepaliveTimer = null
+    }
+  }
+
   // Core initialization logic
-  function initEventSource(): KeepaliveEventSource {
+  function initEventSource(): EventSource {
     const headers: Record<string, string> = {}
     // Setup headers for authentication.
     // We make sure to always use the latest token here, otherwise it may
@@ -62,43 +122,21 @@ function newSSEConnection(
       newEventSource = new NativeEventSource(path)
     }
 
-    // Type assertion to treat the EventSource as our extended interface,
-    // allowing us to add custom methods/properties.
-    const es = newEventSource as KeepaliveEventSource
-
-    // Add keepalive/heartbeat mechanism
-    es.setKeepalive = (seconds: number = 10) => {
-      console.debug('Setting keepalive interval seconds', seconds)
-      es.clearKeepalive()
-      es.keepaliveTimer = setTimeout(
-        () => {
-          console.warn('SSE timeout error')
-          if (heartbeatCallback) {
-            heartbeatCallback(false)
-          }
-        },
-        (seconds + 2) * 1000
-      )
-    }
-
-    es.clearKeepalive = () => {
-      if (es.keepaliveTimer) clearTimeout(es.keepaliveTimer)
-      delete es.keepaliveTimer
-    }
-
     // Event handlers
     if (readyCallback) {
-      es.addEventListener('ready', (e: MessageEvent) => {
+      newEventSource.addEventListener('ready', (e: MessageEvent) => {
+        if (connection.closed) return
         readyCallback(e.data as string)
       })
     }
 
-    es.addEventListener('alive', (e: MessageEvent) => {
+    newEventSource.addEventListener('alive', (e: MessageEvent) => {
+      if (connection.closed) return
       // Type 'e.data' is string, parse to get the object with 'interval'
       let evt: { interval: number }
       try {
         evt = JSON.parse(e.data as string) as { interval: number }
-        es.setKeepalive(evt.interval)
+        connection.setKeepalive(evt.interval)
       } catch (error) {
         console.error('Failed to parse "alive" message data:', error)
         if (heartbeatCallback) heartbeatCallback(false)
@@ -108,7 +146,8 @@ function newSSEConnection(
       if (heartbeatCallback) heartbeatCallback(true)
     })
 
-    es.onmessage = (event: MessageEvent) => {
+    newEventSource.onmessage = (event: MessageEvent) => {
+      if (connection.closed) return
       let evt: unknown
       try {
         evt = JSON.parse(event.data as string)
@@ -119,13 +158,15 @@ function newSSEConnection(
       messageCallback(evt)
     }
 
-    es.onopen = (event: Event) => {
+    newEventSource.onopen = (event: Event) => {
+      if (connection.closed) return
       reconnectSeconds = 1 // Reset reconnection delay on successful open
     }
 
-    es.onerror = (event: Event) => {
+    newEventSource.onerror = (event: Event) => {
+      if (connection.closed) return
       console.warn('SSE error')
-      es.clearKeepalive()
+      connection.clearKeepalive()
       if (errorCallback) {
         errorCallback()
       }
@@ -133,59 +174,61 @@ function newSSEConnection(
       const scheduleReconnect = () => {
         console.debug(`Attempting SSE reconnection in ${reconnectSeconds} seconds...`)
 
-        setTimeout(() => {
+        connection.reconnectTimeout = setTimeout(() => {
+          if (connection.closed) return
           // Check state again before reconnecting
-          if (es.readyState === 2) {
+          if (newEventSource.readyState === 2) {
             reconnectSeconds = reconnectSeconds * 2
             if (reconnectSeconds > 10) reconnectSeconds = 10
             // Close the current broken connection
-            es.close()
-            es.clearKeepalive()
-            // Reinitialize the connection and update openSSEClients so that
-            // SSEService.close() can reach the new live EventSource.
-            const oldIndex = openSSEClients.indexOf(es)
-            eventSource = initEventSource() // Reassign the outer scope's eventSource
-            if (oldIndex >= 0) {
-              openSSEClients.splice(oldIndex, 1, eventSource)
-            } else {
-              openSSEClients.push(eventSource)
-            }
+            newEventSource.close()
+            connection.clearKeepalive()
+            // Reinitialize the connection
+            connection.reconnectTimeout = null
+            connection.currentEventSource = initEventSource()
           }
         }, reconnectSeconds * 1000)
       }
 
       // Handle reconnection logic
       // Note: readyState === 2 is defined as CLOSED in EventSource spec
-      if (es.readyState === 2) {
+      if (newEventSource.readyState === 2) {
         console.log('%c=!= Event source connection broken...', 'background-color: red; color: white')
 
         // Since SSE hides the response status, do a regular fetch to figure out if our credentials are rejected or not
         fetch(path, { method: 'HEAD', headers: headers })
           .then((response) => {
+            if (connection.closed) return
             if (response.status === 401) {
               console.debug(`SSE: The server responded with "${response.status}", aborting reconnect.`)
-              es.close()
-              es.clearKeepalive()
+              newEventSource.close()
+              connection.clearKeepalive()
             } else {
               scheduleReconnect()
             }
           })
           .catch((err) => {
-            console.debug(`SSE: Coudn't connect to the server, scheduling reconnect: ${err}`)
+            if (connection.closed) return
+            console.debug(`SSE: Couldn't connect to the server, scheduling reconnect: ${err}`)
             scheduleReconnect()
           })
       }
     }
 
-    return es
+    return newEventSource
   }
 
-  eventSource = initEventSource()
+  const es = initEventSource()
+  connection.currentEventSource = es
+  interface MutableSSEConnection extends SSEConnection {
+    url: string
+  }
+  ;(connection as MutableSSEConnection).url = es.url
 
-  openSSEClients.push(eventSource)
-  console.debug(`new SSE connection: ${eventSource.url}, ${openSSEClients.length} open`)
+  openSSEClients.push(connection)
+  console.debug(`new SSE connection: ${connection.url}, ${openSSEClients.length} open`)
   console.debug(openSSEClients)
-  return eventSource
+  return connection
 }
 
 const SSEService = {
@@ -203,7 +246,7 @@ const SSEService = {
     messageCallback: MessageCallback,
     errorCallback: ErrorCallback,
     heartbeatCallback?: HeartbeatCallback
-  ): KeepaliveEventSource {
+  ): SSEConnection {
     return newSSEConnection(path, undefined, messageCallback, errorCallback, heartbeatCallback)
   },
 
@@ -221,29 +264,35 @@ const SSEService = {
     updateCallback: StateMessageCallback,
     errorCallback: ErrorCallback,
     heartbeatCallback?: HeartbeatCallback
-  ): KeepaliveEventSource {
+  ): SSEConnection {
     return newSSEConnection(path, readyCallback, updateCallback, errorCallback, heartbeatCallback)
   },
 
   /**
    * Close the given SSE connection.
-   * @param es the SSE connection to close
+   * @param conn the SSE connection to close
    */
-  close(es: EventSource): void {
-    if (!es) return
+  close(conn: SSEConnection): void {
+    if (!conn) return
 
-    const keepaliveEventSource = es as KeepaliveEventSource
-
-    const index = openSSEClients.indexOf(keepaliveEventSource)
+    const index = openSSEClients.indexOf(conn)
     if (index >= 0) {
       openSSEClients.splice(index, 1)
     }
 
-    console.debug(`SSE connection closed: ${keepaliveEventSource.url}, ${openSSEClients.length} open`)
+    console.debug(`SSE connection closed: ${conn.url}, ${openSSEClients.length} open`)
     console.debug(openSSEClients)
 
-    keepaliveEventSource.clearKeepalive()
-    keepaliveEventSource.close()
+    conn.closed = true
+    conn.clearKeepalive()
+    if (conn.reconnectTimeout) {
+      clearTimeout(conn.reconnectTimeout)
+      conn.reconnectTimeout = null
+    }
+    if (conn.currentEventSource) {
+      conn.currentEventSource.close()
+      conn.currentEventSource = null
+    }
   }
 }
 

--- a/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
+++ b/bundles/org.openhab.ui/web/src/js/stores/useStatesStore.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia'
 import { nextTick, ref, reactive } from 'vue'
 
-import sse from '@/js/openhab/sse'
+import sse, { type SSEConnection } from '@/js/openhab/sse'
 import * as api from '@/api'
 
 export type TrackedItems = Record<string, ItemState>
@@ -87,7 +87,7 @@ export const useStatesStore = defineStore('states', () => {
   const trackedItems = reactive<TrackedItems>(new Proxy({}, handler))
   const trackingList = ref<Array<string>>([])
   let trackerConnectionId: string | null = null
-  let trackerEventSource: EventSource | null = null
+  let trackerEventSource: SSEConnection | null = null
   let pendingTrackingListUpdate: boolean = false
   const keepConnectionOpen = ref<boolean>(false)
   const sseConnected = ref<boolean>(false)

--- a/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/developer-tools.vue
@@ -209,6 +209,10 @@ export default {
     },
     ...mapStores(useRuntimeStore, useUIOptionsStore)
   },
+  beforeUnmount() {
+    this.stopSSE()
+    this.stopWS()
+  },
   methods: {
     developerColumnSections(column) {
       return this.developerNavigationSections.filter((section) => section.column === column)
@@ -283,6 +287,8 @@ export default {
       })
     },
     stopSSE() {
+      if (!this.sseClient) return
+
       this.$oh.sse.close(this.sseClient)
       this.sseClient = null
       this.sseEvents = []
@@ -296,6 +302,8 @@ export default {
       })
     },
     stopWS() {
+      if (!this.wsClient) return
+
       this.$oh.ws.close(this.wsClient)
       this.wsClient = null
       this.wsEvents = []

--- a/bundles/org.openhab.ui/web/src/pages/home.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home.vue
@@ -117,7 +117,7 @@
     </f7-block>
     <f7-tabs v-else>
       <f7-tab id="tab-overview" :tab-active="currentTab === 'overview' ? true : null" @tab:show="currentTab = 'overview'">
-        <overview-tab v-if="currentTab === 'overview'" :context="context" :key="overviewPageKey" :allow-chat="allowChat" :f7router />
+        <overview-tab v-if="currentTab === 'overview'" :context="context" :allow-chat="allowChat" :f7router />
       </f7-tab>
       <f7-tab id="tab-locations" :tab-active="currentTab === 'locations' ? true : null" @tab:show="currentTab = 'locations'">
         <model-tab v-if="currentTab === 'locations'" :context="context" type="locations" :page="homePageComponent" />
@@ -185,8 +185,7 @@ export default {
       showCards: false,
       showPinToHome: false,
       showExitToApp: false,
-      currentTab: this.initialTab || 'overview',
-      overviewPageKey: f7.utils.id()
+      currentTab: this.initialTab || 'overview'
     }
   },
   computed: {
@@ -271,9 +270,6 @@ export default {
     }
   },
   methods: {
-    onPageBeforeIn() {
-      this.overviewPageKey = f7.utils.id()
-    },
     onPageAfterIn() {
       if (this.ready) {
         useStatesStore().startTrackingStates()

--- a/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
+++ b/bundles/org.openhab.ui/web/src/pages/home/overview-tab.vue
@@ -123,8 +123,7 @@ export default {
       return {
         component: this.overviewPage,
         store: this.context.store,
-        // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-        vars: Object.assign(this.vars, this.overviewPage?.config?.defineVars ?? {})
+        vars: this.vars
       }
     },
     pageStyle() {
@@ -132,6 +131,16 @@ export default {
       return this.overviewPage.config.style
     },
     ...mapStores(useUserStore, useStatesStore, useComponentsStore, useUIOptionsStore, useRuntimeStore)
+  },
+  watch: {
+    overviewPage: {
+      handler(newPage) {
+        if (newPage?.config?.defineVars) {
+          this.vars = Object.assign(this.vars, newPage.config.defineVars)
+        }
+      },
+      immediate: true
+    }
   }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model-dragdrop-mixin.js
@@ -95,7 +95,9 @@ export default {
       if (!this.moveState.node.item.editable) return
       console.time('Timer: Drag')
       console.debug('Drag start - event:', event)
-      window.addEventListener('keydown', this.keyDownHandler)
+      if (window) {
+        window.addEventListener('keydown', this.keyDownHandler)
+      }
       this.moveState.moving = true
       this.moveState.canAdd = false
       this.moveState.canRemove = false
@@ -174,7 +176,9 @@ export default {
           ? event.explicitOriginalTarget
           : event.explicitOriginalTarget.parentNode
         : null
-      window.removeEventListener('keydown', this.keyDownHandler)
+      if (window) {
+        window.removeEventListener('keydown', this.keyDownHandler)
+      }
       if (this.moveState.cancelled) {
         console.debug('Drag end - cancelled')
         this.restoreModelUpdate()


### PR DESCRIPTION
Related to #4440.

When squash merging this PR, please use this commit message (copy here and paste below):

```md
Addresses several memory leak causes, component lifecycle issues, event listener cleanup problems, and unintended side-effects across the codebase:

* `oh-chart` & `oh-chart-page`: Fix `this` references in `<template>`.
* `oh-list-item`: Clean up leftover event listener from PR #3862.
* `oh-canvas-layout`: Clean-up event listeners referencing non-existing method.
* `$oh.see`: Decouple exposed logical connection handle from underlying EventSource instance. Fixes stale EventSource references in consumers and `$oh.sse`.
* `developer-sidebar` & `developer-tools`: Ensure SSE and WebSocket connections are stopped before unmounting.
* Global event listeners: Always ensure global event listeners are properly removed.
* `model-dragdrop-mixin`: Only add or remove global event listeners if `window` is defined.
* AGENTS.md: Add documentation regarding unclosed SSE/WebSockets and global event listener cleanup.
* Memory Leaks and Async Lifecycle Safety in Framework7:
  * Router: Clear `page.pageFrom` references after `afterIn` callbacks to release retained DOM elements.
  * Tooltip: Extend the `pageBeforeRemove` hook to destroy all `f7Tooltip` instances within `$el` and `$navbarEl`.
  * Menu: Fix `menuClosed` listener never detached.
  * Framework7-Vue: Add `isMounted` checks to async `f7ready` callbacks and ensure explicit `.destroy()` calls on `f7Searchbar` and `f7Tooltip` during `onBeforeUnmount`.
* `overview-tab`: Fix `defineVars` assignment causing side-effects in computed properties (improving the fix from PR #4038).
* `home`: Prevent unnecessary component recreation on overview tab transitions by removing `this.overviewPageKey = f7.utils.id()` from `onPageBeforeIn()`,
   allowing unmount hooks (like window resize listeners in masonry layout) to clean up gracefully.

-----

Signed-off-by: Florian Hotze <dev@florianhotze.com>
```