### PR TITLE
Revert "thing-details: Wrap long ThingUID"

### DIFF
--- a/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
+++ b/bundles/org.openhab.ui/web/src/components/thing/thing-general-settings.vue
@@ -28,11 +28,15 @@
                       @click="$oh.utils.normalizeInputForThingId('#input')" />
                   </template>
                 </f7-list-input>
-                <f7-list-input class="wrap-uid-input" label="Thing UID" type="text" :input="false">
+                <f7-list-input label="Thing UID" type="text" :input="false" disabled>
                   <template #input>
-                    <span class="uid-text">
+                    <span>
                       {{ thing.UID }}
-                      <clipboard-icon v-if="thing.UID && ready" :value="thing.UID" tooltip="Copy UID" class="uid-copy-icon" />
+                      <clipboard-icon
+                        v-if="thing.UID && ready"
+                        :value="thing.UID"
+                        tooltip="Copy UID"
+                        style="pointer-events: initial !important" />
                     </span>
                   </template>
                 </f7-list-input>
@@ -78,28 +82,6 @@
     </f7-col>
   </f7-block>
 </template>
-
-<style lang="stylus" scoped>
-.wrap-uid-input
-  height auto !important
-
-  :deep(.item-content), :deep(.item-input-wrap)
-    align-items flex-start !important
-    height auto !important
-
-  :deep(.item-title.item-label)
-    align-self flex-start !important
-
-  .uid-text
-    white-space normal !important
-    word-break break-all !important
-    display inline-flex
-    gap 8px
-
-    .uid-copy-icon
-      margin-top 5px
-      pointer-events initial !important
-</style>
 
 <script>
 import ThingPicker from '@/components/config/controls/thing-picker.vue'


### PR DESCRIPTION
Reverts openhab/openhab-webui#4499

This backs out a change to be replaced by a global css style to wrap long UIDs