### PR TITLE
Inbox List: Fix a regression from #4498 causing truncation of dialog button texts 

### DIFF
--- a/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
+++ b/bundles/org.openhab.ui/web/src/pages/settings/things/inbox/inbox-list.vue
@@ -210,6 +210,10 @@
   @media (min-width 960px)
     padding-left 0 !important
     padding-right 0 !important
+</style>
+
+/* Unscoped styles for root-level dynamic dialogs */
+<style lang="stylus">
 .thing-inbox-approve-dialog
   width auto
 </style>


### PR DESCRIPTION
A regression was introduced in #4498 when it changed the stylus to `scoped`. The Inbox Thing Add uses  `f7.dialog.create` which dynamically appends the dialog to the root of the app, hence its style mustn't be scoped.

This PR moved the `thing-inbox-approve-dialog` back into an unscoped stylus.

Problem caused:

<img width="333" height="366" alt="image" src="https://github.com/user-attachments/assets/e6a44e63-02ea-4dff-9d29-e3a193aa5029" />

