### PR TITLE
oh-repeater: fix when sourceType is an array of objects

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
@@ -36,7 +36,7 @@ import { ApiError } from '@/js/hey-api'
 import { simpleHash } from '@/js/openhab/utils'
 
 type SourceTypeElement = api.EnrichedItem | api.EnrichedGroupItem | api.EnrichedRule | api.StateOption | api.CommandOption | string | number
-type SourceArray = SourceTypeElement[] | null
+type SourceArray = SourceTypeElement[] | string | null
 
 // define*
 const props = defineProps<{
@@ -164,6 +164,9 @@ const source = computedAsync(async (): Promise<SourceArray> => {
         }
         if (!cfg.in) {
           return []
+        }
+        if (sourceType.value == OhRepeater.SourceType.array) {
+          return cfg.in
         }
         return String(cfg.in)
           .split(',')

--- a/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
+++ b/bundles/org.openhab.ui/web/src/components/widgets/system/oh-repeater.vue
@@ -165,7 +165,7 @@ const source = computedAsync(async (): Promise<SourceArray> => {
         if (!cfg.in) {
           return []
         }
-        if (sourceType.value == OhRepeater.SourceType.array) {
+        if (Array.isArray(cfg.in)) {
           return cfg.in
         }
         return String(cfg.in)


### PR DESCRIPTION
Fix a regression introduced in #4035 

When the source is an array of objects, e.g. `String([ { "foo":"bar" }])` results in `"[object Object]"`.

@jsjames I don't really understand the typing around SourceArray and just added the extra `| string` there - quite likely what I added is wrong there. I'd appreciate it if you could correct it.

This bug broke my page that's relying on oh-repeater with JSON source like this:

```yaml
- component: oh-repeater
  config:
    for: camera
    in: =JSON.parse(@'PhotoFrame_Cameras')
    sourceType: array
```