### PR TITLE
group-box: Fix console error when title isn't used

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/util/group-box.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/group-box.vue
@@ -233,7 +233,7 @@ import { f7 } from 'framework7-vue'
 
 const props = withDefaults(
   defineProps<{
-    title: string
+    title?: string
     description?: string
     accordion?: boolean
     accordionOpened?: boolean


### PR DESCRIPTION
Title was meant to be optional. This fixes an error where title wasn't used, e.g. in `tag-input.vue` or in button wrappers at the bottom of some pages.

<img width="824" height="194" alt="image" src="https://github.com/user-attachments/assets/a98cd9ca-3ed9-4124-b594-bd82d4d6ae4d" />
