### PR TITLE
Harden Content-Security-Policy

### DIFF
--- a/bundles/org.openhab.ui/web/index.html
+++ b/bundles/org.openhab.ui/web/index.html
@@ -2,30 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <!--
-  Cordova recommended default CSP. For more guidance, see:
-      https://cordova.apache.org/docs/en/dev/guide/appdev/allowlist/#content-security-policy-csp
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' data: gap: https://ssl.gstatic.com; style-src 'self' 'unsafe-inline'; media-src *">
-  Explanation:
-    * gap: is required only on iOS (when using UIWebView) and is needed for JS->native communication
-           Note that UIWebView is deprecated, see https://developer.apple.com/documentation/uikit/uiwebview
-    * https://ssl.gstatic.com is required only on Android and is needed for TalkBack to function properly
-    * Disables use of eval() and inline scripts in order to mitigate risk of XSS vulnerabilities. To change this:
-        * Enable inline JS: add 'unsafe-inline' to default-src
-        * Enable eval(): add 'unsafe-eval' to default-src
-  -->
-    <!-- Explanation:
-    * allow loading resources from the same origin, inline scripts (required for inline event listeners) and styles, and the use of eval() (required by ECharts)
-    * allow loading fonts from the same origin, and data: URIs
-    * allow loading images from any source, and data: URIs
-    * allow loading media from any source, and data:, blob: and media: URIs
-    * allow embedding (<iframe>) any source
-    * allow connecting (through fetch(), XMLHttpRequest, WebSocket etc.) to the same origin, *.openhab.org, raw.githubusercontent.com (add-on logos etc.), Iconify icon sources, and any source
-    * allows loading web workers from the same origin, and blob: URIs
-  -->
-  <!-- meta tag is inserted in the build process
-  <meta http-equiv="Content-Security-Policy" content="default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; frame-src *; connect-src 'self' *.openhab.org raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *; worker-src 'self' blob:;">
-  -->
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover"

--- a/bundles/org.openhab.ui/web/vite.config.ts
+++ b/bundles/org.openhab.ui/web/vite.config.ts
@@ -48,7 +48,21 @@ export default defineConfig({
             injectTo: 'head-prepend',
             attrs: {
               'http-equiv': 'Content-Security-Policy',
-              content: "default-src 'self' 'unsafe-inline' 'unsafe-eval'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; frame-src *; connect-src 'self' *.openhab.org raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *; worker-src 'self' blob:;"
+              /*
+               * Content-Security Policy Explanation:
+               * - default: allow loading resources from same origin
+               * - scripts: same origin
+               * - styles: same source & inline style (<style> tags and style attributes)
+               * - fonts: same source & data: URIs
+               * - images: any origin & data: URIs
+               * - media: any origin, data:, blob: & media: URIs
+               * - embedding (<iframe> tag): any origin
+               * - connect (fetch, XHR, WebSocket, etc.): same origin, *.openhab.org & raw.githubusercontent.com (add-on logos, READMEs, etc.), Iconify icon sources, and any origin (until we provide a way to set this dynamically)
+               * - web workers: same origin and blob: URIs (required by Video.js)
+               * - objects (browser plugins, Flash, etc.): blocked
+               * - base: only allow same origin to set <base href="...">
+               */
+              content: "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src * data:; media-src * data: blob: media:; frame-src *; connect-src 'self' *.openhab.org raw.githubusercontent.com api.iconify.design api.unisvg.com api.simplesvg.com *; worker-src 'self' blob:; object-src 'none'; base-uri 'self';"
             }
           }
         ]


### PR DESCRIPTION
- Removes default-src 'unsafe-eval' as ECharts finally doesn't need this anymore.
- Removes script-src 'unsafe-inline' (by moving 'unsafe-inline' from default-src to style-src) as this doesn't cause violations anymore.
- Add object-src 'none' to block plugins such as Flash, Java applets, etc.
- Add base-uri 'self' to only allow same origin to set `<base href="...">`