### PR TITLE
fix import.meta.dirname warning

### DIFF
--- a/bundles/org.openhab.ui/web/vite.config.ts
+++ b/bundles/org.openhab.ui/web/vite.config.ts
@@ -8,7 +8,7 @@ import vueDevtools from 'vite-plugin-vue-devtools'
 import { visualizer } from 'rollup-plugin-visualizer'
 import webpackStats from 'rollup-plugin-webpack-stats'
 
-const projectRootDir = resolve(__dirname)
+const projectRootDir = resolve(import.meta.dirname)
 
 const production: boolean = process.env.NODE_ENV === 'production'
 const apiBaseUrl = process.env.OH_APIBASE || 'http://localhost:8080'


### PR DESCRIPTION
address warning in vite build.

(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:11:32). Use `import.meta.dirname` instead