### PR TITLE
Fix mvn signature, use sha256sum

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -17,4 +17,4 @@
 wrapperVersion=3.3.2
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.13/apache-maven-3.9.13-bin.zip
-distributionSha512Sum=43f82fc40a65079528c0037856c95b8aa04bd74c9851b01225c61c5debeb5e3b7d2acd1266979b4ea359887dfc26f176932b5f10eb47d684add97d262a821592
+distributionSha256Sum=d2a998d737a75a6f6dc4f51e37c28921819f23586b9a6e9fd062409836de58b6


### PR DESCRIPTION
dependabot now handles mvnw and mvn upgrades.
sha512 signature is anyway useless as it is ignored by mvnw.

This PR replaces sha512 checksum by sha256. It will then be updated by dependabot as well.