### PR TITLE
[GHA] Add new workflow for upgrading maven wrapper

### DIFF
--- a/.github/workflows/update-maven.yml
+++ b/.github/workflows/update-maven.yml
@@ -1,0 +1,83 @@
+name: Update Maven Wrapper
+
+on:
+  schedule:
+    - cron: '0 19 * * 5'
+  workflow_dispatch:
+
+jobs:
+  update:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Get latest Maven version
+        # This fetches latest Maven release from maven.org - not the download page; it might be delayed a few days after releases.
+        # Note that the "gav" at the end of the URL is necessary to retrieve more than one version. jq will filter out rc versions.
+        id: maven
+        run: |
+          LATEST=$(curl -s "https://repo1.maven.org/maven2/org/apache/maven/apache-maven/maven-metadata.xml" \
+            | grep -oP '<version>\K[^<]+' \
+            | grep -viE 'rc|alpha|beta|snapshot|milestone' \
+            | tail -1)
+          if [[ -z "$LATEST" || ! "$LATEST" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: failed to determine a valid Maven version (got: '${LATEST}')" >&2
+            exit 1
+          fi
+          echo "version=$LATEST" >> $GITHUB_OUTPUT
+
+      - name: Update wrapper
+        # Update Maven wrapper scripts AND maven-wrapper.properties.
+        # Note that this removes the SHA from properties file.
+        env:
+          VERSION: ${{ steps.maven.outputs.version }}
+        run: ./mvnw wrapper:wrapper -Dmaven="${VERSION}"
+
+      - name: Patch SHA256 into wrapper properties
+        # Apache Maven only publishes .sha512 files, so we download the zip and compute SHA-256 locally.
+        # We might need the -L for curl, as after a new release all old files will move to archive folder.
+        env:
+          VERSION: ${{ steps.maven.outputs.version }}
+        run: |
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          BASE_URL="https://downloads.apache.org/maven/maven-${MAJOR}/${VERSION}/binaries/apache-maven-${VERSION}-bin.zip"
+          ZIP=$(mktemp)
+          curl -sLf "$BASE_URL" -o "$ZIP"
+          EXPECTED_SHA512=$(curl -sLf "${BASE_URL}.sha512")
+          if [[ ! "$EXPECTED_SHA512" =~ ^[0-9a-f]{128}$ ]]; then
+            echo "Error: invalid SHA-512 checksum downloaded for Maven ${VERSION}" >&2
+            exit 1
+          fi
+          ACTUAL_SHA512=$(sha512sum "$ZIP" | awk '{print $1}')
+          if [[ "$ACTUAL_SHA512" != "$EXPECTED_SHA512" ]]; then
+            echo "Error: SHA-512 mismatch for Maven ${VERSION} zip (expected: ${EXPECTED_SHA512}, got: ${ACTUAL_SHA512})" >&2
+            exit 1
+          fi
+          SHA256=$(sha256sum "$ZIP" | awk '{print $1}')
+          rm -f "$ZIP"
+          if [[ ! "$SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Error: failed to compute a valid SHA-256 checksum for Maven ${VERSION}" >&2
+            exit 1
+          fi
+          PROPS=".mvn/wrapper/maven-wrapper.properties"
+          sed -i '/^distributionSha256Sum=/d' "$PROPS"
+          echo "distributionSha256Sum=${SHA256}" >> "$PROPS"
+          # remove entry for SHA-512 if present, as it is not yet supported by wrapper
+          sed -i '/^distributionSha512Sum=/d' "$PROPS"
+
+      - name: Open PR if changed
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # 8.1.1
+        with:
+          commit-message: "Update maven wrapper to ${{ steps.maven.outputs.version }}"
+          title: "Update Maven Wrapper to ${{ steps.maven.outputs.version }}"
+          branch: gha/update-maven-wrapper
+          delete-branch: true
+          labels: infrastructure


### PR DESCRIPTION
This is the same workflow we use on other repos to upgrade mvnw and mvn version.
See openhab/openhab-addons#20593

Once the workflow is triggered (either by cron or manually from the actions tab), it will create a new PR, upgrading mwnw and mvn version from 3.9.13 to 3.9.16.

Project settings might need adaptation to allow the PR creation.