### PR TITLE
Add v-deferred directive to prevent loading flicker

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -62,7 +62,7 @@
     </f7-block>
 
     <!-- skeletons for not ready-->
-    <f7-block v-else class="block-narrow">
+    <f7-block v-else class="block-narrow" v-deferred>
       <f7-col class="skeleton-text skeleton-effect-blink">
         <f7-list inline-labels no-hairlines-md>
           <f7-list-input

--- a/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/channel-link.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!ready" class="loading searchbar-ignore">
+  <div v-if="!ready" class="loading searchbar-ignore" v-deferred>
     <div class="list media-list margin-left searchbar-ignore">
       <ul>
         <li class="item-content skeleton-text searchbar-ignore">

--- a/bundles/org.openhab.ui/web/src/js/directives/vDeferred.ts
+++ b/bundles/org.openhab.ui/web/src/js/directives/vDeferred.ts
@@ -1,0 +1,40 @@
+import type { Directive, DirectiveBinding } from 'vue'
+
+interface DeferredElement extends HTMLElement {
+  __deferredTimer__?: ReturnType<typeof setTimeout>
+}
+
+/**
+ * v-deferred
+ *
+ * Delays the visual rendering of its target DOM element to prevent UI "flicker"
+ * during fast network requests or quick page transitions.
+ *
+ * Note: Must be used with `v-if` or `v-else-if` (not `v-show`) so Vue lifecycle
+ * hooks (`mounted` / `unmounted`) trigger properly to manage the timer.
+ *
+ * @example <f7-col v-if="!ready" v-deferred> ... </f7-col>
+ * @example <f7-col v-if="!ready" v-deferred="300"> ... </f7-col>
+ */
+export const vDeferred: Directive = {
+  mounted(el: DeferredElement, binding: DirectiveBinding<number | undefined>) {
+    const originalVisibility = el.style.visibility
+    el.style.visibility = 'hidden'
+
+    const delay = typeof binding.value === 'number' ? binding.value : 500
+
+    el.__deferredTimer__ = setTimeout(() => {
+      el.style.visibility = originalVisibility
+      delete el.__deferredTimer__
+    }, delay)
+  },
+
+  unmounted(el: DeferredElement) {
+    if (el.__deferredTimer__) {
+      clearTimeout(el.__deferredTimer__)
+      delete el.__deferredTimer__
+    }
+  }
+}
+
+export default vDeferred

--- a/bundles/org.openhab.ui/web/src/main.ts
+++ b/bundles/org.openhab.ui/web/src/main.ts
@@ -7,6 +7,9 @@ import '@/js/monkeypatch'
 // Import Vue
 import { createApp, reactive, type Component } from 'vue'
 
+// Import directives
+import { vDeferred } from '@/js/directives/vDeferred'
+
 // Import globally registered components
 import OhNavContent from '@/components/navigation/oh-nav-content.vue'
 import DeveloperDockIcon from './components/developer/developer-dock-icon.vue'
@@ -76,6 +79,9 @@ app.component('OhIcon', OhIconComponent)
 app.component('GenericWidgetComponent', GenericWidgetComponent)
 app.component('GroupBox', GroupBox)
 registerWidgets(app)
+
+// Register custom directives
+app.directive('deferred', vDeferred)
 
 app.mount('#app')
 performance.mark('app-mounted')

--- a/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addon-details.vue
@@ -65,7 +65,7 @@
               <f7-link @click="descriptionExpanded = true"> more </f7-link>
             </div>
           </f7-block>
-          <f7-block v-else class="skeleton-text skeleton-effect-blink">
+          <f7-block v-else class="skeleton-text skeleton-effect-blink" v-deferred>
             <p>
               Lorem ipsum dolor sit amet, an labore inermis est. Mel ut dicant tamquam commune, duo id accumsan eleifend tractatos, ius
               purto vitae fabulas cu. Te his vide omnis qualisque, in duo soluta persecuti instructior. Ex dicit detraxit voluptaria est.

--- a/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
+++ b/bundles/org.openhab.ui/web/src/pages/addons/addons-store.vue
@@ -61,7 +61,7 @@
         </f7-list-item>
       </f7-list>
     </f7-block>
-    <f7-block v-if="!ready" class="text-align-center padding-top margin-top">
+    <f7-block v-if="!ready" class="text-align-center padding-top margin-top" v-deferred>
       <f7-block-title>
         <f7-preloader :size="30" />
         <div>Loading...</div>

--- a/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/blocks/blocks-list.vue
@@ -49,7 +49,7 @@
 
     <f7-block v-show="!nowidgetEngine" class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-show="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list media-list class="col wide">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/developer/widgets/widget-list.vue
@@ -48,7 +48,7 @@
 
     <f7-block v-show="!nowidgetEngine" class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-show="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list media-list class="col wide">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-orphanlinks.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-orphanlinks.vue
@@ -19,7 +19,7 @@
 
     <f7-block class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list contacts-list class="col">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-persistence.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-persistence.vue
@@ -21,7 +21,7 @@
 
     <f7-block class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list contacts-list class="col">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/health/health-semantics.vue
@@ -24,7 +24,7 @@
 
     <f7-block class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list contacts-list class="col">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/items/items-list-vlist.vue
@@ -58,7 +58,7 @@
       </f7-col>
 
       <!-- skeleton for not ready -->
-      <f7-col v-show="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title class="no-margin-top"> &nbsp;Loading... </f7-block-title>
         <f7-list media-list class="col wide">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/menu/settings-menu.vue
@@ -59,7 +59,7 @@
             </f7-list>
           </group-box>
           <!-- skeleton for not servicesLoaded -->
-          <group-box v-if="!servicesLoaded" :title="$t('settings.groups.system-settings')">
+          <group-box v-if="!servicesLoaded" :title="$t('settings.groups.system-settings')" v-deferred>
             <f7-list>
               <f7-list-item v-for="n in 9" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
             </f7-list>
@@ -73,7 +73,7 @@
               :expanded="expandedTypes.addonsExpanded"
               @expand="expand('addonsExpanded')" />
             <!-- skeleton for not addonsLoaded -->
-            <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')">
+            <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')" v-deferred>
               <f7-list>
                 <f7-list-item v-for="n in 4" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
               </f7-list>
@@ -88,7 +88,7 @@
             :expanded="expandedTypes.addonsExpanded"
             @expand="expand('addonsExpanded')" />
           <!-- skeleton for not addonsLoaded -->
-          <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')">
+          <group-box v-if="!addonsLoaded" :title="$t('settings.groups.addon-settings')" v-deferred>
             <f7-list>
               <f7-list-item v-for="n in 9" :key="n" :class="`skeleton-text skeleton-effect-blink`" title="Service Label" />
             </f7-list>

--- a/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/model/model.vue
@@ -67,7 +67,7 @@
       <f7-link class="right details-link padding-right" ref="detailsLink" @click="detailsOpened = true" icon-f7="chevron_up" />
     </f7-toolbar>
 
-    <f7-block v-if="!ready" class="text-align-center">
+    <f7-block v-if="!ready" class="text-align-center" v-deferred>
       <f7-preloader />
       <div>Loading...</div>
     </f7-block>

--- a/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/pages/pages-list.vue
@@ -57,7 +57,7 @@
 
     <f7-block class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list v-if="!ready" contacts-list class="col wide pages-list">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rule-edit.vue
@@ -72,7 +72,8 @@
         <f7-block
           v-else-if="!createMode && !stubMode"
           class="block-narrow padding-left padding-right skeleton-text skeleton-effect-blink"
-          strong>
+          strong
+          v-deferred>
           <f7-col>
             ______:
             <f7-chip class="margin-left" text="________" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/rules-list.vue
@@ -131,7 +131,7 @@
       title="rules.missingengine.title"
       text="rules.missingengine.text" />
     <!-- rule engine available but not yet ready -->
-    <f7-block v-else-if="!noRuleEngine && !ready" class="block-narrow">
+    <f7-block v-else-if="!noRuleEngine && !ready" class="block-narrow" v-deferred>
       <f7-col v-show="!ready">
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list contacts-list class="col rules-list">

--- a/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/rules/scene/scene-edit.vue
@@ -48,7 +48,11 @@
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
-        <f7-block v-else-if="!createMode" class="block-narrow padding-left padding-right skeleton-text skeleton-effect-blink" strong>
+        <f7-block
+          v-else-if="!createMode"
+          class="block-narrow padding-left padding-right skeleton-text skeleton-effect-blink"
+          strong
+          v-deferred>
           <f7-col>
             ______:
             <f7-chip class="margin-left" text="________" />

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-binding.vue
@@ -23,7 +23,7 @@
     <f7-block class="block-narrow">
       <f7-col>
         <group-box title="Installed Bindings">
-          <f7-list v-if="!ready" class="col">
+          <f7-list v-if="!ready" class="col" v-deferred>
             <f7-list-group>
               <f7-list-item
                 v-for="n in 10"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/choose-thing-type.vue
@@ -55,7 +55,7 @@
 
         <group-box title="Add Manually">
           <f7-list class="thing-type-list">
-            <ul v-if="!ready">
+            <ul v-if="!ready" v-deferred>
               <f7-list-item
                 v-for="n in 10"
                 :key="n"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/add/thing-add.vue
@@ -20,7 +20,7 @@
       </f7-col>
     </f7-block>
     <!-- skeletons for not ready -->
-    <f7-block v-else class="block-narrow skeleton-text skeleton-effect-blink">
+    <f7-block v-else class="block-narrow skeleton-text skeleton-effect-blink" v-deferred>
       <thing-general-settings :thing="thing" :thing-type="thingType" :createMode="true" :ready="false" />
       <f7-col>
         <f7-block-title>____ _______</f7-block-title>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -143,7 +143,7 @@
           </template>
 
           <!-- skeleton for not ready -->
-          <f7-list v-if="!ready" contacts-list class="col inbox-list">
+          <f7-list v-if="!ready" contacts-list class="col inbox-list" v-deferred>
             <f7-list-group>
               <f7-list-item
                 v-for="n in 10"

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/thing-details.vue
@@ -56,7 +56,7 @@
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
-        <f7-block v-else class="block-narrow skeleton-text skeleton-effect-blink" strong>
+        <f7-block v-else class="block-narrow skeleton-text skeleton-effect-blink" strong v-deferred>
           <f7-col class="padding-horizontal">
             ______:
             <f7-chip class="margin-left" text="________" />
@@ -220,7 +220,7 @@
           </f7-col>
         </f7-block>
         <!-- skeletons for not ready -->
-        <f7-block v-else-if="!error" class="block-narrow skeleton-text skeleton-effect-blink">
+        <f7-block v-else-if="!error" class="block-narrow skeleton-text skeleton-effect-blink" v-deferred>
           <f7-col>
             <thing-general-settings :thing="{}" :thing-type="{}" :ready="false" />
             <f7-block-title medium> ____ _______ </f7-block-title>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/things-list.vue
@@ -101,7 +101,7 @@
         <list-filter v-if="ready" ref="filters" :filters="filters" @toggled="updateFilteredItems" @reset="updateFilteredItems" />
       </f7-col>
       <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list contacts-list class="col things-list">
           <f7-list-group>

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformations-list.vue
@@ -46,7 +46,7 @@
 
     <f7-block class="block-narrow">
       <!-- skeleton for not ready -->
-      <f7-col v-if="!ready">
+      <f7-col v-if="!ready" v-deferred>
         <f7-block-title>&nbsp;Loading...</f7-block-title>
         <f7-list contacts-list class="col transformations-list">
           <f7-list-group>


### PR DESCRIPTION
## Description

This PR introduces a lightweight, non-intrusive Vue 3 directive `v-deferred` (`src/js/directives/vDeferred.ts`) to eliminate UI preloader flicker during fast page transitions and API calls.

### Problem

When fast network requests or page initializations complete within a few milliseconds, loading indicators (skeletons, spinners) briefly flash on screen before disappearing, causing uncomfortable visual flicker. This is most noticeable in items-list and addons store (now that it actually loads fast), and to a lesser extent in rules/scenes/scripts list, things list, etc.

### Solution

The `v-deferred` directive delays showing the loading element visually for a configurable threshold (defaulting to 500ms):
- Fast responses (<500ms): Preloader remains hidden, content appears smoothly with zero flicker.
- Slow responses (>500ms): Preloader becomes visible to provide necessary loading feedback.
- Automatically cleans up active timers on `unmounted` to prevent memory leaks.

### Tests

- [x] Tested with `v-if` on loading skeletons in page components (e.g., `<f7-col v-if="!ready" v-deferred>`).
- [x] Verified fast state changes resolve cleanly without preloader flicker or console warnings across tested pages.
- [x] Verified loading indicators correctly appear after the delay on simulated slow network connections.

## Usage

```vue
<f7-col v-if="!ready" v-deferred>
  <f7-block-title>&nbsp;Loading...</f7-block-title>
</f7-col>
```