### PR TITLE
Channel Details: Wrap long Channel UID

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -24,14 +24,7 @@
               @click="$oh.utils.normalizeInput('#input')" />
           </template>
         </f7-list-input>
-        <f7-list-input v-else label="Name" type="text" class="uid-list-input" :input="false">
-          <template #input>
-            <span>
-              {{ item.name }}
-              <clipboard-icon v-if="item.name" :value="item.name" tooltip="Copy UID" />
-            </span>
-          </template>
-        </f7-list-input>
+        <wrapped-list-output v-else label="Name" :value="item.name" clipboard />
         <f7-list-input
           label="Label"
           type="text"
@@ -195,7 +188,7 @@
 <script>
 import { f7 } from 'framework7-vue'
 
-import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+import WrappedListOutput from '@/components/util/wrapped-list-output.vue'
 import SemanticsPicker from '@/components/tags/semantics-picker.vue'
 import ItemPicker from '@/components/config/controls/item-picker.vue'
 import GroupForm from '@/components/item/group-form.vue'
@@ -220,7 +213,7 @@ export default {
     stateDescription: String
   },
   components: {
-    ClipboardIcon,
+    WrappedListOutput,
     SemanticsPicker,
     ItemPicker,
     GroupForm,

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -26,13 +26,14 @@
         </f7-list-input>
         <wrapped-list-output v-else label="Name" :value="item.name" clipboard />
         <f7-list-input
+          v-if="editable"
           label="Label"
           type="text"
           placeholder="Item label for display purposes"
           :value="item.label"
           @input="updateLabel"
-          :disabled="!editable ? true : null"
-          :clear-button="editable" />
+          clear-button />
+        <wrapped-list-output v-else label="Label" :value="item.label" />
       </f7-list-group>
       <f7-list-group v-if="!hideType" v-show="itemType">
         <!-- Type -->

--- a/bundles/org.openhab.ui/web/src/components/item/item-form.vue
+++ b/bundles/org.openhab.ui/web/src/components/item/item-form.vue
@@ -24,7 +24,7 @@
               @click="$oh.utils.normalizeInput('#input')" />
           </template>
         </f7-list-input>
-        <f7-list-input v-else label="Name" type="text" class="uuid-list-input" :input="false">
+        <f7-list-input v-else label="Name" type="text" class="uid-list-input" :input="false">
           <template #input>
             <span>
               {{ item.name }}

--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -27,7 +27,7 @@
                   @click="normalizeUid()" />
               </template>
             </f7-list-input>
-            <f7-list-input v-else label="Rule UID" type="text" class="uuid-list-input" :input="false">
+            <f7-list-input v-else label="Rule UID" type="text" class="uid-list-input" :input="false">
               <template #input>
                 <span>
                   {{ rule.uid }}

--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -4,56 +4,53 @@
       <f7-col>
         <group-box title="Rule Properties">
           <f7-list inline-labels no-hairlines-md>
-            <f7-list-input
-              v-if="createMode"
-              :label="`${type} UID`"
-              type="text"
-              :placeholder="`A unique identifier for the ${type.toLowerCase()}`"
-              :value="rule.uid || ''"
-              required
-              :validate="editable"
-              info="Required. Note: cannot be changed after the creation"
-              input-id="input"
-              :pattern="uidPattern"
-              error-message="Invalid rule UID. It can't contain '/', '\' or have leading or trailing whitespace"
-              @input="rule.uid = $event.target.value || undefined"
-              clear-button>
-              <template #inner>
-                <f7-link
-                  v-if="createMode && !uidValid"
-                  icon-f7="hammer_fill"
-                  style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-                  tooltip="Fix UID"
-                  @click="normalizeUid()" />
-              </template>
-            </f7-list-input>
-            <f7-list-input v-else label="Rule UID" type="text" class="uid-list-input" :input="false">
-              <template #input>
-                <span>
-                  {{ rule.uid }}
-                  <clipboard-icon :value="rule.uid" tooltip="Copy UID" />
-                </span>
-              </template>
-            </f7-list-input>
-            <f7-list-input v-if="!createMode && templateName" label="Template" type="text" :value="templateName" disabled />
-            <f7-list-input
-              label="Label"
-              type="text"
-              :placeholder="`${type} label for display purposes`"
-              :info="createMode ? 'Required' : ''"
-              :value="rule.name || ''"
-              required
-              validate
-              :disabled="!editable ? true : null"
-              @input="rule.name = $event.target.value || undefined"
-              :clear-button="editable" />
-            <f7-list-input
-              label="Description"
-              type="text"
-              :value="rule.description || ''"
-              :disabled="!editable ? true : null"
-              @input="rule.description = $event.target.value || undefined"
-              :clear-button="editable" />
+            <f7-list-group>
+              <f7-list-input
+                v-if="createMode"
+                :label="`${type} UID`"
+                type="text"
+                :placeholder="`A unique identifier for the ${type.toLowerCase()}`"
+                :value="rule.uid || ''"
+                required
+                :validate="editable"
+                info="Required. Note: cannot be changed after the creation"
+                input-id="input"
+                :pattern="uidPattern"
+                error-message="Invalid rule UID. It can't contain '/', '\' or have leading or trailing whitespace"
+                @input="rule.uid = $event.target.value || undefined"
+                clear-button>
+                <template #inner>
+                  <f7-link
+                    v-if="createMode && !uidValid"
+                    icon-f7="hammer_fill"
+                    style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+                    tooltip="Fix UID"
+                    @click="normalizeUid()" />
+                </template>
+              </f7-list-input>
+              <wrapped-list-output v-else label="Rule UID" :value="rule.uid" clipboard />
+              <f7-list-input v-if="!createMode && templateName" label="Template" type="text" :value="templateName" disabled />
+              <f7-list-input
+                v-if="editable"
+                label="Label"
+                type="text"
+                :placeholder="`${type} label for display purposes`"
+                :info="createMode ? 'Required' : ''"
+                :value="rule.name || ''"
+                required
+                validate
+                @input="rule.name = $event.target.value || undefined"
+                clear-button />
+              <wrapped-list-output v-else label="Label" :value="rule.name" />
+              <f7-list-input
+                v-if="editable"
+                label="Description"
+                type="text"
+                :value="rule.description || ''"
+                @input="rule.description = $event.target.value || undefined"
+                clear-button />
+              <wrapped-list-output v-else label="Description" :value="rule.description" />
+            </f7-list-group>
           </f7-list>
         </group-box>
         <tag-input
@@ -105,7 +102,7 @@
 import TagInput from '@/components/tags/tag-input.vue'
 import { RULE_UID_PATTERN } from '@/js/openhab/uid.ts'
 import NotEditableNotice from '@/components/util/not-editable-notice.vue'
-import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+import WrappedListOutput from '@/components/util/wrapped-list-output.vue'
 
 const UID_REGEX = new RegExp('^' + RULE_UID_PATTERN + '$')
 
@@ -123,7 +120,7 @@ export default {
   components: {
     TagInput,
     NotEditableNotice,
-    ClipboardIcon
+    WrappedListOutput
   },
   data() {
     return {

--- a/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/rule/rule-general-settings.vue
@@ -15,9 +15,11 @@
               :disabled="!createMode ? true : null"
               :info="createMode ? 'Required. Note: cannot be changed after the creation' : ''"
               input-id="input"
+              :input="editable"
               :pattern="uidPattern"
               error-message="Invalid rule UID. It can't contain '/', '\' or have leading or trailing whitespace"
               @input="rule.uid = $event.target.value || undefined"
+              class="wrap-text"
               :clear-button="createMode">
               <template #inner>
                 <f7-link
@@ -26,6 +28,9 @@
                   style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
                   tooltip="Fix UID"
                   @click="normalizeUid()" />
+              </template>
+              <template v-if="!editable" #input>
+                  {{ rule.uid }}
               </template>
             </f7-list-input>
             <f7-list-input v-if="!createMode && templateName" label="Template" type="text" :value="templateName" disabled />

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -6,53 +6,52 @@
           <f7-col>
             <group-box title="Thing Details">
               <f7-list inline-labels no-hairlines-md class="no-margin">
-                <f7-list-input
-                  v-if="createMode"
-                  label="Thing ID"
-                  type="text"
-                  placeholder="Required"
-                  :value="thing.ID"
-                  input-id="input"
-                  @input="changeUID"
-                  info="Note: cannot be changed after the creation"
-                  clear-button
-                  required
-                  :error-message="idErrorMessage"
-                  :error-message-force="!!idErrorMessage">
-                  <template #inner>
-                    <f7-link
-                      v-if="idErrorMessage && !idErrorMessage.includes('exists') && thing.ID"
-                      icon-f7="hammer_fill"
-                      style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-                      tooltip="Fix ID"
-                      @click="$oh.utils.normalizeInputForThingId('#input')" />
-                  </template>
-                </f7-list-input>
-                <f7-list-input v-else label="Thing UID" type="text" class="uid-list-input" :input="false">
-                  <template #input>
-                    <span>
-                      {{ thing.UID }}
-                      <clipboard-icon v-if="thing.UID && ready" :value="thing.UID" tooltip="Copy UID" />
-                    </span>
-                  </template>
-                </f7-list-input>
-                <f7-list-input
-                  label="Label"
-                  type="text"
-                  :disabled="!ready || readOnly ? true : null"
-                  placeholder="e.g. My Thing"
-                  :value="thing.label"
-                  @input="thing.label = $event.target.value"
-                  required
-                  validate />
-                <f7-list-input
-                  label="Location"
-                  type="text"
-                  :disabled="!ready || readOnly ? true : null"
-                  placeholder="e.g. Kitchen"
-                  :value="thing.location"
-                  @input="thing.location = $event.target.value"
-                  :clear-button="ready && !readOnly" />
+                <f7-list-group>
+                  <f7-list-input
+                    v-if="createMode"
+                    label="Thing ID"
+                    type="text"
+                    placeholder="Required"
+                    :value="thing.ID"
+                    input-id="input"
+                    @input="changeUID"
+                    info="Note: cannot be changed after the creation"
+                    clear-button
+                    required
+                    :error-message="idErrorMessage"
+                    :error-message-force="!!idErrorMessage">
+                    <template #inner>
+                      <f7-link
+                        v-if="idErrorMessage && !idErrorMessage.includes('exists') && thing.ID"
+                        icon-f7="hammer_fill"
+                        style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+                        tooltip="Fix ID"
+                        @click="$oh.utils.normalizeInputForThingId('#input')" />
+                    </template>
+                  </f7-list-input>
+                  <wrapped-list-output v-else label="Thing UID" :value="thing.UID" clipboard />
+                  <f7-list-input
+                    v-if="!readOnly"
+                    label="Label"
+                    type="text"
+                    :disabled="!ready ? true : null"
+                    placeholder="e.g. My Thing"
+                    :value="thing.label"
+                    @input="thing.label = $event.target.value"
+                    required
+                    validate />
+                  <wrapped-list-output v-else label="Label" :value="thing.label" />
+                  <f7-list-input
+                    v-if="!readOnly"
+                    label="Location"
+                    type="text"
+                    :disabled="!ready ? true : null"
+                    placeholder="e.g. Kitchen"
+                    :value="thing.location"
+                    @input="thing.location = $event.target.value"
+                    clear-button />
+                  <wrapped-list-output v-else label="Location" :value="thing.location" />
+                </f7-list-group>
               </f7-list>
             </group-box>
             <group-box
@@ -81,7 +80,7 @@
 
 <script>
 import ThingPicker from '@/components/config/controls/thing-picker.vue'
-import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+import WrappedListOutput from '@/components/util/wrapped-list-output.vue'
 import ThingMixin from '@/components/thing/thing-mixin'
 
 export default {
@@ -96,7 +95,7 @@ export default {
   },
   components: {
     ThingPicker,
-    ClipboardIcon
+    WrappedListOutput
   },
   computed: {
     editable() {

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -28,7 +28,7 @@
                       @click="$oh.utils.normalizeInputForThingId('#input')" />
                   </template>
                 </f7-list-input>
-                <f7-list-input label="Thing UID" type="text" :input="false" disabled>
+                <f7-list-input label="Thing UID" type="text" class="wrap-text" :input="false" disabled>
                   <template #input>
                     <span>
                       {{ thing.UID }}

--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -28,7 +28,7 @@
                       @click="$oh.utils.normalizeInputForThingId('#input')" />
                   </template>
                 </f7-list-input>
-                <f7-list-input v-else label="Thing UID" type="text" class="uuid-list-input" :input="false">
+                <f7-list-input v-else label="Thing UID" type="text" class="uid-list-input" :input="false">
                   <template #input>
                     <span>
                       {{ thing.UID }}

--- a/bundles/org.openhab.ui/web/src/components/util/wrapped-list-output.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/wrapped-list-output.vue
@@ -1,0 +1,53 @@
+<!--
+  NOTE: This component must be wrapped inside an <f7-list-group>
+  to prevent Framework7's list parser from crashing on custom components.
+-->
+<template>
+  <f7-list-input class="wrapped-list-output" type="text" :input="false" v-bind="$attrs">
+    <template #input>
+      <span class="text-content">
+        {{ value }}
+        <clipboard-icon v-if="clipboard && value" :value="value" :tooltip="tooltip" class="copy-icon" />
+      </span>
+    </template>
+  </f7-list-input>
+</template>
+
+<style lang="stylus" scoped>
+.wrapped-list-output
+  height auto !important
+
+  :deep(.item-content), :deep(.item-input-wrap)
+    align-items flex-start !important
+    height auto !important
+
+  :deep(.item-title.item-label)
+    align-self flex-start !important
+
+  .text-content
+    white-space normal !important
+    word-break break-all !important
+    display inline-flex
+    gap 8px
+
+    .copy-icon
+      margin-top 5px
+      pointer-events initial !important
+</style>
+
+<script setup lang="ts">
+import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+
+withDefaults(
+  defineProps<{
+    value?: string
+    clipboard?: boolean
+    tooltip?: string
+  }>(),
+  {
+    value: '',
+    clipboard: false,
+    tooltip: 'Copy'
+  }
+)
+</script>

--- a/bundles/org.openhab.ui/web/src/components/util/wrapped-list-output.vue
+++ b/bundles/org.openhab.ui/web/src/components/util/wrapped-list-output.vue
@@ -32,7 +32,6 @@
 
     .copy-icon
       margin-top 5px
-      pointer-events initial !important
 </style>
 
 <script setup lang="ts">

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -581,7 +581,7 @@ html
 .toast .toast-content
   justify-content:  center
 
-.list ul li.uuid-list-input .item-input-wrap
-    white-space normal
-    word-break break-all
+.list ul li.uid-list-input .item-input-wrap
+    white-space normal !important
+    word-break break-all !important
 

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -581,7 +581,3 @@ html
 .toast .toast-content
   justify-content:  center
 
-.list ul li.uid-list-input .item-input-wrap
-    white-space normal !important
-    word-break break-all !important
-

--- a/bundles/org.openhab.ui/web/src/css/app.styl
+++ b/bundles/org.openhab.ui/web/src/css/app.styl
@@ -581,3 +581,7 @@ html
 .toast .toast-content
   justify-content:  center
 
+.list ul li.uuid-list-input .item-input-wrap
+    white-space normal
+    word-break break-all
+

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-edit.vue
@@ -16,7 +16,7 @@
           :channel="channel"
           :channelType="channelType"
           :createMode="false"
-          :disabled="!thing.editable ? true : null" />
+          :read-only="!thing.editable ? true : null" />
       </f7-col>
       <f7-col v-if="channelType != null">
         <group-box v-if="!configDescription.parameters || noConfig" title="Configuration">

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -3,57 +3,55 @@
     <f7-col>
       <group-box :title="createMode ? 'Create Channel' : 'Channel Details'">
         <f7-list class="no-margin" inline-labels no-hairlines-md>
-          <f7-list-input
-            v-if="createMode"
-            ref="channelId"
-            label="Channel ID"
-            type="text"
-            placeholder="A unique identifier for the channel"
-            :value="channel.id"
-            info="Required. Note: cannot be changed after the creation"
-            input-id="input"
-            required
-            validate
-            pattern="[A-Za-z0-9_][A-Za-z0-9_\-]*"
-            error-message="Required. Must not start with a dash. A-Z,a-z,0-9,_,- only"
-            @input="channel.id = $event.target.value">
-            <template #inner>
-              <f7-link
-                v-if="$refs.channelId?.state?.inputInvalid && channel.id.trim()"
-                icon-f7="hammer_fill"
-                style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
-                tooltip="Fix ID"
-                @click="$oh.utils.normalizeInputForThingId('#input')" />
-            </template>
-          </f7-list-input>
-          <f7-list-input v-else label="Channel UID" type="text" class="uid-list-input" :input="false">
-            <template #input>
-              <span>
-                {{ channel.uid }}
-                <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
-              </span>
-            </template>
-          </f7-list-input>
+          <f7-list-group>
+            <f7-list-input
+              v-if="createMode"
+              ref="channelId"
+              label="Channel ID"
+              type="text"
+              placeholder="A unique identifier for the channel"
+              :value="channel.id"
+              info="Required. Note: cannot be changed after the creation"
+              input-id="input"
+              required
+              validate
+              pattern="[A-Za-z0-9_][A-Za-z0-9_\-]*"
+              error-message="Required. Must not start with a dash. A-Z,a-z,0-9,_,- only"
+              @input="channel.id = $event.target.value">
+              <template #inner>
+                <f7-link
+                  v-if="$refs.channelId?.state?.inputInvalid && channel.id.trim()"
+                  icon-f7="hammer_fill"
+                  style="margin-top: 4px; margin-left: 4px; margin-bottom: auto"
+                  tooltip="Fix ID"
+                  @click="$oh.utils.normalizeInputForThingId('#input')" />
+              </template>
+            </f7-list-input>
+            <wrapped-list-output v-else label="Channel UID" :value="channel.uid" clipboard />
 
-          <f7-list-input
-            label="Label"
-            type="text"
-            :disabled="disabled ? true : null"
-            :placeholder="channelType !== null ? channelType.label : 'Channel label for display purposes'"
-            :value="channel.label"
-            required
-            validate
-            :info="createMode ? 'Required.' : ''"
-            @input="channel.label = $event.target.value"
-            :clear-button="disabled !== true" />
-          <f7-list-input
-            label="Description"
-            type="text"
-            :disabled="disabled ? true : null"
-            :placeholder="channelType !== null ? channelType.description : ''"
-            :value="channel.description"
-            @input="channel.description = $event.target.value"
-            :clear-button="disabled !== true" />
+            <f7-list-input
+              v-if="!readOnly"
+              label="Label"
+              type="text"
+              :placeholder="channelType !== null ? channelType.label : 'Channel label for display purposes'"
+              :value="channel.label"
+              required
+              validate
+              :info="createMode ? 'Required.' : ''"
+              @input="channel.label = $event.target.value"
+              clear-button />
+            <wrapped-list-output v-else label="Label" :value="channel.label" />
+            <f7-list-input
+              v-if="!readOnly"
+              label="Description"
+              type="text"
+              :placeholder="channelType !== null ? channelType.description : ''"
+              :value="channel.description"
+              @input="channel.description = $event.target.value"
+              clear-button />
+            <wrapped-list-output v-else label="Description" :value="channel.description" />
+          </f7-list-group>
+
           <f7-list-item
             v-if="channel.properties && Object.keys(channel.properties).length > 0"
             accordion-item
@@ -94,16 +92,17 @@
 </style>
 
 <script>
-import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+import WrappedListOutput from '@/components/util/wrapped-list-output.vue'
+
 export default {
   props: {
     channel: Object,
     channelType: Object,
     createMode: Boolean,
-    disabled: Boolean
+    readOnly: Boolean
   },
   components: {
-    ClipboardIcon
+    WrappedListOutput
   }
 }
 </script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -26,14 +26,15 @@
                 @click="$oh.utils.normalizeInputForThingId('#input')" />
             </template>
           </f7-list-input>
-          <f7-list-input v-else media-item label="Channel UID" class="wrap-uid-input" type="text" :input="false">
+          <f7-list-input v-else label="Channel UID" type="text" class="uuid-list-input" :input="false">
             <template #input>
-              <span class="uid-text">
+              <span>
                 {{ channel.uid }}
-                <clipboard-icon :value="channel.uid" tooltip="Copy UID" class="uid-copy-icon" />
+                <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
               </span>
             </template>
           </f7-list-input>
+
           <f7-list-input
             label="Label"
             type="text"
@@ -90,26 +91,6 @@
   .property-key
     display inline-block
     padding-left 12px
-
-  .wrap-uid-input
-    height auto !important
-
-    :deep(.item-content), :deep(.item-input-wrap)
-      align-items flex-start !important
-      height auto !important
-
-    :deep(.item-title.item-label)
-      align-self flex-start !important
-
-    .uid-text
-      white-space normal !important
-      word-break break-all !important
-      display inline-flex
-      gap 8px
-
-      .uid-copy-icon
-        margin-top 5px
-        pointer-events initial !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -26,7 +26,7 @@
                 @click="$oh.utils.normalizeInputForThingId('#input')" />
             </template>
           </f7-list-input>
-          <f7-list-input v-else label="Channel UID" type="text" class="uuid-list-input" :input="false">
+          <f7-list-input v-else label="Channel UID" type="text" class="uid-list-input" :input="false">
             <template #input>
               <span>
                 {{ channel.uid }}

--- a/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/channel/channel-general-settings.vue
@@ -26,15 +26,14 @@
                 @click="$oh.utils.normalizeInputForThingId('#input')" />
             </template>
           </f7-list-input>
-          <f7-list-item v-if="!createMode" media-item class="channel-item" title="Channel UID">
-            <template #subtitle>
-              <div>
+          <f7-list-input v-else media-item label="Channel UID" class="wrap-uid-input" type="text" :input="false">
+            <template #input>
+              <span class="uid-text">
                 {{ channel.uid }}
-                <clipboard-icon :value="channel.uid" tooltip="Copy UID" />
-              </div>
+                <clipboard-icon :value="channel.uid" tooltip="Copy UID" class="uid-copy-icon" />
+              </span>
             </template>
-          </f7-list-item>
-
+          </f7-list-input>
           <f7-list-input
             label="Label"
             type="text"
@@ -91,6 +90,26 @@
   .property-key
     display inline-block
     padding-left 12px
+
+  .wrap-uid-input
+    height auto !important
+
+    :deep(.item-content), :deep(.item-input-wrap)
+      align-items flex-start !important
+      height auto !important
+
+    :deep(.item-title.item-label)
+      align-self flex-start !important
+
+    .uid-text
+      white-space normal !important
+      word-break break-all !important
+      display inline-flex
+      gap 8px
+
+      .uid-copy-icon
+        margin-top 5px
+        pointer-events initial !important
 </style>
 
 <script>

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-general-settings.vue
@@ -15,7 +15,7 @@
           info="Note: cannot be changed after the creation"
           @input="transformation.uid = $event.target.value"
           clear-button />
-        <f7-list-input v-else label="Transformation UID" type="text" :input="false" class="uuid-list-input">
+        <f7-list-input v-else label="Transformation UID" type="text" :input="false" class="uid-list-input">
           <template #input>
             <span>
               {{ transformation.uid }}

--- a/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/transformations/transformation-general-settings.vue
@@ -2,46 +2,42 @@
   <f7-block class="block-narrow">
     <f7-col>
       <f7-list class="no-margin" inline-labels no-hairlines-md>
-        <f7-list-input
-          v-if="createMode"
-          label="Transformation ID"
-          type="text"
-          placeholder="Required"
-          :value="transformation.uid"
-          required
-          validate
-          pattern="[A-Za-z0-9_]+"
-          error-message="Required. A-Z,a-z,0-9,_ only"
-          info="Note: cannot be changed after the creation"
-          @input="transformation.uid = $event.target.value"
-          clear-button />
-        <f7-list-input v-else label="Transformation UID" type="text" :input="false" class="uid-list-input">
-          <template #input>
-            <span>
-              {{ transformation.uid }}
-              <clipboard-icon :value="transformation.uid" tooltip="Copy UID" />
-            </span>
-          </template>
-        </f7-list-input>
-        <f7-list-input
-          label="Label"
-          type="text"
-          placeholder="Tranformation label for display purposes"
-          :info="createMode ? 'Required' : ''"
-          :value="transformation.label"
-          required
-          validate
-          :disabled="!transformation.editable ? true : null"
-          @input="transformation.label = $event.target.value"
-          :clear-button="createMode || transformation.editable" />
-        <f7-list-item v-if="createMode && languages" title="Language" smart-select :smart-select-params="smartSelectParams">
-          <select name="language" @change="$emit('new-language', $event.target.value)">
-            <option value="" selected />
-            <option v-for="lang in languages" :selected="language ? true : null" :value="lang.value" :key="lang.value">
-              {{ lang.label }}
-            </option>
-          </select>
-        </f7-list-item>
+        <f7-list-group>
+          <f7-list-input
+            v-if="createMode"
+            label="Transformation ID"
+            type="text"
+            placeholder="Required"
+            :value="transformation.uid"
+            required
+            validate
+            pattern="[A-Za-z0-9_]+"
+            error-message="Required. A-Z,a-z,0-9,_ only"
+            info="Note: cannot be changed after the creation"
+            @input="transformation.uid = $event.target.value"
+            clear-button />
+          <wrapped-list-output v-else label="Transformation UID" :value="transformation.uid" clipboard />
+          <f7-list-input
+            v-if="transformation.editable"
+            label="Label"
+            type="text"
+            placeholder="Tranformation label for display purposes"
+            :info="createMode ? 'Required' : ''"
+            :value="transformation.label"
+            required
+            validate
+            @input="transformation.label = $event.target.value"
+            clear-button />
+          <wrapped-list-output v-else label="Label" :value="transformation.label" />
+          <f7-list-item v-if="createMode && languages" title="Language" smart-select :smart-select-params="smartSelectParams">
+            <select name="language" @change="$emit('new-language', $event.target.value)">
+              <option value="" selected />
+              <option v-for="lang in languages" :selected="language ? true : null" :value="lang.value" :key="lang.value">
+                {{ lang.label }}
+              </option>
+            </select>
+          </f7-list-item>
+        </f7-list-group>
       </f7-list>
     </f7-col>
     <f7-col v-if="createMode && types">
@@ -65,10 +61,10 @@
 <script>
 import { theme } from 'framework7-vue'
 
-import ClipboardIcon from '@/components/util/clipboard-icon.vue'
+import WrappedListOutput from '@/components/util/wrapped-list-output.vue'
 
 export default {
-  components: { ClipboardIcon },
+  components: { WrappedListOutput },
   props: {
     transformation: Object,
     createMode: Boolean,


### PR DESCRIPTION

## Summary
- Replaces `f7-list-input` (with input box) with a static display component for read‑only fields.
- The new static display:
  - Wraps long text (e.g., long UIDs, labels, descriptions).
  - Supports an optional “copy UID” icon.
  - Provides a consistent, centralized implementation across pages.
- Editable fields continue using the original `f7-list-input`.
- The component is now used for:
  - UID
  - Label
  - Description
- This approach removes duplicated styling logic and avoids global CSS overrides.

Forms affected:
- Item form
- Thing general settings
- Channel general settings
- Rule
- Transformation

## Motivation
Long UIDs and labels were previously truncated or clipped, making them difficult to read.  
This PR introduces a reusable component that ensures proper wrapping and consistent styling everywhere these read‑only fields appear.  
It also lays the groundwork for future refactoring of other pages that need similar treatment.

## Additional Notes
- This resolves the wrapping issues noted in #4491 (except navbar title, to be addressed separately).  
- The component avoids unnecessary global CSS bloat and keeps the implementation DRY.  
- The optional clipboard icon is integrated cleanly, with redundant styling removed.






Before:

<img width="762" height="236" alt="image" src="https://github.com/user-attachments/assets/9d1ea900-dc2a-4124-8c4c-12fe4f59ed6a" />

--- 

After

<img width="762" height="223" alt="image" src="https://github.com/user-attachments/assets/2d9541eb-d275-4d02-a965-e447390171a5" />
