### PR TITLE
Fix HABot compatibility with OpenNLP 2.5.9

### DIFF
--- a/bundles/org.openhab.ui.habot/src/main/feature/feature.xml
+++ b/bundles/org.openhab.ui.habot/src/main/feature/feature.xml
@@ -9,7 +9,7 @@
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.semantics/${project.version}</bundle>
 		<bundle>mvn:org.openhab.core.bundles/org.openhab.core.io.rest/${project.version}</bundle>
 		<bundle dependency="true">mvn:org.bouncycastle/bcprov-jdk18on/1.83</bundle>
-		<bundle dependency="true">mvn:org.apache.opennlp/opennlp-tools/1.9.3</bundle>
+		<bundle dependency="true">wrap:mvn:org.apache.opennlp/opennlp-tools/2.5.9</bundle>
 		<bundle dependency="true">mvn:org.bitbucket.b_c/jose4j/0.9.6</bundle>
 	</feature>
 </features>

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/nlp/internal/AlphaNumericTokenizer.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/nlp/internal/AlphaNumericTokenizer.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 import opennlp.tools.tokenize.SimpleTokenizer;
+import opennlp.tools.tokenize.Tokenizer;
 import opennlp.tools.util.Span;
 
 /**
@@ -24,7 +25,7 @@ import opennlp.tools.util.Span;
  *
  * @author Yannick Schaus - Initial contribution
  */
-public class AlphaNumericTokenizer extends SimpleTokenizer {
+public class AlphaNumericTokenizer implements Tokenizer {
 
     public static final AlphaNumericTokenizer INSTANCE;
 
@@ -41,8 +42,13 @@ public class AlphaNumericTokenizer extends SimpleTokenizer {
     }
 
     @Override
+    public String[] tokenize(String s) {
+        return Span.spansToStrings(tokenizePos(s), s);
+    }
+
+    @Override
     public Span[] tokenizePos(String s) {
-        Span[] tokens = super.tokenizePos(s);
+        Span[] tokens = SimpleTokenizer.INSTANCE.tokenizePos(s);
         Stream<Span> filteredTokens = Arrays.stream(tokens)
                 .filter(span -> Character.isLetter(span.getCoveredText(s).charAt(0))
                         || Character.isDigit(span.getCoveredText(s).charAt(0)));

--- a/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/nlp/internal/IntentTrainer.java
+++ b/bundles/org.openhab.ui.habot/src/main/java/org/openhab/ui/habot/nlp/internal/IntentTrainer.java
@@ -31,7 +31,6 @@ import opennlp.tools.doccat.DoccatFactory;
 import opennlp.tools.doccat.DoccatModel;
 import opennlp.tools.doccat.DocumentCategorizerME;
 import opennlp.tools.doccat.DocumentSample;
-import opennlp.tools.ml.AbstractTrainer;
 import opennlp.tools.namefind.NameFinderME;
 import opennlp.tools.namefind.NameSample;
 import opennlp.tools.namefind.NameSampleDataStream;
@@ -114,7 +113,6 @@ public class IntentTrainer {
                 .concatenateObjectStream(categoryStreams);
 
         TrainingParameters trainingParams = TrainingParameters.defaultParams();
-        trainingParams.put(AbstractTrainer.VERBOSE_PARAM, false);
 
         /* train the categorizer! */
         DoccatModel doccatModel = DocumentCategorizerME.train(language, combinedDocumentSampleStream, trainingParams,


### PR DESCRIPTION
## Summary

- adapt the HABot tokenizer to the OpenNLP 2.5 singleton API while preserving its alphanumeric filtering behavior
- remove the training verbosity parameter that OpenNLP 2.5 removed
- align the Karaf feature manifest with 2.5.9 and wrap the artifact because the new jar is not an OSGi bundle

## Why

The dependency update in #4178 cannot compile because SimpleTokenizer now has a private constructor and AbstractTrainer.VERBOSE_PARAM no longer exists. After compilation, Karaf also rejects the unwrapped OpenNLP 2.5.9 jar as a feature resource.

## Verification

- JDK 21: reproduced the original compiler failures from the exact Dependabot head
- mvn -B --no-transfer-progress install -pl bundles/org.openhab.ui.habot -DskipTests: BUILD SUCCESS; Spotless checked 53 Java files; analysis reported 0 errors; Karaf verified 1 feature with 0 failures
- mvn -B --no-transfer-progress test -pl bundles/org.openhab.ui.habot -DskipTests=false: 28 tests, 0 failures, 0 errors, 0 skipped
- git diff --check

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
