### PR TITLE
Parameter Text: Fix "Show Password" icon layout

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
+++ b/bundles/org.openhab.ui/web/src/components/config/controls/parameter-text.vue
@@ -52,8 +52,8 @@
       :readonly="readOnly || configDescription.readOnly"
       :type="controlType">
       <template #content-end>
-        <div v-if="configDescription.context === 'password'" class="padding-left">
-          <f7-link class="margin" color="gray" @click="showPassword = !showPassword">
+        <div v-if="configDescription.context === 'password'" class="password-toggle-wrapper">
+          <f7-link color="gray" @click="showPassword = !showPassword">
             <f7-icon size="20" :f7="showPassword ? 'eye_slash_fill' : 'eye_fill'" />
           </f7-link>
         </div>
@@ -85,6 +85,14 @@
   .network-address-text
     &:hover
       cursor pointer
+
+  :deep(.item-content)
+    align-items flex-start !important
+  .password-toggle-wrapper
+    display flex
+    align-items center
+    padding-right 16px
+    margin-top 18px
 </style>
 
 <script>


### PR DESCRIPTION
From:

<img width="732" height="125" alt="image" src="https://github.com/user-attachments/assets/ce596986-38a0-42ec-a710-b4279fe176ce" />

---

To:

<img width="737" height="126" alt="image" src="https://github.com/user-attachments/assets/1371d9e5-e8f2-46e2-ab22-4e8c900f7115" />
