### PR TITLE
[Blockly] Fix HTTP POST and PUT generator signatures with headers

### DIFF
--- a/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-http.js
+++ b/bundles/org.openhab.ui/web/src/assets/definitions/blockly/blocks-http.js
@@ -236,6 +236,7 @@ export default function (f7) {
    */
   javascriptGenerator.forBlock['oh_httprequest'] = function (block, generator) {
     const requestType = block.getFieldValue('requestType')
+    const isPayloadRequest = ['HttpPostRequest', 'HttpPutRequest'].includes(requestType)
 
     let url = valueToCode(block, 'url', javascriptGenerator.ORDER_ATOMIC)
 
@@ -246,9 +247,9 @@ export default function (f7) {
     }
 
     const contentType = block.getFieldValue('contentType')
-
     let payload = valueToCode(block, 'payload', javascriptGenerator.ORDER_ATOMIC)
-    if (payload) {
+
+    if (isPayloadRequest && contentType !== 'none' && payload) {
       if (contentType === 'application/x-www-form-urlencoded') {
         const payloadEncodeFunction = encodeParams(payload)
         payload = `${payloadEncodeFunction}(${payload})`
@@ -262,19 +263,31 @@ export default function (f7) {
     const timeout = valueToCode(block, 'timeoutInput', javascriptGenerator.ORDER_ATOMIC) || 3000
 
     let code = ''
-    if (payload) {
-      if (!headers) {
-        code = `actions.HTTP.send${requestType}(${url}, '${contentType}', ${payload}, ${timeout})`
+
+    if (isPayloadRequest) {
+      // Determine string representations for contentType and content
+      const parsedContentType = contentType && contentType !== 'none' ? `'${contentType}'` : '""'
+      const parsedPayload = payload || '""'
+
+      if (headers) {
+        // Must use 5-arg signature when headers are present
+        code = `actions.HTTP.send${requestType}(${url}, ${parsedContentType}, ${parsedPayload}, ${headers}, ${timeout})`
+      } else if (contentType !== 'none' || payload) {
+        // Use 4-arg signature with contentType and content
+        code = `actions.HTTP.send${requestType}(${url}, ${parsedContentType}, ${parsedPayload}, ${timeout})`
       } else {
-        code = `actions.HTTP.send${requestType}(${url}, '${contentType}', ${payload}, ${headers}, ${timeout})`
+        // Fallback 2-arg signature when no payload/contentType/headers are specified
+        code = `actions.HTTP.send${requestType}(${url}, ${timeout})`
       }
     } else {
-      if (!headers) {
-        code = `actions.HTTP.send${requestType}(${url}, ${timeout})`
-      } else {
+      // GET and DELETE requests
+      if (headers) {
         code = `actions.HTTP.send${requestType}(${url}, ${headers}, ${timeout})`
+      } else {
+        code = `actions.HTTP.send${requestType}(${url}, ${timeout})`
       }
     }
+
     return [code, javascriptGenerator.ORDER_NONE]
   }
 


### PR DESCRIPTION
Ensure HttpPostRequest and HttpPutRequest fall back to the 5-argument signature (url, contentType, content, headers, timeout) when headers are present, preventing Java NoSuchMethodError runtime exceptions when contentType is set to 'none'.

The bug:
When selecting POST/PUT with Content-type: none and some headers, it would generate a call to the 3-argument version `sendXxxxxRequest(url, headers, timeout)` which doesn't exist for POST/PUT. See https://www.openhab.org/javadoc/latest/org/openhab/core/model/script/actions/http

This is a candidate for backporting

